### PR TITLE
Revert some of the SPEC file changes, and make the crontabs dependency a Red Hat thing

### DIFF
--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -16,7 +16,6 @@ URL: http://relax-and-recover.org/
 # as GitHub stopped with download section we need to go back to Sourceforge for downloads
 #Source: https://github.com/downloads/rear/rear/rear-%{version}.tar.gz
 Source: https://sourceforge.net/projects/rear/files/rear/%{version}/rear-%{version}.tar.gz
-Source1: %{name}.cron
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 BuildArch: noarch
@@ -30,7 +29,6 @@ Requires: mingetty
 Requires: parted
 Requires: tar
 Requires: util-linux
-Requires: crontabs
 
 ### If you require NFS, you may need the below packages
 #Requires: nfsclient portmap rpcbind
@@ -84,6 +82,7 @@ Requires: mkisofs
 
 ### On RHEL/Fedora the genisoimage packages provides mkisofs
 %if %{?centos_version:1}%{?fedora_version:1}%{?rhel_version:1}0
+Requires: crontabs
 Requires: iproute
 Requires: mkisofs
 #Requires: redhat-lsb
@@ -114,7 +113,7 @@ Professional services and support are available.
 %prep
 %setup -q
 
-echo "30 1 * * * root /usr/sbin/rear checklayout || /usr/sbin/rear mkrescue" >%{SOURCE1}
+echo "30 1 * * * root /usr/sbin/rear checklayout || /usr/sbin/rear mkrescue" >rear.cron
 
 ### Add a specific os.conf so we do not depend on LSB dependencies
 %{?fedora:echo -e "OS_VENDOR=Fedora\nOS_VERSION=%{?fedora}" >etc/rear/os.conf}
@@ -129,7 +128,7 @@ echo "30 1 * * * root /usr/sbin/rear checklayout || /usr/sbin/rear mkrescue" >%{
 %install
 %{__rm} -rf %{buildroot}
 %{__make} install DESTDIR="%{buildroot}"
-%{__install} -Dp -m0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/cron.d/%{name}
+%{__install} -Dp -m0644 rear.cron %{buildroot}%{_sysconfdir}/cron.d/rear
 #%{__install} -Dp -m0644 etc/udev/rules.d/62-rear-usb.rules %{buildroot}%{_sysconfdir}/udev/rules.d/62-rear-usb.rules
 
 %clean
@@ -139,7 +138,7 @@ echo "30 1 * * * root /usr/sbin/rear checklayout || /usr/sbin/rear mkrescue" >%{
 %defattr(-, root, root, 0755)
 %doc AUTHORS COPYING README doc/*.txt
 %doc %{_mandir}/man8/rear.8*
-%config(noreplace) %{_sysconfdir}/cron.d/%{name}
+%config(noreplace) %{_sysconfdir}/cron.d/rear
 %config(noreplace) %{_sysconfdir}/rear/
 #%config(noreplace) %{_sysconfdir}/udev/rules.d/62-rear-usb.rules
 %{_datadir}/rear/
@@ -148,6 +147,7 @@ echo "30 1 * * * root /usr/sbin/rear checklayout || /usr/sbin/rear mkrescue" >%{
 
 %changelog
 * Thu Apr 11 2013 Gratien D'haese <gratien.dhaese@gmail.com>
-- changes Source and added Source1 for crontabs (according new packaging rules of Fedora)
+- changes Source
+
 * Thu Jun 03 2010 Dag Wieers <dag@wieers.com>
 - Initial package. (using DAR)


### PR DESCRIPTION
There is no reason to define a non-existing Source1 that we create ourselves. The cron-job is created in %prep so it's not a real "source" in fact.

There is also no reason to change "rear" by the package name, I know some people think that is a best practice, but it makes it more error-prone and doesn't help in readability. And you can't easily grep for filenames because of it. Explicit trumps implicit. Less abstraction wins too.
