### PR TITLE
fixing changelog owner/timestamp line and replacing outdated function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ endif
 	tar -xOzf $(name)-$(distversion).tar.gz -C $(BUILD_DIR)/$(obspackage) $(name)-$(distversion)/$(dscfile) >$(BUILD_DIR)/$(obspackage)/$(name).dsc
 	tar -xOzf $(name)-$(distversion).tar.gz -C $(BUILD_DIR)/$(obspackage) $(name)-$(distversion)/packaging/debian/control >$(BUILD_DIR)/$(obspackage)/debian.control
 	tar -xOzf $(name)-$(distversion).tar.gz -C $(BUILD_DIR)/$(obspackage) $(name)-$(distversion)/packaging/debian/rules >$(BUILD_DIR)/$(obspackage)/debian.rules
-	echo -e "rear ($(version)-$(debrelease)) stable; urgency=low\n\n  * new snapshot build\n\n -- OpenSUSE Build System <obs@relax-and-recover.org> $$(date -R)" >$(BUILD_DIR)/$(obspackage)/debian.changelog
+	echo -e "rear ($(version)-$(debrelease)) stable; urgency=low\n\n  * new snapshot build\n\n -- OpenSUSE Build System <obs@relax-and-recover.org>  $$(date -R)" >$(BUILD_DIR)/$(obspackage)/debian.changelog
 	tar -xOzf $(name)-$(distversion).tar.gz -C $(BUILD_DIR)/$(obspackage) $(name)-$(distversion)/packaging/debian/changelog >>$(BUILD_DIR)/$(obspackage)/debian.changelog
 	cd $(BUILD_DIR)/$(obspackage); osc addremove
 	cd $(BUILD_DIR)/$(obspackage); osc ci -m "Update to $(name)-$(distversion)" $(BUILD_DIR)/$(obspackage)

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -10,43 +10,43 @@ rear (1.16-1) stable; urgency=high
   * new features
   * lots of bug fixes
 
- -- Gratien Dhaese <gratien.dhaese@gmail.com> Sun 04 May 2014 21:00:36 +0100
+ -- Gratien Dhaese <gratien.dhaese@gmail.com>  Sun, 04 May 2014 21:00:36 +0100
 rear (1.15-1) stable; urgency=high
 
   * new features
   * bugfixes
 
- -- Gratien Dhaese <gratien.dhaese@gmail.com> Wed, 09 Oct 2013 16:15:21 +0100
+ -- Gratien Dhaese <gratien.dhaese@gmail.com>  Wed, 09 Oct 2013 16:15:21 +0100
 rear (1.14-1) stable; urgency=high
 
   * major bugfixes
 
- -- Dag Wieers <dag@wieers.com> Mon, 25 Jun 2012 12:46:21 +0100
+ -- Dag Wieers <dag@wieers.com>  Mon, 25 Jun 2012 12:46:21 +0100
 rear (1.13.0-1) stable; urgency=low
 
   * new features
   * bugfixes
 
- -- Dag Wieers <dag@wieers.com> Mon, 25 Jun 2012 12:46:21 +0100
+ -- Dag Wieers <dag@wieers.com>  Mon, 25 Jun 2012 12:46:21 +0100
 rear (1.12.0-1) stable; urgency=low
 
   * new features
   * bugfixes
   * see http://sourceforge.net/projects/rear/files/rear/1.12/1.12.0/rear-release-notes.txt/download for details
 
- -- Schlomo Schapiro <rear-buildservice@schlomo.schapiro.org> Wed, 15 Feb 2012 11:02:03 +0100
+ -- Schlomo Schapiro <rear-buildservice@schlomo.schapiro.org>  Wed, 15 Feb 2012 11:02:03 +0100
 rear (1.11.0-11) stable; urgency=low
 
   * new features
   * bugfixes
 
- -- Schlomo Schapiro <rear-buildservice@schlomo.schapiro.org> Sun, 23 May 2011 17:47:47 +0100
+ -- Schlomo Schapiro <rear-buildservice@schlomo.schapiro.org>  Sun, 23 May 2011 17:47:47 +0100
 rear (1.10.0-1) stable; urgency=low
 
   * new features
   * bugfixes
 
- -- Schlomo Schapiro <rear-buildservice@schlomo.schapiro.org> Sun, 20 Mar 2011 11:55:54 +0100
+ -- Schlomo Schapiro <rear-buildservice@schlomo.schapiro.org>  Sun, 20 Mar 2011 11:55:54 +0100
 rear (1.7.23-1) stable; urgency=low
 
   * bugfixes, mostly for x86_64

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -25,7 +25,7 @@ clean:
 binary-indep: build
 	dh_testdir
 	dh_testroot
-	dh_clean -k
+	dh_prep
 	dh_installdirs
 	
 	# The DESTDIR Has To Be Exactly debian/rear


### PR DESCRIPTION
(two spaces between email address and timestampt and some timestamps are missing a commata
 https://www.debian.org/doc/debian-policy/ch-source.html )
