### PR TITLE
Add grub2 support in ppc64 platform

### DIFF
--- a/usr/share/rear/conf/Linux-ppc64.conf
+++ b/usr/share/rear/conf/Linux-ppc64.conf
@@ -14,6 +14,7 @@ ofpath
 ybin
 yabootconfig
 bootlist
+pseries_platform
 nvram
 ofpathname
 bc

--- a/usr/share/rear/finalize/Linux-ppc64/20_install_yaboot.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/20_install_yaboot.sh
@@ -1,34 +1,34 @@
+# skip if yaboot conf is not found
+if test ! -f /mnt/local/etc/yaboot.conf; then
+  return
+fi
+
 # Reinstall yaboot boot loader
 LogPrint "Installing PPC PReP Boot partition."
 
 # Find PPC PReP Boot partitions
-if test -f /mnt/local/etc/yaboot.conf; then
-  part=`awk -F '=' '/^boot=/ {print $2}' /mnt/local/etc/yaboot.conf`
+part=`awk -F '=' '/^boot=/ {print $2}' /mnt/local/etc/yaboot.conf`
 
-  if [ -n "$part" ]; then
-    LogPrint "Boot partion found: $part"
-    chroot /mnt/local /bin/bash --login -c "/sbin/mkofboot -b $part --filesystem raw -f"
-    bootdev=`echo $part | sed -e 's/[0-9]*$//'`
-    LogPrint "Boot device is $bootdev."
-    bootlist -m normal $bootdev
-    NOBOOTLOADER=
-  else
-    bootparts=`sfdisk -l 2>&8 | awk '/PPC PReP Boot/ {print $1}'`
-    LogPrint "Boot partitions found: $bootparts."
-    for part in $bootparts
-    do
-      LogPrint "Initializing boot partition $part."
-      chroot /mnt/local /bin/bash --login -c "/sbin/mkofboot -b $part --filesystem raw -f"
-    done
-    bootdev=`for part in $bootparts
-             do
-               echo $part | sed -e 's/[0-9]*$//'
-             done | sort | uniq`
-    LogPrint "Boot device list is $bootdev."
-    bootlist -m normal $bootdev
-    NOBOOTLOADER=
-  fi
+if [ -n "$part" ]; then
+  LogPrint "Boot partion found: $part"
+  chroot /mnt/local /bin/bash --login -c "/sbin/mkofboot -b $part --filesystem raw -f"
+  bootdev=`echo $part | sed -e 's/[0-9]*$//'`
+  LogPrint "Boot device is $bootdev."
+  bootlist -m normal $bootdev
+  NOBOOTLOADER=
 else
-  LogPrint "No bootloader configuration found. Install boot partition manually!"
+  bootparts=`sfdisk -l 2>&8 | awk '/PPC PReP Boot/ {print $1}'`
+  LogPrint "Boot partitions found: $bootparts."
+  for part in $bootparts
+  do
+    LogPrint "Initializing boot partition $part."
+    chroot /mnt/local /bin/bash --login -c "/sbin/mkofboot -b $part --filesystem raw -f"
+  done
+  bootdev=`for part in $bootparts
+           do
+             echo $part | sed -e 's/[0-9]*$//'
+           done | sort | uniq`
+  LogPrint "Boot device list is $bootdev."
+  bootlist -m normal $bootdev
+  NOBOOTLOADER=
 fi
-

