### PR TITLE
Fixed test if filesystem is mounted with user_xattr. Was not working with btrfs.

### DIFF
--- a/usr/share/rear/prep/RSYNC/default/15_check_rsync_protocol_version.sh
+++ b/usr/share/rear/prep/RSYNC/default/15_check_rsync_protocol_version.sh
@@ -37,7 +37,7 @@ if [ "${RSYNC_USER}" != "root" ]; then
         else
             # when using --fake-super we must have user_xattr mount options on the remote mntpt
             _mntpt=$(ssh ${RSYNC_USER}@${RSYNC_HOST} 'cd ${RSYNC_PATH}; df -P .' 2>/dev/null | tail -1 | awk '{print $6}')
-            ssh ${RSYNC_USER}@${RSYNC_HOST} "cd ${RSYNC_PATH} && touch .is_xattr_supported && setfattr -n user.comment -v 'File created by rear to test if this filesystems supports extended attributes.' .is_xattr_supported && getfattr -n user.comment .is_xattr_supported; find .is_xattr_supported -empty -delete"
+            ssh ${RSYNC_USER}@${RSYNC_HOST} "cd ${RSYNC_PATH} && touch .is_xattr_supported && setfattr -n user.comment -v 'File created by rear to test if this filesystems supports extended attributes.' .is_xattr_supported && getfattr -n user.comment .is_xattr_supported 1>/dev/null; find .is_xattr_supported -empty -delete"
             StopIfError "Remote file system $_mntpt does not have user_xattr mount option set!"
             #BACKUP_RSYNC_OPTIONS=( "${BACKUP_RSYNC_OPTIONS[@]}" --xattrs --rsync-path="""rsync --fake-super""" )
             # see issue #366 for explanation of removing --xattrs


### PR DESCRIPTION
user_xattr is the default in btrfs and btrfs does not even allow the mount
option user_xattr (btrfs: unrecognized mount option 'user_xattr') the
previous test did report that the btrfs filesystem is not
mounted with user_xattr.

This new test tries to actually create a file with extended attributes.

Tested it with btrfs and tmpfs.
