### PR TITLE
Have readonly constants in the main rear script

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -54,12 +54,14 @@ if test "$SCRIPT_FILE" != "$( readlink -f /usr/sbin/$PROGRAM )" ; then
 fi
 readonly REAR_DIR_PREFIX
 
-# Program directories - they must be set here. Everything else is then dynamic:
-readonly SHARE_DIR="$REAR_DIR_PREFIX/usr/share/rear"
-readonly VAR_DIR="$REAR_DIR_PREFIX/var/lib/rear"
-readonly LOG_DIR="$REAR_DIR_PREFIX/var/log/rear"
-# Not yet readonly CONFIG_DIR because it might be changed via '-c' command line option:
+# Program directories - they must be set here. Everything else is then dynamic.
+# Not yet readonly here because they are set via the /etc/rear/rescue.conf file
+# in the recovery system that is sourced by the rear command in recover mode
+# and CONFIG_DIR can also be changed via '-c' command line option:
+SHARE_DIR="$REAR_DIR_PREFIX/usr/share/rear"
 CONFIG_DIR="$REAR_DIR_PREFIX/etc/rear"
+VAR_DIR="$REAR_DIR_PREFIX/var/lib/rear"
+LOG_DIR="$REAR_DIR_PREFIX/var/log/rear"
 
 # Generic global variables that are not meant to be configured by the user
 # (i.e. that do not belong into usr/share/rear/conf/default.conf),
@@ -202,10 +204,11 @@ esac
 
 # Mark variables that are not meant to be changed later as constants (i.e. readonly).
 # Exceptions here:
+# CONFIG_DIR because "rear recover" sets it in /etc/rear/rescue.conf in the recovery system
 # WORKFLOW because for the udev workflow WORKFLOW is set to the actual workflow
 # KERNEL_VERSION because if empty it is set when sourcing config files below
 # VERBOSE because there is a special "VERBOSE=1" setting below:
-readonly ARGS CONFIG_DIR
+readonly ARGS
 readonly DEBUG DEBUGSCRIPTS DEBUGSCRIPTS_ARGUMENT DEBUGSCRIPTS_OPPOSITE_ARGUMENT
 readonly SIMULATE STEPBYSTEP
 
@@ -338,8 +341,8 @@ done
 for config in site local rescue ; do
     test -r "$CONFIG_DIR/$config.conf" && Source "$CONFIG_DIR/$config.conf" || true
 done
-# Now KERNEL_VERSION should have been set to a fixed value:
-readonly KERNEL_VERSION
+# Now SHARE_DIR CONFIG_DIR VAR_DIR LOG_DIR and KERNEL_VERSION should be set to a fixed value:
+readonly SHARE_DIR CONFIG_DIR VAR_DIR LOG_DIR KERNEL_VERSION
 
 SourceStage "init"
 

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -56,7 +56,17 @@ VAR_DIR="$REAR_DIR_PREFIX/var/lib/rear"
 LOG_DIR="$REAR_DIR_PREFIX/var/log/rear"
 CMD_OPTS=( "$@" )
 
-# initialize defaults: empty value means "false"/"no"
+# Generic global variables that are not meant to be configured by the user
+# (i.e. that do not belong into usr/share/rear/conf/default.conf),
+# see https://github.com/rear/rear/issues/678
+# and https://github.com/rear/rear/issues/708
+# Location of the disklayout.conf file create by savelayout:
+DISKLAYOUT_FILE="$VAR_DIR/layout/disklayout.conf"
+# Location of the root of the filesystem tree of the to-be-recovered-system in the recovery system
+# i.e. the mountpoint in the recovery system where the filesystem tree of the to-be-recovered-system is mounted:
+RECOVERY_FS_ROOT="/mnt/local"
+
+# Initialize defaults: empty value means "false"/"no"
 DEBUG=""
 DEBUGSCRIPTS=""
 DEBUGSCRIPTS_ARGUMENT=""

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -32,45 +32,53 @@
 # "TODO Use set -eu to die from unset variables and unhandled errors"
 
 # Versioning
