### PR TITLE
Solving Multipath cannot load due to libaio missing in ramdisk

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/28_multipath_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/28_multipath_layout.sh
@@ -27,5 +27,8 @@ done < <( dmsetup ls --target multipath )
 if grep -q ^multipath $DISKLAYOUT_FILE ; then
     PROGS=( "${PROGS[@]}" multipath kpartx multipathd )
     COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/multipath.conf /lib*/multipath )
-    LIB=( "${PROGS[@]}" libaio* )
+
+    # depending to the linux distro and arch, libaio can be located in different dir. (ex: /lib/powerpc64le-linux-gnu)
+    libaio_dir=$(ldconfig -p | awk '/libaio.so/ { print $NF }' | xargs -n1 dirname)
+    LIBS=( "${LIBS[@]}" $libaio_dir/libaio* )
 fi

--- a/usr/share/rear/layout/save/GNU/Linux/28_multipath_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/28_multipath_layout.sh
@@ -29,6 +29,8 @@ if grep -q ^multipath $DISKLAYOUT_FILE ; then
     COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/multipath.conf /lib*/multipath )
 
     # depending to the linux distro and arch, libaio can be located in different dir. (ex: /lib/powerpc64le-linux-gnu)
-    libaio_dir=$(ldconfig -p | awk '/libaio.so/ { print $NF }' | xargs -n1 dirname)
-    LIBS=( "${LIBS[@]}" $libaio_dir/libaio* )
+    for libdir in $(ldconfig -p | awk '/libaio.so/ { print $NF }' | xargs -n1 dirname | sort -u); do
+        libaio2add="$libaio2add $libdir/libaio*"
+    done
+    LIBS=( "${LIBS[@]}" $libaio2add )
 fi


### PR DESCRIPTION
When I boot on rear rescue (tested via grub menu) , I can't use multipath because libaio is missing in the ramdisk.

Here is my proposition for modification:

* Correct `LIB` variable name to `LIBS`
* Changing `${PROGS[@]}` to `${LIBS[@]}`
* Using a local variable to find the directory where libaio is located (can be different depending to the Linux distro and arch; for example `/lib/powerpc64le-linux-gnu/libaio.so.1` for ubuntu 16-04 ppc64le).