### PR TITLE
extend layout-function get_device_name so it can handle /dev/vg/lv forma...

### DIFF
--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -451,6 +451,22 @@ get_device_name() {
         fi
     fi
 
+    ### Translate device name to mapper name. ex: vg/lv -> mapper/vg-lv
+    if [[ "$name" =~ ^mapper/ ]]; then
+        echo "/dev/$name"
+        return 0
+    fi
+    if my_dm=`readlink /dev/$name`; then
+       for mapper_dev in /dev/mapper/*; do
+           if mapper_dm=`readlink $mapper_dev`; then
+              if [ "$my_dm" = "$mapper_dm" ]; then
+                 echo $mapper_dev
+                 return 0
+              fi
+           fi
+       done
+    fi
+
     ### handle cciss sysfs naming
     name=${name//!//}
 


### PR DESCRIPTION
hi:
   this patch tried to fix when drbd use "/dev/vg/lv" as backend device,  rear won't recognize it's the same device as "/dev/mapper/vg-lv". since there maybe other situation which also use "/dev/vg/lv" as backend device, maybe it's better to fix it in the layout-function and other script can benefit with it.
