### PR TITLE
BUG: 20_partition_layout.sh : Multipath partition not found in rhel7.2

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/20_partition_layout.sh
@@ -34,7 +34,7 @@ extract_partitions() {
     if [[ ${#sysfs_paths[@]} -eq 0 ]] ; then
         ### try to find partitions like /dev/mapper/datalun1p1
         if [[ ${device/mapper//} != ${device} ]] ; then
-            for path in ${device}p[0-9]* ${device}-part*  ${device}_part*; do
+            for path in ${device}p[0-9]* ${device}[0-9] ${device}-part* ${device}_part*; do
                 sysfs_path=$(get_sysfs_name $path)
                 if [[ "$sysfs_path" ]] && [[ -e "/sys/block/$sysfs_path" ]] ; then
                     sysfs_paths=( "${sysfs_paths[@]}" "/sys/block/$sysfs_path" )


### PR DESCRIPTION
RHEL 7 is naming multipath partition in a `mpath[1-9] `style.
for example : `/dev/mpath1 `instead of `/dev/mpathp1` or `/dev/mpath-part1 `etc ...
Because of that, `20_partition_layout.sh `failed to detect mpath partition.