### PR TITLE
Add RHEL/Ubuntu PPC64LE support

### DIFF
--- a/usr/share/rear/conf/Linux-ppc64le.conf
+++ b/usr/share/rear/conf/Linux-ppc64le.conf
@@ -1,0 +1,22 @@
+REQUIRED_PROGS=(
+"${REQUIRED_PROGS[@]}"
+parted
+sfdisk
+)
+
+PROGS=(
+"${PROGS[@]}"
+partprobe
+fdisk
+cfdisk
+bootlist
+pseries_platform
+nvram
+ofpathname
+bc
+agetty
+)
+
+COPY_AS_IS_EXCLUDE=( ${COPY_AS_IS_EXCLUDE[@]} /lib*/firmware )
+
+KERNEL_CMDLINE="LANG=en_US.UTF-8 SYSFONT=latarcyrheb-sun16 KEYTABLE=us console=hvc0"

--- a/usr/share/rear/finalize/Linux-ppc64le/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/22_install_grub2.sh
@@ -1,0 +1,61 @@
+#  This  script is an improvement over the default grub-install '(hd0)'
+#
+# However the following issues still exist:
+#
+#  * We don't know what the first disk will be, so we cannot be sure the MBR
+#    is written to the correct disk(s). That's why we make all disks bootable.
+#
+#  * There is no guarantee that GRUB was the boot loader used originally. One
+#    solution is to save and restore the MBR for each disk, but this does not
+#    guarantee a correct boot-order, or even a working boot-lader config (eg.
+#    GRUB stage2 might not be at the exact same location)
+
+# skip if another bootloader was installed
+if [[ -z "$NOBOOTLOADER" ]] ; then
+    return
+fi
+
+# Only for GRUB2 - GRUB Legacy will be handled by its own script
+[[ $(type -p grub-probe) || $(type -p grub2-probe) ]] || return
+
+LogPrint "Installing GRUB2 boot loader"
+mount -t proc none /mnt/local/proc
+
+if [[ -r "$LAYOUT_FILE" ]]; then
+
+    # Check if we find GRUB where we expect it
+    [[ -d "/mnt/local/boot" ]]
+    StopIfError "Could not find directory /boot"
+
+    # grub2 can be in /boot/grub or /boot/grub2
+    grub_name="grub2"
+    if [[ ! -d "/mnt/local/boot/$grub_name" ]] ; then
+        grub_name="grub"
+        [[ -d "/mnt/local/boot/$grub_name" ]]
+        StopIfError "Could not find directory /boot/$grub_name"
+    fi
+    [[ -r "/mnt/local/boot/$grub_name/grub.cfg" ]]
+    LogIfError "Unable to find /boot/$grub_name/grub.cfg."
+
+    # Find PPC PReP Boot partition 
+    part=`awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $LAYOUT_FILE`
+
+    if [ -n "$part" ]; then
+        LogPrint "Boot partition found: $part"
+        chroot /mnt/local /bin/bash --login -c "$grub_name-install $part"
+        # Run bootlist only in PowerVM environment
+        if ! grep -q "PowerNV" /proc/cpuinfo && ! grep -q "emulated by qemu" /proc/cpuinfo ; then
+            bootdev=`echo $part | sed -e 's/[0-9]*$//'`
+            LogPrint "Boot device is $bootdev."
+            bootlist -m normal $bootdev
+        fi
+        NOBOOTLOADER=
+    fi
+fi
+
+if [[ "NOBOOTLOADER" ]]; then
+    LogIfError "No bootloader configuration found. Install boot partition manually"
+fi    
+
+#for i in /dev /dev/pts /proc /sys; do umount  /mnt/local${i} ; done
+umount /mnt/local/proc

