### PR TITLE
Grub2: REAR Improvements proposal

### DIFF
--- a/usr/share/rear/output/default/94_grub2_rescue.sh
+++ b/usr/share/rear/output/default/94_grub2_rescue.sh
@@ -110,6 +110,9 @@ else
     grub-mkconfig -o $grub_conf
 fi
 
+#Finding UUID of filesystem containing /boot 
+grub_boot_uuid=$(df /boot | awk 'END {print $1}' | xargs blkid -s UUID -o value)
+
 awk -f- $grub_conf >$TMP_DIR/grub.cfg <<EOF
 /^menuentry \"Relax and Recover\" --class os --users \"\"/ {
     ISREAR=1
@@ -129,7 +132,7 @@ awk -f- $grub_conf >$TMP_DIR/grub.cfg <<EOF
 
 END {
     print "menuentry \"Relax and Recover\" --class os --users \"\" {"
-    print "\tset root=\'hd0,msdos1\'"
+    print "\tsearch --no-floppy --fs-uuid  --set root $grub_boot_uuid"
     print "\tlinux  /rear-kernel $KERNEL_CMDLINE"
     print "\tinitrd /rear-initrd.cgz"
     print "\tpassword_pbkdf2 $GRUB_SUPERUSER $GRUB_RESCUE_PASSWORD"

--- a/usr/share/rear/output/default/94_grub2_rescue.sh
+++ b/usr/share/rear/output/default/94_grub2_rescue.sh
@@ -98,14 +98,17 @@ if [[ ! $grub_enc_password == $GRUB_RESCUE_PASSWORD ]]; then
     sed -i "s/password_pbkdf2\s\S*\s\S*/password_pbkdf2 $GRUB_SUPERUSER $GRUB_RESCUE_PASSWORD/" /etc/grub.d/01_users
 fi
 
-
 # Ensure 01_users is added to the /boot/grub.d/
 if [[ ! -x /etc/grub.d/01_users ]]; then
     chmod 755 /etc/grub.d/01_users
 fi
 
-#Finding UUID of filesystem containing /boot 
+#Finding UUID of filesystem containing /boot
 grub_boot_uuid=$(df /boot | awk 'END {print $1}' | xargs blkid -s UUID -o value)
+
+#Stop if $grub_boot_uuid is not a valid UUID
+blkid -U $grub_boot_uuid > /dev/null 2>&1
+StopIfError "$grub_boot_uuid is not a valid UUID"
 
 #Creating REAR grub menu entry
 echo "#!/bin/bash

--- a/usr/share/rear/output/default/94_grub2_rescue.sh
+++ b/usr/share/rear/output/default/94_grub2_rescue.sh
@@ -104,43 +104,29 @@ if [[ ! -x /etc/grub.d/01_users ]]; then
     chmod 755 /etc/grub.d/01_users
 fi
 
-if [[ $( type -f grub2-mkconfig ) ]]; then
-    grub2-mkconfig -o $grub_conf
-else
-    grub-mkconfig -o $grub_conf
-fi
-
 #Finding UUID of filesystem containing /boot 
 grub_boot_uuid=$(df /boot | awk 'END {print $1}' | xargs blkid -s UUID -o value)
 
-awk -f- $grub_conf >$TMP_DIR/grub.cfg <<EOF
-/^menuentry \"Relax and Recover\" --class os --users \"\"/ {
-    ISREAR=1
-    next
+#Creating REAR grub menu entry
+echo "#!/bin/bash
+cat << EOF
+menuentry \"Relax and Recover\" --class os --users \"\" {
+        search --no-floppy --fs-uuid  --set root $grub_boot_uuid
+        linux  /rear-kernel $KERNEL_CMDLINE
+        initrd /rear-initrd.cgz
+        password_pbkdf2 $GRUB_SUPERUSER $GRUB_RESCUE_PASSWORD
 }
+EOF" > /etc/grub.d/45_rear
 
-/^menuentry / {
-    ISREAR=0
-}
+chmod 755 /etc/grub.d/45_rear
 
-{
-    if (ISREAR) {
-        next
-    }
-    print
-}
+if [[ $( type -f grub2-mkconfig ) ]]; then
+    grub2-mkconfig -o $TMP_DIR/grub.cfg
+else
+    grub-mkconfig -o $TMP_DIR/grub.cfg
+fi
 
-END {
-    print "menuentry \"Relax and Recover\" --class os --users \"\" {"
-    print "\tsearch --no-floppy --fs-uuid  --set root $grub_boot_uuid"
-    print "\tlinux  /rear-kernel $KERNEL_CMDLINE"
-    print "\tinitrd /rear-initrd.cgz"
-    print "\tpassword_pbkdf2 $GRUB_SUPERUSER $GRUB_RESCUE_PASSWORD"
-    print "}"
-}
-EOF
-
-[[ -s $grub_conf ]]
+[[ -s $TMP_DIR/grub.cfg ]]
 BugIfError "Modified GRUB2 is empty !"
 
 if ! diff -u $grub_conf $TMP_DIR/grub.cfg >&2; then


### PR DESCRIPTION
1- Grub2: Using search --fs-uuid instead of hardcoded root='hd0,msdos1'

Actually we found that ppc64 and ppc64le are not aware of "hd0,msdos1", current grub2 rescue does not work without the above option in ppc64 and ppc64le. Since this search option is used even in x86 grub2 distro menu, so it would be better to handle as platform independent option.

By the way, this search option allows to use GPT formated disk ! Which is not the case of 'hd0,msdos1'

2- Changing the way REAR grub2 menuentry is created. By using the standard /etc/grub.d directory to store the REAR menu, we are sure that it will not be removed by a manual grub-mkconfig (or an automated one after a kernel upgrade.)