### PR TITLE
add workaround for systemd scripts on debian 8: issue #599

### DIFF
--- a/usr/share/rear/build/Debian/61_jessie_link_systemd_lib.sh
+++ b/usr/share/rear/build/Debian/61_jessie_link_systemd_lib.sh
@@ -1,0 +1,18 @@
+Log "Fixup debian jessie systemd files"
+
+# on debian jessie systemd files are located in /lib/systemd not
+# /usr/lib/systemd, as such symlink then within the $ROOTFS_DIR
+# otherwise certain servises wont come up.
+
+if [ -e "$ROOTFS_DIR/lib/systemd/" ]; then
+    cd  $ROOTFS_DIR/lib/systemd/
+    my_systemd_files=( $( ls -1 systemd-* ))
+    if [ -e "$ROOTFS_DIR/usr/lib/systemd/" ]; then
+        cd  $ROOTFS_DIR/usr/lib/systemd/
+        for m in "${my_systemd_files[@]}" ; do
+	        ln -sf  ../../../lib/systemd/$m $m
+        done
+    else
+        Error "Missing usr/lib/systemd/system - too confused to continue"
+    fi
+fi


### PR DESCRIPTION
hi,

this could be a workaround for issue #599. I have only tested it briefly on debian jessie and it makes the boot process not error out due to missing systemd files. Maybe there is a better solution ..