### PR TITLE
obsolete the requirement of dosfslabel

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_filesystem_code.sh
@@ -134,15 +134,16 @@ EOF
         (vfat)
 cat >> "$LAYOUT_CODE" <<EOF
 LogPrint "Creating $fstype-filesystem $mp on $device"
-mkfs.vfat $device
 EOF
             if [ -n "$label" ] ; then
-               echo "$label" | grep -q '\b'  # we substituted all " " with "\\b" in savelayout (\\b becomes \b by reading label)
-               if [ $? -eq 0 ] ; then
-                  label2="$(echo $label | sed -e 's/\\b/ /g')" # replace \b with a " "
-                  label="$label2"
+                echo "$label" | grep -q '\b'  # we substituted all " " with "\\b" in savelayout (\\b becomes \b by reading label)
+                if [ $? -eq 0 ] ; then
+                    label2="$(echo $label | sed -e 's/\\b/ /g')" # replace \b with a " "
+                    label="$label2"
                 fi
-                echo "dosfslabel $device \"$label\" >&2" >> "$LAYOUT_CODE"
+                echo "mkfs.vfat -n \"$label\" $device" >> "$LAYOUT_CODE"
+            else
+                echo "mkfs.vfat $device" >> "$LAYOUT_CODE"
             fi
             if [ -n "$uuid" ]; then
                 # The UUID label of vfat is changed by recreating the fs, we must swap it.

--- a/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
@@ -119,8 +119,7 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
                 fi
                 ;;
             (vfat)
-                # Make sure we don't get any other output from dosfslabel (errors go to stdout :-/)
-                label=$(dosfslabel $device | tail -1 | sed -e 's/ /\\\\b/g')  # replace all " " with "\\b"
+                label=$(blkid_label_of_device $device)
                 uuid=$(blkid_uuid_of_device $device)
                 echo -n " uuid=$uuid label=$label"
                 ;;

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -535,3 +535,15 @@ blkid_uuid_of_device() {
     echo "$uuid"
 }
 
+# Get the LABEL of a device.
+# Device is something like /dev/sda1.
+blkid_label_of_device() {
+    local device=$1
+    local label=""
+    for LINE in $(blkid $device  2>/dev/null)
+    do
+        label=$( echo "$LINE" | grep "^LABEL=" | cut -d= -f2 | sed -e 's/"//g' | sed -e 's/ /\\\\b/g')  # replace all " " with "\\b"
+        [[ ! -z "$label" ]] && break
+    done
+    echo "$label"
+}

--- a/usr/share/rear/prep/default/31_include_uefi_tools.sh
+++ b/usr/share/rear/prep/default/31_include_uefi_tools.sh
@@ -12,7 +12,6 @@ fi
 
 REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}"
 dosfsck
-dosfslabel
 efibootmgr
 )
 


### PR DESCRIPTION
SLE 11 SP3 **dosfsutils** package does not include **dosfslabel** utility. This patch obsoletes **dosfslabel** by **blkid** and **mkfs.vfat**. The installation of no external **dosfsutils** package would be required on UEFI booting system. See also #229.