### PR TITLE
Add sleep command to be sure that network is properly initialized in rescue system

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/58-start-dhclient.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/58-start-dhclient.sh
@@ -12,6 +12,9 @@ fi
 
 echo "Attempting to start the DHCP client daemon"
 
+# To be sure that network is properly initialized (get_device_by_hwaddr sees network interfaces)
+sleep 5
+
 . /usr/share/rear/lib/network-functions.sh
 
 # Need to find the devices and their HWADDR (avoid local and virtual devices)


### PR DESCRIPTION
Hi, 
After the backup of a server with the eth0 interface configured in DHCP mode. 
I started the recovery system, and the dhclient command has not been executed. The culprit is get_device_by_hwaddr that returns no interface. I think this command was executed too early because when I sourced manually 58-start-dhclient.sh the script works fine ! Adding a sleep 5 before calling get_device_by_hwaddr fixes this issue (tested 5 or 6 times to be sure )

``` bash
RESCUE # cat /etc/rear/rescue.conf
# line below was automatically added by 21_include_dhclient.sh
USE_DHCLIENT=y
DHCLIENT_BIN=dhclient
DHCLIENT6_BIN=
NETFS_KEEP_OLD_BACKUP_COPY=""
NETFS_PREFIX="node11"
```
