### PR TITLE
Smaller changes in Makefiles as preperation for Debian packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ sysconfdir = /etc
 sbindir = $(prefix)/sbin
 datadir = $(prefix)/share
 mandir = $(datadir)/man
-docdir = $(datadir)/doc/rear
 localstatedir = /var
 
 specfile = packaging/rpm/$(name).spec
@@ -70,7 +69,6 @@ Relax-and-Recover make variables (optional):\n\
 clean:
 	rm -f $(name)-$(distversion).tar.gz
 	make -C doc clean
-
 
 ### You can call 'make validate' directly from your .git/hooks/pre-commit script
 validate:
@@ -156,7 +154,6 @@ install-doc:
 		-e 's,/usr/share,$(datadir),' \
 		-e 's,/usr/share/doc/packages,$(datadir)/doc,' \
 		$(DESTDIR)$(mandir)/man8/rear.8
-	install -p -m0644 AUTHORS COPYING README $(DESTDIR)$(docdir)
 
 install: validate man install-config rewrite install-bin restore install-data install-var install-doc
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,6 @@
 prefix = /usr
 datadir = $(prefix)/share
 mandir = $(datadir)/man
-docdir = $(datadir)/doc/rear
 
 txttargets = $(shell echo *.txt)
 htmltargets = $(patsubst %.txt, %.html, $(txttargets))
@@ -15,17 +14,12 @@ man: rear.8
 docs: rear.8 $(htmltargets)
 	make -C user-guide docs
 
-install: docs
+install: rear.8
 	install -Dp -m0644 rear.8 $(DESTDIR)$(mandir)/man8/rear.8
-	install -d -m0755 $(DESTDIR)$(docdir)
-	install -p -m0644 $(txttargets) $(DESTDIR)$(docdir)
-	install -p -m0644 $(htmltargets) $(DESTDIR)$(docdir)
-	-rm $(DESTDIR)$(docdir)/rear.8.txt $(DESTDIR)$(docdir)/rear.8.html
-	make -C user-guide install
 
 clean:
-	make -C user-guide clean
 	rm -f unconv.8 *.html *.xml
+	make -C user-guide clean
 
 %.8.html: %.8.txt
 	asciidoc -d manpage $<

--- a/doc/user-guide/Makefile
+++ b/doc/user-guide/Makefile
@@ -1,7 +1,6 @@
 prefix = /usr
 datadir = $(prefix)/share
 mandir = $(datadir)/man
-docdir = $(datadir)/doc/rear
 
 txttargets = relax-and-recover-user-guide.txt
 htmltargets = $(patsubst %.txt, %.html, $(txttargets))
@@ -11,11 +10,6 @@ all: docs
 dist: docs
 
 docs: $(htmltargets)
-
-install: docs
-	install -d -m0755 $(DESTDIR)$(docdir)/user-guide
-	install -p -m0644 *.txt $(DESTDIR)$(docdir)/user-guide
-	install -p -m0644 $(htmltargets) $(DESTDIR)$(docdir)/user-guide
 
 clean:
 	rm -f *.html *.svg *.xml


### PR DESCRIPTION
In the Debian rules file the make target "install" is used to produce a clear installation for creating the package. This changes ensure a clean installation.
