### PR TITLE
Adding support for ppc64le PowerNV (non-virtualized aka Bare-Metal)

### DIFF
--- a/usr/share/rear/conf/Linux-ppc64le.conf
+++ b/usr/share/rear/conf/Linux-ppc64le.conf
@@ -17,6 +17,9 @@ bc
 agetty
 )
 
-COPY_AS_IS_EXCLUDE=( ${COPY_AS_IS_EXCLUDE[@]} /lib*/firmware )
+#Exclude firmware only when running in Virtualized mode (meaning not PowerNV mode).
+if [[ $(awk '/platform/ {print $NF}' < /proc/cpuinfo) != PowerNV ]] ; then
+    COPY_AS_IS_EXCLUDE=( ${COPY_AS_IS_EXCLUDE[@]} /lib*/firmware )
+fi
 
 KERNEL_CMDLINE="LANG=en_US.UTF-8 SYSFONT=latarcyrheb-sun16 KEYTABLE=us console=hvc0"


### PR DESCRIPTION
Need to have `/lib/firmware` in rescue image when running in BareMetal Mode (PowerNV).
Without firmware, we can't get access to the network, SAN disk etc ... 

Since only ppc64le Linux can run in powerNV, we don't need to do the same for Linux-ppc64.conf.

PowerNV mode can be detected in `/proc/cpuinfo`
```
[...]
processor       : 184
cpu             : POWER8E (raw), altivec supported
clock           : 2161.000000MHz
revision        : 2.1 (pvr 004b 0201)

timebase        : 512000000
platform        : PowerNV
model           : 8247-22L
machine         : PowerNV 8247-22L
firmware        : OPAL v3
```

There is may be other solution, If you have a better idea, just tell me.