### PR TITLE
This should fix the loading of modules when systemd is present

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/11_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/11_include_lvm_code.sh
@@ -54,6 +54,10 @@ create_lvmdev() {
 create_lvmgrp() {
     if [ -z "$MIGRATION_MODE" ] ; then
         restore_lvmgrp "$1"
+        cat >> "$LAYOUT_CODE" <<EOF
+LogPrint "Sleeping 3 seconds to let udev or systemd-udevd create their devices..."
+sleep 3 >&2
+EOF
         return
     fi
 

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
@@ -5,7 +5,11 @@
 # of rear mkrescue
 
 # load udev or load modules manually
-if test -s /etc/udev/rules.d/00-rear.rules -a -w /sys/kernel/uevent_helper ; then
+# again, check if current systemd is present
+systemd_version=$(systemd-notify --version 2>/dev/null | grep systemd | awk '{ print $2; }')
+[[ -z "$systemd_version" ]] && systemd_version=0
+
+if [ $systemd_version -gt 190 ] || [ -s /etc/udev/rules.d/00-rear.rules ] && [ -w /sys/kernel/uevent_helper ]; then
 	# found our "special" module-auto-load rule
 
 	# clean away old device nodes from source system


### PR DESCRIPTION
Hi,

I first did not want to create this pull request because I still have some kind of bug in it. The fix is working *correct*. When systemd is present in a recent version, then - in recovery - no additional drivers are loaded.

But when recovery starts, it find the disk (with same size), recreates the LVM group but then fails to create the filesystem on /. I'm very sorry, that I don't have the error message right here (only at home). I think I remember, that I saw a message, that `0 logical volumes are now active` and because of this, the `mkfs` fails. Later, in recovery shell, I could manually do the `mkfs`, so this might be a timing problem.
I will append further information as soon as possible and I hope, that this information is useful for you.
