### PR TITLE
Add -f option to mkfs if fstype=xfs

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
@@ -69,7 +69,7 @@ EOF
         xfs)
 cat >> $LAYOUT_CODE <<EOF
 LogPrint "Creating $fstype-filesystem $mp on $device"
-mkfs -t $fstype $device
+mkfs -f -t $fstype $device
 EOF
             if [ -n "$label" ] ; then
                 echo "xfs_admin -L $label $device >&2" >> $LAYOUT_CODE


### PR DESCRIPTION
Hi,
When Rear recover a xfs filesystem, mkfs will not write to the device if it suspects a file system already exists on that device. Rear have to force mkfs with -f option.
