### PR TITLE
Get and apply bash flags and options settings

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -22,9 +22,12 @@
 # Gratien D'haese  <gdha at sourceforge dot net> [GD]
 # Jeroen Hoekx <jeroen.hoekx at hamok dot be> [JH]
 # Dag Wieers <dag at wieers dot com> [DAG]
+# Johannes Meixner <jsmeix at suse dot de> [jsmeix]
 
-# The complementary global functions to get and apply bash flags and options commands
-# are needed from the very beginning (other functions are sourced at "Include functions" below):
+# Usually functions belong to the library scripts (i.e. $SHARE_DIR/lib/*.sh),
+# but these 2 are exceptions on the rule because the complementary global functions
+# to get and apply bash flags and options commands are needed from the very beginning
+# (the usual functions are sourced at "Include functions" below):
 function get_bash_flags_and_options_commands () {
     # Output bash commands that set the currently set flags
     # in reverse ordering to have "set ... xtrace" (i.e. "set +/- x") first

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -23,6 +23,38 @@
 # Jeroen Hoekx <jeroen.hoekx at hamok dot be> [JH]
 # Dag Wieers <dag at wieers dot com> [DAG]
 
+# The complementary stateful global functions to save and restore bash flags and options
+# and the array where the flags and options are stored are needed from the very beginning.
+# Lowercase bash_flags_and_options_array global name because it is not meant to be ever
+# used directly, only SaveBashFlagsAndOptions and RestoreBashFlagsAndOptions use it.
+# Initially the array has the empty string as dummy first element to avoid 'set -eu' error exit
+# when it is used as ${array[@]} in array=( "${array[@]}" "$e" ) in SaveBashFlagsAndOptions
+# (also array=( "${array[@]:-}" "$e" ) adds empty string as first element and $e as second element):
+bash_flags_and_options_array=("")
+function SaveBashFlagsAndOptions () {
+    # Get current flags and option settings as bash commands:
+    local flags_and_options_setting_commands=$( set +o | tr '\n' ';' ; shopt -p | tr '\n' ';' )
+    # Save current flags and option settings:.
+    bash_flags_and_options_array=( "${bash_flags_and_options_array[@]}" "$flags_and_options_setting_commands" )
+}
+function RestoreBashFlagsAndOptions () {
+    # I <jsmeix@suse.de> prefer using the last array index by subtracting 1 from the array size ${#array[@]}
+    # over string manipulation via ${array[@]:(-1)} because the later makes it less obvious what is done and
+    # using the index -1 to get the last element via ${array[-1]} does not work with bash-3.2 in SLE11
+    # and the last array index is needed anyway to remove the last element from the array:
+    local last_index=$(( ${#bash_flags_and_options_array[@]} - 1 ))
+    # If the array has only one element (the empty string dummy initial element) there is a bug in the code:
+    test "$last_index" -le "0" && BugError "RestoreBashFlagsAndOptions is called more often than SaveBashFlagsAndOptions." || true
+    # Get last saved bash commands to set flags and options:
+    local flags_and_options_setting_commands=${bash_flags_and_options_array[last_index]}
+    # Set flags and options to the last saved ones:
+    eval $flags_and_options_setting_commands
+    # Remove last saved bash commands from the array:
+    unset bash_flags_and_options_array[last_index]
+}
+# Save initial bash flags and options:
+SaveBashFlagsAndOptions
+
 # Enable as needed for development of fail-safe code:
 # set -xvue -o pipefail
 # set -ue -o pipefail
@@ -398,6 +430,9 @@ fi
 if test $EXIT_CODE -eq 0 ; then
     LogToSyslog "DONE: rc=$EXIT_CODE"
 fi
+
+# Restore initial bash flags and options:
+RestoreBashFlagsAndOptions
 
 exit $EXIT_CODE
 

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -23,31 +23,35 @@
 # Jeroen Hoekx <jeroen.hoekx at hamok dot be> [JH]
 # Dag Wieers <dag at wieers dot com> [DAG]
 
-# Enable as needed for development of fail-safe code:
-# set -xvue -o pipefail
-# set -ue -o pipefail
-# Cf. the Relax-and-Recover Coding Style
-# https://github.com/rear/rear/wiki/Coding-Style
-# that reads (excerpt - dated 18. Nov. 2015):
-# "TODO Use set -eu to die from unset variables and unhandled errors"
-
 # The complementary global functions to get and apply bash flags and options commands
-# are needed from the very beginning:
-function GetBashFlagsAndOptionsCommands () {
-    # Output bash commands that set the currently set flags:
-    set +o | tr '\n' ';'
+# are needed from the very beginning (other functions are sourced at "Include functions" below):
+function get_bash_flags_and_options_commands () {
+    # Output bash commands that set the currently set flags
+    # in reverse ordering to have "set ... xtrace" (i.e. "set +/- x") first
+    # so that this flag is set first via apply_bash_flags_and_options_commands
+    # which results better matching logging output in debugscripts mode:
+    set +o | tac | tr '\n' ';'
     # Output bash commands that set the currently set options:
     shopt -p | tr '\n' ';'
 }
-# This function exists only to provide a syntactically matching counterpart of GetBashFlagsAndOptionsCommands:
-function ApplyBashFlagsAndOptionsCommands () {
-    # Must be called with $1 that is the output of a previous GetBashFlagsAndOptionsCommands call:
+# This function exists only to provide a syntactically matching counterpart of get_bash_flags_and_options_commands:
+function apply_bash_flags_and_options_commands () {
+    # Must be called with $1 that is the output of a previous get_bash_flags_and_options_commands:
     eval "$1"
 }
 # At the very beginning save initial bash flags and options in a global readonly variable
 # so that exactly the initial bash flags and options can be restored if needed via
-#   ApplyBashFlagsAndOptionsCommands "$INITIAL_FLAGS_AND_OPTIONS_SETTING_COMMANDS"
-readonly INITIAL_FLAGS_AND_OPTIONS_SETTING_COMMANDS="$( GetBashFlagsAndOptionsCommands )"
+#   apply_bash_flags_and_options_commands "$INITIAL_BASH_FLAGS_AND_OPTIONS_COMMANDS"
+readonly INITIAL_BASH_FLAGS_AND_OPTIONS_COMMANDS="$( get_bash_flags_and_options_commands )"
+
+# Enable as needed for development of fail-safe code:
+# set -ue -o pipefail
+# set -xue -o pipefail
+# set -xvue -o pipefail
+# Cf. the Relax-and-Recover Coding Style
+# https://github.com/rear/rear/wiki/Coding-Style
+# that reads (excerpt - dated 18. Nov. 2015):
+# "TODO Use set -eu to die from unset variables and unhandled errors"
 
 # Versioning
 readonly PRODUCT="Relax-and-Recover"
@@ -261,8 +265,8 @@ fi
 shopt -s nullglob extglob
 # Save the current default bash flags and options in a global readonly variable
 # so that exactly the default bash flags and options can be restored if needed via
-#   ApplyBashFlagsAndOptionsCommands "$DEFAULT_FLAGS_AND_OPTIONS_SETTING_COMMANDS"
-readonly DEFAULT_FLAGS_AND_OPTIONS_SETTING_COMMANDS="$( GetBashFlagsAndOptionsCommands )"
+#   apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"
+readonly DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS="$( get_bash_flags_and_options_commands )"
 
 # Forget all remembered full pathnames of commands:
 hash -r

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -23,38 +23,6 @@
 # Jeroen Hoekx <jeroen.hoekx at hamok dot be> [JH]
 # Dag Wieers <dag at wieers dot com> [DAG]
 
-# The complementary stateful global functions to save and restore bash flags and options
-# and the array where the flags and options are stored are needed from the very beginning.
-# Lowercase bash_flags_and_options_array global name because it is not meant to be ever
-# used directly, only SaveBashFlagsAndOptions and RestoreBashFlagsAndOptions use it.
-# Initially the array has the empty string as dummy first element to avoid 'set -eu' error exit
-# when it is used as ${array[@]} in array=( "${array[@]}" "$e" ) in SaveBashFlagsAndOptions
-# (also array=( "${array[@]:-}" "$e" ) adds empty string as first element and $e as second element):
-bash_flags_and_options_array=("")
-function SaveBashFlagsAndOptions () {
-    # Get current flags and option settings as bash commands:
-    local flags_and_options_setting_commands=$( set +o | tr '\n' ';' ; shopt -p | tr '\n' ';' )
-    # Save current flags and option settings:.
-    bash_flags_and_options_array=( "${bash_flags_and_options_array[@]}" "$flags_and_options_setting_commands" )
-}
-function RestoreBashFlagsAndOptions () {
-    # I <jsmeix@suse.de> prefer using the last array index by subtracting 1 from the array size ${#array[@]}
-    # over string manipulation via ${array[@]:(-1)} because the later makes it less obvious what is done and
-    # using the index -1 to get the last element via ${array[-1]} does not work with bash-3.2 in SLE11
-    # and the last array index is needed anyway to remove the last element from the array:
-    local last_index=$(( ${#bash_flags_and_options_array[@]} - 1 ))
-    # If the array has only one element (the empty string dummy initial element) there is a bug in the code:
-    test "$last_index" -le "0" && BugError "RestoreBashFlagsAndOptions is called more often than SaveBashFlagsAndOptions." || true
-    # Get last saved bash commands to set flags and options:
-    local flags_and_options_setting_commands=${bash_flags_and_options_array[last_index]}
-    # Set flags and options to the last saved ones:
-    eval $flags_and_options_setting_commands
-    # Remove last saved bash commands from the array:
-    unset bash_flags_and_options_array[last_index]
-}
-# Save initial bash flags and options:
-SaveBashFlagsAndOptions
-
 # Enable as needed for development of fail-safe code:
 # set -xvue -o pipefail
 # set -ue -o pipefail
@@ -62,6 +30,24 @@ SaveBashFlagsAndOptions
 # https://github.com/rear/rear/wiki/Coding-Style
 # that reads (excerpt - dated 18. Nov. 2015):
 # "TODO Use set -eu to die from unset variables and unhandled errors"
+
+# The complementary global functions to get and apply bash flags and options commands
+# are needed from the very beginning:
+function GetBashFlagsAndOptionsCommands () {
+    # Output bash commands that set the currently set flags:
+    set +o | tr '\n' ';'
+    # Output bash commands that set the currently set options:
+    shopt -p | tr '\n' ';'
+}
+# This function exists only to provide a syntactically matching counterpart of GetBashFlagsAndOptionsCommands:
+function ApplyBashFlagsAndOptionsCommands () {
+    # Must be called with $1 that is the output of a previous GetBashFlagsAndOptionsCommands call:
+    eval "$1"
+}
+# At the very beginning save initial bash flags and options in a global readonly variable
+# so that exactly the initial bash flags and options can be restored if needed via
+#   ApplyBashFlagsAndOptionsCommands "$INITIAL_FLAGS_AND_OPTIONS_SETTING_COMMANDS"
+readonly INITIAL_FLAGS_AND_OPTIONS_SETTING_COMMANDS="$( GetBashFlagsAndOptionsCommands )"
 
 # Versioning
 readonly PRODUCT="Relax-and-Recover"
@@ -110,7 +96,6 @@ readonly RECOVERY_FS_ROOT="/mnt/local"
 DEBUG=""
 DEBUGSCRIPTS=""
 DEBUGSCRIPTS_ARGUMENT="x"
-DEBUGSCRIPTS_OPPOSITE_ARGUMENT=$DEBUGSCRIPTS_ARGUMENT
 KEEP_BUILD_DIR=""
 KERNEL_VERSION=""
 RECOVERY_MODE=""
@@ -169,11 +154,6 @@ while true ; do
                 exit 1
             fi
             DEBUGSCRIPTS_ARGUMENT="$2"
-            # Assume $DEBUGSCRIPTS_ARGUMENT is "xvue +h -o pipefail"
-            # then the opposite is created by interchanging '+' and '-'
-            # so that DEBUGSCRIPTS_OPPOSITE_ARGUMENT is "xvue -h +o pipefail"
-            # (FIXME: interchanging all '+' and '-' fails for "-o interactive-comments"):
-            DEBUGSCRIPTS_OPPOSITE_ARGUMENT="$( echo "$DEBUGSCRIPTS_ARGUMENT" | tr '+-' '-+' )"
             shift
             ;;
         (-s)
@@ -241,7 +221,7 @@ esac
 # KERNEL_VERSION because if empty it is set when sourcing config files below
 # VERBOSE because there is a special "VERBOSE=1" setting below:
 readonly ARGS
-readonly DEBUG DEBUGSCRIPTS DEBUGSCRIPTS_ARGUMENT DEBUGSCRIPTS_OPPOSITE_ARGUMENT
+readonly DEBUG DEBUGSCRIPTS DEBUGSCRIPTS_ARGUMENT
 readonly SIMULATE STEPBYSTEP
 
 # The udev workflow is a special case because it is only a wrapper workflow
@@ -279,6 +259,10 @@ fi
 # (e.g. "ls foo*bar" becomes plain "ls" without "foo*bar: No such file or directory" error).
 # The extglob shell option enables several extended pattern matching operators.
 shopt -s nullglob extglob
+# Save the current default bash flags and options in a global readonly variable
+# so that exactly the default bash flags and options can be restored if needed via
+#   ApplyBashFlagsAndOptionsCommands "$DEFAULT_FLAGS_AND_OPTIONS_SETTING_COMMANDS"
+readonly DEFAULT_FLAGS_AND_OPTIONS_SETTING_COMMANDS="$( GetBashFlagsAndOptionsCommands )"
 
 # Forget all remembered full pathnames of commands:
 hash -r
@@ -430,9 +414,6 @@ fi
 if test $EXIT_CODE -eq 0 ; then
     LogToSyslog "DONE: rc=$EXIT_CODE"
 fi
-
-# Restore initial bash flags and options:
-RestoreBashFlagsAndOptions
 
 exit $EXIT_CODE
 

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -37,15 +37,16 @@ function Source () {
     Log "Including $relname"
     # DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        Debug "Enabling debugscripts mode: 'set -$DEBUGSCRIPTS_ARGUMENT'"
+        Debug "Entering debugscripts mode: First SaveBashFlagsAndOptions and then 'set -$DEBUGSCRIPTS_ARGUMENT'"
+        SaveBashFlagsAndOptions
         set -$DEBUGSCRIPTS_ARGUMENT
     fi
     # The actual work (source the source file):
     source "$source_file"
     # Undo DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        Debug "Disabling debugscripts mode: 'set +$DEBUGSCRIPTS_OPPOSITE_ARGUMENT'"
-        set +$DEBUGSCRIPTS_OPPOSITE_ARGUMENT
+        Debug "Leaving debugscripts mode: Back to previous settings via RestoreBashFlagsAndOptions"
+        RestoreBashFlagsAndOptions
     fi
     # Breakpoint if needed:
     [[ "$BREAKPOINT" && "$relname" == "$BREAKPOINT" ]] && read -p "Press ENTER to continue ..." 2>&1

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -37,16 +37,16 @@ function Source () {
     Log "Including $relname"
     # DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        Debug "Entering debugscripts mode: First SaveBashFlagsAndOptions and then 'set -$DEBUGSCRIPTS_ARGUMENT'"
-        SaveBashFlagsAndOptions
+        Debug "Entering debugscripts mode via 'set -$DEBUGSCRIPTS_ARGUMENT'."
+        local saved_bash_flags_and_options_commands="$( GetBashFlagsAndOptionsCommands )"
         set -$DEBUGSCRIPTS_ARGUMENT
     fi
     # The actual work (source the source file):
     source "$source_file"
     # Undo DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        Debug "Leaving debugscripts mode: Back to previous settings via RestoreBashFlagsAndOptions"
-        RestoreBashFlagsAndOptions
+        Debug "Leaving debugscripts mode (back to previous bash flags and options settings)."
+        ApplyBashFlagsAndOptionsCommands "$saved_bash_flags_and_options_commands"
     fi
     # Breakpoint if needed:
     [[ "$BREAKPOINT" && "$relname" == "$BREAKPOINT" ]] && read -p "Press ENTER to continue ..." 2>&1

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -38,7 +38,7 @@ function Source () {
     # DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
         Debug "Entering debugscripts mode via 'set -$DEBUGSCRIPTS_ARGUMENT'."
-        local saved_bash_flags_and_options_commands="$( GetBashFlagsAndOptionsCommands )"
+        local saved_bash_flags_and_options_commands="$( get_bash_flags_and_options_commands )"
         set -$DEBUGSCRIPTS_ARGUMENT
     fi
     # The actual work (source the source file):
@@ -46,7 +46,7 @@ function Source () {
     # Undo DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
         Debug "Leaving debugscripts mode (back to previous bash flags and options settings)."
-        ApplyBashFlagsAndOptionsCommands "$saved_bash_flags_and_options_commands"
+        apply_bash_flags_and_options_commands "$saved_bash_flags_and_options_commands"
     fi
     # Breakpoint if needed:
     [[ "$BREAKPOINT" && "$relname" == "$BREAKPOINT" ]] && read -p "Press ENTER to continue ..." 2>&1


### PR DESCRIPTION
Implemented simple functions get_bash_flags_and_options_commands
and apply_bash_flags_and_options_commands that are used
in a fail-safe way via an explicit variable that
stores the current bash flags and options commands
and using that explicit variable to re-apply them, i.e. like
<pre>
      saved_flags_options_cmds="$( get_bash_flags_and_options_commands )"
      ... [change bash flags and options] ...
      ... [do something] ...
      apply_bash_flags_and_options_commands "$saved_flags_options_cmds"
</pre>

Currently those functions are used in framework-functions.sh
when "Entering debugscripts mode" and "Leaving debugscripts mode"
so that the workaround by using DEBUGSCRIPTS_OPPOSITE_ARGUMENT is obsoleted.

See https://github.com/rear/rear/issues/700
