### PR TITLE
support for UEFI secure boot

### DIFF
--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -445,7 +445,7 @@ function make_syslinux_config {
 
 # Create configuration file for elilo
 function create_ebiso_elilo_conf {
-cat > $TMP_DIR/mnt/EFI/BOOT/elilo.conf << EOF
+cat << EOF
 timeout = 5
 default = "Relax and Recover (no Secure Boot)"
 
@@ -453,4 +453,53 @@ image = kernel
     label = "Relax and Recover (no Secure Boot)"
     initrd = initrd.cgz
 EOF
+    [[ -n $KERNEL_CMDLINE ]] && cat << EOF
+    append = "$KERNEL_CMDLINE"
+EOF
 }
+
+# Create configuration grub
+function create_grub2_cfg {
+cat << EOF
+set default="0"
+
+insmod efi_gop
+insmod efi_uga
+insmod video_bochs
+insmod video_cirrus
+insmod all_video
+
+set gfxpayload=keep
+insmod gzio
+insmod part_gpt
+insmod ext2
+
+set timeout=5
+
+search --no-floppy --file /boot/efiboot.img --set
+#set root=(cd0)
+
+menuentry "Relax and Recover (no Secure Boot)"  --class gnu-linux --class gnu --class os {
+     echo 'Loading kernel ...'
+     linux /isolinux/kernel $KERNEL_CMDLINE
+     echo 'Loading initial ramdisk ...'
+     initrd /isolinux/initrd.cgz
+}
+
+menuentry "Relax and Recover (Secure Boot)"  --class gnu-linux --class gnu --class os {
+     echo 'Loading kernel ...'
+     linuxefi /isolinux/kernel $KERNEL_CMDLINE
+     echo 'Loading initial ramdisk ...'
+     initrdefi /isolinux/initrd.cgz
+}
+
+menuentry "Reboot" {
+     reboot
+}
+
+menuentry "Exit to EFI Shell" {
+     exit
+}
+EOF
+}
+

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -50,3 +50,19 @@ function build_bootx86_efi {
     $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -d /usr/lib/grub/x86_64-efi -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo
     StopIfError "Error occurred during $gmkimage of BOOTX64.efi"
 }
+
+# estimate size of efibooot image
+function efiboot_img_size {
+    local size=32000
+    if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" ]]; then
+        case "$(basename $UEFI_BOOTLOADER)" in
+            # we will need more space for initrd and kernel if elilo is used
+            # if shim is used, bootloader can be actually anything (also elilo)
+            # named as grub64.efi (follow-up loader is shim compile time option)
+            # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim
+            (shim.efi|elilo.efi) size=128000 ;;
+            (*) size=32000
+        esac
+    fi
+    echo $size
+}

--- a/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
@@ -1,14 +1,7 @@
 # 20_mount_efibootimg.sh
 (( USING_UEFI_BOOTLOADER )) || return
 
-# we will need more space for initrd and kernel if elilo is used
-if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" && $(basename ${UEFI_BOOTLOADER}) = "elilo.efi" ]]; then
-   size=128000
-else
-   size=32000
-fi
-
-dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$size bs=1024
+dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size) bs=1024
 # make sure we select FAT16 instead of FAT12 as size >30MB
 mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
 mkdir -p $v $TMP_DIR/mnt >&2


### PR DESCRIPTION
An attempt for "secure boot" support for ReaR: 
* if ```shim.efi``` is used as a bootloader, we also copy follow-up loader to the image (we assume it's ```grub*.efi```)
* In addition, ```KERNEL_CMDLINE``` option is now honored also for uefi-booting menu.

We also slightly re-arrange the uefi code, moving some common parts to libs/
I tested this only on SLES11 SP3 (boot-from-san, btrfs). 