### PR TITLE
Implement get_partition_number() to allow for easy testing and trap problems

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/10_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/10_include_partition_code.sh
@@ -182,7 +182,7 @@ EOF
         start=$( echo "$start" | awk '{printf "%u", $1+4096-($1%4096);}')
 
         # Get the partition number from the name
-        local number=$(echo "$partition" | grep -o -E "[0-9]+$" | sed -e 's/.*\(..\)/\1/' -e 's/^[0]*//')
+        local number=$(get_partition_number $partition)
 
         local flags="$(echo $flags | tr ',' ' ')"
         local flag

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -295,6 +295,30 @@ find_partition() {
     get_parent_components "$1" "part"
 }
 
+# Function returns partition number of partition block device name
+#
+# This function should support:
+#   /dev/mapper/36001438005deb05d0000e00005c40000p1
+#   /dev/mapper/36001438005deb05d0000e00005c40000_part1
+#   /dev/mapper/36001438005deb05d0000e00005c400001
+#   /dev/sda1
+#   /dev/cciss/c0d0p1
+
+get_partition_number() {
+    local partition=$1
+    local number=$(echo "$partition" | grep -o -E "[0-9]+$")
+
+    # FIXME: This only supports up to 9 partitions
+    if (( ${#number} > 1 )); then
+        number=${number: -1}
+    fi
+
+    [ $number -gt 0 2>/dev/null ]
+    BugIfError "Partition number '$number' of partition $partition is not a valid number."
+
+    echo $number
+}
+
 # Get the type of a layout component
 get_component_type() {
     grep -E "^[^ ]+ $1 " $LAYOUT_TODO | cut -d " " -f 3


### PR DESCRIPTION
This function now traps when the partition number is not a number or spans more than two characters. Since Relax-and-Recover does not support more than 9 partitions we are not creating another artificial limit. However if we find a better way to get the partition number from inconsistent devices (those that add a partition number directly to a trailing number), I am all for that.

This pull-request relates to #183 and #263
