### PR TITLE
Enhanced the Source function using $SHARE_DIR/$source_file as fallback

### DIFF
--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -16,13 +16,13 @@ function Source () {
         Debug "Skipping Source() because it was called with empty source file name"
         return
     fi
-    # Ensure source file is not a directory:
-    test -d "$source_file" && Error "Source file '$source_file' is a directory, cannot source"
     # If $source_file does not exist try using $SHARE_DIR/$source_file as fallback:
     if ! test -e "$source_file" ; then
         Debug "Using '$SHARE_DIR/$source_file' because '$source_file' does not exist"
         source_file=$SHARE_DIR/$source_file
     fi
+    # Ensure source file is not a directory:
+    test -d "$source_file" && Error "Source file '$source_file' is a directory, cannot source"
     # Skip if source file does not exist of if its content is empty:
     if ! test -s "$source_file" ; then
         Debug "Skipping Source() because source file '$source_file' not found or empty"

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -10,6 +10,7 @@
 # source a file given in $1
 function Source () {
     local source_file="$1"
+    Debug "Trying to Source '$source_file'"
     # Skip if source file name is empty:
     if test -z "$source_file" ; then
         Debug "Skipping Source() because it was called with empty source file name"
@@ -17,6 +18,11 @@ function Source () {
     fi
     # Ensure source file is not a directory:
     test -d "$source_file" && Error "Source file '$source_file' is a directory, cannot source"
+    # If $source_file does not exist try using $SHARE_DIR/$source_file as fallback:
+    if ! test -e "$source_file" ; then
+        Debug "Using '$SHARE_DIR/$source_file' because '$source_file' does not exist"
+        source_file=$SHARE_DIR/$source_file
+    fi
     # Skip if source file does not exist of if its content is empty:
     if ! test -s "$source_file" ; then
         Debug "Skipping Source() because source file '$source_file' not found or empty"

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -19,7 +19,7 @@ function Source () {
     # If $source_file does not exist try using $SHARE_DIR/$source_file as fallback:
     if ! test -e "$source_file" ; then
         Debug "Using '$SHARE_DIR/$source_file' because '$source_file' does not exist"
-        source_file=$SHARE_DIR/$source_file
+        source_file="$SHARE_DIR/$source_file"
     fi
     # Ensure source file is not a directory:
     test -d "$source_file" && Error "Source file '$source_file' is a directory, cannot source"


### PR DESCRIPTION
Now the Source function tries using $SHARE_DIR/$source_file
as fallback if $source_file does not exist so that no longer the
full path is required to include a file from $SHARE_DIR.
E.g. instead of
<pre>
Source "$SHARE_DIR/wrapup/default/99_copy_logfile.sh"
</pre>
one can now use
<pre>
Source "wrapup/default/99_copy_logfile.sh"
</pre>
and the Source function will automatically fall back
including $SHARE_DIR/wrapup/default/99_copy_logfile.sh
(provided wrapup/default/99_copy_logfile.sh does not exist).
