### PR TITLE
Prevent hang on boot if NTP can't reach any servers

### DIFF
--- a/usr/share/rear/rescue/default/43_prepare_timesync.sh
+++ b/usr/share/rear/rescue/default/43_prepare_timesync.sh
@@ -7,7 +7,18 @@ case "$TIMESYNC" in
 		echo "NT:2345:respawn:/bin/ntpd -n -g -p /var/run/ntpd.pid" >>$ROOTFS_DIR/etc/inittab
 		cat >$ROOTFS_DIR/etc/scripts/system-setup.d/90-timesync.sh <<-EOF
 			echo "Setting system time via NTP ..."
-			ntpd -q -g # allow for big jumps
+			ntpd -q -g & # allow for big jumps
+			ntpd_pid=$!
+			i=0
+			while kill -0 $ntpd_pid 2>/dev/null; do
+				if [[ $i -ge 10 ]]; then
+					echo "Gave up on NTP after 10 seconds."
+					kill $ntpd_pid
+					break
+				fi
+				i=$(( $i + 1 ))
+				sleep 1
+			done
 		EOF
 		;;
 	RDATE)


### PR DESCRIPTION
If, for example, no network is available, `ntpd -q` will wait forever for a response from its configured time servers.

This pull request causes NTP syncing to time-out after 10 seconds to allow the boot to complete.  You'll then reach a shell prompt and get a chance to try to figure out what went wrong.
