### PR TITLE
Move nfs-client from depends to recommends

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,7 +8,8 @@ Package: rear
 Architecture: all
 Provides: rear
 Build-Depends: debhelper (>> 5.0.0)
-Depends: mingetty, syslinux, ethtool, libc6, lsb-release, portmap, genisoimage, iproute, iputils-ping, nfs-client, binutils, parted, openssl, gawk, attr
+Depends: mingetty, syslinux, ethtool, libc6, lsb-release, portmap, genisoimage, iproute, iputils-ping, binutils, parted, openssl, gawk, attr
+Recommends: nfs-client
 Description: Relax and Recover is a bare metal disaster recovery and system
  migration framework. See http://relax-and-recover.org/ for all the details.
  We are still looking for a Debian package maintainer who would write better


### PR DESCRIPTION
This PR removes the dependency nfs-client and adds it as recommendation.

The reasons for this are
 * NFS is not really a dependency for rear, as there are many other ways to use it
 * In my eyes NFS is a quite heavy dependency, as it depends on portmap which opens tcp/111 udp/111 by default