### PR TITLE
new usr/share/rear/restore/default/99_move_away_restored_files.sh

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -761,6 +761,48 @@ EXTERNAL_IGNORE_ERRORS=( 23 24 )
 EXTERNAL_CHECK="ssh vms date >&8"
 
 ##
+# BACKUP_RESTORE_MOVE_AWAY
+#
+# Move away restored files that should not have been restored:
+#
+# Do not confuse it with EXCLUDE_RESTORE in the EXCLUDES section below.
+# With EXCLUDE_RESTORE items are excluded during backup restore
+# where each particular backup method must explicitly implement support
+# for the EXCLUDE_RESTORE functionality (most do not support it).
+# In contrast BACKUP_RESTORE_MOVE_AWAY works generically
+# for any backup restore method.
+#
+# See https://github.com/rear/rear/issues/779
+#
+# After backup restore rear should move away files
+# that should not have been restored - maily files that
+# are created and maintained by system tools where
+# a restore from the backup results wrong/outdated
+# content that conflicts with the actual system.
+#
+# The generic traditional example of such a file was /etc/mtab.
+# As long as it was a regular file it must not have been restored
+# with outdated content from a backup. Nowadays it is a symbolic link
+# to /proc/self/mounts which should probably be restored to ensure
+# that link is available.
+#
+# rear will not remove any file (any user data is sacrosanct).
+# Instead rear moves those files away into a rear-specific directory
+# so that the admin can inspect that directory to see what rear thinks
+# should not have been restored:
+readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/backup_restore_moved_away/"
+#
+# There is nothing hardcoded in the scripts.
+# Instead BACKUP_RESTORE_MOVE_AWAY_FILES is a documented list
+# what files are moved away and why each file is moved away.
+# The BACKUP_RESTORE_MOVE_AWAY_FILES list is not readonly
+# so that it can be modified as needed by the scripts.
+#
+# See https://github.com/rear/rear/issues/770
+# why /etc/udev/rules.d/70-persistent-net.rules is moved away.
+BACKUP_RESTORE_MOVE_AWAY_FILES=( /etc/udev/rules.d/70-persistent-net.rules )
+
+##
 # How to exclude something ----- EXCLUDES -------
 #
 # You cannot exclude a device (e.g. /dev/sdg) directly. Instead you have to exclude everything

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -763,7 +763,7 @@ EXTERNAL_CHECK="ssh vms date >&8"
 ##
 # BACKUP_RESTORE_MOVE_AWAY
 #
-# Move away restored files that should not have been restored:
+# Move away restored files or directories that should not have been restored:
 #
 # Do not confuse it with EXCLUDE_RESTORE in the EXCLUDES section below.
 # With EXCLUDE_RESTORE items are excluded during backup restore
@@ -774,9 +774,9 @@ EXTERNAL_CHECK="ssh vms date >&8"
 #
 # See https://github.com/rear/rear/issues/779
 #
-# After backup restore rear should move away files
-# that should not have been restored - maily files that
-# are created and maintained by system tools where
+# After backup restore rear should move away files or directories
+# that should not have been restored - maily files or directories
+# that are created and maintained by system tools where
 # a restore from the backup results wrong/outdated
 # content that conflicts with the actual system.
 #
@@ -790,17 +790,26 @@ EXTERNAL_CHECK="ssh vms date >&8"
 # Instead rear moves those files away into a rear-specific directory
 # so that the admin can inspect that directory to see what rear thinks
 # should not have been restored:
-readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/backup_restore_moved_away/"
+readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/moved_away_after_backup_restore/"
 #
 # There is nothing hardcoded in the scripts.
 # Instead BACKUP_RESTORE_MOVE_AWAY_FILES is a documented list
-# what files are moved away and why each file is moved away.
+# that explains why each file or directory is moved away.
 # The BACKUP_RESTORE_MOVE_AWAY_FILES list is not readonly
 # so that it can be modified as needed by the scripts.
-#
-# See https://github.com/rear/rear/issues/770
-# why /etc/udev/rules.d/70-persistent-net.rules is moved away.
-BACKUP_RESTORE_MOVE_AWAY_FILES=( /etc/udev/rules.d/70-persistent-net.rules )
+# The items in the BACKUP_RESTORE_MOVE_AWAY_FILES list do not need to be only files.
+# Also a whole directory tree can be moved away (automatically recursively).
+# Already existing stuff in the BACKUP_RESTORE_MOVE_AWAY_DIRECTORY that would be (partially)
+# overwritten by the items in the BACKUP_RESTORE_MOVE_AWAY_FILES list is removed before
+# (because such stuff is considered as outdated leftover e.g. from a previous recovery)
+# but already existing stuff in the BACKUP_RESTORE_MOVE_AWAY_DIRECTORY that is not
+# in the curent BACKUP_RESTORE_MOVE_AWAY_FILES list is kept.
+# Example:
+# Perhaps stuff in the /var/tmp directory is not needed after a system recovery
+# and /etc/udev/rules.d/70-persistent-net.rules is created and maintained
+# by systemd/udev (see https://github.com/rear/rear/issues/770):
+# BACKUP_RESTORE_MOVE_AWAY_FILES=( /var/tmp /etc/udev/rules.d/70-persistent-net.rules )
+BACKUP_RESTORE_MOVE_AWAY_FILES=()
 
 ##
 # How to exclude something ----- EXCLUDES -------


### PR DESCRIPTION
moves away restored files that should not have been restored according to the BACKUP_RESTORE_MOVE_AWAY_DIRECTORY and BACKUP_RESTORE_MOVE_AWAY_FILES settings, see https://github.com/rear/rear/issues/779
