### PR TITLE
allow generic yes/no values for USING_UEFI_BOOTLOADER (issue 801)

### DIFF
--- a/usr/share/rear/backup/NETFS/default/50_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/50_make_backup.sh
@@ -37,7 +37,7 @@ if [[ "$opath" ]]; then
     mkdir -p $v "${opath}" >&2
 fi
 
-# Disable BACKUP_PROG_CRYPT_OPTIONS by replacing the default value to cat in 
+# Disable BACKUP_PROG_CRYPT_OPTIONS by replacing the default value to cat in
 # case encryption is disabled
 if (( $BACKUP_PROG_CRYPT_ENABLED == 1 )); then
   LogPrint "Encrypting archive with a key"
@@ -57,7 +57,7 @@ if [[ -n "$ISO_MAX_SIZE" ]]; then
         # We add 15MB which is the average size of all isolinux binaries
         BASE_ISO_SIZE=$(((${INITRD_SIZE}+${KERNEL_SIZE})/1024/1024+15))
         # If we are EFI, add 30MB (+ previous 15MB), UEFI files can't exceed this size
-        (( USING_UEFI_BOOTLOADER )) && BASE_ISO_SIZE=$((${BASE_ISO_SIZE}+30))
+        is_true $USING_UEFI_BOOTLOADER && BASE_ISO_SIZE=$((${BASE_ISO_SIZE}+30))
         ISO_MAX_SIZE=$((${ISO_MAX_SIZE}-${BASE_ISO_SIZE}))
     fi
     SPLIT_COMMAND="split -d -b ${ISO_MAX_SIZE}m - ${backuparchive}."

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -935,11 +935,15 @@ GRUB_RESCUE_PASSWORD="REAR"
 GRUB_SUPERUSER="rearadmin"
 
 # UEFI (Secure booting) support is partly available in rear (at least for Fedora, RHEL)
-# SLES, OpenSuSe do not work out of the box due to issues with making an ISO image UEFI aware
-# and currently there is no solution insight. Therefore the next variable can overrule some settings:
-# USING_UEFI_BOOTLOADER=  means let rear try to find it out by itself (default)
+# SLES, openSUSE do not work out of the box due to issues with making an UEFI bootable ISO image.
+# SLES, openSUSE need the additional tool 'ebiso' to make an UEFI bootable ISO image
+# (via ISO_MKISOFS_BIN=/usr/bin/ebiso - see the ISO_MKISOFS_BIN variable above).
+# The next variable can explitly specify whether or not an UEFI bootloader should be used:
+# USING_UEFI_BOOTLOADER=   means let rear try to find it out by itself (default)
 # USING_UEFI_BOOTLOADER=0  means we do not want UEFI capable ISO and no efi tools in rear image
 # USING_UEFI_BOOTLOADER=1  means we want UEFI ISO image and all efi tools to recreate the secure boot
+# instead of '0' also any value that is recognized as 'no' by the is_false function can be used
+# instead of '1' also any value that is recognized as 'yes' by the is_true function can be used
 USING_UEFI_BOOTLOADER=
 
 ##

--- a/usr/share/rear/finalize/Linux-i386/21_install_grub.sh
+++ b/usr/share/rear/finalize/Linux-i386/21_install_grub.sh
@@ -16,7 +16,7 @@ if [[ -z "$NOBOOTLOADER" ]] ; then
 fi
 
 # for UEFI systems with grub legacy with should use efibootmgr instead
-(( USING_UEFI_BOOTLOADER )) && return # set to 1 means UEFI booting
+is_true $USING_UEFI_BOOTLOADER && return # set to 1 means UEFI booting
 
 # check the BOOTLOADER variable (read by 01_prepare_checks.sh script)
 if [[ "$BOOTLOADER" = "GRUB" ]]; then

