### PR TITLE
Add ppc64le arch into rpmspec

### DIFF
--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -25,14 +25,14 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 # But the meaning of architecture dependent packages should be on what architectures they will work.
 # Therefore only those architectures that are actually supported are explicitly listed.
 # This avoids that rear can be "just installed" on architectures that are actually not supported (e.g. ARM or IBM z Systems):
-ExclusiveArch: %ix86 x86_64 ppc ppc64
+ExclusiveArch: %ix86 x86_64 ppc ppc64 ppc64le
 # Furthermore for some architectures it requires architecture dependent packages (like syslinux for x86 and x86_64)
 # so that rear must be architecture dependent because ifarch conditions never match in case of "BuildArch: noarch"
 # see the GitHub issue https://github.com/rear/rear/issues/629
 %ifarch %ix86 x86_64
 Requires: syslinux
 %endif
-# In the end this should tell the user that rear is known to work only on ix86 x86_64 ppc ppc64
+# In the end this should tell the user that rear is known to work only on ix86 x86_64 ppc ppc64 ppc64le
 # and on ix86 x86_64 syslinux is explicitly required to make the bootable ISO image
 # (in addition to the default installed bootloader grub2) while on ppc ppc64 the
 # default installed bootloader yaboot is also useed to make the bootable ISO image.


### PR DESCRIPTION
Adding ppc64le arch into rpm spec file for RHEL7/ppc64le.
This arch will be used for SLES12 and OpenSUSE as well.
See #663 for details.