### PR TITLE
in 82_create_iso_image.sh error out if ebiso is used but no UEFI (issue 801)

### DIFF
--- a/usr/share/rear/output/ISO/Linux-i386/82_create_iso_image.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/82_create_iso_image.sh
@@ -1,23 +1,29 @@
+
 Log "Starting '$ISO_MKISOFS_BIN'"
 LogPrint "Making ISO image"
 
-if (( USING_UEFI_BOOTLOADER )) ; then
+if is_true $USING_UEFI_BOOTLOADER ; then
     # initialized with 1
     EFIBOOT="-eltorito-alt-boot -e boot/efiboot.img -no-emul-boot"
     Log "Including ISO UEFI boot (as triggered by USING_UEFI_BOOTLOADER=1)"
 else
-   EFIBOOT=""
+    EFIBOOT=""
 fi
 
 pushd $TMP_DIR/isofs >&8
-# ebiso currenlty works only with UEFI
-if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" && $USING_UEFI_BOOTLOADER == 1 ]]; then
-   $ISO_MKISOFS_BIN -R -o $ISO_DIR/$ISO_PREFIX.iso -e boot/efiboot.img .
+# ebiso uses different command line options and parameters:
+if test "ebiso" = $( basename $ISO_MKISOFS_BIN ) ; then
+    # ebiso currently works only with UEFI:
+    if is_true $USING_UEFI_BOOTLOADER ; then
+        $ISO_MKISOFS_BIN -R -o $ISO_DIR/$ISO_PREFIX.iso -e boot/efiboot.img .
+    else
+        Error "$ISO_MKISOFS_BIN works only with UEFI"
+    fi
 else
-   $ISO_MKISOFS_BIN $v -o "$ISO_DIR/$ISO_PREFIX.iso" -b isolinux/isolinux.bin -c isolinux/boot.cat \
-       -no-emul-boot -boot-load-size 4 -boot-info-table \
-       -R -J -volid "$ISO_VOLID" $EFIBOOT -v -iso-level 3 .  >&8
-       ##-R -J -volid "$ISO_VOLID" $EFIBOOT  "${ISO_FILES[@]}"  >&8
+    $ISO_MKISOFS_BIN $v -o "$ISO_DIR/$ISO_PREFIX.iso" -b isolinux/isolinux.bin -c isolinux/boot.cat \
+        -no-emul-boot -boot-load-size 4 -boot-info-table \
+        -R -J -volid "$ISO_VOLID" $EFIBOOT -v -iso-level 3 .  >&8
+        ##-R -J -volid "$ISO_VOLID" $EFIBOOT  "${ISO_FILES[@]}"  >&8
 fi
 StopIfError "Could not create ISO image (with $ISO_MKISOFS_BIN)"
 popd >&8


### PR DESCRIPTION
in 82_create_iso_image.sh error out if ebiso is used but no UEFI,
see https://github.com/rear/rear/issues/801