--- a/usr/share/rear/finalize/Linux-i386/22_install_elilo.sh
+++ b/usr/share/rear/finalize/Linux-i386/22_install_elilo.sh
@@ -7,7 +7,7 @@ if [[ -z "$NOBOOTLOADER" ]] ; then
 fi
 
 # for UEFI systems we defined USING_UEFI_BOOTLOADER=1; BIOS based is 0 or ""
-(( USING_UEFI_BOOTLOADER )) || return # when set to 0
+is_true $USING_UEFI_BOOTLOADER || return # when set to 0
 
 # Only for elilo
 [[ "$BOOTLOADER" == "ELILO" ]] || return  # only continue when bootloader is elilo based

--- a/usr/share/rear/finalize/Linux-i386/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/22_install_grub2.sh
@@ -16,7 +16,7 @@ if [[ -z "$NOBOOTLOADER" ]] ; then
 fi
 
 # for UEFI systems with grub2 we should use efibootmgr instead
-(( USING_UEFI_BOOTLOADER )) && return # when set to 1
+is_true $USING_UEFI_BOOTLOADER && return # when set to 1
 
 # Only for GRUB2 - GRUB Legacy will be handled by its own script
 [[ $(type -p grub-probe) || $(type -p grub2-probe) ]] || return

--- a/usr/share/rear/finalize/Linux-i386/23_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/23_run_efibootmgr.sh
@@ -1,5 +1,5 @@
 # only useful for UEFI systems in combination with grub[2]-efi
