### PR TITLE
Update 81_create_pxelinux_cfg.sh

### DIFF
--- a/usr/share/rear/output/PXE/default/81_create_pxelinux_cfg.sh
+++ b/usr/share/rear/output/PXE/default/81_create_pxelinux_cfg.sh
@@ -25,7 +25,7 @@ PXE_LOCAL_PATH=$PXE_CONFIG_PATH
 PXE_CONFIG_FILE="${PXE_CONFIG_PREFIX}$(uname -n)"
 cat >"$PXE_LOCAL_PATH/$PXE_CONFIG_FILE" <<EOF
 $(test -s $(get_template "PXE_pxelinux.cfg") && cat $(get_template "PXE_pxelinux.cfg"))
-display $PXE_MESSAGE
+display $OUTPUT_PREFIX/$PXE_MESSAGE
 say ----------------------------------------------------------
 say rear = disaster recover this system with Relax and Recover
 label rear


### PR DESCRIPTION
Hi,

both <hostname>.kernel and <hostname>.initrd.cgz are prefixed by $OUTPUT_PREFIX/. So it would make sense to also prefix the <hostname>.message file with $OUTPUT_PREFIX/ as the easiest and cleanest way to make them accessible via tftp at network boot is to put all three of them in the same folder, especially as rear puts them in same directory at rescue image creation time.

Otherwise .message file is not shown during network boot.

BR, Andreas
