### PR TITLE
write os.conf to /etc/rear/

### DIFF
--- a/usr/share/rear/build/default/99_update_os_conf.sh
+++ b/usr/share/rear/build/default/99_update_os_conf.sh
@@ -1,6 +1,6 @@
 # add os/version info to os.conf in the rescue system so that we don't need to pull lsb into the rescue system
 
-echo -e "#\n# WARNING ! This information was added automatically by the $WORKFLOW workflow !!!" >> $ROOTFS_DIR/$CONFIG_DIR/os.conf
+echo -e "#\n# WARNING ! This information was added automatically by the $WORKFLOW workflow !!!" >> $ROOTFS_DIR/etc/rear/os.conf
 for var in ARCH OS OS_VERSION OS_VENDOR OS_VENDOR_VERSION OS_VENDOR_ARCH ; do
 	echo "$var='${!var}'"
-done >> $ROOTFS_DIR/$CONFIG_DIR/os.conf
+done >> $ROOTFS_DIR/etc/rear/os.conf


### PR DESCRIPTION
os.conf MUST be at /etc/rear/os.conf in the rescue image. $CONF_DIR may have been different depending on the rear installation directory.