### PR TITLE
Add getty and agetty handling to upstart tty script

### DIFF
--- a/usr/share/rear/skel/default/etc/init/tty.conf
+++ b/usr/share/rear/skel/default/etc/init/tty.conf
@@ -6,4 +6,17 @@ stop on runlevel [06]
 
 respawn
 instance $TTY
-exec /sbin/mingetty --noclear --autologin root $TTY
+
+script
+    if [ ! -L /sbin/mingetty ]; then
+        exec /sbin/mingetty --noclear --autologin root $TTY
+    else
+        if [ "$TTY" == "/dev/xvc0" ||
+             "$TTY" == "/dev/hvc0" ||
+             "$TTY" == "/dev/hvsi0" ]; then
+            exec /sbin/mingetty -L ${TTY#/dev/} 9600 vt100
+        else
+            exec /sbin/mingetty -8 38400 ${TTY#/dev}
+        fi
+    fi
+end script


### PR DESCRIPTION
In case the rear image does not have mingetty, getty/agetty handling is needed in upstart tty script.
Refer to #661 for details.