### PR TITLE
obsolete the requirement of dosfslabel

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/22_install_elilo.sh
+++ b/usr/share/rear/finalize/Linux-i386/22_install_elilo.sh
@@ -27,7 +27,7 @@ if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]]; then
     StopIfError "Could not find directory /boot/efi"
 
     # the UEFI_BOOTLOADER was saved in /etc/rear/rescue.conf file by rear mkrescue/mkbackup
-    [[ ! -f "/mnt/local${UEFI_BOOTLOADER}" ]]
+    [[ -f "/mnt/local${UEFI_BOOTLOADER}" ]]
     StopIfError "Could not find elilo.efi"
 
     [[ -r "/mnt/local/etc/elilo.conf" ]]

--- a/usr/share/rear/finalize/Linux-i386/23_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/23_run_efibootmgr.sh
@@ -6,9 +6,19 @@
 StopIfError "Could not find directory /mnt/local/boot/efi"
 
 BootEfiDev="$( mount | grep "boot/efi" | awk '{print $1}' )"
-Dev=$( get_device_name $BootEfiDev )    # /dev/sda1
-Disk=$( echo ${Dev} | sed -e 's/[0-9]//g' )  # /dev/sda
-ParNr=$( echo ${Dev} | sed -e 's/.*\([0-9]\).*/\1/' )  # 1 (must anyway be a low nr <9)
+Dev=$( get_device_name $BootEfiDev )    # /dev/sda1 or /dev/mapper/vol34_part2 or /dev/mapper/mpath99p4
+ParNr=$( get_partition_number $Dev )  # 1 (must anyway be a low nr <9)
+Disk=$( echo ${Dev%$ParNr} ) # /dev/sda or /dev/mapper/vol34_part or /dev/mapper/mpath99p
+
+if [[ ${Dev/mapper//} != $Dev ]] ; then # we have 'mapper' in devname
+    # we only expect mpath_partX  or mpathpX or mpath-partX
+    case $Disk in
+        (*p)     Disk=${Disk%p} ;;
+        (*-part) Disk=${Disk%-part} ;;
+        (*_part) Disk=${Disk%_part} ;;
+        (*)      Log "Unsupported kpartx partition delimiter for $Dev"
+    esac
+fi
 BootLoader=$( echo $UEFI_BOOTLOADER | cut -d"/" -f4- | sed -e 's;/;\\;g' ) # EFI\fedora\shim.efi
 Log efibootmgr --create --gpt --disk ${Disk} --part ${ParNr} --write-signature --label \"${OS_VENDOR} ${OS_VERSION}\" --loader \"\\${BootLoader}\"
 efibootmgr --create --gpt --disk ${Disk} --part ${ParNr} --write-signature --label "${OS_VENDOR} ${OS_VERSION}" --loader "\\${BootLoader}"

--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
@@ -134,15 +134,16 @@ EOF
         (vfat)
 cat >> "$LAYOUT_CODE" <<EOF
 LogPrint "Creating $fstype-filesystem $mp on $device"
-mkfs.vfat $device
 EOF
             if [ -n "$label" ] ; then
-               echo "$label" | grep -q '\b'  # we substituted all " " with "\\b" in savelayout (\\b becomes \b by reading label)
-               if [ $? -eq 0 ] ; then
-                  label2="$(echo $label | sed -e 's/\\b/ /g')" # replace \b with a " "
-                  label="$label2"
+                echo "$label" | grep -q '\b'  # we substituted all " " with "\\b" in savelayout (\\b becomes \b by reading label)
+                if [ $? -eq 0 ] ; then
+                    label2="$(echo $label | sed -e 's/\\b/ /g')" # replace \b with a " "
+                    label="$label2"
                 fi
-                echo "dosfslabel $device \"$label\" >&2" >> "$LAYOUT_CODE"
+                echo "mkfs.vfat -n \"$label\" $device" >> "$LAYOUT_CODE"
+            else
+                echo "mkfs.vfat $device" >> "$LAYOUT_CODE"
             fi
             if [ -n "$uuid" ]; then
                 # The UUID label of vfat is changed by recreating the fs, we must swap it.

--- a/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
@@ -26,7 +26,6 @@ extract_partitions() {
     declare device=$1
 
     declare sysfs_name=$(get_sysfs_name $device)
-    declare block_size=$(get_block_size $sysfs_name)
 
     ### check if we can find any partitions
     declare -a sysfs_paths=(/sys/block/$sysfs_name/$sysfs_name*)
@@ -62,13 +61,7 @@ extract_partitions() {
         partition_prefix=${partition_name%$partition_nr}
 
         size=$(get_disk_size ${path#/sys/block/})
-        if [[ -r $path/start ]] ; then
-            start_block=$(< $path/start)
-            start=$(( $start_block*$block_size ))
-        else
-            Log "Could not determine start of partition $partition_name."
-            start="unknown"
-        fi
+        start=$(get_partition_start ${path#/sys/block/})
 
         echo "$partition_nr $size $start">> $TMP_DIR/partitions_unsorted
     done

--- a/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
@@ -119,8 +119,7 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
                 fi
                 ;;
             (vfat)
-                # Make sure we don't get any other output from dosfslabel (errors go to stdout :-/)
-                label=$(dosfslabel $device | tail -1 | sed -e 's/ /\\\\b/g')  # replace all " " with "\\b"
+                label=$(blkid_label_of_device $device)
                 uuid=$(blkid_uuid_of_device $device)
                 echo -n " uuid=$uuid label=$label"
                 ;;

--- a/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
@@ -270,7 +270,9 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
                     # (using subvolid=... can fail because the subvolume ID can be different during system recovery).
                     # Because both "mount ... -o subvol=/path/to/subvolume" and "mount ... -o subvol=path/to/subvolume" work
                     # the subvolume path can be specified with or without leading '/':
-                    btrfs_subvolume_path=$( grep " $subvolume_mountpoint btrfs " /etc/fstab | grep -o 'subvol=[^ ]*' | cut -s -d '=' -f 2 )
+                    btrfs_subvolume_path=$( egrep "[[:space:]]$subvolume_mountpoint[[:space:]]+btrfs[[:space:]]" /etc/fstab \
+                                            | egrep -v '[[:space:]]*#' \
+                                            | grep -o 'subvol=[^ ]*' | cut -s -d '=' -f 2 )
                 fi
                 # Remove leading '/' from btrfs_subvolume_path (except it is only '/') to have same syntax for all entries and
                 # without leading '/' is more clear that it is not an absolute path in the currently mounted tree of filesystems

--- a/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
@@ -74,6 +74,13 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
             Log "Mapping $device to $ndevice"
             device=$ndevice
         fi
+        # FIXME: is the above condition still needed if the following is in place?
+        # get_device_name and get_device_name_mapping below should canonicalize obscured udev names
+
+        # work with the persistent dev name: address the fact than dm-XX may be different disk in the recovery environment
+        device=$(get_device_mapping $device)
+        device=$(get_device_name $device)
+
         # Output generic filesystem layout values:
         echo -n "fs $device $mountpoint $fstype"
         # Output filesystem specific layout values:
@@ -234,6 +241,11 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
             read_mounted_btrfs_subvolumes_command="mount -t btrfs | cut -d ' ' -f 1,3,6"
         fi
         while read device subvolume_mountpoint mount_options btrfs_subvolume_path junk ; do
+
+            # work with the persistent dev name: address the fact than dm-XX may be different disk in the recovery environment
+            device=$(get_device_mapping $device)
+            device=$(get_device_name $device)
+
             if test -n "$device" -a -n "$subvolume_mountpoint" ; then
                 if test -z "$btrfsmountedsubvol_entry_exists" ; then
                     # Output header only once:

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -333,7 +333,35 @@ get_partition_number() {
 
     echo $number
 }
+# Returns partition start block or 'unknown'
+# sda/sda1 or
+# dm-XX
+get_partition_start() {
+    local disk_name=$1
+    local start_block start
 
+    local block_size=$(get_block_size ${disk_name%/*})
+
+    if [[ -r /sys/block/$disk_name/start ]] ; then
+        start_block=$(< $path/start)
+    elif [[ $disk_name =~ ^dm- ]]; then
+        # /dev/mapper/mpath4-part1
+        local devname=$(get_device_name $disk_name)
+        devname=${devname#/dev/mapper/}
+       
+        # 0 536846303 linear 253:7 536895488
+        read junk junk junk junk start_block < <( dmsetup table ${devname} 2>&8 )
+    fi
+    if [[ -z $start_block ]]; then
+        Log "Could not determine start of partition $partition_name."
+        start="unknown"
+    else
+        start=$(( start_block * block_size ))
+    fi
+
+    echo $start
+}
+    
 # Get the type of a layout component
 get_component_type() {
     grep -E "^[^ ]+ $1 " $LAYOUT_TODO | cut -d " " -f 3
@@ -486,7 +514,7 @@ get_device_mapping() {
         echo $1
     else
         local name=${1##*/}      # /dev/disk/by-id/scsi-xxxx -> scsi-xxx
-        local disk_name=$(grep "^${name}" ${VAR_DIR}/recovery/diskbyid_mappings | awk '{print $2}')
+        local disk_name=$(grep -w "^${name}" ${VAR_DIR}/recovery/diskbyid_mappings | awk '{print $2}')
         if [[ -z "$disk_name" ]]; then
             echo $1
         else
@@ -547,3 +575,4 @@ blkid_label_of_device() {
     done
     echo "$label"
 }
+

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -535,3 +535,15 @@ blkid_uuid_of_device() {
     echo "$uuid"
 }
 
+# Get the LABEL of a device.
+# Device is something like /dev/sda1.
+blkid_label_of_device() {
+    local device=$1
+    local label=""
+    for LINE in $(blkid $device  2>/dev/null)
+    do
+        label=$( echo "$LINE" | grep "^LABEL=" | cut -d= -f2 | sed -e 's/"//g' | sed -e 's/ /\\\\b/g')  # replace all " " with "\\b"
+        [[ ! -z "$label" ]] && break
+    done
+    echo "$label"
+}

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -50,3 +50,19 @@ function build_bootx86_efi {
     $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -d /usr/lib/grub/x86_64-efi -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo
     StopIfError "Error occurred during $gmkimage of BOOTX64.efi"
 }
+
+# estimate size of efibooot image
+function efiboot_img_size {
+    local size=32000
+    if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" ]]; then
+        case "$(basename $UEFI_BOOTLOADER)" in
+            # we will need more space for initrd and kernel if elilo is used
+            # if shim is used, bootloader can be actually anything (also elilo)
+            # named as grub64.efi (follow-up loader is shim compile time option)
+            # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim
+            (shim.efi|elilo.efi) size=128000 ;;
+            (*) size=32000
+        esac
+    fi
+    echo $size
+}

--- a/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
@@ -1,14 +1,7 @@
 # 20_mount_efibootimg.sh
 (( USING_UEFI_BOOTLOADER )) || return
 
-# we will need more space for initrd and kernel if elilo is used
-if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" && $(basename ${UEFI_BOOTLOADER}) = "elilo.efi" ]]; then
-   size=128000
-else
-   size=32000
-fi
-
-dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$size bs=1024
+dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size) bs=1024
 # make sure we select FAT16 instead of FAT12 as size >30MB
 mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
 mkdir -p $v $TMP_DIR/mnt >&2

--- a/usr/share/rear/prep/default/31_include_uefi_tools.sh
+++ b/usr/share/rear/prep/default/31_include_uefi_tools.sh
@@ -12,7 +12,6 @@ fi
 
 REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}"
 dosfsck
-dosfslabel
 efibootmgr
 )
 

--- a/usr/share/rear/prep/default/40_save_mountpoint_details.sh
+++ b/usr/share/rear/prep/default/40_save_mountpoint_details.sh
@@ -5,10 +5,12 @@
 # Script restore/default/90_create_missing_directories.sh will recreate the missing dirs (all other
 # script may be deleted)
 
+: > "$VAR_DIR/recovery/mountpoint_permissions"
 # drwxr-xr-x.  20 root root  4096 Nov  2 07:44 /
 while read junk junk userid groupid junk junk junk junk dir
 do
-    echo $dir $(stat -c %a $dir) $userid $groupid >> "$VAR_DIR/recovery/mountpoint_permissions"
+    [[ $dir = / ]] && continue
+    echo ${dir#/*} $(stat -c %a $dir) $userid $groupid >> "$VAR_DIR/recovery/mountpoint_permissions"
 done < <(ls -ld $(mount | grep -vE '(cgroup|fuse|nfs|/sys/|REAR-000)' | awk '{print $3}'))
 
-# output looks like / 755 root root
+# output looks like boot 755 root root


### PR DESCRIPTION
SLE 11 SP3 **dosfsutils** package does not include **dosfslabel** utility. This patch obsoletes **dosfslabel** by **blkid** and **mkfs.vfat**. The installation of no external **dosfsutils** package would be required on UEFI booting system. See also #229.