### PR TITLE
Update 10_include_partition_code.sh

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/10_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/10_include_partition_code.sh
@@ -178,7 +178,12 @@ EOF
         # the start of the next partition is where this one ends
         # We can't use $end because of extended partitions
         # extended partitions have a small actual size as reported by sysfs
-        start=$(( start + ${size%B} ))
+        # in front of a logical partition should be at least 512B empty space
+        if [ -n "$MIGRATION_MODE" ] && [ "$name" = "logical" ] ; then
+            start=$(( start + ${size%B} + block_size ))
+        else
+            start=$(( start + ${size%B} ))
+        fi
 
         # round starting size to next multiple of 4096
         # 4096 is a good match for most device's block size


### PR DESCRIPTION
While recover a system to a smaller disk, we get the following error message:

```
# rear recover
....
Device sda has size 53687091200, 146778685440 expected
Switching to manual disk layout configuration.
Original disk /dev/sda does not exist in the target system. Please choose an appropriate replacement.
1) /dev/sda            6) /dev/sdf          11) /dev/sdk
2) /dev/sdb            7) /dev/sdg          12) /dev/sdl
3) /dev/sdc            8) /dev/sdh          13) /dev/sdm
4) /dev/sdd            9) /dev/sdi          14) /dev/sdn
5) /dev/sde           10) /dev/sdj          15) Do not map disk.
#? 7
2014-10-14 11:02:07 Disk /dev/sdg chosen as replacement for /dev/sda.
Disk /dev/sdg chosen as replacement for /dev/sda.
This is the disk mapping table:
    /dev/sda /dev/sdg
Please confirm that '/var/lib/rear/layout/disklayout.conf' is as you expect.

1) View disk layout (disklayout.conf)  4) Go to Relax-and-Recover shell
2) Edit disk layout (disklayout.conf)  5) Continue recovery
3) View original disk space usage      6) Abort Relax-and-Recover
#? 5
Partition logical on /dev/sdg: size reduced to fit on disk.
Please confirm that '/var/lib/rear/layout/diskrestore.sh' is as you expect.

1) View restore script (diskrestore.sh)
2) Edit restore script (diskrestore.sh)
3) View original disk space usage
4) Go to Relax-and-Recover shell
5) Continue recovery
6) Abort Relax-and-Recover
#? 5
Start system layout restoration.
Creating partitions for disk /dev/sdg (msdos)
An error occurred during layout recreation.

1) View Relax-and-Recover log
2) View original disk space usage
3) Go to Relax-and-Recover shell
4) Edit restore script (diskrestore.sh)
5) Continue restore script
6) Abort Relax-and-Recover
#? 1

....
2014-10-14 11:02:07 Resized partition /dev/sdg5 from 4301520896B to 2901097224B.
2014-10-14 11:02:07 Resized partition /dev/sdg6 from 2154823680B to 1453288999B.
2014-10-14 11:02:07 Resized partition /dev/sdg7 from 4301520896B to 2901097224B.
2014-10-14 11:02:07 Resized partition /dev/sdg8 from 84448641024B to 56955138428B.
....
+++ parted -s /dev/sdg mkpart '"logical"' 47517990912B 50419088135B
Error: You requested a partition from 47.5GB to 50.4GB.
The closest location we can manage is 47.5GB to 50.4GB.
2014-10-14 11:02:29 An error occurred during layout recreation.
```

We tried then to create the partition by hand with unit B

```
# parted -s /dev/sdg unit B mkpart '"logical"' 47517990912B 50419088135B
Error: You requested a partition from 47517990912B to 50419087872B.
The closest location we can manage is 47517991424B to 50419087872B.

# echo '47517991424 - 47517990912' | bc
512
```

As you can see, parted needs 512B empty space before the partition start point.
After adding one block to $start it works without a problem.
