### PR TITLE
Fix btrfs subvolumes with TSM, sshd config

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/run-sshd
+++ b/usr/share/rear/skel/default/etc/scripts/run-sshd
@@ -1,5 +1,7 @@
 #!/bin/bash
 # check inittab for "ssh:23:respawn:/bin/sshd -D"
 if $(grep -q ^ssh: /etc/inittab) ; then
+        sed -i 's/^PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+        sed -i 's/^ClientAliveInterval.*/ClientAliveInterval 0/' /etc/ssh/sshd_config
 	exec /bin/sshd -D
 fi

--- a/usr/share/rear/verify/TSM/default/40_verify_tsm.sh
+++ b/usr/share/rear/verify/TSM/default/40_verify_tsm.sh
@@ -28,8 +28,8 @@ fi
 
 # Use the included_mountpoints array derived from the disklayout.conf to determine the default
 # TSM filespaces to include in a restore. 
-included_mountpoints=( $(grep ^fs $VAR_DIR/layout/disklayout.conf  | awk '{print $3}') $(grep ^btrfsmountedsubvol $VAR_DIR/layout/disklayout.conf | awk '{print $3}') )
-included_mountpoints=( `echo "${included_mountpoints[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '` )
+included_mountpoints=( $(grep ^fs $VAR_DIR/layout/disklayout.conf  | awk '{print $3}') $(grep ^btrfsmountedsubvol $VAR_DIR/layout/disklayout.conf | awk '{print $3}' | grep -v "/.snapshots") )
+included_mountpoints=($(tr ' ' '\n' <<<"${included_mountpoints[@]}" | awk '!u[$0]++' |  tr '\n' ' '))
 
 # TSM does not restore the mountpoints for filesystems it does not recover. Setting the
 # MOUNTPOINTS_TO_RESTORE variable allows this to be recreated in the restore 

--- a/usr/share/rear/verify/TSM/default/40_verify_tsm.sh
+++ b/usr/share/rear/verify/TSM/default/40_verify_tsm.sh
@@ -28,7 +28,8 @@ fi
 
 # Use the included_mountpoints array derived from the disklayout.conf to determine the default
 # TSM filespaces to include in a restore. 
-included_mountpoints=( $(grep ^fs $VAR_DIR/layout/disklayout.conf  | awk '{print $3}') )
+included_mountpoints=( $(grep ^fs $VAR_DIR/layout/disklayout.conf  | awk '{print $3}') $(grep ^btrfsmountedsubvol $VAR_DIR/layout/disklayout.conf | awk '{print $3}') )
+included_mountpoints=( `echo "${included_mountpoints[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '` )
 
 # TSM does not restore the mountpoints for filesystems it does not recover. Setting the
 # MOUNTPOINTS_TO_RESTORE variable allows this to be recreated in the restore 


### PR DESCRIPTION
Avoid Problems with ssh-logins when the original sshd_config has some extra secure lines.
Fix the problem where the btrfs subvlums are not restored via TSM.

See Issue #823