### PR TITLE
Save and restore bash flags and options settings

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,11 +3,11 @@ Relax-and-Recover
 
 Relax-and-Recover is the leading Open Source bare metal disaster recovery
 and system migration solution. It is a modular framework with many
-ready-to-go workflows for common situations. 
+ready-to-go workflows for common situations.
 
 Relax-and-Recover produces a bootable image. This image can repartition the
 system. Once that is done it initiates a restore from backup. Restores to
-different hardware are possible. Relax-and-Recover can therefore be used as a 
+different hardware are possible. Relax-and-Recover can therefore be used as a
 migration tool as well.
 
 Currently Relax-and-Recover supports various boot media (incl. ISO, PXE,
@@ -115,11 +115,10 @@ Now you are ready to create a rescue image. We want verbose output (-v option).
 
 The output I get is:
 ----
-Relax-and-Recover 1.13.0 / $Date$
-Using log file: /home/jeroen/tmp/quickstart/rear/var/log/rear/rear-fireflash.log
+Relax-and-Recover <version>
+Using log file: /var/log/rear/rear-<hostname>.log
 Creating disk layout
 Creating root filesystem layout
-TIP: To login as root via ssh you need to set up /root/.ssh/authorized_keys
 Copying files and directories
 Copying binaries and libraries
 Copying kernel modules
@@ -196,19 +195,23 @@ To use Relax-and-Recover you always call the main script '/usr/sbin/rear':
 
 ----
 # rear help
-Usage: rear [-d] [-D] [-r KERNEL] [-s] [-S] [-v] [-V] COMMAND [ARGS...]
+
+Usage: rear [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-r KERNEL] [--] COMMAND [ARGS...]
 
 Relax-and-Recover comes with ABSOLUTELY NO WARRANTY; for details see
 the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 Available options:
- -d           debug mode; log debug messages
- -D           debugscript mode; log every function call
- -r KERNEL    kernel version to use; current: '2.6.32-131.2.1.el6.x86_64'
- -s           simulation mode; show what scripts rear would include
- -S           step-by-step mode; acknowledge each script individually
- -v           verbose mode; show more output
- -V           version information
+ -h --help           usage information
+ -c DIR              alternative config directory; instead of /etc/rear
+ -d                  debug mode; log debug messages
+ -D                  debugscript mode; log every function call (via 'set -x')
+ --debugscripts SET  same as -d -v -D but debugscript mode with 'set -SET'
+ -r KERNEL           kernel version to use; current: '3.12.49-3-default'
+ -s                  simulation mode; show what scripts rear would include
+ -S                  step-by-step mode; acknowledge each script individually
+ -v                  verbose mode; show more output
+ -V --version        version information
 
 List of commands:
  checklayout     check if the disk layout has changed
@@ -217,6 +220,7 @@ List of commands:
  mkbackup        create rescue media and backup system
  mkbackuponly    backup system without creating rescue media
  mkrescue        create rescue media only
+ recover         recover the system
  validate        submit validation information
 
 Use 'rear -v help' for more advanced commands.

--- a/doc/rear-presentation.adoc
+++ b/doc/rear-presentation.adoc
@@ -252,7 +252,8 @@ ISO_URL=http://server:port/path/
 
 ----
 [root@moria rear]# rear help
-Usage: rear [-dDsSvV] [-r KERNEL] COMMAND [-- ARGS...]
+
+Usage: $PROGRAM [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-r KERNEL] [--] COMMAND [ARGS...]
 -snip-
 List of commands:
  checklayout     check if the disk layout has changed
@@ -271,16 +272,20 @@ Use 'rear -v help' for more advanced commands.
 
 ----
 [root@moria rear]# rear help
-Usage: rear [-dDsSvV] [-r KERNEL] COMMAND [-- ARGS...]
+
+Usage: $PROGRAM [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-r KERNEL] [--] COMMAND [ARGS...]
 
 Available options:
- -d           debug mode; log debug messages
- -D           debugscript mode; log every function call
- -r KERNEL    kernel version to use
- -s           simulation mode; show included scripts
- -S           step-by-step mode; ack each script one-by-one
- -v           verbose mode; show more output
- -V           version information
+ -h --help           usage information
+ -c DIR              alternative config directory; instead of /etc/rear
+ -d                  debug mode; log debug messages
+ -D                  debugscript mode; log every function call (via 'set -x')
+ --debugscripts SET  same as -d -v -D but debugscript mode with 'set -SET'
+ -r KERNEL           kernel version to use; current: '$KERNEL_VERSION'
+ -s                  simulation mode; show what scripts rear would include
+ -S                  step-by-step mode; acknowledge each script individually
+ -v                  verbose mode; show more output
+ -V --version        version information
 
 -snip-
 ----
@@ -294,7 +299,7 @@ Available options:
   - Use: +rear -s <workflow>+
 
 * Logging
-  - Logfile in: _/tmp/rear-hostname.log_
+  - Logfile in: _/var/log/rear/rear-<hostname>.log_
 
 * Debugging
   - Verbose: +rear -v+

--- a/doc/rear.8
+++ b/doc/rear.8
@@ -31,7 +31,7 @@
 rear \- bare metal disaster recovery and system migration tool
 .SH "SYNOPSIS"
 .sp
-\fBrear\fR [\fB\-dDsSvV\fR] [\fB\-r\fR \fIKERNEL\fR] \fICOMMAND\fR [\-\- \fIARGS\fR\&...]
+\fBrear\fR [\fB\-h\fR \||\| \fB\-\-help\fR] [\fB\-V\fR \||\| \fB\-\-version\fR] [\fB\-dsSv\fR] [\fB\-D\fR \||\| \fB\-\-debugscripts\fR \fISET\fR] [\fB\-c\fR \fIDIR\fR] [\fB\-r\fR \fIKERNEL\fR] [\-\-] \fICOMMAND\fR [\fIARGS\fR\&...]
 .SH "DESCRIPTION"
 .sp
 Relax\-and\-Recover is the leading Open Source disaster recovery solution\&. It is a modular framework with many ready\-to\-go workflows for common situations\&.
@@ -50,6 +50,17 @@ Relax\-and\-Recover comes with ABSOLUTELY NO WARRANTY; for details see the GNU G
 .SH "OPTIONS"
 .SS "GLOBAL OPTIONS"
 .PP
+\-h --help
+.RS 4
+\fBusage information\fR
+.RE
+.PP
+\-c DIR
+.RS 4
+alternative config directory
+(instead of /etc/rear)
+.RE
+.PP
 \-d
 .RS 4
 \fBdebug mode\fR
@@ -59,7 +70,13 @@ Relax\-and\-Recover comes with ABSOLUTELY NO WARRANTY; for details see the GNU G
 \-D
 .RS 4
 \fBdebugscript mode\fR
-(log every function call)
+(log every function call via 'set -x')
+.RE
+.PP
+\--debugscripts SET
+.RS 4
+\fBdebugscript mode\fR
+(same as -d -v -D but with 'set -SET')
 .RE
 .PP
 \-r KERNEL
@@ -85,7 +102,7 @@ kernel version to use (by default use running kernel)
 (show progress output)
 .RE
 .PP
-\-V
+\-V --version
 .RS 4
 version information
 .RE

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -12,16 +12,16 @@ rear - bare metal disaster recovery and system migration tool
 
 
 == SYNOPSIS
-*rear* [*-dDsSvV*] [*-r* _KERNEL_] _COMMAND_ [-- _ARGS_...]
+*rear* [*-h*|*--help*] [*-V*|*--version*] [*-dsSv*] [*-D*|*--debugscripts* _SET_] [*-c* _DIR_] [*-r* _KERNEL_] [--] _COMMAND_ [_ARGS_...]
 
 
 == DESCRIPTION
 Relax-and-Recover is the leading Open Source disaster recovery solution. It
-is a modular framework with many ready-to-go workflows for common situations. 
+is a modular framework with many ready-to-go workflows for common situations.
 
 Relax-and-Recover produces a bootable image. This image can repartition the
 system. Once that is done it initiates a restore from backup. Restores to
-different hardware are possible. Relax-and-Recover can therefore be used as a 
+different hardware are possible. Relax-and-Recover can therefore be used as a
 migration tool as well.
 
 Currently Relax-and-Recover supports various boot media (incl. ISO, PXE,
@@ -53,11 +53,21 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 === GLOBAL OPTIONS
 
+-h --help::
+    usage information
+
+
+-c DIR::
+    alternative config directory; instead of /etc/rear
+
 -d::
     *debug mode* (log debug messages to log file)
 
 -D::
-    *debugscript mode* (log every function call)
+    *debugscript mode* (log every function call via 'set -x')
+
+--debugscripts SET::
+    same as -d -v -D but *debugscript mode* with 'set -SET'
 
 -r KERNEL::
     kernel version to use (by default use running kernel)
@@ -71,7 +81,7 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 -v::
     *verbose mode* (show progress output)
 
--V::
+-V --version::
     version information
 
 === COMMANDS
@@ -158,8 +168,8 @@ OUTPUT=*USB*::
 Create a bootable USB disk (using extlinux). Specify the USB storage
 device by using +USB_DEVICE+.
 
-When using +OUTPUT=ISO+, +RAMDISK+, +OBDR+ or +USB+ you should provide the 
-backup target location through the +OUTPUT_URL+ variable. Possible +OUTPUT_URL+ 
+When using +OUTPUT=ISO+, +RAMDISK+, +OBDR+ or +USB+ you should provide the
+backup target location through the +OUTPUT_URL+ variable. Possible +OUTPUT_URL+
 settings are:
 
 OUTPUT_URL=*file://*::
@@ -316,7 +326,7 @@ If you combine this with +OUTPUT=USB+ you will end up with a bootable USB
 device.
 
 BACKUP_URL=*sshfs://*::
-To backup to a remote server via sshfs (SSH protocol), use 
+To backup to a remote server via sshfs (SSH protocol), use
 +BACKUP_URL=sshfs://user@remote-system.domain.org/home/user/backup-dir/+
 +
 It is advisable to add *ServerAliveInterval 15* in the +/root/.ssh/config+
@@ -441,7 +451,7 @@ issue-tracker at: http://github.com/rear/issues/
 Furthermore, we welcome pull requests via GitHub.
 
 == SEE ALSO
-Relax-and-Recover comes with extensive documentation located in 
+Relax-and-Recover comes with extensive documentation located in
 _/usr/share/doc_.
 
 

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -23,6 +23,38 @@
 # Jeroen Hoekx <jeroen.hoekx at hamok dot be> [JH]
 # Dag Wieers <dag at wieers dot com> [DAG]
 
+# The complementary stateful global functions to save and restore bash flags and options
+# and the array where the flags and options are stored are needed from the very beginning.
+# Lowercase bash_flags_and_options_array global name because it is not meant to be ever
+# used directly, only SaveBashFlagsAndOptions and RestoreBashFlagsAndOptions use it.
+# Initially the array has the empty string as dummy first element to avoid 'set -eu' error exit
+# when it is used as ${array[@]} in array=( "${array[@]}" "$e" ) in SaveBashFlagsAndOptions
+# (also array=( "${array[@]:-}" "$e" ) adds empty string as first element and $e as second element):
+bash_flags_and_options_array=("")
+function SaveBashFlagsAndOptions () {
+    # Get current flags and option settings as bash commands:
+    local flags_and_options_setting_commands=$( set +o | tr '\n' ';' ; shopt -p | tr '\n' ';' )
+    # Save current flags and option settings:.
+    bash_flags_and_options_array=( "${bash_flags_and_options_array[@]}" "$flags_and_options_setting_commands" )
+}
+function RestoreBashFlagsAndOptions () {
+    # I <jsmeix@suse.de> prefer using the last array index by subtracting 1 from the array size ${#array[@]}
+    # over string manipulation via ${array[@]:(-1)} because the later makes it less obvious what is done and
+    # using the index -1 to get the last element via ${array[-1]} does not work with bash-3.2 in SLE11
+    # and the last array index is needed anyway to remove the last element from the array:
+    local last_index=$(( ${#bash_flags_and_options_array[@]} - 1 ))
+    # If the array has only one element (the empty string dummy initial element) there is a bug in the code:
+    test "$last_index" -le "0" && BugError "RestoreBashFlagsAndOptions is called more often than SaveBashFlagsAndOptions." || true
+    # Get last saved bash commands to set flags and options:
+    local flags_and_options_setting_commands=${bash_flags_and_options_array[last_index]}
+    # Set flags and options to the last saved ones:
+    eval $flags_and_options_setting_commands
+    # Remove last saved bash commands from the array:
+    unset bash_flags_and_options_array[last_index]
+}
+# Save initial bash flags and options:
+SaveBashFlagsAndOptions
+
 # Enable as needed for development of fail-safe code:
 # set -xvue -o pipefail
 # set -ue -o pipefail
@@ -398,6 +430,9 @@ fi
 if test $EXIT_CODE -eq 0 ; then
     LogToSyslog "DONE: rc=$EXIT_CODE"
 fi
+
+# Restore initial bash flags and options:
+RestoreBashFlagsAndOptions
 
 exit $EXIT_CODE
 

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -23,38 +23,6 @@
 # Jeroen Hoekx <jeroen.hoekx at hamok dot be> [JH]
 # Dag Wieers <dag at wieers dot com> [DAG]
 
-# The complementary stateful global functions to save and restore bash flags and options
-# and the array where the flags and options are stored are needed from the very beginning.
-# Lowercase bash_flags_and_options_array global name because it is not meant to be ever
-# used directly, only SaveBashFlagsAndOptions and RestoreBashFlagsAndOptions use it.
-# Initially the array has the empty string as dummy first element to avoid 'set -eu' error exit
-# when it is used as ${array[@]} in array=( "${array[@]}" "$e" ) in SaveBashFlagsAndOptions
-# (also array=( "${array[@]:-}" "$e" ) adds empty string as first element and $e as second element):
-bash_flags_and_options_array=("")
-function SaveBashFlagsAndOptions () {
-    # Get current flags and option settings as bash commands:
-    local flags_and_options_setting_commands=$( set +o | tr '\n' ';' ; shopt -p | tr '\n' ';' )
-    # Save current flags and option settings:.
-    bash_flags_and_options_array=( "${bash_flags_and_options_array[@]}" "$flags_and_options_setting_commands" )
-}
-function RestoreBashFlagsAndOptions () {
-    # I <jsmeix@suse.de> prefer using the last array index by subtracting 1 from the array size ${#array[@]}
-    # over string manipulation via ${array[@]:(-1)} because the later makes it less obvious what is done and
-    # using the index -1 to get the last element via ${array[-1]} does not work with bash-3.2 in SLE11
-    # and the last array index is needed anyway to remove the last element from the array:
-    local last_index=$(( ${#bash_flags_and_options_array[@]} - 1 ))
-    # If the array has only one element (the empty string dummy initial element) there is a bug in the code:
-    test "$last_index" -le "0" && BugError "RestoreBashFlagsAndOptions is called more often than SaveBashFlagsAndOptions." || true
-    # Get last saved bash commands to set flags and options:
-    local flags_and_options_setting_commands=${bash_flags_and_options_array[last_index]}
-    # Set flags and options to the last saved ones:
-    eval $flags_and_options_setting_commands
-    # Remove last saved bash commands from the array:
-    unset bash_flags_and_options_array[last_index]
-}
-# Save initial bash flags and options:
-SaveBashFlagsAndOptions
-
 # Enable as needed for development of fail-safe code:
 # set -xvue -o pipefail
 # set -ue -o pipefail
@@ -62,6 +30,24 @@ SaveBashFlagsAndOptions
 # https://github.com/rear/rear/wiki/Coding-Style
 # that reads (excerpt - dated 18. Nov. 2015):
 # "TODO Use set -eu to die from unset variables and unhandled errors"
+
+# The complementary global functions to get and apply bash flags and options commands
+# are needed from the very beginning:
+function GetBashFlagsAndOptionsCommands () {
+    # Output bash commands that set the currently set flags:
+    set +o | tr '\n' ';'
+    # Output bash commands that set the currently set options:
+    shopt -p | tr '\n' ';'
+}
+# This function exists only to provide a syntactically matching counterpart of GetBashFlagsAndOptionsCommands:
+function ApplyBashFlagsAndOptionsCommands () {
+    # Must be called with $1 that is the output of a previous GetBashFlagsAndOptionsCommands call:
+    eval "$1"
+}
+# At the very beginning save initial bash flags and options in a global readonly variable
+# so that exactly the initial bash flags and options can be restored if needed via
+#   ApplyBashFlagsAndOptionsCommands "$INITIAL_FLAGS_AND_OPTIONS_SETTING_COMMANDS"
+readonly INITIAL_FLAGS_AND_OPTIONS_SETTING_COMMANDS="$( GetBashFlagsAndOptionsCommands )"
 
 # Versioning
 readonly PRODUCT="Relax-and-Recover"
@@ -110,7 +96,6 @@ readonly RECOVERY_FS_ROOT="/mnt/local"
 DEBUG=""
 DEBUGSCRIPTS=""
 DEBUGSCRIPTS_ARGUMENT="x"
-DEBUGSCRIPTS_OPPOSITE_ARGUMENT=$DEBUGSCRIPTS_ARGUMENT
 KEEP_BUILD_DIR=""
 KERNEL_VERSION=""
 RECOVERY_MODE=""
@@ -169,11 +154,6 @@ while true ; do
                 exit 1
             fi
             DEBUGSCRIPTS_ARGUMENT="$2"
-            # Assume $DEBUGSCRIPTS_ARGUMENT is "xvue +h -o pipefail"
-            # then the opposite is created by interchanging '+' and '-'
-            # so that DEBUGSCRIPTS_OPPOSITE_ARGUMENT is "xvue -h +o pipefail"
-            # (FIXME: interchanging all '+' and '-' fails for "-o interactive-comments"):
-            DEBUGSCRIPTS_OPPOSITE_ARGUMENT="$( echo "$DEBUGSCRIPTS_ARGUMENT" | tr '+-' '-+' )"
             shift
             ;;
         (-s)
@@ -241,7 +221,7 @@ esac
 # KERNEL_VERSION because if empty it is set when sourcing config files below
 # VERBOSE because there is a special "VERBOSE=1" setting below:
 readonly ARGS
-readonly DEBUG DEBUGSCRIPTS DEBUGSCRIPTS_ARGUMENT DEBUGSCRIPTS_OPPOSITE_ARGUMENT
+readonly DEBUG DEBUGSCRIPTS DEBUGSCRIPTS_ARGUMENT
 readonly SIMULATE STEPBYSTEP
 
 # The udev workflow is a special case because it is only a wrapper workflow
@@ -279,6 +259,10 @@ fi
 # (e.g. "ls foo*bar" becomes plain "ls" without "foo*bar: No such file or directory" error).
 # The extglob shell option enables several extended pattern matching operators.
 shopt -s nullglob extglob
+# Save the current default bash flags and options in a global readonly variable
+# so that exactly the default bash flags and options can be restored if needed via
+#   ApplyBashFlagsAndOptionsCommands "$DEFAULT_FLAGS_AND_OPTIONS_SETTING_COMMANDS"
+readonly DEFAULT_FLAGS_AND_OPTIONS_SETTING_COMMANDS="$( GetBashFlagsAndOptionsCommands )"
 
 # Forget all remembered full pathnames of commands:
 hash -r
@@ -430,9 +414,6 @@ fi
 if test $EXIT_CODE -eq 0 ; then
     LogToSyslog "DONE: rc=$EXIT_CODE"
 fi
-
-# Restore initial bash flags and options:
-RestoreBashFlagsAndOptions
 
 exit $EXIT_CODE
 

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -37,15 +37,16 @@ function Source () {
     Log "Including $relname"
     # DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        Debug "Enabling debugscripts mode: 'set -$DEBUGSCRIPTS_ARGUMENT'"
+        Debug "Entering debugscripts mode: First SaveBashFlagsAndOptions and then 'set -$DEBUGSCRIPTS_ARGUMENT'"
+        SaveBashFlagsAndOptions
         set -$DEBUGSCRIPTS_ARGUMENT
     fi
     # The actual work (source the source file):
     source "$source_file"
     # Undo DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        Debug "Disabling debugscripts mode: 'set +$DEBUGSCRIPTS_OPPOSITE_ARGUMENT'"
-        set +$DEBUGSCRIPTS_OPPOSITE_ARGUMENT
+        Debug "Leaving debugscripts mode: Back to previous settings via RestoreBashFlagsAndOptions"
+        RestoreBashFlagsAndOptions
     fi
     # Breakpoint if needed:
     [[ "$BREAKPOINT" && "$relname" == "$BREAKPOINT" ]] && read -p "Press ENTER to continue ..." 2>&1

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -37,16 +37,16 @@ function Source () {
     Log "Including $relname"
     # DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        Debug "Entering debugscripts mode: First SaveBashFlagsAndOptions and then 'set -$DEBUGSCRIPTS_ARGUMENT'"
-        SaveBashFlagsAndOptions
+        Debug "Entering debugscripts mode via 'set -$DEBUGSCRIPTS_ARGUMENT'."
+        local saved_bash_flags_and_options_commands="$( GetBashFlagsAndOptionsCommands )"
         set -$DEBUGSCRIPTS_ARGUMENT
     fi
     # The actual work (source the source file):
     source "$source_file"
     # Undo DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        Debug "Leaving debugscripts mode: Back to previous settings via RestoreBashFlagsAndOptions"
-        RestoreBashFlagsAndOptions
+        Debug "Leaving debugscripts mode (back to previous bash flags and options settings)."
+        ApplyBashFlagsAndOptionsCommands "$saved_bash_flags_and_options_commands"
     fi
     # Breakpoint if needed:
     [[ "$BREAKPOINT" && "$relname" == "$BREAKPOINT" ]] && read -p "Press ENTER to continue ..." 2>&1


### PR DESCRIPTION
Implemented simple functions GetBashFlagsAndOptionsCommands
and ApplyBashFlagsAndOptionsCommands that are used
in a fail-safe way via an explicit variable that stores the
current bash flags and options commands and using
that explicit variable to re-apply them, i.e. like
<pre>
      saved_flags_options_cmds="$( GetBashFlagsAndOptionsCommands )"
      ... [change bash flags and options]
      ... [do something]
      ApplyBashFlagsAndOptionsCommands "$saved_flags_options_cmds"
</pre>
See https://github.com/rear/rear/issues/700