### PR TITLE
Fix bug SF3487949

### DIFF
--- a/usr/share/rear/output/OBDR/default/81_write_image.sh
+++ b/usr/share/rear/output/OBDR/default/81_write_image.sh
@@ -11,10 +11,10 @@ StopIfError "ISO image could not be written to tape device '$TAPE_DEVICE'"
 mt -f ${TAPE_DEVICE} eof
 StopIfError "Could not write EOF to tape device '$TAPE_DEVICE'"
 
-mt -f ${TAPE_DEVICE} compression on
+mt -f ${TAPE_DEVICE} compression on >&2
 if [[ $? -ne 0 ]] ; then
     ### Try datcompression (for SLES10,11)
-    mt -f ${TAPE_DEVICE} datcompression on
+    mt -f ${TAPE_DEVICE} datcompression on >&2
 fi
 LogIfError "Could not enable compression on tape device '$TAPE_DEVICE'"
 

--- a/usr/share/rear/prep/OBDR/default/50_check_tape_label.sh
+++ b/usr/share/rear/prep/OBDR/default/50_check_tape_label.sh
@@ -7,10 +7,10 @@ mt -f $TAPE_DEVICE rewind
 StopIfError "Problem with rewinding tape in drive '$TAPE_DEVICE'"
 
 # Turn compression off for reading tape label
-mt -f $TAPE_DEVICE compression off
+mt -f $TAPE_DEVICE compression off >&2
 if [[ $? -ne 0 ]] ; then
     ### Try datcompression (for SLES10,11)
-    mt -f ${TAPE_DEVICE} datcompression off
+    mt -f ${TAPE_DEVICE} datcompression off >&2
 fi
 LogIfError "Could not disable compression on tape device '$TAPE_DEVICE'"
 

--- a/usr/share/rear/prep/OBDR/default/70_write_OBDR_header.sh
+++ b/usr/share/rear/prep/OBDR/default/70_write_OBDR_header.sh
@@ -6,10 +6,10 @@ LogPrint "Writing OBDR header to tape in drive '$TAPE_DEVICE'"
 mt -f  "$TAPE_DEVICE" rewind
 StopIfError "Problem with rewinding tape in drive '$TAPE_DEVICE'"
 
-mt -f "$TAPE_DEVICE" compression off
+mt -f "$TAPE_DEVICE" compression off >&2
 if [[ $? -ne 0 ]] ; then
     ### Try datcompression (for SLES10,11)
-    mt -f "${TAPE_DEVICE}" datcompression off
+    mt -f "${TAPE_DEVICE}" datcompression off >&2
 fi
 LogIfError "Could not disable compression on tape device '$TAPE_DEVICE'"
 


### PR DESCRIPTION
mt produces output on stdout when deactivating compression/datcompression on tape drive, rear should suppress this because its not an error.
