### PR TITLE
Teaming enhancement

### DIFF
--- a/usr/share/rear/rescue/GNU/Linux/35_routing.sh
+++ b/usr/share/rear/rescue/GNU/Linux/35_routing.sh
@@ -83,7 +83,8 @@ else # use original routes
 				ifslaves=($(cat /proc/net/bonding/$device | grep "Slave Interface:" | cut -d : -f 2))
 				Log "X${ifslaves[@]}X"
 				echo "ip route add $destination $via $gateway $dev ${ifslaves[0]} table $table" >>$netscript
-			else
+			# be sure that it is not a teaming-interface
+			elif ! ethtool -i $device | grep -w "driver:" | grep -qw team ; then
 				echo "ip route add $destination $via $gateway $dev $device table $table" >>$netscript
 			fi
 		done
@@ -95,7 +96,8 @@ else # use original routes
 				ifslaves=($(cat /proc/net/bonding/$device | grep "Slave Interface:" | cut -d : -f 2))
 				Log "X${ifslaves[@]}X"
 				echo "ip route add $destination $via $gateway $dev ${ifslaves[0]} table $table" >>$netscript
-			else
+			# be sure that it is not a teaming-interface
+			elif ! ethtool -i $device | grep -w "driver:" | grep -qw team ; then
 				echo "ip route add $destination $via $gateway $dev $device table $table" >>$netscript
 			fi
 		done

--- a/usr/share/rear/rescue/GNU/Linux/36_teaming.sh
+++ b/usr/share/rear/rescue/GNU/Linux/36_teaming.sh
@@ -1,0 +1,107 @@
+# 36_teaming.sh
+#
+# record teaming information (network and routing) for Relax-and-Recover
+#
+#    Relax-and-Recover is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+
+#    Relax-and-Recover is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+
+#    You should have received a copy of the GNU General Public License
+#    along with Relax-and-Recover; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+# BUG: Supports Ethernet only (so far)
+
+# where to build networking configuration
+netscript=$ROOTFS_DIR/etc/scripts/system-setup.d/63-teaming.sh
+
+### Skip netscript if noip is configured on the command line
+cat <<EOT >> ${netscript}
+if [[ -e /proc/cmdline ]] ; then
+    if grep -q 'noip' /proc/cmdline ; then
+        return
+    fi
+fi
+EOT
+
+# add a line at the top of netscript to skip if dhclient will be used
+cat - <<EOT > ${netscript}
+# if USE_DHCLIENT=y then use DHCP instead and skip 60-network-devices.sh
+[[ ! -z "\$USE_DHCLIENT" && -z "\$USE_STATIC_NETWORKING" ]] && return
+# if IPADDR=1.2.3.4 has been defined at boot time via ip=1.2.3.4 then configure
+if [[ "\$IPADDR" ]] && [[ "\$NETMASK" ]] ; then
+    device=\${NETDEV:-eth0}
+    ip link set dev "\$device" up
+    ip addr add "\$IPADDR"/"\$NETMASK" dev "\$device"
+    if [[ "\$GATEWAY" ]] ; then
+        ip route add default via "\$GATEWAY"
+    fi
+    return
+fi
+EOT
+
+# store virtual devices, because teaming interfaces are declared as virtual
+VIRTUAL_DEVICES=$(ls /sys/devices/virtual/net)
+
+TEAMINGS=()
+
+# check if virtual interface is a teaming interface
+for VIRT_DEV in ${VIRTUAL_DEVICES}
+do
+    if ethtool -i ${VIRT_DEV} | grep -w "driver:" | grep -qw team
+    then
+        TEAMINGS+=($VIRT_DEV)
+    fi
+
+done
+
+for TEAM in "${TEAMINGS[@]}"
+do
+    # catch all ip-addresses for the teaming interface
+    ADDR=()
+    for x in $(ip ad show dev ${TEAM} scope global | grep "inet.*\ " | tr -s " " | cut -d " " -f 3)
+    do
+        ADDR+=($x)
+    done
+
+    # create netscript only when the interface has at least one configured ip
+    # to simplify we attach the configured ip-addresses to the first teaming-member
+    if [[ ${ADDR[*]} ]]
+    then
+        # find out one member interface. Greping for "active port:" will not work for all possible teaming configs (e.g. roundrobin, loadbalance, ...)
+        FIRST_PORT=$(teamdctl ${TEAM} state | grep -A1 -w ports: | tail -1  | sed 's/[[:blank:]]*//g')
+
+        for TEAM_IP in ${ADDR[@]}
+        do
+            echo "ip addr add ${TEAM_IP} dev ${FIRST_PORT}" >>${netscript}
+        done
+
+        echo "ip link set dev ${FIRST_PORT} up" >>${netscript}
+
+        PORT_MTU="$(cat /sys/class/net/${FIRST_PORT}/mtu)"
+        echo "ip link set dev ${FIRST_PORT} mtu ${PORT_MTU}" >>${netscript}
+    fi
+
+    # catch the routing for the teaming interface as we disabled it in 35_routing.sh
+    for table in $( { echo "254     main" ; cat /etc/iproute2/rt_tables ; } |\
+            grep -E '^[0-9]+' |\
+                tr -s " \t" " " |\
+                cut -d " " -f 2 | sort -u | grep -Ev '(local|default|unspec)' ) ;
+        do
+            ip route list table $table |\
+                grep -Ev 'scope (link|host)' |\
+                while read destination via gateway dev device junk;
+                do
+            if [[ "${device}" == "${TEAM}" ]]
+            then
+                echo "ip route add ${destination} ${via} ${gateway} ${dev} ${FIRST_PORT} table ${table}" >>${netscript}
+            fi
+        done
+    done
+done


### PR DESCRIPTION
Hi guys, as discussed in Issue https://github.com/rear/rear/issues/655 I created a workaround for me to add the teaming function easily to rear. I changed the routing script so that no routing of teaming interfaces will be done within and created a new script 36_teaming which handles everything about the teaming function. Because teaming runs in user space we would need more than just the kernel and the driver (e.g. daemons and tools). Because of this I simplified the function that all ip-addresses and routing-entries of a teaming-interface will be attached to its first available teaming-member (output by teamdctl).

Tested with RHEL 7.1, latest. Also single interfaces and bonding interfaces were working after this changes.

Maybe it is something to add to rear, because from my point of view teaming will become more popular and important in the future.

Thanks for your great work!

Cheers :beer: 