### PR TITLE
Fix Duply/Duplicity backup logging:

### DIFF
--- a/usr/share/rear/backup/DUPLICITY/default/50_make_duplicity_backup.sh
+++ b/usr/share/rear/backup/DUPLICITY/default/50_make_duplicity_backup.sh
@@ -11,7 +11,7 @@ if [ "$BACKUP_PROG" = "duply" ] && has_binary duply; then
     StopIfError "Duply profile $DUPLY_PROFILE backup returned errors - see $LOGFILE"
 
     LogPrint "The last full backup taken with duply/duplicity was:"
-    LogPrint "$( tail -50 $LOGFILE | grep "Last full backup date:" )"
+    LogPrint "$( tail -50 $LOGFILE | grep 'Last full backup date:' )"
 fi
 
 

--- a/usr/share/rear/prep/DUPLICITY/default/20_find_duply_profile.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/20_find_duply_profile.sh
@@ -13,7 +13,7 @@ if [ "$BACKUP_PROG" = "duplicity" ] && has_binary duply; then
     # we found the duply program; check if we can find a profile defined
     if [[ -z "$DUPLY_PROFILE" ]]; then
         # no profile pre-set; let's try to find one
-        DUPLY_PROFILE=$( find /etc/duply /root/.duply -name conf )
+        DUPLY_PROFILE=$( find /etc/duply /root/.duply -name conf 2>&1)
         [[ -z "$DUPLY_PROFILE" ]] && return
 
         # there could be more then one profile present - select where SOURCE='/'
@@ -49,6 +49,6 @@ if [ "$BACKUP_PROG" = "duplicity" ] && has_binary duply; then
     LogIfError "Could not add DUPLY_PROFILE variable to rescue.conf"
 
     LogPrint "The last full backup taken with duply/duplicity was:"
-    LogPrint "$( tail -10 $LOGFILE | grep Full )"
+    LogPrint "$( tail -50 $LOGFILE | grep 'Last full backup date:' )"
 fi
 


### PR DESCRIPTION
Start information added and last backup time recognition fixed.

Start duply v1.5.5.5, time is 2014-10-15 18:31:18.
Using profile '/etc/duply/rear-test'.
Using installed duplicity version 0.6.18, python 2.7.3, gpg 1.4.12 (Home: ~/.gnupg), awk 'GNU Awk 4.0.1', bash '4.2.37(1)-release (x86_64-pc-linux-gnu)'.
Signing disabled. Not GPG_KEY entries in config.
Test - Encryption with passphrase (OK)
Test - Decryption with passphrase (OK)
Test - Compare (OK)
Cleanup - Delete '/tmp/duply.10932.1413397878_*'(OK)

--- Start running command PRE at 18:31:18.583 ---
Running '/etc/duply/rear-test/pre' - OK
Output: kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]
--- Finished state OK at 18:31:18.618 - Runtime 00:00:00.035 ---

--- Start running command BKP at 18:31:18.630 ---
Reading globbing filelist /etc/duply/rear-test/exclude
Local and Remote metadata are synchronized, no sync needed.
Last full backup date: none
No signatures found, switching to full backup.
--------------[ Backup Statistics ]--------------
StartTime 1413397878.77 (Wed Oct 15 18:31:18 2014)
EndTime 1413398143.49 (Wed Oct 15 18:35:43 2014)
ElapsedTime 264.72 (4 minutes 24.72 seconds)
SourceFiles 99165
SourceFileSize 1911766153 (1.78 GB)
NewFiles 99165
NewFileSize 1911766153 (1.78 GB)
DeletedFiles 0
ChangedFiles 0
ChangedFileSize 0 (0 bytes)
ChangedDeltaSize 0 (0 bytes)
DeltaEntries 99165
RawDeltaSize 1864277950 (1.74 GB)
TotalDestinationSizeChange 1035585479 (988 MB)
## Errors 0

--- Finished state OK at 18:35:55.435 - Runtime 00:04:36.804 ---

--- Start running command POST at 18:35:55.447 ---
Running '/etc/duply/rear-test/post' - OK
--- Finished state OK at 18:35:55.466 - Runtime 00:00:00.018 ---
