### PR TITLE
SAN booting related improvements

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/23_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/23_run_efibootmgr.sh
@@ -6,9 +6,19 @@
 StopIfError "Could not find directory /mnt/local/boot/efi"
 
 BootEfiDev="$( mount | grep "boot/efi" | awk '{print $1}' )"
-Dev=$( get_device_name $BootEfiDev )    # /dev/sda1
-Disk=$( echo ${Dev} | sed -e 's/[0-9]//g' )  # /dev/sda
-ParNr=$( echo ${Dev} | sed -e 's/.*\([0-9]\).*/\1/' )  # 1 (must anyway be a low nr <9)
+Dev=$( get_device_name $BootEfiDev )    # /dev/sda1 or /dev/mapper/vol34_part2 or /dev/mapper/mpath99p4
+ParNr=$( get_partition_number $Dev )  # 1 (must anyway be a low nr <9)
+Disk=$( echo ${Dev%$ParNr} ) # /dev/sda or /dev/mapper/vol34_part or /dev/mapper/mpath99p
+
+if [[ ${Dev/mapper//} != $Dev ]] ; then # we have 'mapper' in devname
+    # we only expect mpath_partX  or mpathpX or mpath-partX
+    case $Disk in
+        (*p)     Disk=${Disk%p} ;;
+        (*-part) Disk=${Disk%-part} ;;
+        (*_part) Disk=${Disk%_part} ;;
+        (*)      Log "Unsupported kpartx partition delimiter for $Dev"
+    esac
+fi
 BootLoader=$( echo $UEFI_BOOTLOADER | cut -d"/" -f4- | sed -e 's;/;\\;g' ) # EFI\fedora\shim.efi
 Log efibootmgr --create --gpt --disk ${Disk} --part ${ParNr} --write-signature --label \"${OS_VENDOR} ${OS_VERSION}\" --loader \"\\${BootLoader}\"
 efibootmgr --create --gpt --disk ${Disk} --part ${ParNr} --write-signature --label "${OS_VENDOR} ${OS_VERSION}" --loader "\\${BootLoader}"

--- a/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
@@ -26,7 +26,6 @@ extract_partitions() {
     declare device=$1
 
     declare sysfs_name=$(get_sysfs_name $device)
-    declare block_size=$(get_block_size $sysfs_name)
 
     ### check if we can find any partitions
     declare -a sysfs_paths=(/sys/block/$sysfs_name/$sysfs_name*)
@@ -62,13 +61,7 @@ extract_partitions() {
         partition_prefix=${partition_name%$partition_nr}
 
         size=$(get_disk_size ${path#/sys/block/})
-        if [[ -r $path/start ]] ; then
-            start_block=$(< $path/start)
-            start=$(( $start_block*$block_size ))
-        else
-            Log "Could not determine start of partition $partition_name."
-            start="unknown"
-        fi
+        start=$(get_partition_start ${path#/sys/block/})
 
         echo "$partition_nr $size $start">> $TMP_DIR/partitions_unsorted
     done

--- a/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
@@ -271,7 +271,7 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
                     # Because both "mount ... -o subvol=/path/to/subvolume" and "mount ... -o subvol=path/to/subvolume" work
                     # the subvolume path can be specified with or without leading '/':
                     btrfs_subvolume_path=$( egrep "[[:space:]]$subvolume_mountpoint[[:space:]]+btrfs[[:space:]]" /etc/fstab \
-                                            | egrep -v '[[:space:]]*#' \
+                                            | egrep -v '^[[:space:]]*#' \
                                             | grep -o 'subvol=[^ ]*' | cut -s -d '=' -f 2 )
                 fi
                 # Remove leading '/' from btrfs_subvolume_path (except it is only '/') to have same syntax for all entries and

--- a/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
@@ -270,7 +270,9 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
                     # (using subvolid=... can fail because the subvolume ID can be different during system recovery).
                     # Because both "mount ... -o subvol=/path/to/subvolume" and "mount ... -o subvol=path/to/subvolume" work
                     # the subvolume path can be specified with or without leading '/':
-                    btrfs_subvolume_path=$( grep " $subvolume_mountpoint btrfs " /etc/fstab | grep -o 'subvol=[^ ]*' | cut -s -d '=' -f 2 )
+                    btrfs_subvolume_path=$( egrep "[[:space:]]$subvolume_mountpoint[[:space:]]+btrfs[[:space:]]" /etc/fstab \
+                                            | egrep -v '[[:space:]]*#' \
+                                            | grep -o 'subvol=[^ ]*' | cut -s -d '=' -f 2 )
                 fi
                 # Remove leading '/' from btrfs_subvolume_path (except it is only '/') to have same syntax for all entries and
                 # without leading '/' is more clear that it is not an absolute path in the currently mounted tree of filesystems

--- a/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
@@ -74,6 +74,13 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
             Log "Mapping $device to $ndevice"
             device=$ndevice
         fi
+        # FIXME: is the above condition still needed if the following is in place?
+        # get_device_name and get_device_name_mapping below should canonicalize obscured udev names
+
+        # work with the persistent dev name: address the fact than dm-XX may be different disk in the recovery environment
+        device=$(get_device_mapping $device)
+        device=$(get_device_name $device)
+
         # Output generic filesystem layout values:
         echo -n "fs $device $mountpoint $fstype"
         # Output filesystem specific layout values:
@@ -234,6 +241,11 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
             read_mounted_btrfs_subvolumes_command="mount -t btrfs | cut -d ' ' -f 1,3,6"
         fi
         while read device subvolume_mountpoint mount_options btrfs_subvolume_path junk ; do
+
+            # work with the persistent dev name: address the fact than dm-XX may be different disk in the recovery environment
+            device=$(get_device_mapping $device)
+            device=$(get_device_name $device)
+
             if test -n "$device" -a -n "$subvolume_mountpoint" ; then
                 if test -z "$btrfsmountedsubvol_entry_exists" ; then
                     # Output header only once:

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -333,7 +333,35 @@ get_partition_number() {
 
     echo $number
 }
+# Returns partition start block or 'unknown'
+# sda/sda1 or
+# dm-XX
+get_partition_start() {
+    local disk_name=$1
+    local start_block start
 
+    local block_size=$(get_block_size ${disk_name%/*})
+
+    if [[ -r /sys/block/$disk_name/start ]] ; then
+        start_block=$(< $path/start)
+    elif [[ $disk_name =~ ^dm- ]]; then
+        # /dev/mapper/mpath4-part1
+        local devname=$(get_device_name $disk_name)
+        devname=${devname#/dev/mapper/}
+       
+        # 0 536846303 linear 253:7 536895488
+        read junk junk junk junk start_block < <( dmsetup table ${devname} 2>&8 )
+    fi
+    if [[ -z $start_block ]]; then
+        Log "Could not determine start of partition $partition_name."
+        start="unknown"
+    else
+        start=$(( start_block * block_size ))
+    fi
+
+    echo $start
+}
+    
 # Get the type of a layout component
 get_component_type() {
     grep -E "^[^ ]+ $1 " $LAYOUT_TODO | cut -d " " -f 3
@@ -486,7 +514,7 @@ get_device_mapping() {
         echo $1
     else
         local name=${1##*/}      # /dev/disk/by-id/scsi-xxxx -> scsi-xxx
-        local disk_name=$(grep "^${name}" ${VAR_DIR}/recovery/diskbyid_mappings | awk '{print $2}')
+        local disk_name=$(grep -w "^${name}" ${VAR_DIR}/recovery/diskbyid_mappings | awk '{print $2}')
         if [[ -z "$disk_name" ]]; then
             echo $1
         else
@@ -547,3 +575,4 @@ blkid_label_of_device() {
     done
     echo "$label"
 }
+


### PR DESCRIPTION
Multiple san-booting/uefi related fixes implemented.
* correctly find disk and partition number for efibootmgr.
* find now partition start also for multipath (dm-XX) disk
* save ```/dev/mapper/mpathX``` dev names instead of ```dm-XX``` names to the disklayout file for btrfs and ```/dev/disk/by-id/``` disks description.  Addresses the issue, when ```/dev/dm-XX``` is recoreded in disklayout, but ```dm-XX``` can by different disk with the same size in the recovery environment.