### PR TITLE
Fix doublequotes in NETFS

### DIFF
--- a/doc/rear.8
+++ b/doc/rear.8
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: rear
 .\"    Author: [see the "AUTHORS" section]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 11 Sep 2013
+.\" Generator: DocBook XSL Stylesheets v1.75.2 <http://docbook.sf.net/>
+.\"      Date: 07/14/2014
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "REAR" "8" "11 Sep 2013" "\ \&" "\ \&"
+.TH "REAR" "8" "07/14/2014" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -52,12 +52,14 @@ Relax\-and\-Recover comes with ABSOLUTELY NO WARRANTY; for details see the GNU G
 .PP
 \-d
 .RS 4
+
 \fBdebug mode\fR
 (log debug messages to log file)
 .RE
 .PP
 \-D
 .RS 4
+
 \fBdebugscript mode\fR
 (log every function call)
 .RE
@@ -69,18 +71,21 @@ kernel version to use (by default use running kernel)
 .PP
 \-s
 .RS 4
+
 \fBsimulation mode\fR
 (show what scripts rear would include)
 .RE
 .PP
 \-S
 .RS 4
+
 \fBstep\-by\-step mode\fR
 (acknowledge each script individually)
 .RE
 .PP
 \-v
 .RS 4
+
 \fBverbose mode\fR
 (show progress output)
 .RE
@@ -184,6 +189,7 @@ Create only the Relax\-and\-Recover initramfs\&.
 .PP
 OUTPUT=\fBISO\fR
 .RS 4
+
 \fB(Default)\fR
 Create a bootable ISO9660 image on disk as
 \fIrear\-$(hostname)\&.iso\fR
@@ -284,6 +290,7 @@ The following BACKUP methods are external of Relax\-and\-Recover meaning that yo
 .PP
 BACKUP=\fBREQUESTRESTORE\fR
 .RS 4
+
 \fB(default)\fR
 Not really a backup method at all, Relax\-and\-Recover simply halts the recovery and requests that somebody will restore the data to the appropriate location (e\&.g\&. via SSH)\&. This method works especially well with an rsync bases backup that is pushed back to the backup client\&.
 .RE

--- a/usr/share/rear/prep/NETFS/default/07_set_backup_archive.sh
+++ b/usr/share/rear/prep/NETFS/default/07_set_backup_archive.sh
@@ -10,7 +10,7 @@ case "$TAPE_DEVICE:$scheme" in
         backuparchive="${opath}/${BACKUP_PROG_ARCHIVE}${BACKUP_PROG_SUFFIX}${BACKUP_PROG_COMPRESS_SUFFIX}"
         ;;
     (:*)
-        if [ $BACKUP_TYPE == "incremental" ]; then
+        if [ "$BACKUP_TYPE" == "incremental" ]; then
             for i in $(ls ${BUILD_DIR}/outputfs/${NETFS_PREFIX}/*.tar.gz); do restorearchive=$i;done
             if [ $(date +%a) = $FULLBACKUPDAY ]; then
 		Log "It is Full-Backup-Day"

--- a/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
@@ -39,7 +39,7 @@ case "$BACKUP_PROG" in
 		if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
 			BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --exclude-from=$TMP_DIR/restore-exclude-list.txt "
 		fi
-		if [ $BACKUP_TYPE == "incremental" ]; then
+		if [ "$BACKUP_TYPE" == "incremental" ]; then
 			LAST="$restorearchive"
 			BASE=$(dirname "$restorearchive")/$(tar --test-label -f "$restorearchive")
 			if [ "$BASE" == "$LAST" ]; then


### PR DESCRIPTION
Jeremy Laidmann reported a bug in /usr/share/rear/restore/NETFS/default/40_restore_backup.sh

> > The error in line 42 of 40_restore_backup.sh appears to be expecting $BACKUP_TYPE to be non-empty.  I 
> > think the default is "full" and so I suspect this can be fixed by enclosing "$BACKUP_TYPE" in double quotes.  
> > If I set BACKUP_TYPE to "full" in my site.conf then this message doesn't show up.  I can't tell if this is 
> > causing other problems like...
