### PR TITLE
better naming for Secure Boot options (issue#866)

### DIFF
--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -263,9 +263,9 @@ function make_syslinux_config {
 	if [ "$ISO_DEFAULT" == "manual" ] ; then
                echo "default rear"
                syslinux_menu "default"
-        fi 
+        fi
 	echo ""
-	
+
 	echo "say rear - Recover $(uname -n)"
 	echo "label rear-automatic"
 	syslinux_menu "label ^Automatic Recover $(uname -n)"
@@ -277,9 +277,9 @@ function make_syslinux_config {
 	if [ "$ISO_DEFAULT" == "automatic" ] ; then
                echo "default rear-automatic"
                syslinux_menu "default"
-        fi	
+        fi
 	echo ""
-	
+
 	syslinux_menu separator
 	echo "label -"
 	syslinux_menu "label Other actions"
@@ -447,10 +447,10 @@ function make_syslinux_config {
 function create_ebiso_elilo_conf {
 cat << EOF
 timeout = 5
-default = "Relax and Recover (no Secure Boot)"
+default = "Relax and Recover (no UEFI - usually BIOS boot)"
 
 image = kernel
-    label = "Relax and Recover (no Secure Boot)"
+    label = "Relax and Recover (no UEFI - usually BIOS boot)"
     initrd = initrd.cgz
 EOF
     [[ -n $KERNEL_CMDLINE ]] && cat << EOF
@@ -479,14 +479,14 @@ set timeout=5
 search --no-floppy --file /boot/efiboot.img --set
 #set root=(cd0)
 
-menuentry "Relax and Recover (no Secure Boot)"  --class gnu-linux --class gnu --class os {
+menuentry "Relax and Recover (no UEFI - usually BIOS boot)"  --class gnu-linux --class gnu --class os {
      echo 'Loading kernel ...'
      linux /isolinux/kernel $KERNEL_CMDLINE
      echo 'Loading initial ramdisk ...'
      initrd /isolinux/initrd.cgz
 }
 
-menuentry "Relax and Recover (Secure Boot)"  --class gnu-linux --class gnu --class os {
+menuentry "Relax and Recover (UEFI boot)"  --class gnu-linux --class gnu --class os {
      echo 'Loading kernel ...'
      linuxefi /isolinux/kernel $KERNEL_CMDLINE
      echo 'Loading initial ramdisk ...'

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -447,10 +447,10 @@ function make_syslinux_config {
 function create_ebiso_elilo_conf {
 cat << EOF
 timeout = 5
-default = "Relax and Recover (no UEFI - usually BIOS boot)"
+default = "Relax and Recover (using elilo)"
 
 image = kernel
-    label = "Relax and Recover (no UEFI - usually BIOS boot)"
+    label = "Relax and Recover (using elilo)"
     initrd = initrd.cgz
 EOF
     [[ -n $KERNEL_CMDLINE ]] && cat << EOF
@@ -479,14 +479,14 @@ set timeout=5
 search --no-floppy --file /boot/efiboot.img --set
 #set root=(cd0)
 
-menuentry "Relax and Recover (no UEFI - usually BIOS boot)"  --class gnu-linux --class gnu --class os {
+menuentry "Relax and Recover (using GRUB 2 'linux' and 'initrd')"  --class gnu-linux --class gnu --class os {
      echo 'Loading kernel ...'
      linux /isolinux/kernel $KERNEL_CMDLINE
      echo 'Loading initial ramdisk ...'
      initrd /isolinux/initrd.cgz
 }
 
-menuentry "Relax and Recover (UEFI boot)"  --class gnu-linux --class gnu --class os {
+menuentry "Relax and Recover (using GRUB 2 'linuxefi' and 'initrdefi')"  --class gnu-linux --class gnu --class os {
      echo 'Loading kernel ...'
      linuxefi /isolinux/kernel $KERNEL_CMDLINE
      echo 'Loading initial ramdisk ...'

--- a/usr/share/rear/output/ISO/Linux-i386/25_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/25_populate_efibootimg.sh
@@ -45,26 +45,29 @@ if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" ]]; then
     fi
 fi
 
+# create GRUB config
 if [[ -n "$(type -p grub)" ]]; then
+# we are using GRUB Legacy
 cat > $TMP_DIR/mnt/EFI/BOOT/BOOTX64.conf << EOF
 default=0
 timeout 5
 splashimage=/EFI/BOOT/splash.xpm.gz
-title Relax and Recover (no UEFI - usually BIOS boot)
+title Relax and Recover (using GRUB Legacy)
     kernel /isolinux/kernel
     initrd /isolinux/initrd.cgz
 
 EOF
 else
-# create small embedded grub.cfg file for grub-mkimage
+# we are using GRUB 2
+# create small embedded grub.cfg file for grub2-mkimage
 cat > $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg <<EOF
 set prefix=(cd0)/EFI/BOOT
 configfile /EFI/BOOT/grub.cfg
 EOF
-
-# create a grub.cfg
+# create a grub.cfg for GRUB 2
     create_grub2_cfg > $TMP_DIR/mnt/EFI/BOOT/grub.cfg
 fi
+
 # create BOOTX86.efi
 build_bootx86_efi
 

--- a/usr/share/rear/output/ISO/Linux-i386/25_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/25_populate_efibootimg.sh
@@ -50,7 +50,7 @@ cat > $TMP_DIR/mnt/EFI/BOOT/BOOTX64.conf << EOF
 default=0
 timeout 5
 splashimage=/EFI/BOOT/splash.xpm.gz
-title Relax and Recover (no Secure Boot)
+title Relax and Recover (no UEFI - usually BIOS boot)
     kernel /isolinux/kernel
     initrd /isolinux/initrd.cgz
 

--- a/usr/share/rear/output/USB/Linux-i386/10_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/10_create_efiboot.sh
@@ -44,7 +44,7 @@ Log "Copied kernel and initrd.cgz to ${EFI_DST}"
 # Configure elilo for EFI boot
 if test "$uefi_bootloader_basename" = "elilo.efi" ; then
     Log "Configuring elilo for EFI boot"
-    
+
     # Create config for elilo
     Log "Creating ${EFI_DST}/elilo.conf"
 
@@ -61,49 +61,49 @@ EOF
 else
     # Hope this assumption is not wrong ...
     if has_binary grub-install grub2-install; then
-    
+
         # Choose right grub binary
         # Issue #849
         if has_binary grub2-install; then
             NUM=2
         fi
-        
+
         GRUB_MKIMAGE=grub${NUM}-mkimage
         GRUB_INSTALL=grub${NUM}-install
-        
+
         # What version of grub are we using
         # substr() for awk did not work as expected for this reason cut was used
         # First charecter should be enough to identify grub version
         grub_version=$($GRUB_INSTALL --version | awk '{print $NF}' | cut -c1-1)
-        
+
         case ${grub_version} in
             0)
                 Log "Configuring grub 0.97 for EFI boot"
-                
+
                 # Create config for grub 0.97
                 cat > ${EFI_DST}/BOOTX64.conf << EOF
 default=0
 timeout=5
 
-title Relax and Recover (no Secure Boot)
+title Relax and Recover (no UEFI - usually BIOS boot)
     kernel ${EFI_DIR}/kernel
     initrd ${EFI_DIR}/initrd.cgz
 EOF
             ;;
             2)
                 Log "Configuring grub 2.0 for EFI boot"
-                
+
                 # Create bootloader, this overwrite BOOTX64.efi copied in previous step ...
                 # Fail if BOOTX64.efi can't be created
                 ${GRUB_MKIMAGE} -o ${EFI_DST}/BOOTX64.efi -p ${EFI_DIR} -O x86_64-efi linux part_gpt ext2 normal gfxterm gfxterm_background gfxterm_menu test all_video loadenv fat
                 StopIfError "Failed to create BOOTX64.efi"
-                
+
                 # Create config for grub 2.0
                 cat > ${EFI_DST}/grub.cfg << EOF
 set timeout=5
-set default=0 
+set default=0
 
-menuentry "Relax and Recover (no Secure Boot)" {
+menuentry "Relax and Recover (no UEFI - usually BIOS boot)" {
     linux ${EFI_DIR}/kernel
     initrd ${EFI_DIR}/initrd.cgz
 }

--- a/usr/share/rear/output/USB/Linux-i386/10_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/10_create_efiboot.sh
@@ -85,7 +85,7 @@ else
 default=0
 timeout=5
 
-title Relax and Recover (no UEFI - usually BIOS boot)
+title Relax and Recover (using grub 0.97)
     kernel ${EFI_DIR}/kernel
     initrd ${EFI_DIR}/initrd.cgz
 EOF
@@ -103,7 +103,7 @@ EOF
 set timeout=5
 set default=0
 
-menuentry "Relax and Recover (no UEFI - usually BIOS boot)" {
+menuentry "Relax and Recover (using grub 2.0 'linux' and 'initrd')" {
     linux ${EFI_DIR}/kernel
     initrd ${EFI_DIR}/initrd.cgz
 }


### PR DESCRIPTION
renamed recovery system boot menue entries
from 'Secure Boot' to 'UEFI boot' and
from 'no Secure Boot' to 'no UEFI - usually BIOS boot'
see https://github.com/rear/rear/issues/866