### PR TITLE
ebiso image size is too small if BACKUP is TSM

### DIFF
--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -52,21 +52,23 @@ function build_bootx86_efi {
 }
 
 # estimate size of efibooot image
-function efiboot_img_size {
-    local size=32000
+function efiboot_img_size_MiB {
+    local size=32
     if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" ]]; then
         case "$(basename $UEFI_BOOTLOADER)" in
             # we will need more space for initrd and kernel if elilo is used
             # if shim is used, bootloader can be actually anything (also elilo)
             # named as grub64.efi (follow-up loader is shim compile time option)
             # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim
-            (shim.efi|elilo.efi) size=128000 ;;
-            (*) size=32000
+            (shim.efi|elilo.efi) size=128 ;;
+            (*) size=32
         esac
     fi
     # this is purely experimental value.
     # FIXME: calculating size dynamically would be more robust.
-    [[ $BACKUP = "TSM" ]] && size=$((size + 96000))
+    if [[ $BACKUP = "TSM" ]]; then
+        size=$((size + 96))
+    fi
 
     echo $size
 }

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -64,5 +64,9 @@ function efiboot_img_size {
             (*) size=32000
         esac
     fi
+    # this is purely experimental value.
+    # FIXME: calculating size dynamically would be more robust.
+    [[ $BACKUP = "TSM" ]] && size=$((size + 96000))
+
     echo $size
 }

--- a/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
@@ -1,7 +1,7 @@
 # 20_mount_efibootimg.sh
 is_true $USING_UEFI_BOOTLOADER || return
 
-dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size) bs=1024
+dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size_MiB) bs=1048576
 # make sure we select FAT16 instead of FAT12 as size >30MB
 mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
 mkdir -p $v $TMP_DIR/mnt >&2


### PR DESCRIPTION
The patch increases the UEFI image size, if BACKUP is TSM. The reference issue: #810

I must admit I start to dislike this UEFI image size determination code (which is my own partly).
Perhaps we should think about more scientific approach to calculate needed size for the UEFI image?
On the other hands its just few lines of code (compared to bit more if 'more scientific approach' is in place). Any comments please?