### PR TITLE
Ignoring block device which are part of a multipath device.

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
@@ -253,7 +253,7 @@ function is_multipath_path {
             devsize=$(get_disk_size ${disk#/sys/block/})
 
             #Check if blockd is a path of a multipath device.
-            if is_multipath_path /dev/${blockd} ; then
+            if is_multipath_path ${blockd} ; then
                 Log "Ignoring $blockd: it is a path of a multipath device"
             else
                 disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")

--- a/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
@@ -237,8 +237,11 @@ extract_partitions() {
     done < $TMP_DIR/partitions
 }
 
-
 Log "Saving disk partitions."
+
+function is_multipath_path {
+    [ "$1" ] && type multipath &>/dev/null && multipath -c /dev/$1 &>/dev/null
+}
 
 (
     # Disk sizes
@@ -250,7 +253,7 @@ Log "Saving disk partitions."
             devsize=$(get_disk_size ${disk#/sys/block/})
 
             #Check if blockd is a path of a multipath device.
-            if multipath -c /dev/${blockd} > /dev/null 2>&1 ; then
+            if is_multipath_path /dev/${blockd} ; then
                 Log "Ignoring $blockd: it is a path of a multipath device"
             else
                 disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")

--- a/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
@@ -249,15 +249,20 @@ Log "Saving disk partitions."
             devname=$(get_device_name $disk)
             devsize=$(get_disk_size ${disk#/sys/block/})
 
-            disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")
+            #Check if blockd is a path of a multipath device.
+            if multipath -c /dev/${blockd} > /dev/null 2>&1 ; then
+                Log "Ignoring $blockd: it is a path of a multipath device"
+            else
+                disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")
 
-            echo "# Disk $devname"
-            echo "# Format: disk <devname> <size(bytes)> <partition label type>"
-            echo "disk $devname $devsize $disktype"
+                echo "# Disk $devname"
+                echo "# Format: disk <devname> <size(bytes)> <partition label type>"
+                echo "disk $devname $devsize $disktype"
 
-            echo "# Partitions on $devname"
-            echo "# Format: part <device> <partition size(bytes)> <partition start(bytes)> <partition type|name> <flags> /dev/<partition>"
-            extract_partitions "$devname"
+                echo "# Partitions on $devname"
+                echo "# Format: part <device> <partition size(bytes)> <partition start(bytes)> <partition type|name> <flags> /dev/<partition>"
+                extract_partitions "$devname"
+            fi
         fi
     done
 


### PR DESCRIPTION
`20_partition_layout.sh `gets partition size from `/sys/block` filesystem for every hdX or sdX device. 
But if the block device `$blockd` is a path of a multipath device, partition and size information does not exist anymore in `/sys/block` which stop the script with the following message:

> "ERROR: BUG BUG BUG!  Could not determine size of disk sdb/sdb2, please file a bug.
> === Issue report === Please report this unexpected issue at: https://github.com/rear/rear/issues Also include the relevant bits from /var/log/rear/rear-XXXXXXXX.log.lockless"

To avoid this situation, I propose to test if the sdX or hdX (`$blockd`) is part of a multipath device. 
If yes, we ignore it because it will be handled by `28_multipath_layout script` (real multipath device `dm-X` will be treated further by multipath scripts).