### PR TITLE
Adding ISO_DEFAULT boot option and BAREOS_FILESET for automation purposes

### DIFF
--- a/doc/user-guide/03-configuration.adoc
+++ b/doc/user-guide/03-configuration.adoc
@@ -69,6 +69,11 @@ Write the image using sshfs and the SSH protocol.
 OUTPUT_URL=null::
 To avoid duplicate ISO images. Useful in combination with an _external_ backup program, or when +BACKUP_URL=iso://backup+
 
+The default boot option of the created ISO is boothd / "boot from first harddisk". If you want to change this, e.g. because you integrate REAR
+into some automation process, you can change the default using
+ISO_DEFAULT={manual,automatic,boothd}
+
+
 == Backup/Restore strategy (BACKUP)
 The +BACKUP+ setting defines our backup/restore strategy. The +BACKUP+ can be handled via internal archive executable (+tar+ or +rsync+) or by an external backup program (commercial or open source).
 
@@ -94,6 +99,10 @@ Use Bacula programs
 
 BACKUP=BAREOS::
 Use Bareos fork of Bacula
+
+BAREOS_FILESET=Full
+Only if you have more than one fileset defined for your clients backup jobs, you need to specify which
+to use for restore
 
 BACKUP=GALAXY::
 Use CommVault Galaxy (5, probably 6)

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -177,6 +177,13 @@ ISO_IMAGES=()
 # This might get a number appended (for splitting data onto multiple CDs).
 ISO_PREFIX="rear-$HOSTNAME"
 
+# Default boot option for ISO image. If unset, system will boot from first HD
+# by default. This is usefull in almost all cases. If empty "boothd" will be used.
+# Change this only, if you are about to automate things
+# E.g. ISO_DEFAULT=manual
+# This will start the REAR system and you can connect via ssh and issue 'rear recover'
+ISO_DEFAULT=boothd
+
 ##
 # OUTPUT=USB stuff
 ##
@@ -541,6 +548,11 @@ BEXTRACT_VOLUME=
 # name of a tape device or a disk block device as configured for bareos-sd.
 #  eg. Ultrium-1 or /dev/sda1
 BEXTRACT_DEVICE=
+# If you have more than one fileset configured for your client, specify one here.
+# Otherwise interaction is needed during restore.
+# Leave unset, if you have only one fileset for your client (this is almost always the case)
+# E.g. BAREOS_FILESET=Full
+# BAREOS_FILESET=
 
 ##
 # BACKUP=DUPLICITY stuff

--- a/usr/share/rear/restore/BAREOS/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/BAREOS/default/40_restore_backup.sh
@@ -101,13 +101,15 @@ else
         then
                 BAREOS_CLIENT=$(grep $(hostname -s) /etc/bareos/bareos-fd.conf | awk '/-fd/ {print $3}' )
         fi
+	
+	if [ -n "$BAREOS_FILESET" ]
+	then
+		FILESET="fileset=\"$BAREOS_FILESET\""
+	fi
 
-        if [ -n "$BAREOS_FILESET" ]
-        then
-                FILESET="fileset=\"$BAREOS_FILESET\""
-        fi
+        echo "restore client=$BAREOS_CLIENT $FILESET where=/mnt/local select all done
 
-        echo "restore client=$BAREOS_CLIENT $FILESET where=/mnt/local select all done " |     bconsole
+" |     bconsole
 
         # wait for job to start
         LogPrint "waiting for job to start"
@@ -148,10 +150,15 @@ Please verify that the backup has been restored correctly to '/mnt/local'
 in the provided shell. When finished, type exit in the shell to continue
 recovery.
 "
+
+if [ "$ISO_DEFAULT" != "unattended" ]
+then
+
     rear_shell "Did the backup successfully restore to '/mnt/local' ? Ready to continue ?" \
             "bls -j -V$BEXTRACT_VOLUME $BEXTRACT_DEVICE
 vi bootstrap.txt
 bextract$exclude_list -b bootstrap.txt -V$BEXTRACT_VOLUME $BEXTRACT_DEVICE /mnt/local"
+fi
 
 fi
 

--- a/usr/share/rear/restore/BAREOS/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/BAREOS/default/40_restore_backup.sh
@@ -102,9 +102,12 @@ else
                 BAREOS_CLIENT=$(grep $(hostname -s) /etc/bareos/bareos-fd.conf | awk '/-fd/ {print $3}' )
         fi
 
-        echo "restore client=$BAREOS_CLIENT where=/mnt/local select all done
+        if [ -n "$BAREOS_FILESET" ]
+        then
+                FILESET="fileset=\"$BAREOS_FILESET\""
+        fi
 
-" |     bconsole
+        echo "restore client=$BAREOS_CLIENT $FILESET where=/mnt/local select all done " |     bconsole
 
         # wait for job to start
         LogPrint "waiting for job to start"


### PR DESCRIPTION
Mainly needed for automating the recover process, i.e. create a boot image that will automatically go into recover mode. BAREOS_FILESET option is needed, if you have more than one fileset defined for the recovery-client, otherwise bconsole will interactively ask for the fileset to use.