### PR TITLE
device name conflict when grep disklayout file without proper space

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/10_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/10_include_partition_code.sh
@@ -205,7 +205,7 @@ EOF
         if [[ "$label" = "gpt" ]] && [[ "$name" != "rear-noname" ]] ; then
             echo "parted -s $device name $number '\"$name\"' >&2" >> $LAYOUT_CODE
         fi
-    done < <(grep "^part $device" $LAYOUT_FILE)
+    done < <(grep "^part $device " $LAYOUT_FILE)
 
     # Ensure we have the new partitioning on the device.
     echo "partprobe -s $device >&2" >> "$LAYOUT_CODE"

--- a/usr/share/rear/layout/prepare/GNU/Linux/11_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/11_include_lvm_code.sh
@@ -23,7 +23,7 @@ fi
 # Create a new PV.
 create_lvmdev() {
     local lvmdev vgrp device uuid junk
-    read lvmdev vgrp device uuid junk < <(grep "^lvmdev.*${1#pv:}" "$LAYOUT_FILE")
+    read lvmdev vgrp device uuid junk < <(grep "^lvmdev.*${1#pv:} " "$LAYOUT_FILE")
 
     (
     echo "LogPrint \"Creating LVM PV $device\""
@@ -60,7 +60,7 @@ create_lvmgrp() {
     local lvmgrp vgrp extentsize junk
     read lvmgrp vgrp extentsize junk < <(grep "^lvmgrp $1 " "$LAYOUT_FILE")
 
-    local -a devices=($(grep "^lvmdev $vgrp" "$LAYOUT_FILE" | cut -d " " -f 3))
+    local -a devices=($(grep "^lvmdev $vgrp " "$LAYOUT_FILE" | cut -d " " -f 3))
 
 cat >> "$LAYOUT_CODE" <<EOF
 LogPrint "Creating LVM VG ${vgrp#/dev/}"

--- a/usr/share/rear/layout/prepare/GNU/Linux/12_include_raid_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/12_include_raid_code.sh
@@ -20,7 +20,7 @@ fi
 
 create_raid() {
     local raid device options
-    read raid device options < <(grep "^raid $1" "$LAYOUT_FILE")
+    read raid device options < <(grep "^raid $1 " "$LAYOUT_FILE")
 
     local mdadmcmd="mdadm --create $device --force"
 

--- a/usr/share/rear/layout/prepare/GNU/Linux/15_include_drbd_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/15_include_drbd_code.sh
@@ -3,7 +3,7 @@
 # This requires DRBD configuration present!
 create_drbd() {
     local drbd disk resource device junk
-    read drbd disk resource device junk < <(grep "^drbd $1" "$LAYOUT_FILE")
+    read drbd disk resource device junk < <(grep "^drbd $1 " "$LAYOUT_FILE")
 
     cat >> "$LAYOUT_CODE" <<EOF
 if [ ! -e /proc/drbd ] ; then

--- a/usr/share/rear/layout/prepare/GNU/Linux/16_include_luks_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/16_include_luks_code.sh
@@ -2,7 +2,7 @@
 
 create_crypt() {
     local crypt device encdevice options
-    read crypt device encdevice options < <(grep "^crypt $1" "$LAYOUT_FILE")
+    read crypt device encdevice options < <(grep "^crypt $1 " "$LAYOUT_FILE")
 
     local name=${device#/dev/mapper/}
 

--- a/usr/share/rear/layout/prepare/GNU/Linux/17_include_hpraid_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/17_include_hpraid_code.sh
@@ -4,7 +4,7 @@ define_HPSSACLI  # Call function to find proper Smart Storage Administrator CLI 
 
 create_smartarray() {
     local sa slotnr junk
-    read sa slotnr junk < <(grep "^smartarray ${1#sma:}" "$LAYOUT_FILE")
+    read sa slotnr junk < <(grep "^smartarray ${1#sma:} " "$LAYOUT_FILE")
     cat <<EOF >>"$LAYOUT_CODE"
 LogPrint "Clearing HP SmartArray controller $slotnr"
 if ! $HPSSACLI ctrl slot=$slotnr delete forced >&8; then
@@ -15,7 +15,7 @@ EOF
 
 create_logicaldrive() {
     local ld disk path options
-    read ld disk path options < <(grep "^logicaldrive ${1#ld:}" "$LAYOUT_FILE")
+    read ld disk path options < <(grep "^logicaldrive ${1#ld:} " "$LAYOUT_FILE")
 
     local slotnr=${path%%|*}
     local arrayname=${path%|*}


### PR DESCRIPTION
hi:
    I found the bug because my system has /dev/drbd1 and /dev/drbd11. but after checking the code, I found similar bug exists in other scripts. so if the system has "/dev/md2","/dev/md21", or "/dev/lvm-a","/dev/lvm-ab". the same bug will bite. 
     I tried to fix all the bugs for scripts under the same directory. but I don't know if the bug exists at other directory. since I don't have all the layout to test, so please take a look to see if the patches are proper. 
