### PR TITLE
Using "do_something || Error_handling" when "set -e" is set

### DIFF
--- a/usr/share/rear/layout/prepare/default/20_recreate_hpraid.sh
+++ b/usr/share/rear/layout/prepare/default/20_recreate_hpraid.sh
@@ -12,10 +12,7 @@ cat <<EOF >$LAYOUT_CODE
 set -e
 
 # Unload CCISS module to make sure nothing is using it
-rmmod cciss
-if (( $? != 0 )); then
-    Error "CCISS failed to unload, something is still using it !"
-fi
+rmmod cciss || Error "CCISS failed to unload, something is still using it !"
 
 modprobe cciss
 sleep 2


### PR DESCRIPTION
to fix commit ae3a930bf26f82e5739c7799e1be0d79444dc19e
see https://github.com/rear/rear/issues/534