### PR TITLE
Rename RECOVERY_FS_ROOT into TARGET_FS_ROOT

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -95,9 +95,10 @@ LOG_DIR="$REAR_DIR_PREFIX/var/log/rear"
 # Location of the disklayout.conf file created by savelayout
 # (no readonly DISKLAYOUT_FILE because it is also set in checklayout-workflow.sh and mkbackuponly-workflow.sh):
 DISKLAYOUT_FILE="$VAR_DIR/layout/disklayout.conf"
-# Location of the root of the filesystem tree of the to-be-recovered-system in the recovery system
+# Location of the root of the filesystem tree of the target system
+# in particular the root of the filesystem tree of the to-be-recovered-system in the recovery system
 # i.e. the mountpoint in the recovery system where the filesystem tree of the to-be-recovered-system is mounted:
-readonly RECOVERY_FS_ROOT="/mnt/local"
+readonly TARGET_FS_ROOT="/mnt/local"
 
 # Initialize defaults: empty value means "false"/"no":
 DEBUG=""

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -268,7 +268,7 @@ BACKUP_PROG_OPTIONS="--anchored"
 # the exclude list correctly
 BACKUP_PROG_OPTIONS_CREATE_ARCHIVE=""
 # for unsupported backup programs, the last RESTORE_ARCHIVE options must be to restore the archive
-# into a specific path (like tar -C $RECOVERY_FS_ROOT)
+# into a specific path (like tar -C $TARGET_FS_ROOT)
 BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE=""
 BACKUP_PROG_SUFFIX=".tar"
 BACKUP_PROG_COMPRESS_OPTIONS="--gzip"
@@ -698,7 +698,7 @@ PING=
 # The text to display in order to prompt the user to restore the data
 REQUESTRESTORE_TEXT="Please start the restore process on your backup host.
 
-Make sure that you restore the data into $RECOVERY_FS_ROOT (by default '/mnt/local')
+Make sure that you restore the data into $TARGET_FS_ROOT (by default '/mnt/local')
 instead of '/' because the hard disks of the recovered system are mounted there.
 "
 
@@ -737,8 +737,8 @@ RBME_HOSTNAME=$HOSTNAME
 # Command to backup the required data
 # This example saves the data via SSH to a remote system called vms
 EXTERNAL_BACKUP="tar -c -l -z / | ssh vms 'cat >rear64/backup.tar.gz'"
-# Command to restore the data (by default $RECOVERY_FS_ROOT is '/mnt/local')
-EXTERNAL_RESTORE="ssh vms cat rear64/backup.tar.gz | tar -C $RECOVERY_FS_ROOT -x -z"
+# Command to restore the data (by default $TARGET_FS_ROOT is '/mnt/local')
+EXTERNAL_RESTORE="ssh vms cat rear64/backup.tar.gz | tar -C $TARGET_FS_ROOT -x -z"
 # The following exit codes from EXTERNAL_* should not abort the backup or recovery
 # This example is useful for rsync
 EXTERNAL_IGNORE_ERRORS=( 23 24 )
@@ -909,7 +909,7 @@ ELILO_BIN=
 # NOTE: The scripts can be defined as an array to better handly spaces in parameters.
 # The scripts are called like this: eval "${PRE_RECOVERY_SCRIPT[@]}"
 # Call this after Rela-and-Recover did everything in the recover workflow.
-# Use $RECOVERY_FS_ROOT (by default '/mnt/local') to refer to the recovered system.
+# Use $TARGET_FS_ROOT (by default '/mnt/local') to refer to the recovered system.
 POST_RECOVERY_SCRIPT=
 
 # call this before Relax-and-Recover starts to do anything in the recover workflow. You have the rescue system but nothing else

