### PR TITLE
First step to support new ftpfs BACKUP_URL

### DIFF
--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -263,6 +263,8 @@ mount_url() {
             local path=$( url_path $url )
             test "$path" || Error "Cannot run 'curlftpfs' because no path found in URL '$url'."
             local username=$( url_username $url )
+            # ensure the fuse kernel module is loaded because ftpfs (via CurlFtpFS) is based on FUSE
+            lsmod | grep -q '^fuse' || modprobe $verbose fuse || Error "Cannot run 'curlftpfs' because 'fuse' kernel module is not loadable."
             if test "$username" ; then
                 local password=$( url_password $url )
                 if test "$password" ; then

--- a/usr/share/rear/output/default/95_copy_result_files.sh
+++ b/usr/share/rear/output/default/95_copy_result_files.sh
@@ -14,7 +14,7 @@ fi
 LogPrint "Copying resulting files to $scheme location"
 
 case "$scheme" in
-    (nfs|cifs|usb|file|sshfs|davfs)
+    (nfs|cifs|usb|file|sshfs|ftpfs|davfs)
         # if called as mkbackuponly then we just don't have any result files.
         if test "$RESULT_FILES" ; then
             Log "Copying files '${RESULT_FILES[@]}' to $scheme location"


### PR DESCRIPTION
See https://github.com/rear/rear/issues/845

I tested it on SLE12 x86_64 kvm/qemu virtual machine
with BIOS and this /etc/rear/local.conf:
<pre>
OUTPUT=ISO
BACKUP=NETFS
BACKUP_URL=ftpfs://rear:rear@10.160.4.244/rear
NETFS_KEEP_OLD_BACKUP_COPY=yes
SSH_ROOT_PASSWORD="rear"
USE_DHCLIENT="yes"
</pre>

The currently supported ftpfs BACKUP_URL syntax is
<pre>
ftpfs://user:password@host/path
</pre>
where password is optional.

The only missing piece for me is that
in the rear recovery system one must
manually load the fuse kernel module with
<pre>
modprobe fuse
</pre>
because otherwise "rear recover" aborts with
<pre>
Mount command 'curlftpfs ...' failed.
</pre>

At least for me the backup via curlftpfs is
very much slower than the backup via NFS.

For backup via NFS "rear mkbackup" reports
<pre>
Archived 916 MiB in 163 seconds [avg 5759 KiB/sec]
</pre>
while in contrast for backup via curlftpfs "rear mkbackup" reports
<pre>
Archived 916 MiB in 1744 seconds [avg 538 KiB/sec]
</pre>

But the restore via curlftpfs is as fast as via NFS.
For restore via curlftpfs "rear recover" reports
<pre>
Restored 2409 MiB in 38 seconds [avg 64942 KiB/sec]
</pre>
