### PR TITLE
Don't exceed the maximum ISO size defined by ISO_MAX_SIZE

### DIFF
--- a/usr/share/rear/backup/NETFS/default/50_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/50_make_backup.sh
@@ -60,7 +60,6 @@ if [[ -n "$ISO_MAX_SIZE" ]]; then
         [[ $USING_UEFI_BOOTLOADER ]] && BASE_ISO_SIZE=$((${BASE_ISO_SIZE}+30))
         ISO_MAX_SIZE=$((${ISO_MAX_SIZE}-${BASE_ISO_SIZE}))
     fi
-    LogPrint "New ISO_MAX_SIZE : $ISO_MAX_SIZE  BASE_ISO_SIZE : $BASE_ISO_SIZE  INITRD_SIZE : $INITRD_SIZE  KERNEL_SIZE : KERNEL_SIZE"
     SPLIT_COMMAND="split -d -b ${ISO_MAX_SIZE}m - ${backuparchive}."
 else
     SPLIT_COMMAND="dd of=$backuparchive"


### PR DESCRIPTION
Indeed, the first ISO image contains additional files such as EFI, ramdisk and kernel
So, for BIOS : real backup size = ISO_MAX_SIZE - kernel/ramdisk size - 15MB
For EFI : real backup size = ISO_MAX_SIZE - kernel/ramdisk size - 45MB
