### PR TITLE
Fix installing grub when /boot is inside the root filesystem

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/22_install_grub2.sh
@@ -41,12 +41,14 @@ if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]]; then
     [[ -r "/mnt/local/boot/$grub_name/grub.cfg" ]]
     LogIfError "Unable to find /boot/$grub_name/grub.cfg."
 
-    # Find exclusive partitions belonging to /boot (subtract root partitions from deps)
-    bootparts=$( (find_partition fs:/boot; find_partition fs:/) | sort | uniq -u )
-    grub_prefix=/grub
-    if [[ -z "$bootparts" ]]; then
+    # Find exclusive partition(s) belonging to /boot
+    # or / (if /boot is inside root filesystem)
+    if [[ "$(filesystem_name /mnt/local/boot)" == "/mnt/local" ]]; then
         bootparts=$(find_partition fs:/)
         grub_prefix=/boot/grub2
+    else
+        bootparts=$(find_partition fs:/boot)
+        grub_prefix=/grub2
     fi
     # Should never happen
     [[ "$bootparts" ]]

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -288,11 +288,11 @@ get_parent_components() {
 # find_devices <other>
 # Find the disk device(s) component $1 resides on.
 find_disk() {
-    get_parent_components $1 "disk"
+    get_parent_components "$1" "disk"
 }
 
 find_partition() {
-    get_parent_components $1 "part"
+    get_parent_components "$1" "part"
 }
 
 # Get the type of a layout component

--- a/usr/share/rear/lib/linux-functions.sh
+++ b/usr/share/rear/lib/linux-functions.sh
@@ -351,5 +351,10 @@ EOF
 # Return the filesystem name related to a path
 function filesystem_name() {
     local path=$1
-    df $path | awk 'END { print $6 }'
+    local fs=$(df -P "$path" | awk 'END { print $6 }')
+    if [[ -z "$fs" ]]; then
+        echo "/"
+    else
+        echo "$fs"
+    fi
 }


### PR DESCRIPTION
This fixes simplifies the code by using df in order to find the filesystem name (mountpoint) of a path and using this to determine whether /boot is in the root filesystem.

This change patches both grub and grub2 (since it was copied from grub).

This fixes #210.
