### PR TITLE
An attempt to deal with #189

### DIFF
--- a/usr/share/rear/restore/DP/default/20_request_gui_restore.sh
+++ b/usr/share/rear/restore/DP/default/20_request_gui_restore.sh
@@ -1,0 +1,14 @@
+##############################################################################
+#
+# Press [gG] to failback to GUI restore
+
+#set -e
+rm -f /tmp/DP_GUI_RESTORE # ensure the flag DP GUI restore request does not exists
+
+unset REPLY
+read -t 30 -r -n 1 -p "press \"G\" to failback to DP GUI restore [30sec]: " 2>&1
+
+if test "${REPLY}" = "g" -o "${REPLY}" = "G"; then
+    Log "DP GUI restore requested"
+    > /tmp/DP_GUI_RESTORE
+fi

--- a/usr/share/rear/restore/DP/default/30_create_dp_restore_fs_list.sh
+++ b/usr/share/rear/restore/DP/default/30_create_dp_restore_fs_list.sh
@@ -4,6 +4,8 @@
 # $ /opt/omni/bin/omnidb -filesystem | grep $(hostname)
 # test.internal.it3.be:/ '/'                                      FileSystem
 
+[ -f /tmp/DP_GUI_RESTORE ] && return # GUI restore explicetely requested
+
 /opt/omni/bin/omnidb -session $(cat /tmp/dp_recovery_session) | cut -d"'" -f -2 > /tmp/list_of_fs_objects
 [ -s /tmp/list_of_fs_objects ]
 StopIfError "Data Protector did not find any file system objects for $(hostname)"

--- a/usr/share/rear/restore/DP/default/40_restore_with_dp.sh
+++ b/usr/share/rear/restore/DP/default/40_restore_with_dp.sh
@@ -21,7 +21,7 @@
 # The list of file systems to restore is listed in file /tmp/list_of_fs_objects
 # per line we have something like: test.internal.it3.be:/ '/'
 
-rm -f /tmp/DP_RESTORE_FAILED # make sure the flag of failed restore does not exist
+[ -f /tmp/DP_GUI_RESTORE ] && return # GUI restore explicetely requested
 
 # we will loop over all objects listed in /tmp/list_of_fs_objects
 cat /tmp/list_of_fs_objects | while read object
@@ -39,7 +39,7 @@ do
 			0)  Log "Restore of ${fs} was successful." ;;
 			10) Log "Restore of ${fs} finished with warnings." ;;
 			*)  LogPrint "Restore of ${fs} failed."
-				> /tmp/DP_RESTORE_FAILED
+				> /tmp/DP_GUI_RESTORE
 				break # get out of the loop
 				;;
 		esac

--- a/usr/share/rear/restore/DP/default/45_restore_via_gui.sh
+++ b/usr/share/rear/restore/DP/default/45_restore_via_gui.sh
@@ -1,14 +1,14 @@
 # 45_restore_via_gui.sh
 # id the automatic restore failed give the end-user the option to execute a retsore via GUI
 
-[ ! -f /tmp/DP_RESTORE_FAILED ] && return	# restore was OK - skip this option
+[ ! -f /tmp/DP_GUI_RESTORE ] && return	# restore was OK - skip this option
 
 Log "Request for a manual restore via the GUI"
 
 echo "
 ***************************************************************************
 **  Please try to push the backups of the latest session from DP GUI     **
-**  Make sure you select \"overwrite\" (destination tab) and make the    **
+**  Make sure you select \"overwrite\" (destination tab) and make the      **
 **  new destination /mnt/local.                                          **
 **  When the restore is complete press ANY key to continue!              **
 ***************************************************************************


### PR DESCRIPTION
For your consideration: `rear recover` of `BACKUP=DP` will - after layout recreation - wait 30s with 

```
press "G" to failback to DP GUI restore [30sec]:
```

If "G" is pressed within 30sec, unattended omnir routines are skipped.
