### PR TITLE
removed EXCLUDE_RECREATE from btrfs example configs

### DIFF
--- a/usr/share/rear/conf/examples/SLE12-SP1-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-SP1-btrfs-example.conf
@@ -55,25 +55,10 @@ COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib/snapper/installation-helper /etc/snappe
 # in the below example not included to be in the backup
 #   /.snapshots/*  /var/crash/*
 # but files in /home/* are included to be in the backup.
-# Note that not having '/tmp/*' in BACKUP_PROG_INCLUDE when there are
-# matching entries in EXCLUDE_RECREATE like "fs:/tmp" would result
-# that during restore a /tmp/rear.*/tmp/restore-exclude-list.txt file
-# would contain the tar exclude patterns 'tmp' and 'tmp/*' so that
-# also other files and directories that match those tar exclude patterns
-# would not be restored (e.g. '/usr/tmp').
 # You may use a command like
 #   findmnt -t btrfs | cut -d ' ' -f 1 | cut -s -d '-' -f2 | egrep -v 'snapshots|crash' | sed -e "s/$/\/*'/" -e "s/^/'/" | tr '\n' ' '
 # to generate the values:
 BACKUP_PROG_INCLUDE=( '/var/tmp/*' '/srv/*' '/var/lib/pgsql/*' '/var/spool/*' '/var/lib/libvirt/images/*' '/var/opt/*' '/tmp/*' '/var/lib/named/*' '/var/log/*' '/boot/grub2/i386/*' '/var/lib/mariadb/*' '/home/*' '/var/lib/mailman/*' '/opt/*' '/usr/local/*' '/boot/grub2/x86_64/*' )
-# Also for every mounted btrfs subvolume exclude the mountpoint
-# of the mounted btrfs subvolumes from component recreation
-# see /usr/share/doc/packages/rear/user-guide/06-layout-configuration.txt
-# and /usr/share/rear/conf/default.conf
-# When /home is a separated filesystem remove "fs:/home" from the list below.
-# You may use a command like
-#   findmnt -t btrfs | cut -d ' ' -f 1 | cut -s -d '-' -f2 | sed -e "s/$/'/" -e "s/^/'fs:/" | tr '\n' ' '
-# to generate the values:
-EXCLUDE_RECREATE=( "${EXCLUDE_RECREATE[@]}" 'fs:/var/tmp' 'fs:/srv' 'fs:/var/lib/pgsql' 'fs:/var/spool' 'fs:/var/lib/libvirt/images' 'fs:/var/opt' 'fs:/tmp' 'fs:/.snapshots' 'fs:/var/lib/named' 'fs:/var/log' 'fs:/boot/grub2/i386' 'fs:/var/lib/mariadb' 'fs:/home' 'fs:/var/crash' 'fs:/var/lib/mailman' 'fs:/opt' 'fs:/usr/local' 'fs:/boot/grub2/x86_64' )
 # This option defines a root password to allow SSH connection
 # whithout a public/private key pair
 #SSH_ROOT_PASSWORD="password_on_the_rear_recovery_system"

--- a/usr/share/rear/conf/examples/SLE12-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-btrfs-example.conf
@@ -34,20 +34,7 @@ NETFS_KEEP_OLD_BACKUP_COPY=yes
 # in the below example not included to be in the backup
 #   /.snapshots/*  /var/crash/*
 # but files in /home/* are included to be in the backup.
-# Note that not having '/tmp/*' in BACKUP_PROG_INCLUDE when there are
-# matching entries in EXCLUDE_RECREATE like "fs:/tmp" would result
-# that during restore a /tmp/rear.*/tmp/restore-exclude-list.txt file
-# would contain the tar exclude patterns 'tmp' and 'tmp/*' so that
-# also other files and directories that match those tar exclude patterns
-# would not be restored (e.g. '/usr/tmp'):
 BACKUP_PROG_INCLUDE=( '/home/*' '/var/tmp/*' '/var/spool/*' '/var/opt/*' '/var/log/*' '/var/lib/pgsql/*' '/var/lib/mailman/*' '/var/lib/named/*' '/usr/local/*' '/tmp/*' '/srv/*' '/boot/grub2/x86_64-efi/*' '/opt/*' '/boot/grub2/i386-pc/*' )
-# Avoid that "rear recover" is 'Creating btrfs-filesystem' by default
-# also for every mounted btrfs subvolume by excluding the mountpoints
-# of the mounted btrfs subvolumes from component recreation
-# see /usr/share/doc/packages/rear/user-guide/06-layout-configuration.txt
-# and /usr/share/rear/conf/default.conf
-# When /home is a separated filesystem remove "fs:/home" from the list below:
-EXCLUDE_RECREATE=( "${EXCLUDE_RECREATE[@]}" "fs:/home" "fs:/.snapshots" "fs:/var/tmp" "fs:/var/spool" "fs:/var/opt" "fs:/var/log" "fs:/var/lib/pgsql" "fs:/var/lib/mailman" "fs:/var/lib/named" "fs:/usr/local" "fs:/tmp" "fs:/srv" "fs:/var/crash" "fs:/boot/grub2/x86_64-efi" "fs:/opt" "fs:/boot/grub2/i386-pc" )
 # This option defines a root password to allow SSH connection
 # whithout a public/private key pair
 #SSH_ROOT_PASSWORD="password_on_the_rear_recovery_system"


### PR DESCRIPTION
removed EXCLUDE_RECREATE from
SLE12-SP1-btrfs-example.conf and
SLE12-btrfs-example.conf
see https://github.com/rear/rear/issues/821