-(( USING_UEFI_BOOTLOADER )) || return  # empty or 0 means using BIOS
+is_true $USING_UEFI_BOOTLOADER || return  # empty or 0 means using BIOS
 
 # check if $TARGET_FS_ROOT/boot/efi is mounted
 [[ -d "$TARGET_FS_ROOT/boot/efi" ]]

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -47,7 +47,7 @@ function find_syslinux_modules_dir {
     if version_newer "$syslinux_version" 5.00; then
         # check for the default location - fast and easy
         if [[ -d /usr/lib/syslinux/modules ]]; then
-            if (( USING_UEFI_BOOTLOADER )); then
+            if is_true $USING_UEFI_BOOTLOADER ; then
                 syslinux_modules_dir=/usr/lib/syslinux/modules/efi64
             else
                 syslinux_modules_dir=/usr/lib/syslinux/modules/bios
@@ -59,7 +59,7 @@ function find_syslinux_modules_dir {
             file=$( find /usr -name "$1" 2>/dev/null | tail -1 )
             syslinux_modules_dir=$( dirname "$file" )        # /usr/lib/syslinux/modules/efi32
             syslinux_modules_dir=${syslinux_modules_dir%/*}  # /usr/lib/syslinux/modules
-            if (( USING_UEFI_BOOTLOADER )); then
+            if is_true $USING_UEFI_BOOTLOADER ; then
                 syslinux_modules_dir=${syslinux_modules_dir}/efi64
             else
                 syslinux_modules_dir=${syslinux_modules_dir}/bios

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -34,10 +34,30 @@ function is_numeric () {
     fi
 }
 
+# two explicit functions to be able to test explicitly for true and false (see issue #625)
+# because "tertium non datur" (cf. https://en.wikipedia.org/wiki/Law_of_excluded_middle)
+# does not hold for variables because variables could be unset or have empty value
+# and to test if a variable is true or false its value is tested by that functions
+# but the variable may not have a real value (i.e. be unset or have empty value):
+
 function is_true () {
-    # argument is variable which needs to be tested if it is true or not (see issue #625)
+    # the argument is usually the value of a variable which needs to be tested
+    # only if there is explicitly a 'true' value then is_true returns true
+    # so that an unset variable or an empty value is not true:
     case "$1" in
-        [tT] | [yY] | [yY][eE][sS] | [tT][rR][uU][eE] | 1)
+        ([tT] | [yY] | [yY][eE][sS] | [tT][rR][uU][eE] | 1)
+        return 0 ;;
+    esac
+    return 1
+}
+
+function is_false () {
+    # the argument is usually the value of a variable which needs to be tested
+    # only if there is explicitly a 'false' value then is_false returns true
+    # so that an unset variable or an empty value is not false
+    # caution: for unset or empty variables is_false is false
+    case "$1" in
+        ([fF] | [nN] | [nN][oO] | [fF][aA][lL][sS][eE] | 0)
         return 0 ;;
     esac
     return 1
@@ -85,7 +105,7 @@ backup_path() {
                path="${TMP_DIR}/isofs${path}"
            fi
            ;;
-       (*)     # nfs, cifs, usb, a.o. need a temporary mount-path 
+       (*)     # nfs, cifs, usb, a.o. need a temporary mount-path
            path="${BUILD_DIR}/outputfs/${NETFS_PREFIX}"
            ;;
     esac
@@ -102,7 +122,7 @@ output_path() {
        (file)  # type file needs a local path (must be mounted by user)
            path="$path/${OUTPUT_PREFIX}"
            ;;
-       (*)     # nfs, cifs, usb, a.o. need a temporary mount-path 
+       (*)     # nfs, cifs, usb, a.o. need a temporary mount-path
            path="${BUILD_DIR}/outputfs/${OUTPUT_PREFIX}"
            ;;
     esac
@@ -192,7 +212,7 @@ umount_url() {
             # and delete only the just used cache
             #rm -rf /var/cache/davfs2/*<mountpoint-hash>*
             rm -rf /var/cache/davfs2/*outputfs*
-            
+
 	    ;;
         (var)
             local var=$(url_host $url)
@@ -238,3 +258,4 @@ umount_mountpoint() {
     Log "Unmounting '$mountpoint' failed."
     return 1
 }
+

--- a/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
@@ -1,5 +1,5 @@
 # 20_mount_efibootimg.sh
-(( USING_UEFI_BOOTLOADER )) || return
+is_true $USING_UEFI_BOOTLOADER || return
 
 dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size) bs=1024
 # make sure we select FAT16 instead of FAT12 as size >30MB

--- a/usr/share/rear/output/ISO/Linux-i386/25_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/25_populate_efibootimg.sh
@@ -1,6 +1,6 @@
 # 25_populate_efibootimg.sh
 
-(( USING_UEFI_BOOTLOADER )) || return    # empty or 0 means NO UEFI
+is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
 
 mkdir $v -p $TMP_DIR/mnt/EFI/BOOT >&2
 StopIfError "Could not create $TMP_DIR/mnt/EFI/BOOT"
@@ -11,7 +11,7 @@ StopIfError "Could not create $TMP_DIR/mnt/EFI/BOOT/fonts"
 mkdir $v -p $TMP_DIR/mnt/EFI/BOOT/locale >&2
 StopIfError "Could not create $TMP_DIR/mnt/EFI/BOOT/locale"
 
-# copy the grub*.efi executable to EFI/BOOT/BOOTX64.efi 
+# copy the grub*.efi executable to EFI/BOOT/BOOTX64.efi
 cp  $v "${UEFI_BOOTLOADER}" $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi >&2
 StopIfError "Could not find ${UEFI_BOOTLOADER}"
 if [[ $(basename ${UEFI_BOOTLOADER}) = shim.efi ]]; then
@@ -40,7 +40,7 @@ if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" ]]; then
         StopIfError "Could not copy kernel to UEFI"
         cp $v $TMP_DIR/initrd.cgz $TMP_DIR/mnt/EFI/BOOT/initrd.cgz >&2
         StopIfError "Could not copy initrd to UEFI"
-        create_ebiso_elilo_conf > $TMP_DIR/mnt/EFI/BOOT/elilo.conf 
+        create_ebiso_elilo_conf > $TMP_DIR/mnt/EFI/BOOT/elilo.conf
         create_grub2_cfg > $TMP_DIR/mnt/EFI/BOOT/grub.cfg
     fi
 fi

--- a/usr/share/rear/output/ISO/Linux-i386/70_umount_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/70_umount_efibootimg.sh
@@ -1,5 +1,5 @@
 # 90_umount_bootimg.sh
-(( USING_UEFI_BOOTLOADER )) || return    # empty or 0 means NO UEFI
+is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
 umount $v $TMP_DIR/efiboot.img >&2
 #mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/boot/efiboot.img >&2
 mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/isofs/boot/efiboot.img >&2

--- a/usr/share/rear/output/default/94_grub2_rescue.sh
+++ b/usr/share/rear/output/default/94_grub2_rescue.sh
@@ -54,7 +54,7 @@ if (( available_space + used_space < required_space )); then
     return
 fi
 
-if (( USING_UEFI_BOOTLOADER )) ; then
+if is_true $USING_UEFI_BOOTLOADER ; then
     # set to 1 means using UEFI
     grub_conf="`dirname $UEFI_BOOTLOADER`/grub.cfg"
 elif has_binary grub2-probe ; then

--- a/usr/share/rear/output/default/94_grub_rescue.sh
+++ b/usr/share/rear/output/default/94_grub_rescue.sh
@@ -22,7 +22,7 @@ fi
 #grub_version=$(get_version "grub --version")
 grub_version=$(strings $grub_binary | sed -rn 's/^[^0-9\.]*([0-9]+\.[-0-9a-z\.]+).*$/\1/p' | tail -n 1)
 if version_newer "$grub_version" 1.0; then
-    # only for grub-legacy we make special rear boot entry in menu.lst 
+    # only for grub-legacy we make special rear boot entry in menu.lst
     return
 fi
 
@@ -47,7 +47,7 @@ if (( available_space + used_space < required_space )); then
     return
 fi
 
-if (( USING_UEFI_BOOTLOADER )) ; then
+if is_true $USING_UEFI_BOOTLOADER ; then
     # set to 1 means using UEFI
     # SLES uses elilo instead of grub-efi; we will return if that is the case (and do not add a rear rescue entry)
     [[ "${UEFI_BOOTLOADER##*/}" = "elilo.efi" ]] && return

--- a/usr/share/rear/rescue/default/85_save_sysfs_uefi_vars.sh
+++ b/usr/share/rear/rescue/default/85_save_sysfs_uefi_vars.sh
@@ -1,5 +1,5 @@
 # a simplified uefivars replacement
-(( USING_UEFI_BOOTLOADER )) || return    # empty or 0 means NO UEFI
+is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
 
 [[ ! -d $VAR_DIR/recovery ]] && mkdir -p -m 755 $VAR_DIR/recovery
 rm -f $VAR_DIR/recovery/uefi-variables

--- a/usr/share/rear/restore/NETFS/Linux-i386/51_selinux_fixfiles_exclude_dirs.sh
+++ b/usr/share/rear/restore/NETFS/Linux-i386/51_selinux_fixfiles_exclude_dirs.sh
@@ -2,7 +2,7 @@
 # for UEFI only we should avoid SElinux relabeling vfat filesystem: /boot/efi
 
 # empty or 0 means using BIOS method
-(( USING_UEFI_BOOTLOADER )) || return
+is_true $USING_UEFI_BOOTLOADER || return
 
 # check if $TARGET_FS_ROOT/boot/efi is mounted
 if ! test -d "$TARGET_FS_ROOT/boot/efi" ; then


### PR DESCRIPTION
allow generic yes/no values for USING_UEFI_BOOTLOADER

as a conseqence use everywhere generic tests via
is_true $USING_UEFI_BOOTLOADER
and
is_false $USING_UEFI_BOOTLOADER

the latter requires the new counterpart function
is_false to test for an explicit no value

see https://github.com/rear/rear/issues/801
