### PR TITLE
Add the --selinux option to be safe with SELinux context restoration

### DIFF
--- a/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
@@ -20,6 +20,12 @@ ProgressStart "Preparing restore operation"
 case "$BACKUP_PROG" in
 	# tar compatible programs here
 	(tar)
+		# Add the --selinux option to be safe with SELinux context restoration
+		if [[ ! $BACKUP_SELINUX_DISABLE =~ ^[yY1] ]]; then
+			if tar --usage | grep -q selinux;  then
+				BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --selinux"
+			fi
+		fi
 		if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
 			BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --exclude-from=$TMP_DIR/restore-exclude-list.txt "
 		fi


### PR DESCRIPTION
During a test on Fedora 19 I face some issues with SELinux and especially tar.

Example (take a look at the output of ls -Z) :
With tar 1.23 (on RHEL 6.4) : 

``` bash
touch /tmp/foo && mv /tmp/foo ~/
ls -Z foo
-rw-r--r--. root root unconfined_u:object_r:user_tmp_t:s0 foo 
tar cf foo.tar foo --xattrs
tar xf foo.tar --xattrs
ls -Z foo
-rw-r--r--. root root unconfined_u:object_r:user_tmp_t:s0 foo 
```

With tar 1.26 (on Fedora 19) :

``` bash
touch /tmp/foo && mv /tmp/foo ~/
ls -Z foo
-rw-r--r--. root root unconfined_u:object_r:user_tmp_t:s0 foo
tar cf foo.tar foo --xattrs
tar xf foo.tar --xattrs
ls -Z foo
-rw-r--r--. root root unconfined_u:object_r:admin_home_t:s0 foo
```

This commit add the --selinux option when SELinux is not disabled
What do you think about this weird behaviour ?
