### PR TITLE
Adjusting PermitRootLogin and PasswordAuthentication if SSH_ROOT_PASSWOR...

### DIFF
--- a/usr/share/rear/build/GNU/Linux/16_adjust_sshd_config.sh
+++ b/usr/share/rear/build/GNU/Linux/16_adjust_sshd_config.sh
@@ -1,0 +1,26 @@
+# 16_adjust_sshd_config.sh
+#
+# Edit the sshd_config for Relax and Recover to allow password login if set
+#
+#    Relax-and-Recover is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+
+#    Relax-and-Recover is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+
+#    You should have received a copy of the GNU General Public License
+#    along with Relax-and-Recover; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+#
+if has_binary sshd; then
+    if [[ $SSH_ROOT_PASSWORD ]] ; then
+        sed -i 's/.*PermitRootLogin.*/PermitRootLogin yes/g' $ROOTFS_DIR/etc/ssh/sshd_config
+        sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication yes/g' $ROOTFS_DIR/etc/ssh/sshd_config
+    fi
+fi
+

--- a/usr/share/rear/rescue/default/50_ssh.sh
+++ b/usr/share/rear/rescue/default/50_ssh.sh
@@ -52,7 +52,5 @@ if has_binary sshd; then
 	# Set the SSH root password
 	if [[ $SSH_ROOT_PASSWORD ]] ; then
 		echo "root:$(echo $SSH_ROOT_PASSWORD | openssl passwd -1 -stdin):::::::" > $ROOTFS_DIR/etc/shadow
-        sed -i 's/.*PermitRootLogin.*/PermitRootLogin yes/g' $ROOTFS_DIR/etc/ssh/sshd_config
-        sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication yes/g' $ROOTFS_DIR/etc/ssh/sshd_config
 	fi
 fi


### PR DESCRIPTION
...D is set

ReaR first sets up array of files to be copied. So any attempt to edit a file before copy, will be unsuccessful.
The first patch tried to edit a file that wasn't there .

I don't know why it worked the first time (probably a PEBKAC), but this change has been tested several times now, and works everytime.
