### PR TITLE
fix drbd layout so it can handle /dev/vg/lv format backend and mulitple ...

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/25_drbd_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/25_drbd_layout.sh
@@ -4,9 +4,13 @@ if [ -e /proc/drbd ] ; then
     Log "Saving DRBD configuration."
 
     for resource in $(drbdadm sh-resources) ; do
-        dev=$(drbdadm sh-dev $resource)
-        disk=$(drbdadm sh-ll-dev $resource)
+        dev=( $(drbdadm sh-dev $resource) )
+        disk=( $(drbdadm sh-ll-dev $resource) )
 
-        echo "drbd $dev $resource $disk" >> $DISKLAYOUT_FILE
+        for i in ${!dev[*]}; do
+            vol_dev=${dev[$i]}
+            vol_disk=$(get_device_name ${disk[$i]})
+            echo "drbd $vol_dev $resource $vol_disk" >> $DISKLAYOUT_FILE
+        done
     done
 fi


### PR DESCRIPTION
hi:
   this patch fix two problems:
1. drbd use /dev/vg/lv device as backend. with enhanced get_device_name function it can translate correctly to /dev/mapper/vg-lv
2. it can handle multiple volumes with single resource correctly. and still maintain compatibility with older drbd versions which didn't know anything about volumes. to maintain compatibility the layout is not perfect but workable.
