### PR TITLE
Add SLES ppc64 support

### DIFF
--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -33,6 +33,20 @@ function find_syslinux_file {
     echo "$syslinux_file"
 }
 
+function find_yaboot_file {
+    # input argument is usually: yaboot
+    # output argument is the full path of the yaboot binary
+    local yaboot_file=""
+
+    for file in /{lib/lilo,usr/lib}/*/"$1" ; do
+        if [[ -s "$file" ]]; then
+            yaboot_file="$file"
+            break
+        fi
+    done
+    echo "$yaboot_file"
+}
+
 function set_syslinux_features {
 	# Test for features in syslinux
 	# true if isolinux supports booting from /boot/syslinux, /boot or only from / of the ISO

--- a/usr/share/rear/output/ISO/Linux-ppc64/30_create_yaboot.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64/30_create_yaboot.sh
@@ -18,9 +18,32 @@
 #
 #
 
+SUSE_STYLE=
+
 # create yaboot directory structure
 mkdir -p $v $TMP_DIR/ppc/chrp >&2
-cp $v /usr/lib/yaboot/yaboot $TMP_DIR/ppc/chrp >&2
+ISO_YABOOT_BIN=$(find_yaboot_file yaboot)
+
+if [[ $ISO_YABOOT_BIN == *"/lib/lilo/pmac"* ]]
+then
+   SUSE_STYLE=1
+fi
+
+if [[ "$SUSE_STYLE" ]]; then
+  #SUSE type distos
+  cp $v $ISO_YABOOT_BIN $TMP_DIR >&2
+
+cat >"$TMP_DIR/ppc/bootinfo.txt" <<EOF
+<chrp-boot>
+<description>Relax-and-Recover</description>
+<os-name>Linux</os-name>
+<boot-script>boot &device;:\yaboot</boot-script>
+</chrp-boot>
+EOF
+
+else
+  #Red Hat type distros
+  cp $v $ISO_YABOOT_BIN $TMP_DIR/ppc/chrp >&2
 
 cat >"$TMP_DIR/ppc/bootinfo.txt" <<EOF
 <chrp-boot>
@@ -29,6 +52,8 @@ cat >"$TMP_DIR/ppc/bootinfo.txt" <<EOF
 <boot-script>boot &device;:\ppc\chrp\yaboot</boot-script>
 </chrp-boot>
 EOF
+
+fi
 
 mkdir -p $v $TMP_DIR/etc >&2
 cat >"$TMP_DIR/etc/yaboot.conf" <<EOF

--- a/usr/share/rear/output/ISO/Linux-ppc64/80_create_isofs.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64/80_create_isofs.sh
@@ -25,7 +25,11 @@ StopIfError "ISO_MKISOFS_BIN [$ISO_MKISOFS_BIN] not an executable !"
 Log "Copying kernel"
 cp -pL $v $KERNEL_FILE $TMP_DIR/kernel >&2
 
-ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel initrd.cgz )
+if [[ "$SUSE_STYLE" ]]; then
+  ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel initrd.cgz yaboot)
+else
+  ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel initrd.cgz)
+fi
 Log "Starting '$ISO_MKISOFS_BIN'"
 LogPrint "Making ISO image"
 


### PR DESCRIPTION
This is a fix for issue #610 
There is a new function in usr/share/rear/lib/bootloader-functions.sh that is used to find the yaboot binary. It's stored in a different place on SUSE based systems.
There was also some needed changes in usr/share/rear/output/ISO/Linux-ppc64/30_create_yaboot.sh and usr/share/rear/output/ISO/Linux-ppc64/80_create_isofs.sh.
These were necessary since the yaboot binary from SLES is compiled to look for the kernel in the same directory, unlike the versions in Red Hat-type distros.