### PR TITLE
Add a new config option USE_STATIC_NETWORKING

### DIFF
--- a/doc/rear-release-notes.txt
+++ b/doc/rear-release-notes.txt
@@ -113,6 +113,10 @@ functionality:
   can be forced via the variable *USE_DHCLIENT=yes* (define in _/etc/rear/local.conf_).
   It is also possible to force DHCP at boot time with kernel option `dhcp`
 
+* By default, if DHCP is used, static network configuration is ignored.
+  Override this with *USE_STATIC_NETWORKING=yes* in
+  _/etc/rear/local.conf_.
+
 * Save layout and compare layouts for easy automation of making
   Relax-and-Recover snapshots (checklayout option)
 
@@ -144,6 +148,10 @@ Relax-and-Recover, unless otherwise noted.
 
 The references pointing to *fix #nr* or *issue #nr* refer to our [issues tracker](https://github.com/rear/rear/issues)
 
+
+### Version 1.17.0
+
+* A new configuration option, `USE_STATIC_NETWORKING=y`, will cause statically configured network settings to be applied even when `USE_DHCLIENT` is in effect.
 
 ### Version 1.16.1 (June 2014)
 

--- a/usr/share/rear/rescue/GNU/Linux/31_network_devices.sh
+++ b/usr/share/rear/rescue/GNU/Linux/31_network_devices.sh
@@ -37,7 +37,7 @@ EOT
 # add a line at the top of netscript to skip if dhclient will be used
 cat - <<EOT > $netscript
 # if USE_DHCLIENT=y then use DHCP instead and skip 60-network-devices.sh
-[[ ! -z "\$USE_DHCLIENT" ]] && return
+[[ ! -z "\$USE_DHCLIENT" && -z "\$USE_STATIC_NETWORKING" ]] && return
 # if IPADDR=1.2.3.4 has been defined at boot time via ip=1.2.3.4 then configure 
 if [[ "\$IPADDR" ]] && [[ "\$NETMASK" ]] ; then
     device=\${NETDEV:-eth0}

--- a/usr/share/rear/rescue/GNU/Linux/35_routing.sh
+++ b/usr/share/rear/rescue/GNU/Linux/35_routing.sh
@@ -27,7 +27,7 @@ netscript=$ROOTFS_DIR/etc/scripts/system-setup.d/62-routing.sh
 # add a line at the top of netscript to skip if dhclient will be used
 cat - <<EOT > $netscript
 # if USE_DHCLIENT=y then skip 62-routing.sh as we are using DHCP instead
-[[ ! -z "\$USE_DHCLIENT" ]] && return
+[[ ! -z "\$USE_DHCLIENT" && -z "\$USE_STATIC_NETWORKING" ]] && return
 # if GATEWAY is defined as boot option gw=1.2.3.4 then use that one
 [[ ! -z "\$GATEWAY" ]] && return
 EOT


### PR DESCRIPTION
USE_STATIC_NETWORKING will prevent the detected config from being ignored when DHCP is also detected.  With `USE_DHCLIENT=yes` set, the behaviour is:
- Interfaces using DHCP are configured by `dhclient` if `USE_STATIC_NETWORKING=yes` is not present.
- Interfaces using DHCP are configured by `dhclient` if `USE_STATIC_NETWORKING=yes` is present.
- Interfaces not using DHCP are configured by 60-network-devices.sh if `USE_STATIC_NETWORKING=yes` is present.
