### PR TITLE
workaround for rear/rear#649

### DIFF
--- a/usr/share/rear/finalize/SUSE_LINUX/i386/17_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/SUSE_LINUX/i386/17_rebuild_initramfs.sh
@@ -48,7 +48,8 @@ if test -s $TMP_DIR/storage_drivers && ! diff $TMP_DIR/storage_drivers $VAR_DIR/
 
 	sed -i -e '/^INITRD_MODULES/s/^.*$/#&\nINITRD_MODULES="'"${OLD_INITRD_MODULES[*]} ${NEW_INITRD_MODULES[*]}"'"/' $TARGET_FS_ROOT/etc/sysconfig/kernel
    fi
-
+	udevadm trigger
+	sleep 5
 	mount -t proc none $TARGET_FS_ROOT/proc
 	mount -t sysfs none $TARGET_FS_ROOT/sys
         echo "Running mkinitrd..."

--- a/usr/share/rear/finalize/SUSE_LINUX/i386/17_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/SUSE_LINUX/i386/17_rebuild_initramfs.sh
@@ -48,7 +48,7 @@ if test -s $TMP_DIR/storage_drivers && ! diff $TMP_DIR/storage_drivers $VAR_DIR/
 
 	sed -i -e '/^INITRD_MODULES/s/^.*$/#&\nINITRD_MODULES="'"${OLD_INITRD_MODULES[*]} ${NEW_INITRD_MODULES[*]}"'"/' $TARGET_FS_ROOT/etc/sysconfig/kernel
    fi
-	udevadm trigger
+	my_udevtrigger
 	sleep 5
 	mount -t proc none $TARGET_FS_ROOT/proc
 	mount -t sysfs none $TARGET_FS_ROOT/sys


### PR DESCRIPTION
workaround the problem in which the partition containing `/boot/` is detected with a wrong uuid when creating the initrd. 
As mentioned, it's a workaround because it fixes the problem but not the cause.