### PR TITLE
determine EFI virtual disk size automatically

### DIFF
--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -50,23 +50,3 @@ function build_bootx86_efi {
     $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -d /usr/lib/grub/x86_64-efi -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo
     StopIfError "Error occurred during $gmkimage of BOOTX64.efi"
 }
-
-# get exact size of EFI virtual image (efiboot.img)
-function efiboot_img_size {
-    # minimum EFI virtual image size in [MB]
-    # default: 128MB
-    EFI_IMG_MIN_SZ=128
-     
-    # get size of directory holding EFI virtual image content
-    SIZE=$(du -ms ${1} | awk '{print $1}')
-   
-    if [ ${SIZE} -lt ${EFI_IMG_MIN_SZ} ]; then
-        FINAL_SIZE=${EFI_IMG_MIN_SZ}
-    else
-        FINAL_SIZE=${SIZE}
-    fi
-   
-    # final size must be aligned to 32
-    # +1 to add some buffer space when going marginal    
-    echo $(((FINAL_SIZE / 32 + 1) * 32))
-}

--- a/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
@@ -1,8 +1,0 @@
-# 20_mount_efibootimg.sh
-is_true $USING_UEFI_BOOTLOADER || return
-
-dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size) bs=1024
-# make sure we select FAT16 instead of FAT12 as size >30MB
-mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
-mkdir -p $v $TMP_DIR/mnt >&2
-mount $v -o loop -t vfat -o fat=16 $TMP_DIR/efiboot.img $TMP_DIR/mnt >&2

--- a/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
@@ -1,0 +1,18 @@
+# 70_create_efibootimg.sh
+is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
+
+# prepare EFI virtual image
+dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size $TMP_DIR/mnt) bs=1M
+mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
+mkdir -p $v $TMP_DIR/efi_virt >&2
+mount $v -o loop -t vfat -o fat=16 $TMP_DIR/efiboot.img $TMP_DIR/efi_virt >&2
+
+# copy files from staging directory
+cp $v -r $TMP_DIR/mnt/. $TMP_DIR/efi_virt
+
+umount $v $TMP_DIR/efiboot.img >&2
+#mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/boot/efiboot.img >&2
+mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/isofs/boot/efiboot.img >&2
+StopIfError "Could not move efiboot.img file"
+
+#ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/boot/efiboot.img )

--- a/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
@@ -1,6 +1,35 @@
 # 70_create_efibootimg.sh
 is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
 
+# function to calculate exact size of EFI virtual image (efiboot.img)
+function efiboot_img_size {
+    # get size of directory holding EFI virtual image content
+    SIZE=$(du -ms ${1} | awk '{print $1}')
+    
+    case "$(basename $UEFI_BOOTLOADER)" in
+        (shim.efi|elilo.efi)
+            # minimum EFI virtual image size for shim and elilo in [MB]
+            # default: 128MB
+            EFI_IMG_MIN_SZ=128
+        ;;
+        (*)
+            # minimum EFI virtual image size for grub in [MB]
+            # default: 32MB
+            EFI_IMG_MIN_SZ=32
+        ;;
+    esac
+    
+    if [ ${SIZE} -lt ${EFI_IMG_MIN_SZ} ]; then
+        FINAL_SIZE=${EFI_IMG_MIN_SZ}
+    else
+        FINAL_SIZE=${SIZE}
+    fi
+       
+    # final size must be aligned to 32
+    # +1 to add some buffer space when going marginal    
+    echo $(((FINAL_SIZE / 32 + 1) * 32))
+}
+
 # prepare EFI virtual image
 dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size $TMP_DIR/mnt) bs=1M
 mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2

--- a/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
@@ -14,8 +14,8 @@ function efiboot_img_size {
         ;;
         (*)
             # minimum EFI virtual image size for grub in [MB]
-            # default: 32MB
-            EFI_IMG_MIN_SZ=32
+            # default: 0MB (this will create EFI virtual image with size of 32MB)
+            EFI_IMG_MIN_SZ=0
         ;;
     esac
     

--- a/usr/share/rear/output/ISO/Linux-i386/70_umount_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/70_umount_efibootimg.sh
@@ -1,8 +1,0 @@
-# 90_umount_bootimg.sh
-is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
-umount $v $TMP_DIR/efiboot.img >&2
-#mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/boot/efiboot.img >&2
-mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/isofs/boot/efiboot.img >&2
-StopIfError "Could not move efiboot.img file"
-
-#ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/boot/efiboot.img )


### PR DESCRIPTION
Fix for manual detection of EFI virtual image (efiboot.img) size.