### PR TITLE
do not use $SHARE_DIR in sesam startup script as it is not set which results in cl...

### DIFF
--- a/usr/share/rear/skel/SESAM/etc/scripts/system-setup.d/59-start-sesam-client.sh
+++ b/usr/share/rear/skel/SESAM/etc/scripts/system-setup.d/59-start-sesam-client.sh
@@ -2,7 +2,7 @@
 if [ -e /etc/sesam2000.ini ]; then
 
         # get sesam installation
-        source $SHARE_DIR/lib/sesam-functions.sh
+        source /usr/share/rear/lib/sesam-functions.sh
         # set the sesam environment profile
         source $SESAM_VAR_DIR/var/ini/sesam2000.profile
 


### PR DESCRIPTION
hi,

$SHARE_DIR is not set while startup scripts are executed (dhclient for example hardcodes the directory), this 
makes the sesam client fail during startup. Simple fix attached which hardodes the directory here.
