### PR TITLE
Ensure password login possible when SSH_ROOT_PASSWORD is set

### DIFF
--- a/usr/share/rear/rescue/default/50_ssh.sh
+++ b/usr/share/rear/rescue/default/50_ssh.sh
@@ -52,7 +52,7 @@ if has_binary sshd; then
 	# Set the SSH root password
 	if [[ $SSH_ROOT_PASSWORD ]] ; then
 		echo "root:$(echo $SSH_ROOT_PASSWORD | openssl passwd -1 -stdin):::::::" > $ROOTFS_DIR/etc/shadow
-        sed -i 's/.*PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
-        sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+        sed -i 's/.*PermitRootLogin.*/PermitRootLogin yes/g' $ROOTFS_DIR/etc/ssh/sshd_config
+        sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication yes/g' $ROOTFS_DIR/etc/ssh/sshd_config
 	fi
 fi


### PR DESCRIPTION
I have added a couple of lines that ensures password login being possible when SSH_ROOT_PASSWORD has been set.

The reason for not adding to end of sshd_config as proposed is due to any Match blocks that could be used in sshd_config needs to be at the very end of the file - thus only a complete in-place line substitution should be done (and looks cleaner as well).

Info on Match blocks: http://unix.stackexchange.com/questions/67334/openssh-how-to-end-a-match-block
