### PR TITLE
Change TSM default filespaces restored

### DIFF
--- a/usr/share/rear/verify/TSM/default/40_verify_tsm.sh
+++ b/usr/share/rear/verify/TSM/default/40_verify_tsm.sh
@@ -26,6 +26,15 @@ else
 	Log "Skipping ping test"
 fi
 
+# Use the included_mountpoints array derived from the disklayout.conf to determine the default
+# TSM filespaces to include in a restore. 
+included_mountpoints=( $(grep ^fs $VAR_DIR/layout/disklayout.conf  | awk '{print $3}') )
+
+# TSM does not restore the mountpoints for filesystems it does not recover. Setting the
+# MOUNTPOINTS_TO_RESTORE variable allows this to be recreated in the restore 
+# default 90_create_missing_directories.sh script
+excluded_mountpoints=( $(grep ^#fs $VAR_DIR/layout/disklayout.conf  | awk '{print $3}') )
+MOUNTPOINTS_TO_RESTORE=${excluded_mountpoints[@]#/}
 
 # find out which filespaces (= mountpoints) are available for restore
 LC_ALL=${LANG_RECOVER} dsmc query filespace -date=2 -time=1 | grep -A 10000 'File' >$TMP_DIR/tsm_filespaces
@@ -36,9 +45,16 @@ StopIfError "'dsmc query filespace' failed !"
 TSM_FILESPACE_TEXT="$(cat $TMP_DIR/tsm_filespaces)"
 TSM_FILESPACES=()
 TSM_FILESPACE_NUMS=( )
+# TSM_FILESPACE_INCLUDED arrays for use as default value for TSM_RESTORE_FILESPACE_NUMS
+TSM_FILESPACE_INCLUDED=( )
+TSM_FILESPACE_INCLUDED_NUMS=( )
 while read num date time type path ; do
 	TSM_FILESPACES[$num]="$path"
 	TSM_FILESPACE_NUMS[$num]="$num"
+        if IsInArray $path "${included_mountpoints[@]}" ; then
+              TSM_FILESPACE_INCLUDED[$num]="$path"
+              TSM_FILESPACE_INCLUDED_NUMS[$num]="$num"
+        fi
 done < <(grep -A 10000 '^  1' <<<"$TSM_FILESPACE_TEXT")
 
 Log "Available filespaces:
@@ -50,10 +66,10 @@ $(echo "$TSM_FILESPACE_TEXT" | sed -e 's/^/\t\t/')
 Please enter the numbers of the filespaces we should restore.
 Pay attention to enter the filesystems in the correct order
 (like restore / before /var/log) ! "
-read -t $WAIT_SECS -p "(default: ${TSM_FILESPACE_NUMS[*]}): [$WAIT_SECS secs] " -r TSM_RESTORE_FILESPACE_NUMS 2>&1
+read -t $WAIT_SECS -p "(default: ${TSM_FILESPACE_INCLUDED_NUMS[*]}): [$WAIT_SECS secs] " -r TSM_RESTORE_FILESPACE_NUMS 2>&1
 if test -z "$TSM_RESTORE_FILESPACE_NUMS" ; then
-	TSM_RESTORE_FILESPACE_NUMS="${TSM_FILESPACE_NUMS[*]}" # set default on ENTER
-	Log "User pressed ENTER, setting default of ${TSM_FILESPACE_NUMS[*]}"
+	TSM_RESTORE_FILESPACE_NUMS="${TSM_FILESPACE_INCLUDED_NUMS[*]}" # set default on ENTER
+	Log "User pressed ENTER, setting default of ${TSM_FILESPACE_INCLUDED_NUMS[*]}"
 fi
 # remove extra spaces
 TSM_RESTORE_FILESPACE_NUMS="$(echo "$TSM_RESTORE_FILESPACE_NUMS" |tr -s " ")"


### PR DESCRIPTION
See Issue #528

The TSM_RESTORE_FILESPACE_NUMS defaulted to all known filespaces
which might not be desired if the filesystem was not recovered
as part of the rescue image. This change still allows to choose
any filespaces that TSM knows about but will default to only those
that are part of the rescue image.

- Created new TSM_FILESPACE_INCLUDED_NUMS array which is now used
  as the default for the TSM_RESTORE_FILESPACE_NUMS
- Populated the MOUNTPOINTS_TO_RESTORE variable with those
  fileystems that were excluded from the rescue image because TSM
  does not recreate those by default