### PR TITLE
Determine EFI virtual disk size automatically (take 2)

### DIFF
--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -50,19 +50,3 @@ function build_bootx86_efi {
     $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -d /usr/lib/grub/x86_64-efi -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo
     StopIfError "Error occurred during $gmkimage of BOOTX64.efi"
 }
-
-# estimate size of efibooot image
-function efiboot_img_size {
-    local size=32000
-    if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" ]]; then
-        case "$(basename $UEFI_BOOTLOADER)" in
-            # we will need more space for initrd and kernel if elilo is used
-            # if shim is used, bootloader can be actually anything (also elilo)
-            # named as grub64.efi (follow-up loader is shim compile time option)
-            # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim
-            (shim.efi|elilo.efi) size=128000 ;;
-            (*) size=32000
-        esac
-    fi
-    echo $size
-}

--- a/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/20_mount_efibootimg.sh
@@ -1,8 +1,0 @@
-# 20_mount_efibootimg.sh
-is_true $USING_UEFI_BOOTLOADER || return
-
-dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$(efiboot_img_size) bs=1024
-# make sure we select FAT16 instead of FAT12 as size >30MB
-mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
-mkdir -p $v $TMP_DIR/mnt >&2
-mount $v -o loop -t vfat -o fat=16 $TMP_DIR/efiboot.img $TMP_DIR/mnt >&2

--- a/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
@@ -1,48 +1,18 @@
 # 70_create_efibootimg.sh
 is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
 
-# function to calculate exact size of EFI virtual image (efiboot.img)
-function efiboot_img_size {
-    # Get size of directory holding EFI virtual image content.
-    # The virtual image must be aligned to 32MiB blocks
-    # therefore the size of directory is measured in 32MiB blocks.
-    efi_img_dir=$1
-    
-    # Specify a minimum EFI virtual image size measured in 32MiB blocks:
-    case "$( basename $UEFI_BOOTLOADER )" in
-        (shim.efi|elilo.efi)
-            # minimum EFI virtual image size for shim and elilo
-            # default: 160MiB = 5 * 32MiB blocks
-            efi_img_min_sz=5
-        ;;
-        (*)
-            # minimum EFI virtual image size for grub
-            # default: 32MiB = 1 * 32MiB block
-            efi_img_min_sz=1
-        ;;
-    esac
-    
-    # Fallback output of the minimum EFI virtual image size measured in 32MiB blocks:
-    test $efi_img_dir || { echo $efi_img_min_sz ; return ; }
-    
-    # The du output is stored in an artificial bash array
-    # so that $efi_img_sz can be simply used to get the first word
-    # which is the efi_img_sz value measured in 32MiB blocks:
-    efi_img_sz=( $( du --block-size=32M --summarize $efi_img_dir ) )
-    
-    # Fallback output of the minimum EFI virtual image size measured in 32MiB blocks:
-    test $efi_img_sz -ge 1 || { echo $efi_img_min_sz ; return ; }
-    
-    # Output at least the minimum EFI virtual image size measured in 32MiB blocks:
-    if test $efi_img_sz -lt $efi_img_min_sz ; then
-        echo $efi_img_min_sz
-    else
-        echo $efi_img_sz
-    fi
-}
+# Calculate exact size of EFI virtual image (efiboot.img):
+# Get size of directory holding EFI virtual image content.
+# The virtual image must be aligned to 32MiB blocks
+# therefore the size of directory is measured in 32MiB blocks.
+# The du output is stored in an artificial bash array
+# so that $efi_img_sz can be simply used to get the first word
+# which is the disk usage of the directory measured in 32MiB blocks:
+efi_img_sz=( $( du --block-size=32M --summarize $TMP_DIR/mnt ) )
+StopIfError "Failed to determine disk usage of EFI virtual image content directory."
 
-# prepare EFI virtual image
-dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$( efiboot_img_size $TMP_DIR/mnt ) bs=32M
+# prepare EFI virtual image aligned to 32MiB blocks:
+dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$efi_img_sz bs=32M
 mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
 mkdir -p $v $TMP_DIR/efi_virt >&2
 mount $v -o loop -t vfat -o fat=16 $TMP_DIR/efiboot.img $TMP_DIR/efi_virt >&2

