### PR TITLE
Fix for "Could not find elilo.efi"

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/22_install_elilo.sh
+++ b/usr/share/rear/finalize/Linux-i386/22_install_elilo.sh
@@ -27,7 +27,7 @@ if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]]; then
     StopIfError "Could not find directory /boot/efi"
 
     # the UEFI_BOOTLOADER was saved in /etc/rear/rescue.conf file by rear mkrescue/mkbackup
-    [[ ! -f "/mnt/local${UEFI_BOOTLOADER}" ]]
+    [[ -f "/mnt/local${UEFI_BOOTLOADER}" ]]
     StopIfError "Could not find elilo.efi"
 
     [[ -r "/mnt/local/etc/elilo.conf" ]]


### PR DESCRIPTION
Rear recovery fails at final stage with ```Could not find elilo.efi``` error. Manual run of ```elilo``` works ok. This patch addresses this bug.