### PR TITLE
Better wording by using variable named "attributes" and "attribute"

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_filesystem_code.sh
@@ -5,26 +5,30 @@
 
 mount_fs() {
     Log "Begin mount_fs( $@ )"
-    local fs device mountpoint fstype uuid label options
-    read fs device mountpoint fstype uuid label options < <(grep "^fs.* ${1#fs:} " "$LAYOUT_FILE")
+    local fs device mountpoint fstype uuid label attributes
+    read fs device mountpoint fstype uuid label attributes < <(grep "^fs.* ${1#fs:} " "$LAYOUT_FILE")
 
     label=${label#label=}
     uuid=${uuid#uuid=}
 
-    # Extract mount options.
-    local option mountopts
+    # Extract mount options:
+    local attribute mountopts
     # An input line could look like this (an example from SLES12-SP1):
-    # fs /dev/sda2 / btrfs uuid=a2b2c3 label= options=rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot
-    # which means by the above 'read' the variable (that is unfortunately) named 'options' gets the
-    # value 'options=rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot'
-    # i.e. options='options=rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot'
-    for option in $options ; do
-        name=${option%%=*}     # an option can contain more '=' signs (see the above example value)
-        value=${option#*=}     # therefore split the name from the actual value at the leftmost '='
-
+    #   Format: fs <device> <mountpoint> <fstype> [uuid=<uuid>] [label=<label>] [<attributes>]
+    #   fs /dev/sda2 / btrfs uuid=a2b2c3 label= options=rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot
+    # For example the attributes variable can contain a value like:
+    #   "reserved_blocks=5% max_mounts=-1 default_mount_options=user_xattr,acl options=rw,relatime,barrier=1,data=ordered"
+    # I.e. the attributes variable can contain several attributes separated by space each of the form name=value.
+    for attribute in $attributes ; do
+        # An attribute can contain more '=' signs (see the above "options=foo,this=that,..." example values)
+        # therefore split the name from the actual value at the leftmost '='
+        # (e.g. name="options" value="rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot"):
+        name=${attribute%%=*}
+        value=${attribute#*=}
+        # The attribute with name "options" contains the mount options:
         case $name in
             (options)
-                ### Do not mount nodev, as chrooting later on would fail.
+                # Do not mount nodev, as chrooting later on would fail:
                 value=${value//nodev/dev}
                 # btrfs mount options like subvolid=259 or subvol=/@/.snapshots/1/snapshot
                 # from the old system cannot work here for recovery because btrfs subvolumes


### PR DESCRIPTION
Better wording by using variable named "attributes" and "attribute" (instead of "options" and "option") so that the wording in the code
matches the comment in disklayout.conf and avoids confusion by multiple
meanings of the word "option(s)" see https://github.com/rear/rear/issues/561