### PR TITLE
more safely remove for move away functionality

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -802,13 +802,19 @@ readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/moved_away_after_backup_re
 # so that it can be modified as needed by the scripts.
 # The items in the BACKUP_RESTORE_MOVE_AWAY_FILES list do not need to be only files.
 # Also a whole directory tree can be moved away (automatically recursively).
+# If an item in BACKUP_RESTORE_MOVE_AWAY_FILES is a directory only its content
+# is (recursively) removed but the original (empty) directory is kept because
+# the empty directory alone should not cause issues and usually only the content
+# is what results wrong/outdated content that conflicts with the actual system
+# or what is no longer needed after system recovery (e.g. content in /var/tmp
+# is probably no longer needed but the /var/tmp directory is still needed).
 # Already existing stuff in the BACKUP_RESTORE_MOVE_AWAY_DIRECTORY that would be (partially)
 # overwritten by the items in the BACKUP_RESTORE_MOVE_AWAY_FILES list is removed before
 # (because such stuff is considered as outdated leftover e.g. from a previous recovery)
 # but already existing stuff in the BACKUP_RESTORE_MOVE_AWAY_DIRECTORY that is not
 # in the curent BACKUP_RESTORE_MOVE_AWAY_FILES list is kept.
 # Example:
-# Perhaps stuff in the /var/tmp directory is not needed after a system recovery
+# Probably stuff in the /var/tmp directory is not needed after a system recovery
 # and /etc/udev/rules.d/70-persistent-net.rules is created and maintained
 # by systemd/udev (see https://github.com/rear/rear/issues/770):
 # BACKUP_RESTORE_MOVE_AWAY_FILES=( /var/tmp /etc/udev/rules.d/70-persistent-net.rules )


### PR DESCRIPTION
more safely remove for move away functionality so that only the directory content is removed but the empty directory itself is kept (e.g. useful to remove content in /var/tmp but keep /var/tmp), see https://github.com/rear/rear/issues/779