### PR TITLE
fix debian package build error

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -66,7 +66,6 @@ binary-indep: build
 	# dh_installman usr/share/rear/doc/rear.8
 	find debian/rear -name ".git*" -exec rm {} \;
 	rm debian/rear/usr/share/doc/rear/Makefile
-	rm debian/rear/usr/share/doc/rear/rear.8.txt
 	rm debian/rear/usr/share/doc/rear/user-guide/Makefile
 	rm debian/rear/usr/share/doc/rear/rear.8
 	dh_link


### PR DESCRIPTION
because the extension has been changed from .txt to .asciidoc, the build fails, because it cannot remove missing file ...rear.8.txt