--- a/usr/share/rear/finalize/Linux-ppc64/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/22_install_grub2.sh
@@ -1,0 +1,61 @@
+#  This  script is an improvement over the default grub-install '(hd0)'
+#
+# However the following issues still exist:
+#
+#  * We don't know what the first disk will be, so we cannot be sure the MBR
+#    is written to the correct disk(s). That's why we make all disks bootable.
+#
+#  * There is no guarantee that GRUB was the boot loader used originally. One
+#    solution is to save and restore the MBR for each disk, but this does not
+#    guarantee a correct boot-order, or even a working boot-lader config (eg.
+#    GRUB stage2 might not be at the exact same location)
+
+# skip if another bootloader was installed
+if [[ -z "$NOBOOTLOADER" ]] ; then
+    return
+fi
+
+# Only for GRUB2 - GRUB Legacy will be handled by its own script
+[[ $(type -p grub-probe) || $(type -p grub2-probe) ]] || return
+
+LogPrint "Installing GRUB2 boot loader"
+mount -t proc none /mnt/local/proc
+
+if [[ -r "$LAYOUT_FILE" ]]; then
+
+    # Check if we find GRUB where we expect it
+    [[ -d "/mnt/local/boot" ]]
+    StopIfError "Could not find directory /boot"
+
+    # grub2 can be in /boot/grub or /boot/grub2
+    grub_name="grub2"
+    if [[ ! -d "/mnt/local/boot/$grub_name" ]] ; then
+        grub_name="grub"
+        [[ -d "/mnt/local/boot/$grub_name" ]]
+        StopIfError "Could not find directory /boot/$grub_name"
+    fi
+    [[ -r "/mnt/local/boot/$grub_name/grub.cfg" ]]
+    LogIfError "Unable to find /boot/$grub_name/grub.cfg."
+
+    # Find PPC PReP Boot partition 
+    part=`awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $LAYOUT_FILE`
+
+    if [ -n "$part" ]; then
+        LogPrint "Boot partition found: $part"
+        chroot /mnt/local /bin/bash --login -c "$grub_name-install $part"
+        # Run bootlist only in PowerVM environment
+        if ! grep -q "PowerNV" /proc/cpuinfo && ! grep -q "emulated by qemu" /proc/cpuinfo ; then
+            bootdev=`echo $part | sed -e 's/[0-9]*$//'`
+            LogPrint "Boot device is $bootdev."
+            bootlist -m normal $bootdev
+        fi
+        NOBOOTLOADER=
+    fi
+fi
+
+if [[ "NOBOOTLOADER" ]]; then
+    LogIfError "No bootloader configuration found. Install boot partition manually"
+fi    
+
+#for i in /dev /dev/pts /proc /sys; do umount  /mnt/local${i} ; done
+umount /mnt/local/proc

--- a/usr/share/rear/output/ISO/Linux-ppc64/30_create_yaboot.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64/30_create_yaboot.sh
@@ -18,6 +18,12 @@
 #
 #
 
+## other bootloader distro case
+if [[ ! -r /etc/yaboot.conf ]]
+then
+    return
+fi
+
 SUSE_STYLE=
 
 # create yaboot directory structure

--- a/usr/share/rear/output/ISO/Linux-ppc64/31_create_grub2.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64/31_create_grub2.sh
@@ -1,0 +1,54 @@
+# #31_create_grub2.sh
+#
+# create grub.cfg for Relax-and-Recover
+#
+#    Relax-and-Recover is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+
+#    Relax-and-Recover is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+
+#    You should have received a copy of the GNU General Public License
+#    along with Relax-and-Recover; if not, write to the Free Software
+#    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+#
+
+# other boot loader distro case
+if [[ ! -r /boot/grub2/grub.cfg ]]; then
+    return
+fi
+
+# create grub directory structure
+mkdir -p $v $TMP_DIR/ppc >&2
+cat >"$TMP_DIR/ppc/bootinfo.txt" <<EOF
+<chrp-boot>
+<description>Relax-and-Recover</description>
+<os-name>Linux</os-name>
+<boot-script>boot &device;:\boot\grub\powerpc.elf</boot-script>
+</chrp-boot>
+EOF
+
+mkdir -p $v $TMP_DIR/boot/grub >&2
+cat >"$TMP_DIR/boot/grub/grub.cfg" <<EOF
+set timeout=100
+
+menuentry "Relax-and-Recover" {
+	linux   /kernel root=/dev/ram0 $KERNEL_CMDLINE
+	initrd  /initrd.cgz
+}
+EOF
+
+grub_name=grub2
+$grub_name-mkimage --version >&8
+if [ $? -ne 0 ]; then
+    grub_name=grub
+fi
+
+$grub_name-mkimage -O powerpc-ieee1275 -p '()/boot/grub' -o $TMP_DIR/boot/grub/powerpc.elf linux normal iso9660
+
+ISO_FILES=( "${ISO_FILES[@]}" boot=boot ppc=ppc )


### PR DESCRIPTION
To support rear in RHEL7/ppc64 big endian distribution, I've added grub2 support in ppc64 platform.
Tested platform:
RHEL7.1 ppc64 Big Endian / PowerKVM

This is minor change, but I verified other following distribution works correctly with this patch.
SLES11 ppc64 / PowerKVM
RHEL6.7 ppc64 / PowerKVM