-PRODUCT="Relax-and-Recover"
-PROGRAM=${0##*/}
-VERSION=1.17.2
-RELEASE_DATE=Git
+readonly PRODUCT="Relax-and-Recover"
+readonly PROGRAM=${0##*/}
+readonly VERSION=1.17.2
+readonly RELEASE_DATE=Git
 
-STARTTIME=$SECONDS
+# Used in framework-functions.sh to calculate the time spent executing rear:
+readonly STARTTIME=$SECONDS
 
-# Allow workflows to set the exit code to a different value.
+# Provide the command line options in an array so that other scripts may read them:
+readonly CMD_OPTS=( "$@" )
+
+# Allow workflows to set the exit code to a different value (not "readonly"):
 EXIT_CODE=0
 
 # Find out if we're running from checkout
 REAR_DIR_PREFIX=""
-SCRIPT_FILE="$( readlink -f $( type -p "$0" || echo "$0" ) )"
+readonly SCRIPT_FILE="$( readlink -f $( type -p "$0" || echo "$0" ) )"
 if test "$SCRIPT_FILE" != "$( readlink -f /usr/sbin/$PROGRAM )" ; then
     REAR_DIR_PREFIX=${SCRIPT_FILE%/usr/sbin/$PROGRAM}
 fi
+readonly REAR_DIR_PREFIX
 
-# Program directories - they must be set here. Everything else is then dynamic
-SHARE_DIR="$REAR_DIR_PREFIX/usr/share/rear"
+# Program directories - they must be set here. Everything else is then dynamic:
+readonly SHARE_DIR="$REAR_DIR_PREFIX/usr/share/rear"
+readonly VAR_DIR="$REAR_DIR_PREFIX/var/lib/rear"
+readonly LOG_DIR="$REAR_DIR_PREFIX/var/log/rear"
+# Not yet readonly CONFIG_DIR because it might be changed via '-c' command line option:
 CONFIG_DIR="$REAR_DIR_PREFIX/etc/rear"
-VAR_DIR="$REAR_DIR_PREFIX/var/lib/rear"
-LOG_DIR="$REAR_DIR_PREFIX/var/log/rear"
-CMD_OPTS=( "$@" )
 
 # Generic global variables that are not meant to be configured by the user
 # (i.e. that do not belong into usr/share/rear/conf/default.conf),
 # see https://github.com/rear/rear/issues/678
 # and https://github.com/rear/rear/issues/708
-# Location of the disklayout.conf file create by savelayout:
+# Location of the disklayout.conf file created by savelayout
+# (no readonly DISKLAYOUT_FILE because it is also set in checklayout-workflow.sh and mkbackuponly-workflow.sh):
 DISKLAYOUT_FILE="$VAR_DIR/layout/disklayout.conf"
 # Location of the root of the filesystem tree of the to-be-recovered-system in the recovery system
 # i.e. the mountpoint in the recovery system where the filesystem tree of the to-be-recovered-system is mounted:
-RECOVERY_FS_ROOT="/mnt/local"
+readonly RECOVERY_FS_ROOT="/mnt/local"
 
-# Initialize defaults: empty value means "false"/"no"
+# Initialize defaults: empty value means "false"/"no":
 DEBUG=""
 DEBUGSCRIPTS=""
-DEBUGSCRIPTS_ARGUMENT=""
+DEBUGSCRIPTS_ARGUMENT="x"
+DEBUGSCRIPTS_OPPOSITE_ARGUMENT=$DEBUGSCRIPTS_ARGUMENT
 KEEP_BUILD_DIR=""
+KERNEL_VERSION=""
 RECOVERY_MODE=""
 STEPBYSTEP=""
 SIMULATE=""
@@ -79,7 +87,7 @@ WORKFLOW=""
 
 # Parse options
 help_note_text="Use '$PROGRAM --help' or 'man $PROGRAM' for more information."
-OPTS="$( getopt -n $PROGRAM -o "c:dDhsSvVr:" -l "help,version,debugscripts:" -- "$@" )"
+readonly OPTS="$( getopt -n $PROGRAM -o "c:dDhsSvVr:" -l "help,version,debugscripts:" -- "$@" )"
 if test $? -ne 0 ; then
     echo "$help_note_text"
     exit 1
@@ -127,6 +135,11 @@ while true ; do
                 exit 1
             fi
             DEBUGSCRIPTS_ARGUMENT="$2"
+            # Assume $DEBUGSCRIPTS_ARGUMENT is "xvue +h -o pipefail"
+            # then the opposite is created by interchanging '+' and '-'
+            # so that DEBUGSCRIPTS_OPPOSITE_ARGUMENT is "xvue -h +o pipefail"
+            # (FIXME: interchanging all '+' and '-' fails for "-o interactive-comments"):
+            DEBUGSCRIPTS_OPPOSITE_ARGUMENT="$( echo "$DEBUGSCRIPTS_ARGUMENT" | tr '+-' '-+' )"
             shift
             ;;
         (-s)
@@ -163,13 +176,13 @@ while true ; do
     shift
 done
 
-# set workflow to first command line argument or to usage
+# Set workflow to first command line argument or to "help" as fallback:
 if test -z "$WORKFLOW" ; then
-    # usually workflow is now in $1 (after the options and its arguments were shifted above)
+    # Usually workflow is now in $1 (after the options and its arguments were shifted above)
     # but when rear is called without a workflow there exists no $1 here so that
     # an empty default value is used to avoid 'set -eu' error exit if $1 is unset:
-    if test -n "${1:-}" ; then
-        # not "$1" to get rid of compound commands
+    if test "${1:-}" ; then
+        # Not "$1" to get rid of compound commands:
         WORKFLOW=$1
         shift
     else
@@ -177,15 +190,31 @@ if test -z "$WORKFLOW" ; then
     fi
 fi
 
-# keep the remaining command line arguments to feed to the workflow
+# Keep the remaining command line arguments to feed to the workflow:
 ARGS=( "$@" )
 
-# the following workflows are always verbose
+# The following workflows are always verbose:
 case "$WORKFLOW" in
     (validate|dump|shell|recover)
         VERBOSE=1
-	;;
+        ;;
 esac
+
+# Mark variables that are not meant to be changed later as constants (i.e. readonly).
+# Exceptions here:
+# WORKFLOW because for the udev workflow WORKFLOW is set to the actual workflow
+# KERNEL_VERSION because if empty it is set when sourcing config files below
+# VERBOSE because there is a special "VERBOSE=1" setting below:
+readonly ARGS CONFIG_DIR
+readonly DEBUG DEBUGSCRIPTS DEBUGSCRIPTS_ARGUMENT DEBUGSCRIPTS_OPPOSITE_ARGUMENT
+readonly SIMULATE STEPBYSTEP
+
+# The udev workflow is a special case because it is only a wrapper workflow
+# that calls an actual workflow that is specified as $UDEV_WORKFLOW
+# (e.g. the default UDEV_WORKFLOW is "mkrescue" in default.conf)
+# and then WORKFLOW is set to the actual workflow in udev-workflow.sh
+# so that WORKFLOW cannot be set readonly for the udev workflow:
+test "$WORKFLOW" = "udev" || readonly WORKFLOW
 
 # Make sure we have the necessary paths (eg. in cron), /sbin will be the first path to search.
 # some needed binaries are in /lib/udev or /usr/lib/udev
@@ -200,25 +229,32 @@ for path in /usr/bin /bin /usr/sbin /sbin ; do
             ;;
     esac
 done
+# No readonly PATH so that it can be later extended if needed
+# (e.g. to have third-party backup/restore tools available via PATH):
 PATH=$PATH:/lib/udev:/usr/lib/udev
 
-# are we root ?
+# Are we root?
 if test "$( id --user )" != "0" ; then
     echo "ERROR: $PRODUCT needs ROOT privileges!" >&2
     exit 1
 fi
 
-# set some bash options
+# Set some bash options:
+# With nullglob set when e.g. for foo*bar no file matches are found, then foo*bar is removed
+# (e.g. "ls foo*bar" becomes plain "ls" without "foo*bar: No such file or directory" error).
+# The extglob shell option enables several extended pattern matching operators.
 shopt -s nullglob extglob
+
+# Forget all remembered full pathnames of commands:
 hash -r
 
-# make sure that we use only english
+# Make sure that we use only English:
 export LC_CTYPE=C LC_ALL=C LANG=C
 
-# include default config
+# Include default config:
 source $SHARE_DIR/conf/default.conf
 
-# include functions
+# Include functions:
 for script in $SHARE_DIR/lib/*.sh ; do
     source $script
 done
@@ -227,14 +263,14 @@ done
 if IsInArray "$WORKFLOW" "${LOCKLESS_WORKFLOWS[@]}" ; then
     LOGFILE="$LOGFILE.lockless"
 else
-    # when this currently running instance is not one of the LOCKLESS_WORKFLOWS
+    # When this currently running instance is not one of the LOCKLESS_WORKFLOWS
     # then it cannot run simultaneously with another instance
     # in this case pidof is needed to test what running instances there are:
     if ! has_binary pidof ; then
         echo "ERROR: Required program 'pidof' missing, please check your PATH" >&2
         exit 1
     fi
-    # for unknown reasons '-o %PPID' does not work for pidof at least in SLES11
+    # For unknown reasons '-o %PPID' does not work for pidof at least in SLES11
     # so that a manual test is done to find out if another pid != $$ is running:
     for pid in $( pidof -x "$SCRIPT_FILE" ) ; do
         if test "$pid" != $$ ; then
@@ -244,75 +280,71 @@ else
     done
 fi
 
-# keep old log file
+# Keep old log file:
 if test -r "$LOGFILE" ; then
     mv -f "$LOGFILE" "$LOGFILE".old 2>&8
 fi
 mkdir -p $LOG_DIR
 
 exec 2>"$LOGFILE" || echo "ERROR: Could not create $LOGFILE" >&2
-# keep our default $LOGFILE location in a seperate variable REAR_LOGFILE
-# in case end-user overruled it in the local.conf file
-REAR_LOGFILE="$LOGFILE"
+# Keep our default $LOGFILE location in a seperate variable REAR_LOGFILE
+# in case end-user overruled it in the local.conf file:
+readonly REAR_LOGFILE="$LOGFILE"
 
 if test "$WORKFLOW" != "help" ; then
     LogPrint "$PRODUCT $VERSION / $RELEASE_DATE"
     Log "Command line options: $0 ${CMD_OPTS[@]}"
-    if test -n "$VERBOSE" ; then
-        LogPrint "Using log file: $LOGFILE"
-    fi
+    test "$VERBOSE" && LogPrint "Using log file: $LOGFILE" || true
 fi
 
 v=""
 verbose=""
-# enable progress subsystem only in verbose mode, set some stuff that others can use
-if test -n "$VERBOSE" ; then
+# Enable progress subsystem only in verbose mode, set some stuff that others can use:
+if test "$VERBOSE" ; then
     source $SHARE_DIR/lib/progresssubsystem.nosh
     v="-v"
     verbose="--verbose"
 fi
 
-# enable debug output of the progress pipe
-if test -n "$DEBUG" ; then
-    KEEP_BUILD_DIR=1
-fi
+# Enable debug output of the progress pipe
+# (no readonly KEEP_BUILD_DIR because it is also set to 1 in build/default/98_verify_rootfs.sh):
+test "$DEBUG" && KEEP_BUILD_DIR=1 || true
 
-# check if we are in recovery mode
-if test -e "/etc/rear-release" ; then
-    RECOVERY_MODE="y"
-fi
+# Check if we are in recovery mode:
+test -e "/etc/rear-release" && RECOVERY_MODE="y" || true
+readonly RECOVERY_MODE
 
-if test -n "$SIMULATE" ; then
-    LogPrint "Simulation mode activated, Relax-and-Recover base directory: $SHARE_DIR"
-fi
+test "$SIMULATE" && LogPrint "Simulation mode activated, Relax-and-Recover base directory: $SHARE_DIR" || true
 
-if test -n "$DEBUGSCRIPTS_ARGUMENT" ; then
+if test "$DEBUGSCRIPTS_ARGUMENT" ; then
     Debug "Current set of flags is '$-'"
     Debug "The debugscripts flags are '$DEBUGSCRIPTS_ARGUMENT'"
 fi
 
 # All workflows need to read the configurations first.
-# Combine configuration files
+# Combine configuration files:
 Debug "Combining configuration files"
-# use this file to manually override the OS detection
+# Use this file to manually override the OS detection:
 test -r "$CONFIG_DIR/os.conf" && Source "$CONFIG_DIR/os.conf" || true
 test -r "$CONFIG_DIR/$WORKFLOW.conf" && Source "$CONFIG_DIR/$WORKFLOW.conf" || true
 SetOSVendorAndVersion
-# distribution configuration files
+# Distribution configuration files:
 for config in "$ARCH" "$OS" \
         "$OS_MASTER_VENDOR" "$OS_MASTER_VENDOR_ARCH" "$OS_MASTER_VENDOR_VERSION" "$OS_MASTER_VENDOR_VERSION_ARCH" \
         "$OS_VENDOR" "$OS_VENDOR_ARCH" "$OS_VENDOR_VERSION" "$OS_VENDOR_VERSION_ARCH" ; do
     test -r "$SHARE_DIR/conf/$config.conf" && Source "$SHARE_DIR/conf/$config.conf" || true
 done
-# user configuration files, last thing is to overwrite variables if we are in the rescue system
+# User configuration files, last thing is to overwrite variables if we are in the rescue system:
 for config in site local rescue ; do
     test -r "$CONFIG_DIR/$config.conf" && Source "$CONFIG_DIR/$config.conf" || true
 done
+# Now KERNEL_VERSION should have been set to a fixed value:
+readonly KERNEL_VERSION
 
 SourceStage "init"
 
-# check for requirements, do we have all required binaries ?
-# without the empty string as initial value MISSING_PROGS would be
+# Check for requirements, do we have all required binaries?
+# Without the empty string as initial value MISSING_PROGS would be
 # an unbound variable that would result an error exit if 'set -eu' is used:
 MISSING_PROGS=("")
 for f in "${REQUIRED_PROGS[@]}" ; do
@@ -320,11 +352,9 @@ for f in "${REQUIRED_PROGS[@]}" ; do
         MISSING_PROGS=( "${MISSING_PROGS[@]}" "$f" )
     fi
 done
-if test -n "$MISSING_PROGS" ; then
-    Error "Cannot find required programs: ${MISSING_PROGS[@]}"
-fi
+test "$MISSING_PROGS" && Error "Cannot find required programs: ${MISSING_PROGS[@]}"
 
-VERSION_INFO="
+readonly VERSION_INFO="
 $PRODUCT $VERSION / $RELEASE_DATE
 
 $PRODUCT comes with ABSOLUTELY NO WARRANTY; for details see
@@ -335,7 +365,7 @@ Build date: $( date -R )
 "
 
 if test "$WORKFLOW" != "help" ; then
-    # create temporary work area and register removal exit task
+    # Create temporary work area and register removal exit task:
     BUILD_DIR="$( mktemp -d -t rear.XXXXXXXXXXXXXXX || Error "Could not create build area '$BUILD_DIR'" )"
     QuietAddExitTask cleanup_build_area_and_end_program
     Log "Using build area '$BUILD_DIR'"
@@ -345,10 +375,10 @@ if test "$WORKFLOW" != "help" ; then
     mkdir -p $v $TMP_DIR >&2 || Error "Could not create $TMP_DIR"
 fi
 
-# Check for and run the requested workflow
+# Check for and run the requested workflow:
 if has_binary WORKFLOW_$WORKFLOW ; then
     Log "Running $WORKFLOW workflow"
-    # there could be no ARGS[@] which means it would be an unbound variable so that
+    # There could be no ARGS[@] which means it would be an unbound variable so that
     # an empty default is used here to avoid an error exit if 'set -eu' is used:
     WORKFLOW_$WORKFLOW "${ARGS[@]:-}"
     Log "Finished running $WORKFLOW workflow"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -32,7 +32,7 @@
 # The kernel configuration is used to collect the kernel binary and modules
 # it can be set to a different version, e.g. to create a UP rescue media on a
 # SMP system
-KERNEL_VERSION="${KERNEL_VERSION:-$(uname -r)}"
+KERNEL_VERSION="${KERNEL_VERSION:-$( uname -r )}"
 # specify file of running kernel, overrides autodetection
 KERNEL_FILE=""
 # append special kernel parameters on rescue media
@@ -46,7 +46,7 @@ KERNEL_CMDLINE=""
 # These variables are used to include arch/os/version specific stuff
 
 # machine architecture, OS independant
-REAL_MACHINE="$(uname -m)"
+REAL_MACHINE="$( uname -m )"
 case "$REAL_MACHINE" in
 	(x86_64|i686|i586)
 		# all these behave exactly like i386. For 64bit we took care to handle the
@@ -58,18 +58,18 @@ case "$REAL_MACHINE" in
 esac
 
 # Architecture, e.g. Linux-i386
-ARCH="$(uname -s)-$MACHINE" 2>>/dev/null
-REAL_ARCH="$(uname -s)-$REAL_MACHINE" 2>>/dev/null
+ARCH="$( uname -s )-$MACHINE" 2>>/dev/null
+REAL_ARCH="$( uname -s )-$REAL_MACHINE" 2>>/dev/null
 
 # Short hostname
-HOSTNAME="$(hostname -s 2>/dev/null || uname -n | cut -d. -f1)"
+HOSTNAME="$( hostname -s 2>/dev/null || uname -n | cut -d. -f1 )"
 
 # Logfile name
 # NOTE: This may not be dynamic, else deal with .bash_history in rescue system
 LOGFILE="$LOG_DIR/rear-$HOSTNAME.log"
 
 # Operating System, e.g. GNU/Linux
-OS="$(uname -o)"
+OS="$( uname -o )"
 # vendors are SuSE Linux, Red Hat, Debian, Ubuntu, etc. as returned by lsb_release -i -s
 OS_VENDOR=generic
 # versions are 9.0 10 6.06, as returned by lsb_release -r -s
@@ -166,7 +166,7 @@ ISO_MAX_SIZE=
 # for mkisofs/genisoimage on UEFI bootable systems
 # to use ebiso, specify ISO_MKISOFS_BIN=<full_path_to_ebiso>/ebiso
 # in /etc/rear/local.conf or /etc/rear/site.conv
-ISO_MKISOFS_BIN="$(type -p mkisofs || type -p genisoimage)"
+ISO_MKISOFS_BIN="$( type -p mkisofs || type -p genisoimage )"
 
 # which files to include in the ISO image
 ISO_FILES=()
@@ -278,7 +278,7 @@ BACKUP_PROG_CRYPT_ENABLED=0
 BACKUP_PROG_CRYPT_KEY=""
 BACKUP_PROG_CRYPT_OPTIONS="/usr/bin/openssl des3 -salt -k "
 BACKUP_PROG_DECRYPT_OPTIONS="/usr/bin/openssl des3 -d -k "
-# one could also create a dynamic name, e.g. "backup_$(date -Iseconds)"
+# one could also create a dynamic name, e.g. "backup_$( date -Iseconds )"
 BACKUP_PROG_ARCHIVE="backup"
 BACKUP_PROG_EXCLUDE=( '/tmp/*' '/dev/shm/*' $VAR_DIR/output/\* )
 BACKUP_PROG_INCLUDE=( )

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -268,7 +268,7 @@ BACKUP_PROG_OPTIONS="--anchored"
 # the exclude list correctly
 BACKUP_PROG_OPTIONS_CREATE_ARCHIVE=""
 # for unsupported backup programs, the last RESTORE_ARCHIVE options must be to restore the archive
-# into a specific path (like tar -C /mnt/local)
+# into a specific path (like tar -C $RECOVERY_FS_ROOT)
 BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE=""
 BACKUP_PROG_SUFFIX=".tar"
 BACKUP_PROG_COMPRESS_OPTIONS="--gzip"
@@ -459,7 +459,7 @@ TSM_RESTORE_PIT_TIME=
 #
 # Should the result from mkrecover/backup saved via TSM
 # You can disable these saving when the result is saved on an different way (ISO_URL....)
-# (y/n) default to y 
+# (y/n) default to y
 TSM_RESULT_SAVE=y
 
 # TSM archive management class definition
@@ -570,14 +570,14 @@ BEXTRACT_DEVICE=
 DUPLY_PROFILE=""
 
 #######################################################################
-# Extention for DUPLICITY 
+# Extention for DUPLICITY
 #
 # BACKUP=DUPLICITY
 # BACKUP_PROG="duplicity"
 #
 # DUPLICITY_PROG="/usr/bin/duplicity"
 #
-# the ssh/rsync user at the backup server that is allowed to read/write the Backup 
+# the ssh/rsync user at the backup server that is allowed to read/write the Backup
 # for this host
 #
 # DUPLICITY_USER="<user>"
@@ -585,22 +585,22 @@ DUPLY_PROFILE=""
 # the backup server to write/read the backup:
 #
 # DUPLICITY_HOST="<hostname|ip>"
-# 
+#
 # the protocol duplicity should use for backup/restore (must be rsync for this case)
 # duplicity supports much more (ssh, scp, ftp, ..) but this isnt test in rear yet
-# 
+#
 # DUPLICITY_PROTO="rsync"
-# 
+#
 # the path at the remote host, that contain the host-dirs with the backups
 #
 # DUPLICITY_PATH="</dir1/dir2>"
 #
-# combining the upper parameters 
+# combining the upper parameters
 # should result e.g. in BACKUP_DUPLICITY_URL="rsync://rear-user@192.168.99.10//backup/rear"
-# 
+#
 # BACKUP_DUPLICITY_URL="${DUPLICITY_PROTO}://${DUPLICITY_USER}@${DUPLICITY_HOST}/${DUPLICITY_PATH}"
 #
-# value for duplicity action 'remove-older-than' 
+# value for duplicity action 'remove-older-than'
 # for format of time see the TIME FORMATS section at man duplicity
 # default = 2M ^= 2 Month
 #
@@ -611,19 +611,19 @@ DUPLY_PROFILE=""
 # BACKUP_DUPLICITY_GPG_ENC_KEY="<gpg-key-id>"
 # BACKUP_DUPLICITY_GPG_ENC_PASSPHRASE="passphrase"
 #
-# GPG-KEY for sign backup (e.g. root-User) 
+# GPG-KEY for sign backup (e.g. root-User)
 # BACKUP_DUPLICITY_GPG_SIGN_KEY=""
 #
 # Some extra options for duplicity, see man duplicity.
 # BACKUP_DUPLICITY_OPTIONS="--volsize 100"
-# 
+#
 # directories NOT to backup
 # NOTE: for mountpoints to restore use MOUNTPOINTS_TO_RESTORE (extra)
 # Mountpoints for proc (e.g. /proc and /var/lib/ntp/proc) and /sys MUST given -
-# if not duplicity will fail! 
+# if not duplicity will fail!
 # BACKUP_DUPLICITY_EXCLUDE=( '/proc' '/sys' '/run' '/var/lib/ntp/proc' "$HOME/.cache" '/tmp' '/var/tmp' '/app' '/var/app' )
 #
-# Mountpoints to restore 
+# Mountpoints to restore
 # if defined, used by restore/default/90_create_missing_directories.sh
 # MOUNTPOINTS_TO_RESTORE="proc sys run tmp dev/pts dev/shm app app/rear var/app"
 #
@@ -696,8 +696,8 @@ PING=
 # The text to display in order to prompt the user to restore the data
 REQUESTRESTORE_TEXT="Please start the restore process on your backup host.
 
-Make sure that you restore the data into '/mnt/local' instead of '/' because the
-hard disks of the recovered system are mounted there.
+Make sure that you restore the data into $RECOVERY_FS_ROOT (by default '/mnt/local')
+instead of '/' because the hard disks of the recovered system are mounted there.
 "
 
 # The example command added to the history to make it easier for the user.
@@ -735,8 +735,8 @@ RBME_HOSTNAME=$HOSTNAME
 # Command to backup the required data
 # This example saves the data via SSH to a remote system called vms
 EXTERNAL_BACKUP="tar -c -l -z / | ssh vms 'cat >rear64/backup.tar.gz'"
-# Command to restore the data
-EXTERNAL_RESTORE="ssh vms cat rear64/backup.tar.gz | tar -C /mnt/local -x -z"
+# Command to restore the data (by default $RECOVERY_FS_ROOT is '/mnt/local')
+EXTERNAL_RESTORE="ssh vms cat rear64/backup.tar.gz | tar -C $RECOVERY_FS_ROOT -x -z"
 # The following exit codes from EXTERNAL_* should not abort the backup or recovery
 # This example is useful for rsync
 EXTERNAL_IGNORE_ERRORS=( 23 24 )
@@ -904,9 +904,10 @@ ELILO_BIN=
 
 ################ ---- custom scripts
 #
-# NOTE: The scripts can be defined as an array to better handly spaces in parameters. The
-# scripts are called like this: eval "${PRE_RECOVERY_SCRIPT[@]}"
-# call this after Rela-and-Recover did everything in the recover workflow. /mnt/local refers to the recovered system
+# NOTE: The scripts can be defined as an array to better handly spaces in parameters.
+# The scripts are called like this: eval "${PRE_RECOVERY_SCRIPT[@]}"
+# Call this after Rela-and-Recover did everything in the recover workflow.
+# Use $RECOVERY_FS_ROOT (by default '/mnt/local') to refer to the recovered system.
 POST_RECOVERY_SCRIPT=
 
 # call this before Relax-and-Recover starts to do anything in the recover workflow. You have the rescue system but nothing else
@@ -933,5 +934,3 @@ export TMPDIR    # the export is required so that mktemp can pickup the variable
 # Specify if rear is managed from DRLM (y/n) [ default (n) ].
 DRLM_MANAGED=n
 
-# default location of the disklayout.conf file create by savelayout
-DISKLAYOUT_FILE="$VAR_DIR/layout/disklayout.conf"

--- a/usr/share/rear/finalize/Fedora/i386/17_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Fedora/i386/17_rebuild_initramfs.sh
@@ -23,7 +23,7 @@ if test -s $TMP_DIR/storage_drivers && ! diff $TMP_DIR/storage_drivers $VAR_DIR/
 	# To see what has been added by the migration process, the new modules are added to the
 	# end of the list. To achieve this, we list the old modules twice in the variable
 	# NEW_INITRD_MODULES and then add the new modules. Then we use "uniq -u" to filter out
-	# the modules which only appear once in the list. The resulting array 
+	# the modules which only appear once in the list. The resulting array
 	# contains the new modules also.
 	NEW_INITRD_MODULES=( ${OLD_INITRD_MODULES[@]} ${OLD_INITRD_MODULES[@]} $( cat $TMP_DIR/storage_drivers ) )
 
@@ -35,7 +35,7 @@ if test -s $TMP_DIR/storage_drivers && ! diff $TMP_DIR/storage_drivers $VAR_DIR/
 	INITRD_MODULES="${OLD_INITRD_MODULES[@]} ${NEW_INITRD_MODULES[@]}"
 
 	WITH_INITRD_MODULES=$( printf '%s\n' ${INITRD_MODULES[@]} | awk '{printf "--with=%s ", $1}' )
-	
+
 	mount -t proc none /mnt/local/proc
 	mount -t sysfs none /mnt/local/sys
 
@@ -49,21 +49,20 @@ if test -s $TMP_DIR/storage_drivers && ! diff $TMP_DIR/storage_drivers $VAR_DIR/
         unalias ls 2>/dev/null
 
         for INITRD_IMG in $(ls /mnt/local/boot/initramfs-*.img /mnt/local/boot/initrd-*.img | egrep -v '(kdump|rescue|plymouth)') ; do
-
-            KERNEL_VERSION=$(basename $(echo $INITRD_IMG) | cut -f2- -d"-" | sed s/"\.img"//)
-            INITRD=$(echo $INITRD_IMG|egrep -o "/boot/.*")
+            # do not use KERNEL_VERSION here because that is readonly in the rear main script:
+            kernel_version=$( basename $( echo $INITRD_IMG ) | cut -f2- -d"-" | sed s/"\.img"// )
+            INITRD=$( echo $INITRD_IMG|egrep -o "/boot/.*" )
 
             echo "Running mkinitrd..."
-            if chroot /mnt/local /bin/bash --login -c "mkinitrd -v -f ${WITH_INITRD_MODULES[@]} $INITRD $KERNEL_VERSION" >&2 ; then
-                        LogPrint "Updated initramfs with new drivers for Kernel $KERNEL_VERSION."
+            if chroot /mnt/local /bin/bash --login -c "mkinitrd -v -f ${WITH_INITRD_MODULES[@]} $INITRD $kernel_version" >&2 ; then
+                LogPrint "Updated initramfs with new drivers for Kernel $kernel_version."
             else
-                        LogPrint "WARNING !!!
-initramfs creation for Kernel $KERNEL_VERSION failed, please check '$LOGFILE' to see the error
-messages in detail and decide yourself, wether the system will boot or not.
+                LogPrint "WARNING !!!
+initramfs creation for Kernel version '$kernel_version' failed,
+please check '$LOGFILE' to see the error messages in detail
+and decide yourself, wether the system will boot or not.
 "
             fi
-
-
 
         done
 

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -82,7 +82,7 @@ function DoExitTasks () {
 # activate the trap function
 builtin trap "DoExitTasks" 0
 # keep PID of main process
-MASTER_PID=$$
+readonly MASTER_PID=$$
 # duplication STDOUT to fd7 to use for Print
 exec 7>&1
 QuietAddExitTask "exec 7>&-"

--- a/usr/share/rear/lib/format-workflow.sh
+++ b/usr/share/rear/lib/format-workflow.sh
@@ -13,13 +13,14 @@ WORKFLOW_format () {
     local DEVICE=""
 
     # Parse options
-    OPTS="$(getopt -n "$PROGRAM format" -o "efhy" -l "efi,force,help,yes" -- "$@")"
+    # (do not use OPTS here because that is readonly in the rear main script):
+    format_workflow_opts="$(getopt -n "$PROGRAM format" -o "efhy" -l "efi,force,help,yes" -- "$@")"
     if (( $? != 0 )); then
         echo "Try \`$PROGRAM format -- --help' for more information."
         exit 1
     fi
 
-    eval set -- "$OPTS"
+    eval set -- "$format_workflow_opts"
     while true; do
         case "$1" in
             (-e|--efi) EFI=y;;
@@ -52,3 +53,4 @@ WORKFLOW_format () {
     SourceStage "format"
 
 }
+

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -36,7 +36,6 @@ function Source () {
     [[ "$STEPBYSTEP" || ( "$BREAKPOINT" && "$relname" == "$BREAKPOINT" ) ]] && read -p "Press ENTER to include '$source_file' ..." 2>&1
     Log "Including $relname"
     # DEBUGSCRIPTS mode settings:
-    test "$DEBUGSCRIPTS_ARGUMENT" || DEBUGSCRIPTS_ARGUMENT="x"
     if test "$DEBUGSCRIPTS" ; then
         Debug "Enabling debugscripts mode: 'set -$DEBUGSCRIPTS_ARGUMENT'"
         set -$DEBUGSCRIPTS_ARGUMENT
@@ -45,10 +44,6 @@ function Source () {
     source "$source_file"
     # Undo DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        # Assume $DEBUGSCRIPTS_ARGUMENT is "xvue +h -o pipefail"
-        # then the opposite is created by interchanging '+' and '-'
-        # so that DEBUGSCRIPTS_OPPOSITE_ARGUMENT is "xvue -h +o pipefail"
-        DEBUGSCRIPTS_OPPOSITE_ARGUMENT="$( echo "$DEBUGSCRIPTS_ARGUMENT" | tr '+-' '-+' )"
         Debug "Disabling debugscripts mode: 'set +$DEBUGSCRIPTS_OPPOSITE_ARGUMENT'"
         set +$DEBUGSCRIPTS_OPPOSITE_ARGUMENT
     fi

--- a/usr/share/rear/restore/NBU/default/40_restore_with_nbu.sh
+++ b/usr/share/rear/restore/NBU/default/40_restore_with_nbu.sh
@@ -19,17 +19,18 @@ LogPrint "NetBackup: restoring / into /mnt/local"
 
 echo "change / to /mnt/local" > $TMP_DIR/nbu_change_file
 
+# Do not use ARGS here because that is readonly in the rear main script:
 if [ ${#NBU_ENDTIME[@]} -gt 0 ]
 then
    edate="${NBU_ENDTIME[@]}"
-   ARGS="-B -H -L $TMP_DIR/bplog.restore -8 -R $TMP_DIR/nbu_change_file -t 0 -w 0 -e ${edate} -C ${NBU_CLIENT_SOURCE} -D ${NBU_CLIENT_NAME} -f $TMP_DIR/restore_fs_list"
+   bprestore_args="-B -H -L $TMP_DIR/bplog.restore -8 -R $TMP_DIR/nbu_change_file -t 0 -w 0 -e ${edate} -C ${NBU_CLIENT_SOURCE} -D ${NBU_CLIENT_NAME} -f $TMP_DIR/restore_fs_list"
 else
-   ARGS="-B -H -L $TMP_DIR/bplog.restore -8 -R $TMP_DIR/nbu_change_file -t 0 -w 0 -C ${NBU_CLIENT_SOURCE} -D ${NBU_CLIENT_NAME} -f $TMP_DIR/restore_fs_list"
+   bprestore_args="-B -H -L $TMP_DIR/bplog.restore -8 -R $TMP_DIR/nbu_change_file -t 0 -w 0 -C ${NBU_CLIENT_SOURCE} -D ${NBU_CLIENT_NAME} -f $TMP_DIR/restore_fs_list"
 fi
 
-LogPrint "RUN: /usr/openv/netbackup/bin/bprestore ${ARGS}"
+LogPrint "RUN: /usr/openv/netbackup/bin/bprestore $bprestore_args"
 LogPrint "Restore progress: see $TMP_DIR/bplog.restore"
-LANG=C /usr/openv/netbackup/bin/bprestore ${ARGS}
+LANG=C /usr/openv/netbackup/bin/bprestore $bprestore_args
 if (( $? > 1 )); then
     Error "bprestore failed (return code = $?)"
 fi

--- a/usr/share/rear/restore/NETFS/Linux-i386/51_selinux_fixfiles_exclude_dirs.sh
+++ b/usr/share/rear/restore/NETFS/Linux-i386/51_selinux_fixfiles_exclude_dirs.sh
@@ -1,11 +1,16 @@
+
 # for UEFI only we should avoid SElinux relabeling vfat filesystem: /boot/efi
-(( USING_UEFI_BOOTLOADER )) || return  # empty or 0 means using BIOS method
 
-# check if /mnt/local/boot/efi is mounted
-[[ -d "/mnt/local/boot/efi" ]]
-StopIfError "Could not find directory /mnt/local/boot/efi"
+# empty or 0 means using BIOS method
+(( USING_UEFI_BOOTLOADER )) || return
 
-cat > /mnt/local/etc/selinux/fixfiles_exclude_dirs <<EOF
+# check if $RECOVERY_FS_ROOT/boot/efi is mounted
+if ! test -d "$RECOVERY_FS_ROOT/boot/efi" ; then
+    Error "Could not find directory $RECOVERY_FS_ROOT/boot/efi"
+fi
+
+cat > $RECOVERY_FS_ROOT/etc/selinux/fixfiles_exclude_dirs <<EOF
 /boot/efi
 /boot/efi(/.*)?
 EOF
+

--- a/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
@@ -43,30 +43,30 @@ case "$BACKUP_PROG" in
             LAST="$restorearchive"
             BASE=$(dirname "$restorearchive")/$(tar --test-label -f "$restorearchive")
             if [ "$BASE" == "$LAST" ]; then
-                Log dd if=$BASE \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
-                dd if=$BASE | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
+                Log dd if=$BASE \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
+                dd if=$BASE | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
             else
-                Log dd if="$BASE" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
-                dd if="$BASE" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
-                Log dd if="$LAST" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
-                dd if="$LAST" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
+                Log dd if="$BASE" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
+                dd if="$BASE" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
+                Log dd if="$LAST" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
+                dd if="$LAST" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
             fi
         else
-            Log dd if=$restoreinput \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
-            dd if=$restoreinput | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C /mnt/local/ -x -f -
+            Log dd if=$restoreinput \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
+            dd if=$restoreinput | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
         fi
     ;;
     (rsync)
         if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
             BACKUP_RSYNC_OPTIONS=( "${BACKUP_RSYNC_OPTIONS[@]}" --exclude-from=$TMP_DIR/restore-exclude-list.txt )
         fi
-        Log $BACKUP_PROG $v "${BACKUP_RSYNC_OPTIONS[@]}"  "$backuparchive"/ /mnt/local/
-        $BACKUP_PROG  $v "${BACKUP_RSYNC_OPTIONS[@]}" "$backuparchive"/ /mnt/local/
+        Log $BACKUP_PROG $v "${BACKUP_RSYNC_OPTIONS[@]}"  "$backuparchive"/ $RECOVERY_FS_ROOT/
+        $BACKUP_PROG  $v "${BACKUP_RSYNC_OPTIONS[@]}" "$backuparchive"/ $RECOVERY_FS_ROOT/
     ;;
     (*)
         Log "Using unsupported backup program '$BACKUP_PROG'"
         $BACKUP_PROG $BACKUP_PROG_COMPRESS_OPTIONS \
-            $BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE /mnt/local \
+            $BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE $RECOVERY_FS_ROOT \
             $BACKUP_PROG_OPTIONS $backuparchive
     ;;
 esac >"${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log"

--- a/usr/share/rear/restore/NETFS/default/50_selinux_autorelabel.sh
+++ b/usr/share/rear/restore/NETFS/default/50_selinux_autorelabel.sh
@@ -1,9 +1,11 @@
-# If selinux was turned off for the backup we have to label the
-local scheme=$(url_scheme $BACKUP_URL)
-local path=$(url_path $BACKUP_URL)
-local opath=$(backup_path $scheme $path)
 
-[ -f "${opath}/selinux.autorelabel" ] && { \
-	touch /mnt/local/.autorelabel
-	Log "Created /.autorelabel file : after reboot SELinux will relabel all files"
-	}
+# If selinux was turned off for the backup we have to label the
+local scheme=$( url_scheme $BACKUP_URL )
+local path=$( url_path $BACKUP_URL )
+local opath=$( backup_path $scheme $path )
+
+if test -f "$opath/selinux.autorelabel" ; then
+    touch $RECOVERY_FS_ROOT/.autorelabel
+    Log "Created /.autorelabel file : after reboot SELinux will relabel all files"
+fi
+

--- a/usr/share/rear/restore/SUSE_LINUX/91_create_missing_directories.sh
+++ b/usr/share/rear/restore/SUSE_LINUX/91_create_missing_directories.sh
@@ -1,7 +1,23 @@
 #
-# SuSE likes to have stuff under /media
-#
-# create missing directories
-pushd /mnt/local >&8
-mkdir -p media/cdrom media/floppy
+# In some cases SUSE has /media plus /media/cdrom and /media/floppy.
+# On SLE11 the filesystem RPM contains them.
+# On SLE12 they are dropped from the filesystem RPM because nowadays /run/media is used.
+# There is the SUSE-internal issue https://bugzilla.suse.com/show_bug.cgi?id=890198
+# and the "SUSE Linux Enterprise Server 12 Release Notes" mention it
+# see https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12/ that reads:
+#   "/run/media/<user_name> is now used as top directory for removable
+#    media mount points. It replaces /media , which is not longer available."
+# Therefore for SLE12 "rear recover" must no longer create them.
+# FIXME: The following test for SLE12 products is intentionally sloppy
+# because I <jsmeix@suse.de> have no better idea how to test for various
+# posible SLE12-based products like "SUSE Linux Enterprise Server 12"
+# "SUSE Linux Enterprise Desktop 12" "SUSE Linux Enterprise Server 12 SP1"
+# "SUSE Linux Enterprise Desktop 12 SP1" "SUSE Linux Enterprise <whatever> <whichever>".
+# Therefore it is triggered only by the absence of /etc/os-release because
+# I assume that the switch from /media to /run/media matches reasonably well
+# with the switch from /etc/SuSE-release to /etc/os-release so that
+# this test is also (hopefully) somewhat future-proof (e.g. for SLE13):
+pushd $RECOVERY_FS_ROOT >&8
+test -f etc/os-release || mkdir -p media/cdrom media/floppy
 popd >&8
+

--- a/usr/share/rear/wrapup/default/98_good_bye.sh
+++ b/usr/share/rear/wrapup/default/98_good_bye.sh
@@ -2,5 +2,6 @@
 ###
 
 Print "
-Finished recovering your system. You can explore it under '/mnt/local'.
+Finished recovering your system. You can explore it under '$RECOVERY_FS_ROOT'.
 "
+


### PR DESCRIPTION
In particular have '/mnt/local' as readonly
variable RECOVERY_FS_ROOT in usr/sbin/rear
see https://github.com/rear/rear/issues/708
and use $RECOVERY_FS_ROOT in the scripts instead
of hardcoded '/mnt/local' but currently only a few scripts
are adapted so that I can test if it works at all (and for me
it does work).

Have several more readonly constants in the main rear script
like SHARE_DIR CONFIG_DIR VAR_DIR LOG_DIR ...
see https://github.com/rear/rear/issues/678
and fixed if readonly constants are modified in other scripts
as far as currently possible for me.

Additionally the DISKLAYOUT_FILE variable is moved from
usr/share/rear/conf/default.conf to usr/sbin/rear because
it is not meant to be configured by the user
see https://github.com/rear/rear/issues/678
    
By the way fixed creation of /media /media/cdrom /media/floppy in
usr/share/rear/restore/SUSE_LINUX/91_create_missing_directories.sh
because those directories ar no longer needed since SLE12.