--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_filesystem_code.sh
@@ -61,14 +61,14 @@ mount_fs() {
             # its top-level/root subvolume is the btrfs default subvolume which gets mounted when no other subvolume is specified.
             # For a plain btrfs filesystem without subvolumes it is effectively the same as for other filesystems (like ext2/3/4).
             (
-            echo "mkdir -p $RECOVERY_FS_ROOT$mountpoint"
-            echo "mount -t btrfs $mountopts $device $RECOVERY_FS_ROOT$mountpoint"
+            echo "mkdir -p $TARGET_FS_ROOT$mountpoint"
+            echo "mount -t btrfs $mountopts $device $TARGET_FS_ROOT$mountpoint"
             ) >> "$LAYOUT_CODE"
             # But btrfs filesystems with subvolumes need a special handling.
             # In particular when in the original system the btrfs filesystem had a special different default subvolume,
             # that different subvolume needs to be first created, then set to be the default subvolume, and
             # finally that btrfs filesystem needs to be unmounted and mounted again so that in the end
-            # that special different default subvolume is mounted at the mountpoint $RECOVERY_FS_ROOT$mountpoint.
+            # that special different default subvolume is mounted at the mountpoint $TARGET_FS_ROOT$mountpoint.
             # All btrfs subvolume handling happens in the btrfs_subvolumes_setup function in 13_include_mount_subvolumes_code.sh
             # For a plain btrfs filesystem without subvolumes the btrfs_subvolumes_setup function does nothing.
             # Call the btrfs_subvolumes_setup function for the btrfs filesystem that was mounted above:
@@ -77,14 +77,14 @@ mount_fs() {
         (vfat)
             # mounting vfat filesystem - avoid using mount options - issue #576
             (
-            echo "mkdir -p $RECOVERY_FS_ROOT$mountpoint"
-            echo "mount $device $RECOVERY_FS_ROOT$mountpoint"
+            echo "mkdir -p $TARGET_FS_ROOT$mountpoint"
+            echo "mount $device $TARGET_FS_ROOT$mountpoint"
             ) >> "$LAYOUT_CODE"
             ;;
         (*)
             (
-            echo "mkdir -p $RECOVERY_FS_ROOT$mountpoint"
-            echo "mount $mountopts $device $RECOVERY_FS_ROOT$mountpoint"
+            echo "mkdir -p $TARGET_FS_ROOT$mountpoint"
+            echo "mount $mountopts $device $TARGET_FS_ROOT$mountpoint"
             ) >> "$LAYOUT_CODE"
             ;;
     esac

--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_subvolumes_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_subvolumes_code.sh
@@ -9,7 +9,7 @@ btrfs_subvolumes_setup() {
     Log "Begin btrfs_subvolumes_setup( $@ )"
     # Local variables are visible only in this btrfs_subvolumes_setup function and its children:
     local dummy junk keyword info_message
-    local device mountpoint mountopts recovery_system_mountpoint
+    local device mountpoint mountopts target_system_mountpoint
     local subvolume_path subvolume_directory_path subvolume_mountpoint subvolume_mount_options
     local snapshot_subvolumes_devices_and_paths snapshot_subvolume_device_and_path snapshot_subvolume_device snapshot_subvolume_path
     local default_subvolume_path
@@ -118,7 +118,7 @@ btrfs_subvolumes_setup() {
             # but 'mysubvol' must not be made as a normal directory by 'mkdir' below:
             subvolume_directory_path=""
         fi
-        recovery_system_mountpoint=$RECOVERY_FS_ROOT$mountpoint
+        target_system_mountpoint=$TARGET_FS_ROOT$mountpoint
         info_message="Creating normal btrfs subvolume $subvolume_path on $device at $mountpoint"
         Log $info_message
         (
@@ -127,11 +127,11 @@ btrfs_subvolumes_setup() {
             # Test in the recovery system if the directory path already exists to avoid that
             # useless 'mkdir -p' commands are run which look confusing in the "rear recover" log
             # regardless that 'mkdir -p' does nothing when its argument already exists:
-            echo "if ! test -d $recovery_system_mountpoint/$subvolume_directory_path ; then"
-            echo "    mkdir -p $recovery_system_mountpoint/$subvolume_directory_path"
+            echo "if ! test -d $target_system_mountpoint/$subvolume_directory_path ; then"
+            echo "    mkdir -p $target_system_mountpoint/$subvolume_directory_path"
             echo "fi"
         fi
-        echo "btrfs subvolume create $recovery_system_mountpoint/$subvolume_path"
+        echo "btrfs subvolume create $target_system_mountpoint/$subvolume_path"
         ) >> "$LAYOUT_CODE"
         # Btrfs subvolumes 'no copy on write' attribute setup:
         if grep -q "^btrfsnocopyonwrite $subvolume_path\$" "$LAYOUT_FILE" ; then
@@ -139,7 +139,7 @@ btrfs_subvolumes_setup() {
             Log $info_message
             (
             echo "# $info_message"
-            echo "chattr +C $recovery_system_mountpoint/$subvolume_path"
+            echo "chattr +C $target_system_mountpoint/$subvolume_path"
             ) >> "$LAYOUT_CODE"
         fi
     done < <( grep "^btrfsnormalsubvol $device $mountpoint " "$LAYOUT_FILE" )
@@ -172,7 +172,7 @@ btrfs_subvolumes_setup() {
         # When in the original system the btrfs filesystem had a special different default subvolume
         # (i.e. when the btrfs default subvolume is not the toplevel/root subvolume), then
         # that different subvolume needs to be set to be the default subvolume:
-        recovery_system_mountpoint=$RECOVERY_FS_ROOT$mountpoint
+        target_system_mountpoint=$TARGET_FS_ROOT$mountpoint
         Log "Setting $subvolume_path as btrfs default subvolume for $device at $mountpoint"
         if test -n "$SLES12SP1_btrfs_subvolumes_setup" ; then
             (
@@ -181,11 +181,11 @@ btrfs_subvolumes_setup() {
             echo "# because the default subvolume path '$subvolume_path' contains '@/.snapshots/'"
             echo "# Making the $SLES12SP1_initial_default_subvolume_path subvolume the initial default subvolume"
             echo "# Get the ID of the $initial_default_subvolume_path subvolume"
-            echo "subvolumeID=\$( btrfs subvolume list -a $recovery_system_mountpoint | sed -e 's/<FS_TREE>\///' | grep ' $SLES12SP1_initial_default_subvolume_path\$' | tr -s '[:blank:]' ' ' | cut -d ' ' -f 2 )"
+            echo "subvolumeID=\$( btrfs subvolume list -a $target_system_mountpoint | sed -e 's/<FS_TREE>\///' | grep ' $SLES12SP1_initial_default_subvolume_path\$' | tr -s '[:blank:]' ' ' | cut -d ' ' -f 2 )"
             echo "# Set the $SLES12SP1_initial_default_subvolume_path subvolume as initial default subvolume using its subvolume ID"
-            echo "btrfs subvolume set-default \$subvolumeID $recovery_system_mountpoint"
+            echo "btrfs subvolume set-default \$subvolumeID $target_system_mountpoint"
             echo "# Begin step 1 of special SLES 12 SP1 btrfs default snapper snapshot subvolume setup"
-            echo "umount $recovery_system_mountpoint"
+            echo "umount $target_system_mountpoint"
             echo "# Configuring snapper for root filesystem - step 1:"
             echo "# - temporarily mounting device"
             echo "# - copying/modifying config-file"
@@ -196,7 +196,7 @@ btrfs_subvolumes_setup() {
             echo "then $SLES12SP1_installation_helper_executable --step 1 --device $device --description 'first root filesystem'"
             echo "else LogPrint '$SLES12SP1_installation_helper_executable not executable may indicate an error with btrfs default subvolume setup for $subvolume_path on $device'"
             echo "fi"
-            echo " mount -t btrfs -o subvolid=0 $mountopts $device $recovery_system_mountpoint"
+            echo " mount -t btrfs -o subvolid=0 $mountopts $device $target_system_mountpoint"
             echo "# End step 1 of special SLES 12 SP1 btrfs default snapper snapshot subvolume setup"
             ) >> "$LAYOUT_CODE"
         else
@@ -204,9 +204,9 @@ btrfs_subvolumes_setup() {
             echo "# Begin btrfs default subvolume setup on $device at $mountpoint"
             echo "# Making the $subvolume_path subvolume the default subvolume"
             echo "# Get the ID of the $subvolume_path subvolume"
-            echo "subvolumeID=\$( btrfs subvolume list -a $recovery_system_mountpoint | sed -e 's/<FS_TREE>\///' | grep ' $subvolume_path\$' | tr -s '[:blank:]' ' ' | cut -d ' ' -f 2 )"
+            echo "subvolumeID=\$( btrfs subvolume list -a $target_system_mountpoint | sed -e 's/<FS_TREE>\///' | grep ' $subvolume_path\$' | tr -s '[:blank:]' ' ' | cut -d ' ' -f 2 )"
             echo "# Set the $subvolume_path subvolume as default subvolume using its subvolume ID"
-            echo "btrfs subvolume set-default \$subvolumeID $recovery_system_mountpoint"
+            echo "btrfs subvolume set-default \$subvolumeID $target_system_mountpoint"
             ) >> "$LAYOUT_CODE"
         fi
         # When the btrfs filesystem has a special default subvolume (one that is not the toplevel/root subvolume)
@@ -214,12 +214,12 @@ btrfs_subvolumes_setup() {
         # FIXME: It is possible that the admin has actually mounted something else in his original system
         # which would result a wrong recovery because currently such an awkward setup is not supported.
         # Under the above assumption the btrfs filesystem needs to be umonted and mounted again so that
-        # the special default subvolume gets mounted in the recovery system at $RECOVERY_FS_ROOT$mountpoint.
+        # the special default subvolume gets mounted in the recovery system at $TARGET_FS_ROOT$mountpoint.
         Log "Remounting the btrfs default subvolume $subvolume_path for $device at $mountpoint"
         (
-        echo "# Remounting the $subvolume_path default subvolume at $recovery_system_mountpoint"
-        echo "umount $recovery_system_mountpoint"
-        echo "mount -t btrfs $mountopts $device $recovery_system_mountpoint"
+        echo "# Remounting the $subvolume_path default subvolume at $target_system_mountpoint"
+        echo "umount $target_system_mountpoint"
+        echo "mount -t btrfs $mountopts $device $target_system_mountpoint"
         echo "# End btrfs default subvolume setup on $device at $mountpoint"
         ) >> "$LAYOUT_CODE"
     done
@@ -270,7 +270,7 @@ btrfs_subvolumes_setup() {
                 continue 2
             fi
         done
-        recovery_system_mountpoint=$RECOVERY_FS_ROOT$subvolume_mountpoint
+        target_system_mountpoint=$TARGET_FS_ROOT$subvolume_mountpoint
         # Remounting is needed when at the '/' mountpoint not the btrfs default subvolume is mounted:
         # On Fedora 21 what is mounted at the root of the filesystem tree (i.e. at the '/' mountpoint)
         # is not the btrfs default subvolume (the default subvolume is the toplevel/root subvolume).
@@ -326,21 +326,21 @@ btrfs_subvolumes_setup() {
             # Remounting is needed when the subvolume_path is not the default_subvolume_path for this device:
             Log "On $device btrfs subvolume $subvolume_path currently not mounted at $subvolume_mountpoint, needs remounting"
             (
-            echo "# Begin remounting btrfs subvolume $subvolume_path at $recovery_system_mountpoint"
-            echo "# On $device btrfs subvolume $subvolume_path is currently not mounted at $recovery_system_mountpoint, needs remounting:"
+            echo "# Begin remounting btrfs subvolume $subvolume_path at $target_system_mountpoint"
+            echo "# On $device btrfs subvolume $subvolume_path is currently not mounted at $target_system_mountpoint, needs remounting:"
             echo "# Get the ID of the $subvolume_path subvolume because it must be mounted with subvolid=ID"
             echo "# (using subvol=NAME may not work as long as it is falsely mounted so that subvolume names may not match)"
-            echo "subvolumeID=\$( btrfs subvolume list -a $recovery_system_mountpoint | sed -e 's/<FS_TREE>\///' | grep ' $subvolume_path\$' | tr -s '[:blank:]' ' ' | cut -d ' ' -f 2 )"
+            echo "subvolumeID=\$( btrfs subvolume list -a $target_system_mountpoint | sed -e 's/<FS_TREE>\///' | grep ' $subvolume_path\$' | tr -s '[:blank:]' ' ' | cut -d ' ' -f 2 )"
             echo "if test -n \"\$subvolumeID\" ; then"
             echo "    # No remounting when subvolumeID is empty because then umount would work but mount would fail"
-            echo "    # Remounting the $subvolume_path subvolume at $recovery_system_mountpoint"
-            echo "    umount $recovery_system_mountpoint"
-            echo "    mount -t btrfs -o $subvolume_mount_options -o subvolid=\$subvolumeID $device $recovery_system_mountpoint"
+            echo "    # Remounting the $subvolume_path subvolume at $target_system_mountpoint"
+            echo "    umount $target_system_mountpoint"
+            echo "    mount -t btrfs -o $subvolume_mount_options -o subvolid=\$subvolumeID $device $target_system_mountpoint"
             echo "else"
             echo "    # Empty subvolumeID may indicate an error. Therefore be verbose and inform the user:"
             echo "    LogPrint 'Empty subvolumeID for $subvolume_path on $device may indicate an error, skipping remounting it to $subvolume_mountpoint'"
             echo "fi"
-            echo "# End remounting btrfs subvolume $subvolume_path at $recovery_system_mountpoint"
+            echo "# End remounting btrfs subvolume $subvolume_path at $target_system_mountpoint"
             ) >> "$LAYOUT_CODE"
             # Handling of the '/' mountpoint is done hereby:
             continue
@@ -350,18 +350,18 @@ btrfs_subvolumes_setup() {
         # One same subvolume can be mounted at several mountpoints but one mountpoint cannot be used several times.
         Log "Mounting btrfs normal subvolume $subvolume_path on $device at $subvolume_mountpoint (if not something is already mounted there)."
         (
-        echo "# Mounting btrfs normal subvolume $subvolume_path on $device at $recovery_system_mountpoint (if not something is already mounted there):"
-        # If recovery_system_mountpoint has a trailing '/' it must be cut, otherwise it is not found as an already mounted mountpoint.
-        # In particular a subvolume_mountpoint '/' leads to a trailing '/' in recovery_system_mountpoint (e.g. '/mnt/local/')
-        # and at least the recovery filesystem root $RECOVERY_FS_ROOT (by default '/mnt/local') is already mounted in any case here:
-        echo "if ! mount -t btrfs | tr -s '[:blank:]' ' ' | grep -q ' on ${recovery_system_mountpoint%/} ' ; then"
-        # Test in the recovery system if the recovery_system_mountpoint directory already exists to avoid that
+        echo "# Mounting btrfs normal subvolume $subvolume_path on $device at $target_system_mountpoint (if not something is already mounted there):"
+        # If target_system_mountpoint has a trailing '/' it must be cut, otherwise it is not found as an already mounted mountpoint.
+        # In particular a subvolume_mountpoint '/' leads to a trailing '/' in target_system_mountpoint (e.g. '/mnt/local/')
+        # and at least the recovery filesystem root $TARGET_FS_ROOT (by default '/mnt/local') is already mounted in any case here:
+        echo "if ! mount -t btrfs | tr -s '[:blank:]' ' ' | grep -q ' on ${target_system_mountpoint%/} ' ; then"
+        # Test in the recovery system if the target_system_mountpoint directory already exists to avoid that
         # useless 'mkdir -p' commands are run which look confusing in the "rear recover" log
         # regardless that 'mkdir -p' does nothing when its argument already exists:
-        echo "    if ! test -d $recovery_system_mountpoint ; then"
-        echo "        mkdir -p $recovery_system_mountpoint"
+        echo "    if ! test -d $target_system_mountpoint ; then"
+        echo "        mkdir -p $target_system_mountpoint"
         echo "    fi"
-        echo "    mount -t btrfs -o $subvolume_mount_options -o subvol=$subvolume_path $device $recovery_system_mountpoint"
+        echo "    mount -t btrfs -o $subvolume_mount_options -o subvol=$subvolume_path $device $target_system_mountpoint"
         echo "fi"
         ) >> "$LAYOUT_CODE"
     done < <( grep "^btrfsmountedsubvol $device " "$LAYOUT_FILE" )

--- a/usr/share/rear/restore/NETFS/Linux-i386/51_selinux_fixfiles_exclude_dirs.sh
+++ b/usr/share/rear/restore/NETFS/Linux-i386/51_selinux_fixfiles_exclude_dirs.sh
@@ -4,12 +4,12 @@
 # empty or 0 means using BIOS method
 (( USING_UEFI_BOOTLOADER )) || return
 
-# check if $RECOVERY_FS_ROOT/boot/efi is mounted
-if ! test -d "$RECOVERY_FS_ROOT/boot/efi" ; then
-    Error "Could not find directory $RECOVERY_FS_ROOT/boot/efi"
+# check if $TARGET_FS_ROOT/boot/efi is mounted
+if ! test -d "$TARGET_FS_ROOT/boot/efi" ; then
+    Error "Could not find directory $TARGET_FS_ROOT/boot/efi"
 fi
 
-cat > $RECOVERY_FS_ROOT/etc/selinux/fixfiles_exclude_dirs <<EOF
+cat > $TARGET_FS_ROOT/etc/selinux/fixfiles_exclude_dirs <<EOF
 /boot/efi
 /boot/efi(/.*)?
 EOF

--- a/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
@@ -43,30 +43,30 @@ case "$BACKUP_PROG" in
             LAST="$restorearchive"
             BASE=$(dirname "$restorearchive")/$(tar --test-label -f "$restorearchive")
             if [ "$BASE" == "$LAST" ]; then
-                Log dd if=$BASE \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
-                dd if=$BASE | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
+                Log dd if=$BASE \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
+                dd if=$BASE | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
             else
-                Log dd if="$BASE" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
-                dd if="$BASE" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
-                Log dd if="$LAST" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
-                dd if="$LAST" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
+                Log dd if="$BASE" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
+                dd if="$BASE" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
+                Log dd if="$LAST" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
+                dd if="$LAST" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
             fi
         else
-            Log dd if=$restoreinput \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
-            dd if=$restoreinput | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $RECOVERY_FS_ROOT/ -x -f -
+            Log dd if=$restoreinput \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
+            dd if=$restoreinput | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
         fi
     ;;
     (rsync)
         if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
             BACKUP_RSYNC_OPTIONS=( "${BACKUP_RSYNC_OPTIONS[@]}" --exclude-from=$TMP_DIR/restore-exclude-list.txt )
         fi
-        Log $BACKUP_PROG $v "${BACKUP_RSYNC_OPTIONS[@]}"  "$backuparchive"/ $RECOVERY_FS_ROOT/
-        $BACKUP_PROG  $v "${BACKUP_RSYNC_OPTIONS[@]}" "$backuparchive"/ $RECOVERY_FS_ROOT/
+        Log $BACKUP_PROG $v "${BACKUP_RSYNC_OPTIONS[@]}"  "$backuparchive"/ $TARGET_FS_ROOT/
+        $BACKUP_PROG  $v "${BACKUP_RSYNC_OPTIONS[@]}" "$backuparchive"/ $TARGET_FS_ROOT/
     ;;
     (*)
         Log "Using unsupported backup program '$BACKUP_PROG'"
         $BACKUP_PROG $BACKUP_PROG_COMPRESS_OPTIONS \
-            $BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE $RECOVERY_FS_ROOT \
+            $BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE $TARGET_FS_ROOT \
             $BACKUP_PROG_OPTIONS $backuparchive
     ;;
 esac >"${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log"

--- a/usr/share/rear/restore/NETFS/default/50_selinux_autorelabel.sh
+++ b/usr/share/rear/restore/NETFS/default/50_selinux_autorelabel.sh
@@ -5,7 +5,7 @@ local path=$( url_path $BACKUP_URL )
 local opath=$( backup_path $scheme $path )
 
 if test -f "$opath/selinux.autorelabel" ; then
-    touch $RECOVERY_FS_ROOT/.autorelabel
+    touch $TARGET_FS_ROOT/.autorelabel
     Log "Created /.autorelabel file : after reboot SELinux will relabel all files"
 fi
 

--- a/usr/share/rear/restore/SUSE_LINUX/91_create_missing_directories.sh
+++ b/usr/share/rear/restore/SUSE_LINUX/91_create_missing_directories.sh
@@ -8,16 +8,16 @@
 #   "/run/media/<user_name> is now used as top directory for removable
 #    media mount points. It replaces /media , which is not longer available."
 # Therefore for SLE12 "rear recover" must no longer create them.
-# FIXME: The following test for SLE12 products is intentionally sloppy
+# The following test for SLE12 products is intentionally sloppy
 # because I <jsmeix@suse.de> have no better idea how to test for various
-# posible SLE12-based products like "SUSE Linux Enterprise Server 12"
+# possible SLE12-based products like "SUSE Linux Enterprise Server 12"
 # "SUSE Linux Enterprise Desktop 12" "SUSE Linux Enterprise Server 12 SP1"
 # "SUSE Linux Enterprise Desktop 12 SP1" "SUSE Linux Enterprise <whatever> <whichever>".
-# Therefore it is triggered only by the absence of /etc/os-release because
+# Therefore it is triggered by the absence of /etc/os-release because
 # I assume that the switch from /media to /run/media matches reasonably well
 # with the switch from /etc/SuSE-release to /etc/os-release so that
 # this test is also (hopefully) somewhat future-proof (e.g. for SLE13):
-pushd $RECOVERY_FS_ROOT >&8
+pushd $TARGET_FS_ROOT >&8
 test -f etc/os-release || mkdir -p media/cdrom media/floppy
 popd >&8
 

--- a/usr/share/rear/wrapup/default/98_good_bye.sh
+++ b/usr/share/rear/wrapup/default/98_good_bye.sh
@@ -2,6 +2,6 @@
 ###
 
 Print "
-Finished recovering your system. You can explore it under '$RECOVERY_FS_ROOT'.
+Finished recovering your system. You can explore it under '$TARGET_FS_ROOT'.
 "
 


### PR DESCRIPTION
Rename RECOVERY_FS_ROOT into TARGET_FS_ROOT to describe what it actually is.

The former name RECOVERY_FS_ROOT (see https://github.com/rear/rear/issues/708) is misleading.
In the "recover" workflow it is not the root of the filesystem tree of the recovery system
but it is the root of the filesystem tree of the to-be-recovered system
i.e. it is the root of the filesystem tree of the target system of the "recover" workflow.
Furthermore the former name RECOVERY_FS_ROOT is incomprehensible in future workflows
like the "install" workflow (see https://github.com/rear/rear/issues/732)
where the root of the filesystem tree of the to-be-installed system
would have to be called INSTALL_FS_ROOT to have a meaningful name.
Therefore the name TARGET_FS_ROOT is now used because
it describes what it actually is independent of the workflow.