### PR TITLE
Implement splitted backup support on multiple ISO images

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -148,6 +148,10 @@ ISO_VOLID="RELAXRECOVER"
 # or "/path/to/isolinux.bin"
 ISO_ISOLINUX_BIN=""
 
+# maximum size of generated ISO images. Multiple images will be generated if the size exceed.
+# it's usefull when backups are located in the ISO image
+ISO_MAX_SIZE=
+
 # how to find mkisofs
 # guess the common names mkisofs or genisoimage
 # script in prep stage will verify this and complain if not found

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -108,7 +108,7 @@ mount_url() {
             ;;
         (iso)
             if [[ "$WORKFLOW" = "recover" ]]; then
-                mount_cmd="mount -o loop /dev/disk/by-label/${ISO_VOLID} $mountpoint"
+                mount_cmd="mount /dev/disk/by-label/${ISO_VOLID} $mountpoint"
             else
                 return 0
             fi

--- a/usr/share/rear/output/ISO/Linux-i386/81_prepare_multiple_iso.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/81_prepare_multiple_iso.sh
@@ -1,0 +1,60 @@
+# 81_prepare_multiple_iso.sh
+#
+# multiple isos preparation
+#
+#    Relax-and-Recover is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+
+#    Relax-and-Recover is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+
+#    You should have received a copy of the GNU General Public License
+#    along with Relax-and-Recover; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+#
+
+[[ -n $ISO_MAX_SIZE ]] || return
+
+local backup_path=$(url_path $BACKUP_URL)
+local isofs_path=$(dirname $backuparchive)
+
+NB_ISOS=$(ls $backuparchive.?? | wc -l)
+
+Print "Preparing $NB_ISOS ISO images ..."
+echo -n "$(basename $backuparchive.00)" >> "${isofs_path}/backup.splitted"
+echo -n " $(stat -c '%s' $backuparchive.00)" >> "${isofs_path}/backup.splitted"
+echo " ${ISO_VOLID}" >> "${isofs_path}/backup.splitted"
+
+for i in `seq -f '%02g' 1 $(($NB_ISOS-1))`; do
+    TEMP_ISO_DIR="${TMP_DIR}/isofs_${i}"
+    TEMP_BACKUP_DIR="${TEMP_ISO_DIR}${backup_path}"
+    BACKUP_NAME="$backuparchive.$i"
+    ISO_NAME="${ISO_PREFIX}_${i}.iso"
+    ISO_OUTPUT_PATH="${ISO_DIR}/${ISO_NAME}"
+    
+    echo -n "$(basename $BACKUP_NAME)" >> "${isofs_path}/backup.splitted"
+    echo -n " $(stat -c '%s' $BACKUP_NAME)" >> "${isofs_path}/backup.splitted"
+    echo " ${ISO_VOLID}_${i}" >> "${isofs_path}/backup.splitted"
+    
+    mkdir -p $TEMP_BACKUP_DIR
+    mv $BACKUP_NAME $TEMP_BACKUP_DIR
+    
+    LogPrint "Making additionnal ISO image : ${ISO_NAME}"
+
+    pushd $TEMP_ISO_DIR >&8
+    $ISO_MKISOFS_BIN $v -o "${ISO_OUTPUT_PATH}" -R -J -volid "${ISO_VOLID}_${i}" -v .  >&8
+    StopIfError "Could not create ISO image ${ISO_NAME} (with $ISO_MKISOFS_BIN)"
+    popd >&8
+
+    ISO_IMAGES=( "${ISO_IMAGES[@]}" "${ISO_OUTPUT_PATH}" )
+    iso_image_size=( $(du -h "${ISO_OUTPUT_PATH}") )
+    LogPrint "Wrote ISO image: ${ISO_OUTPUT_PATH} ($iso_image_size)"
+
+    # Add ISO image to result files
+    RESULT_FILES=( "${RESULT_FILES[@]}" "${ISO_OUTPUT_PATH}" )
+done

--- a/usr/share/rear/restore/NETFS/default/38_prepare_multiple_isos.sh
+++ b/usr/share/rear/restore/NETFS/default/38_prepare_multiple_isos.sh
@@ -1,0 +1,17 @@
+# 38_prepare_multiple_isos
+#
+
+local scheme=$(url_scheme $BACKUP_URL)
+local path=$(url_path $BACKUP_URL)
+local opath=$(backup_path $scheme $path)
+
+[[ -f "${opath}/backup.splitted" ]] || return
+
+FIFO="$TMP_DIR/tar_fifo"
+mkfifo $FIFO
+( cat > $FIFO <&9 & echo $! > "${TMP_DIR}/cat_pid" ) 9<&0
+
+cp "${opath}/backup.splitted" ${TMP_DIR}
+cp "${backuparchive}.md5" ${TMP_DIR}/backup.md5
+
+Log "fifo creation succesful !" 

--- a/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
@@ -1,6 +1,10 @@
 # 40_restore_backup.sh
 #
 
+local scheme=$(url_scheme $BACKUP_URL)
+local path=$(url_path $BACKUP_URL)
+local opath=$(backup_path $scheme $path)
+
 mkdir -p "${BUILD_DIR}/outputfs/${NETFS_PREFIX}"
 
 # Disable BACKUP_PROG_CRYPT_OPTIONS by replacing the default value to cat in
@@ -13,6 +17,12 @@ else
   BACKUP_PROG_CRYPT_KEY=""
 fi
 
+if [[ -f "${TMP_DIR}/backup.splitted" ]]; then
+    restoreinput=$FIFO
+else
+    restoreinput=$backuparchive
+fi
+
 Log "Restoring $BACKUP_PROG archive '$backuparchive'"
 Print "Restoring from '$backuparchive'"
 ProgressStart "Preparing restore operation"
@@ -23,8 +33,8 @@ case "$BACKUP_PROG" in
 		if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
 			BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --exclude-from=$TMP_DIR/restore-exclude-list.txt "
 		fi
-		Log dd if=$backuparchive \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
-		dd if=$backuparchive | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
+		Log dd if=$restoreinput \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
+		dd if=$restoreinput | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
 	;;
 	(rsync)
 		if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
@@ -49,6 +59,57 @@ starttime=$SECONDS
 
 sleep 1 # Give the backup software a good chance to start working
 
+(
+# In case of a splitted backup
+if [[ -f "${TMP_DIR}/backup.splitted" ]]; then
+    Print ""
+    while read file; do
+        name=${file%% *}
+        vol_name=${file##* }
+        file_path="${opath}/${name}"
+
+        touch ${TMP_DIR}/wait_dvd
+
+        while ! [[ -f $file_path ]]; do
+            umount "${BUILD_DIR}/outputfs"
+            ProgressInfo "Please insert the media called $vol_name in your CD-ROM drive..."
+            sleep 2
+            drive=$(cat /proc/sys/dev/cdrom/info | grep -i "drive name:" | awk '{print $3 " " $4}')
+            for dev in $drive; do
+                label=$(blkid /dev/${dev} | awk 'BEGIN{FS="[=\"]"} {print $3}')
+                if [[ $label = $vol_name ]]; then
+                    LogPrint "\n${vol_name} detected in /dev/${dev} ..."
+                    mount /dev/${dev} "${BUILD_DIR}/outputfs"
+                fi
+            done
+        done
+
+        if [[ -f $file_path ]]; then
+            if [[ $BACKUP_INTEGRITY_CHECK =~ ^[yY1] && -f "${TMP_DIR}/backup.md5" ]] ; then
+                LogPrint "Checking $name ..."
+                (cd $(dirname $backuparchive) && grep $name "${TMP_DIR}/backup.md5" | md5sum -c)
+                ret=$?
+                if [[ $ret -ne 0 ]]; then
+                    Error "Integrity check failed ! Restore aborted.
+If you want to bypass this check, disable the option in your Rear configuration."
+                    return
+                fi
+            fi
+            rm ${TMP_DIR}/wait_dvd
+            LogPrint "Processing $name ..."
+            dd if="${file_path}" of="$FIFO"
+        else
+            StopIfError "$name could not be found on the $vol_name media !"
+        fi
+
+    done < "${TMP_DIR}/backup.splitted"
+    kill -9 $(cat "${TMP_DIR}/cat_pid")
+    rm "${TMP_DIR}/cat_pid"
+    rm "${TMP_DIR}/backup.splitted"
+    rm "${TMP_DIR}/backup.md5"
+fi
+) &
+
 # make sure that we don't fall for an old size info
 unset size
 # while the backup runs in a sub-process, display some progress information to the user
@@ -57,7 +118,11 @@ case "$BACKUP_PROG" in
 		while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
 			blocks="$(tail -1 "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log" | awk 'BEGIN { FS="[ :]" } /^block [0-9]+: / { print $2 }')"
 			size="$((blocks*512))"
-			ProgressInfo "Restored $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec]"
+			if [ -f ${TMP_DIR}/wait_dvd ]; then
+                            starttime=$((starttime+1))
+			else
+                            ProgressInfo "Restored $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec]"
+                        fi
 		done
 		;;
 	*)

--- a/usr/share/rear/verify/NETFS/default/55_check_backup_archive.sh
+++ b/usr/share/rear/verify/NETFS/default/55_check_backup_archive.sh
@@ -7,19 +7,25 @@ case $(url_scheme "$BACKUP_URL") in
         ;;
 esac
 
-[ -s "$backuparchive" -o -d "$backuparchive" ]
+[ -s "$backuparchive" -o -d "$backuparchive" -o -f "$(dirname $backuparchive)/backup.splitted" ]
 StopIfError "Backup archive '$backuparchive' not found !"
 
 LogPrint "Calculating backup archive size"
 
-du -sh "$backuparchive" >$TMP_DIR/backuparchive_size
+if [[ -f "$(dirname $backuparchive)/backup.splitted" ]]; then
+    cut -d ' ' -f2 "$(dirname $backuparchive)/backup.splitted" | awk '{s+=$1} END {print s/(1024*1024)"M"}' >$TMP_DIR/backuparchive_size
+else
+    du -sh "$backuparchive" | cut -d ' ' -f1 >$TMP_DIR/backuparchive_size
+fi
 StopIfError "Failed to determine backup archive size."
 
-read backuparchive_size junk <$TMP_DIR/backuparchive_size
+read backuparchive_size <$TMP_DIR/backuparchive_size
 LogPrint "Backup archive size is $backuparchive_size${BACKUP_PROG_COMPRESS_SUFFIX:+ (compressed)}"
 
 if [[ $BACKUP_INTEGRITY_CHECK =~ ^[yY1] && -f ${backuparchive}.md5 ]] ; then
-    LogPrint "Checking integrity of $(basename $backuparchive) ..."
-    (cd $(dirname $backuparchive) && md5sum -c ${backuparchive}.md5)
-    StopIfError "Integrity check failed !! \nIf you want to bypass this check please edit the configuration file (/etc/rear/local.conf) and unset BACKUP_INTEGRITY_CHECK."
+    if [[ ! -f "$(dirname $backuparchive)/backup.splitted" ]]; then
+        LogPrint "Checking integrity of $(basename $backuparchive) ..."
+        (cd $(dirname $backuparchive) && md5sum -c ${backuparchive}.md5)
+        StopIfError "Integrity check failed !! \nIf you want to bypass this check please edit the configuration file (/etc/rear/local.conf) and unset BACKUP_INTEGRITY_CHECK."
+    fi
 fi


### PR DESCRIPTION
As backups can now be included inside the ISO image, it can be usefull to split them onto several ISO images. (eg: burn to CD or DVD)
I introduced the ISO_MAX_SIZE option (default unset, so feature disabled) which will be the maximum size of the backup in any ISO image.
The first ISO image name isn't changed. Additional ISO images are called with the same name but with a number as suffix.
All ISO images are pushed to the OUPTUT_URL as before.
A file called backup.splitted is generated and is used to know if a backup is splitted or not. This file also contains several informations about generated images.

About restore, it's a bit more complex. I use a fifo pipe to be able to restore backup from multiple DVD/ISO without interrupting the restore process. About the wait for next DVDs, a loop is used to detect automatically when a new DVD is inserted (by volid). When integrity check is enabled, backup checksum are checked when each new DVD is inserted as it isn't possible to do that at the beginning of the recover.

As this feature introduced a lot of new code, it has been checked in a lot of configuration and is, according to all my tests, regression free.
