### PR TITLE
Replace experimental option 'grep -P' to 'grep -E'

### DIFF
--- a/usr/share/rear/layout/save/default/31_autoexclude_usb.sh
+++ b/usr/share/rear/layout/save/default/31_autoexclude_usb.sh
@@ -36,7 +36,7 @@ do
 
     grep -q "^$REAL_USB_DEVICE " /proc/mounts
     if [[ $? -eq 0 ]]; then
-        local usb_mntpt=$(grep -P "^$REAL_USB_DEVICE\s" /proc/mounts | cut -d" " -f2 | tail -1)
+        local usb_mntpt=$(grep -E "^$REAL_USB_DEVICE\s" /proc/mounts | cut -d" " -f2 | tail -1)
         if ! IsInArray "$usb_mntpt" "${AUTOEXCLUDE_USB_PATH[@]}" ; then
             AUTOEXCLUDE_USB_PATH=( ${AUTOEXCLUDE_USB_PATH[@]} $usb_mntpt )
             Log "Auto-excluding USB path $usb_mntpt [device $REAL_USB_DEVICE]"

--- a/usr/share/rear/output/USB/Linux-i386/85_make_USB_bootable.sh
+++ b/usr/share/rear/output/USB/Linux-i386/85_make_USB_bootable.sh
@@ -22,7 +22,7 @@ if [[ "$usb_syslinux_version" ]] && version_newer "$usb_syslinux_version" "$sysl
 fi
 
 # Make the USB bootable
-usb_filesystem=$(grep -P "^($USB_DEVICE|$REAL_USB_DEVICE)\\s" /proc/mounts | cut -d' ' -f3 | tail -1)
+usb_filesystem=$(grep -E "^($USB_DEVICE|$REAL_USB_DEVICE)\\s" /proc/mounts | cut -d' ' -f3 | tail -1)
 case "$usb_filesystem" in
 	(ext?)
 		if [[ "$FEATURE_SYSLINUX_EXTLINUX_INSTALL" ]]; then


### PR DESCRIPTION
Signed-off-by: Petr Hracek <phracek@redhat.com>

Remove experimental 'grep -P' switch in the executable scripts
https://bugzilla.redhat.com/show_bug.cgi?id=1290205

When rear is being executed, e.g. /usr/sbin/rear mkrescue an SELinux AVC is generated. 

~~~
type=AVC msg=audit(1448377615.693:35710): avc:  denied  { execmem } for  pid=21398 comm="grep" scontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=process

type=SYSCALL msg=audit(1448377615.693:35710): arch=x86_64 syscall=mmap success=no exit=EACCES a0=0 a1=10000 a2=7 a3=22 items=0 ppid=9928 pid=21398 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=4294967295 comm=grep exe=/usr/bin/grep subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null)
~~~
SELinux is preventing /usr/bin/grep from using the execmem access on a process. The root cause seems to be the usage of "grep -P".

Replace the switch from 'grep -P' to 'grep -E' from the following scripts
~~~
$ grep -wnr "grep -P" /usr/share/rear/ 
/usr/share/rear/layout/save/default/31_autoexclude_usb.sh:39:        local usb_mntpt=$(grep -P "^$REAL_USB_DEVICE\s" /proc/mounts | cut -d" " -f2 | tail -1)
/usr/share/rear/output/USB/Linux-i386/30_create_extlinux.sh:6:            strings $file | grep -P -m1 "^(EXT|SYS)LINUX \\d+.\\d+" | cut -d' ' -f2
/usr/share/rear/output/USB/Linux-i386/85_make_USB_bootable.sh:25:usb_filesystem=$(grep -P "^($USB_DEVICE|$REAL_USB_DEVICE)\\s" /proc/mounts | cut -d' ' -f3 | tail -1)
/usr/share/rear/prep/USB/Linux-i386/35_check_usb_disk.sh:12:StopIfError "USB device '$USB_DEVICE' is already mounted on $(grep -P "^$REAL_USB_DEVICE\\s" /proc/mounts | cut -d' ' -f2 |tail -1)"
~~~