### PR TITLE
Fix btrfs partitions recreation on RHEL6

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
@@ -94,7 +94,7 @@ EOF
 cat >> $LAYOUT_CODE <<EOF
 LogPrint "Creating $fstype-filesystem $mp on $device"
 # if $device is already mounted, skip
-mount | grep -q $device || mkfs -t $fstype -f $device
+mount | grep -q $device || mkfs -t $fstype $device
 EOF
             if [ -n "$label" ] ; then
                 echo "mount | grep -q $device || btrfs filesystem label $device $label >&2" >> $LAYOUT_CODE


### PR DESCRIPTION
Don't use -f in the btrfs mkfs command. It doesn't exist on old versions of mkfs.btrfs such as RHEL6 one.
Regression introduced by : 2d5445466d389b331c9ad1a984c66354415f21ea
