### PR TITLE
add OUTPUT_URL=null support

### DIFF
--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -87,7 +87,7 @@ output_path() {
     local scheme=$1
     local path=$2
     case $scheme in
-       (tape)  # no path for tape required
+       (null|tape)  # no path for tape required
            path=""
            ;;
        (file)  # type file needs a local path (must be mounted by user)
@@ -111,7 +111,7 @@ mount_url() {
     ### Generate a mount command
     local mount_cmd
     case $(url_scheme $url) in
-        (tape|file|rsync|fish|ftp|ftps|hftp|http|https|sftp)
+        (null|tape|file|rsync|fish|ftp|ftps|hftp|http|https|sftp)
             ### Don't need to mount anything for these
             return 0
             ;;
@@ -162,7 +162,7 @@ umount_url() {
     local mountpoint=$2
 
     case $(url_scheme $url) in
-        (tape|file|rsync|fish|ftp|ftps|hftp|http|https|sftp)
+        (null|tape|file|rsync|fish|ftp|ftps|hftp|http|https|sftp)
             ### Don't need to umount anything for these
             return 0
             ;;


### PR DESCRIPTION
the patch add support for "OUTPUT_URL=null" and fix my situation below. maybe there are other situations which user will want to set "null" OUTPUT_URL.

my /etc/rear/local.conf is setup like below base on the advice from email list:
BACKUP=NETFS
BACKUP_URL=iso://backup/
OUTPUT=ISO
OUTPUT_URL=nfs://10.1.1.1/share/nfs/

the archived file will first goto /tmp, then create iso to /var/lib/rear/output, and finally copy iso to nfs share. if the iso file is large, it will consume  huge space at local server. so I tried to tune "ISO_DIR" to remote server.
then I don't need OUTPUT_URL anymore. but rear won't let me set it to blank, so I add 'null' method for it.