--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
@@ -9,6 +9,11 @@ create_fs() {
     label=${label#label=}
     uuid=${uuid#uuid=}
 
+#need to wait for udev device creation
+cat >> "$LAYOUT_CODE" <<EOF
+my_udevsettle
+EOF
+
     case "$fstype" in
         (ext*)
             # File system parameters.

--- a/usr/share/rear/output/ISO/Linux-ppc64le/30_create_grub2.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64le/30_create_grub2.sh
@@ -1,0 +1,49 @@
+# #30_create_grub2.sh
+#
+# create grub.cfg for Relax-and-Recover
+#
+#    Relax-and-Recover is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+
+#    Relax-and-Recover is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+
+#    You should have received a copy of the GNU General Public License
+#    along with Relax-and-Recover; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+#
+
+# create grub directory structure
+mkdir -p $v $TMP_DIR/ppc >&2
+cat >"$TMP_DIR/ppc/bootinfo.txt" <<EOF
+<chrp-boot>
+<description>Relax-and-Recover</description>
+<os-name>Linux</os-name>
+<boot-script>boot &device;:\boot\grub\powerpc.elf</boot-script>
+</chrp-boot>
+EOF
+
+mkdir -p $v $TMP_DIR/boot/grub >&2
+cat >"$TMP_DIR/boot/grub/grub.cfg" <<EOF
+set timeout=100
+
+menuentry "Relax-and-Recover" {
+	linux   /kernel root=/dev/ram0 $KERNEL_CMDLINE
+	initrd  /initrd.cgz
+}
+EOF
+
+grub_name=grub2
+$grub_name-mkimage --version >&8
+if [ $? -ne 0 ]; then
+    grub_name=grub
+fi
+
+$grub_name-mkimage -O powerpc-ieee1275 -p '()/boot/grub' -o $TMP_DIR/boot/grub/powerpc.elf linux normal iso9660
+
+ISO_FILES=( "${ISO_FILES[@]}" boot=boot ppc=ppc )

--- a/usr/share/rear/output/ISO/Linux-ppc64le/80_create_isofs.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64le/80_create_isofs.sh
@@ -1,0 +1,44 @@
+# #80_create_isofs.sh
+#
+# create initramfs for Relax-and-Recover
+#
+#    Relax-and-Recover is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+
+#    Relax-and-Recover is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+
+#    You should have received a copy of the GNU General Public License
+#    along with Relax-and-Recover; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+#
+
+# check that we have mkisofs
+[ -x "$ISO_MKISOFS_BIN" ]
+StopIfError "ISO_MKISOFS_BIN [$ISO_MKISOFS_BIN] not an executable !"
+
+Log "Copying kernel"
+cp -pL $v $KERNEL_FILE $TMP_DIR/kernel >&2
+
+ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel initrd.cgz )
+Log "Starting '$ISO_MKISOFS_BIN'"
+LogPrint "Making ISO image"
+
+mkdir -p $v "$ISO_DIR" >&2
+StopIfError "Could not create ISO ouput directory ($ISO_DIR)"
+
+pushd $TMP_DIR >&8 # so that relative paths will work
+$ISO_MKISOFS_BIN $v -o "$ISO_DIR/$ISO_PREFIX.iso" -U -chrp-boot \
+	-R -J -volid "$ISO_VOLID" -v -graft-points "${ISO_FILES[@]}" >&8
+StopIfError "Could not create ISO image"
+ISO_IMAGES=( "${ISO_IMAGES[@]}" "$ISO_DIR/$ISO_PREFIX.iso" )
+popd >&8
+Print "Wrote ISO Image $ISO_DIR/$ISO_PREFIX.iso ($(du -h "$ISO_DIR/$ISO_PREFIX.iso"| tr -s " \t" " " | cut -d " " -f 1))"
+
+# Add ISO image to result files
+RESULT_FILES=( "${RESULT_FILES[@]}" "$ISO_DIR/$ISO_PREFIX.iso" )

--- a/usr/share/rear/pack/Linux-ppc64le/30_copy_kernel.sh
+++ b/usr/share/rear/pack/Linux-ppc64le/30_copy_kernel.sh
@@ -1,0 +1,58 @@
+# 30_copy_kernel.sh
+#
+# copy kernel for Relax-and-Recover
+#
+#    Relax-and-Recover is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+
+#    Relax-and-Recover is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+
+#    You should have received a copy of the GNU General Public License
+#    along with Relax-and-Recover; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+#
+
+# find and copy kernel
+# we only try to find the currently running kernel
+# Using another kernel is a TODO for now
+
+if [ ! -s "$KERNEL_FILE" ]; then
+	if [ -r "/boot/vmlinuz-$KERNEL_VERSION" ]; then
+		KERNEL_FILE="/boot/vmlinuz-$KERNEL_VERSION"
+	elif has_binary get_kernel_version; then
+		for src in /boot/* ; do
+			if VER=$(get_kernel_version "$src") && test "$VER" == "$KERNEL_VERSION" ; then
+				KERNEL_FILE="$src"
+				break
+			fi
+		done
+	elif [ -f /etc/redhat-release ]; then
+		# GD - kernel not found under /boot - 19/May/2008
+		# check under /boot/efi/efi/redhat (for Red Hat)
+		[ -f "/boot/efi/efi/redhat/vmlinuz-$KERNEL_VERSION" ]
+		StopIfError "Could not find a matching kernel in /boot/efi/efi/redhat !"
+		KERNEL_FILE="/boot/efi/efi/redhat/vmlinuz-$KERNEL_VERSION"
+	elif [ -f /etc/debian_version ]; then
+		[ -f "/boot/vmlinux-$KERNEL_VERSION" ]
+		StopIfError "Could not find a matching kernel in /boot (debian) !"
+		KERNEL_FILE="/boot/vmlinux-$KERNEL_VERSION"
+	else
+		Error "Could not find a matching kernel in /boot !"
+	fi
+fi
+
+[ -s "$KERNEL_FILE" ]
+StopIfError "Could not find a suitable kernel. Maybe you have to set KERNEL_FILE [$KERNEL_FILE] ?"
+
+if [ -L $KERNEL_FILE ]; then
+    KERNEL_FILE=$(readlink -f $KERNEL_FILE)
+fi
+
+Log "Found kernel $KERNEL_FILE"
+#cp -aL $v "$KERNEL_FILE" "$TMP_DIR/kernel" >&2

--- a/usr/share/rear/rescue/Linux-ppc64le/41_use_hvc_console.sh
+++ b/usr/share/rear/rescue/Linux-ppc64le/41_use_hvc_console.sh
@@ -1,0 +1,8 @@
+# if this system has a hvc console then start a getty on it
+
+if [ -c /dev/hvc0 ] ; then
+	pushd $ROOTFS_DIR/usr/lib/systemd/system/getty.target.wants >&8
+	ln -s ../getty\@.service getty\@hvc0.service
+	popd >&8
+	Log "hvc console support enabled"
+fi

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
@@ -10,6 +10,17 @@ systemd_version=$(systemd-notify --version 2>/dev/null | grep systemd | awk '{ p
 [[ -z "$systemd_version" ]] && systemd_version=0
 
 if [ $systemd_version -gt 190 ] || [ -s /etc/udev/rules.d/00-rear.rules ] && [ -w /sys/kernel/uevent_helper ]; then
+
+	# systemd-udevd case: systemd-udevd is started by systemd
+	ps ax | grep -v grep | grep -q systemd-udevd && { # check if daemon is actually running
+		my_udevtrigger
+		echo -n "Waiting for udev ... "
+		sleep 1
+		my_udevsettle
+		echo "done."
+		return
+   	}
+
 	# found our "special" module-auto-load rule
 
 	# clean away old device nodes from source system

--- a/usr/share/rear/skel/default/usr/lib/systemd/system/sysinit.service
+++ b/usr/share/rear/skel/default/usr/lib/systemd/system/sysinit.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Initialize Rescue System
+After=systemd-udevd.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Hi,
I've created the initial support for new ppc64 little endian platform, ppc64le.
##### Supported OUTPUT=ISO / BACKUP=NETFS combination only so far
##### Tested platform (I tested simple LVM / single network/storage path configuration)
PowerVM: RHEL7.1 LE / Ubuntu 14.04.2 / Ubuntu 15.04
PowerKVM : RHEL7.1LE / Ubuntu 14.04.2 / Uubntu 15.04
##### It includes the general fixes of REAR, I encountered in my test
* usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
   - I got intermittent error in creating filesystem. Need to wait device creation with udevsettle
* usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
* usr/share/rear/skel/default/usr/lib/systemd/system/sysinit.service
  - Need to skip starting udevd in case of systemd-udevd environment. 
  - Also need to add dependency sysinit.service after systemd-udevd.service

For regression test of general fixes, I confirmed backup and recovery on RHEL7.1 x86_64 works correctly.
Please review the code and let me know any comments.
(I'm a newbie of github and rear, so please correct me if there are any wrong parts of github usage and rear coding convention)