### PR TITLE
Revert "ebiso image size is too small if BACKUP is TSM"

### DIFF
--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -52,23 +52,17 @@ function build_bootx86_efi {
 }
 
 # estimate size of efibooot image
-function efiboot_img_size_MiB {
-    local size=32
+function efiboot_img_size {
+    local size=32000
     if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" ]]; then
         case "$(basename $UEFI_BOOTLOADER)" in
             # we will need more space for initrd and kernel if elilo is used
             # if shim is used, bootloader can be actually anything (also elilo)
             # named as grub64.efi (follow-up loader is shim compile time option)
             # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim
-            (shim.efi|elilo.efi) size=128 ;;
-            (*) size=32
+            (shim.efi|elilo.efi) size=128000 ;;
+            (*) size=32000
         esac
     fi
-    # this is purely experimental value.
-    # FIXME: calculating size dynamically would be more robust.
-    if [[ $BACKUP = "TSM" ]]; then
-        size=$((size + 96))
-    fi
-
     echo $size
 }

--- a/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
@@ -1,7 +1,7 @@
 # 20_mount_efibootimg.sh
 is_true $USING_UEFI_BOOTLOADER || return
 
-dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size_MiB) bs=1048576
+dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size) bs=1024
 # make sure we select FAT16 instead of FAT12 as size >30MB
 mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
 mkdir -p $v $TMP_DIR/mnt >&2


### PR DESCRIPTION
Reverts rear/rear#811 on request. It seems to be an older obsolete pull request.