### PR TITLE
Added possibility to only backup BACKUP_PROG_INCLUDE

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -266,6 +266,13 @@ BACKUP_PROG_DECRYPT_OPTIONS="/usr/bin/openssl des3 -d -k "
 BACKUP_PROG_ARCHIVE="backup"
 BACKUP_PROG_EXCLUDE=( '/tmp/*' '/dev/shm/*' $VAR_DIR/output/\* )
 BACKUP_PROG_INCLUDE=( )
+# Do NOT use MANUAL_INCLUDE mode. In MANUAL_INCLUDE mode, only the filesystems explicitly specified
+# in BACKUP_PROG_INCLUDE will be saved. MANUAL_INCLUDE (=YES) is only useful, if your systems do always have the
+# same "basic" mountpoints you want to save (either flat partitions or LVM or even mixed) and want to ignore
+# additional filesystems, that might have been included into the system (via SAN) to not blow up the
+# recovery system
+# Be sure to test your recovery when you want to use this mode! Default is NO
+MANUAL_INCLUDE=NO
 # Disable SELinux policy during backup with NETFS or RSYNC (default yes)
 BACKUP_SELINUX_DISABLE=1
 # Enable integrity check of the backup archive (only with BACKUP=NETFS and BACKUP_PROG=tar)

--- a/usr/share/rear/layout/save/default/31_include_exclude.sh
+++ b/usr/share/rear/layout/save/default/31_include_exclude.sh
@@ -20,6 +20,18 @@
 #    mark_tree_as_done "fs:$mountpoint"
 #done
 
+# check if in MANUAL_INCLUDE mode. If YES, mark all filesystems
+# NOT included in BACKUP_PROG_INCLUDE as done
+if [ "${MANUAL_INCLUDE:-NO}" == "YES" ] ; then
+    while read fs device mountpoint junk ; do
+        if ! IsInArray "$mountpoint" "${BACKUP_PROG_INCLUDE[@]}" ; then
+            LogPrint "Excluding mountpoint $mountpoint. (MANUAL_INCLUDE mode)"
+            mark_as_done "fs:$mountpoint"
+            mark_tree_as_done "fs:$mountpoint"
+        fi
+    done < <(grep ^fs $LAYOUT_FILE)
+fi
+
 for md in "${EXCLUDE_MD[@]}" ; do
     LogPrint "Excluding RAID $md."
     mark_as_done "/dev/$md"


### PR DESCRIPTION
Hi,

this is only a suggestion that might be included into rear.

We use this kind of patch on all of our servers to only backup filesystems and directories, that are explicitly given in BACKUP_PROG_INCLUDE. So later added mountpoints and big data does NOT blow up the amount of data within the rear backup, when someone misses to update the local.conf.

Currently, we use the variable "MANUAL_INCLUDE" which we set to "YES" in "local.conf" to activate this mode.

As I said....just an idea.