### PR TITLE
Add ppc64 grub support for PowerVM virtualization environment

### DIFF
--- a/usr/share/rear/conf/Linux-ppc64.conf
+++ b/usr/share/rear/conf/Linux-ppc64.conf
@@ -29,4 +29,6 @@ COPY_AS_IS=(
 /usr/lib/yaboot/addnote
 )
 
+COPY_AS_IS_EXCLUDE=( ${COPY_AS_IS_EXCLUDE[@]} /lib*/firmware )
+
 KERNEL_CMDLINE="LANG=en_US.UTF-8 SYSFONT=latarcyrheb-sun16 KEYTABLE=us console=hvc0"

--- a/usr/share/rear/finalize/Linux-ppc64/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/22_install_grub2.sh
@@ -42,6 +42,7 @@ if [[ -r "$LAYOUT_FILE" ]]; then
 
     if [ -n "$part" ]; then
         LogPrint "Boot partition found: $part"
+        dd if=/dev/zero of=$part
         chroot /mnt/local /bin/bash --login -c "$grub_name-install $part"
         # Run bootlist only in PowerVM environment
         if ! grep -q "PowerNV" /proc/cpuinfo && ! grep -q "emulated by qemu" /proc/cpuinfo ; then

--- a/usr/share/rear/finalize/Linux-ppc64le/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/22_install_grub2.sh
@@ -42,6 +42,7 @@ if [[ -r "$LAYOUT_FILE" ]]; then
 
     if [ -n "$part" ]; then
         LogPrint "Boot partition found: $part"
+        dd if=/dev/zero of=$part
         chroot /mnt/local /bin/bash --login -c "$grub_name-install $part"
         # Run bootlist only in PowerVM environment
         if ! grep -q "PowerNV" /proc/cpuinfo && ! grep -q "emulated by qemu" /proc/cpuinfo ; then

--- a/usr/share/rear/rescue/Linux-ppc64/41_use_hvc_console.sh
+++ b/usr/share/rear/rescue/Linux-ppc64/41_use_hvc_console.sh
@@ -1,0 +1,8 @@
+# if this system has a hvc console then start a getty on it
+
+if [ -d $ROOTFS_DIR/usr/lib/systemd/system ] && [ -c /dev/hvc0 ] ; then
+	pushd $ROOTFS_DIR/usr/lib/systemd/system/getty.target.wants >&8
+	ln -s ../getty\@.service getty\@hvc0.service
+	popd >&8
+	Log "hvc console support enabled"
+fi


### PR DESCRIPTION
In addition to #672 (for PowerKVM), some changes are needed for another virtualization environment, PowerVM.

Tested platform:
RHEL7.1 ppc64 Big Endian / PowerVM

Other verified platform for regression:
SLES11 ppc64 / PowerVM
RHEL6.7 ppc64 / PowerVM 