### PR TITLE
Make sure all VG are disabled before trying to erase the disk.

### DIFF
--- a/usr/share/rear/layout/prepare/default/54_generate_device_code.sh
+++ b/usr/share/rear/layout/prepare/default/54_generate_device_code.sh
@@ -8,10 +8,7 @@ cat <<EOF >$LAYOUT_CODE
 LogPrint "Start system layout restoration."
 
 mkdir -p /mnt/local
-if create_component "vgchange" "rear" ; then
-    lvm vgchange -a n >&8
-    component_created "vgchange" "rear"
-fi
+lvm vgchange -a n >&8
 
 set -e
 set -x


### PR DESCRIPTION
It fixes issues when we want to restore again after an incomplete layout restoration.