--- a/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
@@ -1,0 +1,59 @@
+# 70_create_efibootimg.sh
+is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
+
+# function to calculate exact size of EFI virtual image (efiboot.img)
+function efiboot_img_size {
+    # Get size of directory holding EFI virtual image content.
+    # The virtual image must be aligned to 32MiB blocks
+    # therefore the size of directory is measured in 32MiB blocks.
+    efi_img_dir=$1
+    
+    # Specify a minimum EFI virtual image size measured in 32MiB blocks:
+    case "$( basename $UEFI_BOOTLOADER )" in
+        (shim.efi|elilo.efi)
+            # minimum EFI virtual image size for shim and elilo
+            # default: 128MiB = 4 * 32MiB blocks
+            efi_img_min_sz=4
+        ;;
+        (*)
+            # minimum EFI virtual image size for grub
+            # default: 32MiB = 1 * 32MiB block
+            efi_img_min_sz=1
+        ;;
+    esac
+    
+    # Fallback output of the minimum EFI virtual image size measured in 32MiB blocks:
+    test $efi_img_dir || echo $efi_img_min_sz
+    
+    # The du output is stored in an artificial bash array
+    # so that $efi_img_sz can be simply used to get the first word
+    # which is the efi_img_sz value measured in 32MiB blocks:
+    efi_img_sz=( $( du --block-size=32M --summarize $efi_img_dir ) )
+    
+    # Fallback output of the minimum EFI virtual image size measured in 32MiB blocks:
+    test $efi_img_sz || echo $efi_img_min_sz
+    test $efi_img_sz -ge 1 || echo $efi_img_min_sz
+    
+    # Output at least the minimum EFI virtual image size measured in 32MiB blocks:
+    if test $efi_img_sz -lt $efi_img_min_sz ; then
+        echo $efi_img_min_sz
+    else
+        echo $efi_img_sz
+    fi
+}
+
+# prepare EFI virtual image
+dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$( efiboot_img_size $TMP_DIR/mnt ) bs=32M
+mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
+mkdir -p $v $TMP_DIR/efi_virt >&2
+mount $v -o loop -t vfat -o fat=16 $TMP_DIR/efiboot.img $TMP_DIR/efi_virt >&2
+
+# copy files from staging directory
+cp $v -r $TMP_DIR/mnt/. $TMP_DIR/efi_virt
+
+umount $v $TMP_DIR/efiboot.img >&2
+#mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/boot/efiboot.img >&2
+mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/isofs/boot/efiboot.img >&2
+StopIfError "Could not move efiboot.img file"
+
+#ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/boot/efiboot.img )

--- a/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/70_create_efibootimg.sh
@@ -12,8 +12,8 @@ function efiboot_img_size {
     case "$( basename $UEFI_BOOTLOADER )" in
         (shim.efi|elilo.efi)
             # minimum EFI virtual image size for shim and elilo
-            # default: 128MiB = 4 * 32MiB blocks
-            efi_img_min_sz=4
+            # default: 160MiB = 5 * 32MiB blocks
+            efi_img_min_sz=5
         ;;
         (*)
             # minimum EFI virtual image size for grub
@@ -23,7 +23,7 @@ function efiboot_img_size {
     esac
     
     # Fallback output of the minimum EFI virtual image size measured in 32MiB blocks:
-    test $efi_img_dir || echo $efi_img_min_sz
+    test $efi_img_dir || { echo $efi_img_min_sz ; return ; }
     
     # The du output is stored in an artificial bash array
     # so that $efi_img_sz can be simply used to get the first word
@@ -31,8 +31,7 @@ function efiboot_img_size {
     efi_img_sz=( $( du --block-size=32M --summarize $efi_img_dir ) )
     
     # Fallback output of the minimum EFI virtual image size measured in 32MiB blocks:
-    test $efi_img_sz || echo $efi_img_min_sz
-    test $efi_img_sz -ge 1 || echo $efi_img_min_sz
+    test $efi_img_sz -ge 1 || { echo $efi_img_min_sz ; return ; }
     
     # Output at least the minimum EFI virtual image size measured in 32MiB blocks:
     if test $efi_img_sz -lt $efi_img_min_sz ; then
@@ -52,8 +51,5 @@ mount $v -o loop -t vfat -o fat=16 $TMP_DIR/efiboot.img $TMP_DIR/efi_virt >&2
 cp $v -r $TMP_DIR/mnt/. $TMP_DIR/efi_virt
 
 umount $v $TMP_DIR/efiboot.img >&2
-#mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/boot/efiboot.img >&2
 mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/isofs/boot/efiboot.img >&2
 StopIfError "Could not move efiboot.img file"
-
-#ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/boot/efiboot.img )

--- a/usr/share/rear/output/ISO/Linux-i386/70_umount_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/70_umount_efibootimg.sh
@@ -1,8 +1,0 @@
-# 90_umount_bootimg.sh
-is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
-umount $v $TMP_DIR/efiboot.img >&2
-#mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/boot/efiboot.img >&2
-mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/isofs/boot/efiboot.img >&2
-StopIfError "Could not move efiboot.img file"
-
-#ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/boot/efiboot.img )


### PR DESCRIPTION
Fix for manual detection of EFI virtual image (efiboot.img) size.