### PR TITLE
Don‘t include encfs filesystems in the df.txt file.

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/51_current_disk_usage.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/51_current_disk_usage.sh
@@ -2,4 +2,4 @@
 # Public License. Refer to the included LICENSE for full text of license.
 
 # Save the current disk usage (POSIX output format) in the rescue image
-df -Plh > $VAR_DIR/layout/config/df.txt
+df -Plh |grep -vP '^(encfs)' > $VAR_DIR/layout/config/df.txt


### PR DESCRIPTION
This filesystem type is not needed in the output.

What do you think? Would that make sense?
