### PR TITLE
Limit ppc64/ppc64le bootlist parameter to 5 entries

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/22_install_grub2.sh
@@ -48,7 +48,18 @@ if [[ -r "$LAYOUT_FILE" ]]; then
         if ! grep -q "PowerNV" /proc/cpuinfo && ! grep -q "emulated by qemu" /proc/cpuinfo ; then
             bootdev=`echo $part | sed -e 's/[0-9]*$//'`
             LogPrint "Boot device is $bootdev."
-            bootlist -m normal $bootdev
+
+            # Test if $bootdev is a multipath device
+            if dmsetup ls --target multipath | grep -w ${bootdev#/dev/mapper/} >/dev/null 2>&1; then
+                LogPrint "Limiting bootlist to 5 entries..."
+                bootlist_path=$(dmsetup deps $bootdev -o devname | awk -F: '{gsub (" ",""); gsub("\\(","/dev/",$2) ; gsub("\\)"," ",$2) ; print $2}' | cut -d" " -f-5)
+                LogPrint "bootlist will be $bootlist_path"
+                bootlist -m normal $bootlist_path
+                LogIfError "Unable to set bootlist. You will have to start in SMS to set it up manually."
+            else
+                LogPrint "bootlist will be $bootdev"
+                bootlist -m normal $bootdev
+            fi
         fi
         NOBOOTLOADER=
     fi

--- a/usr/share/rear/finalize/Linux-ppc64/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/22_install_grub2.sh
@@ -46,7 +46,11 @@ if [[ -r "$LAYOUT_FILE" ]]; then
         chroot $TARGET_FS_ROOT /bin/bash --login -c "$grub_name-install $part"
         # Run bootlist only in PowerVM environment
         if ! grep -q "PowerNV" /proc/cpuinfo && ! grep -q "emulated by qemu" /proc/cpuinfo ; then
-            bootdev=`echo $part | sed -e 's/[0-9]*$//'`
+            #Using $LAYOUT_DEPS file to find the disk device containing the partition.
+            bootdev=$(awk '$1==PART { print $NF}' PART=$part $LAYOUT_DEPS)
+            if [[ -z $bootdev ]]; then
+                bootdev=`echo $part | sed -e 's/[0-9]*$//'`
+            fi
             LogPrint "Boot device is $bootdev."
 
             # Test if $bootdev is a multipath device

--- a/usr/share/rear/finalize/Linux-ppc64le/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/22_install_grub2.sh
@@ -48,7 +48,18 @@ if [[ -r "$LAYOUT_FILE" ]]; then
         if ! grep -q "PowerNV" /proc/cpuinfo && ! grep -q "emulated by qemu" /proc/cpuinfo ; then
             bootdev=`echo $part | sed -e 's/[0-9]*$//'`
             LogPrint "Boot device is $bootdev."
-            bootlist -m normal $bootdev
+
+            # Test if $bootdev is a multipath device
+            if dmsetup ls --target multipath | grep -w ${bootdev#/dev/mapper/} >/dev/null 2>&1; then
+                LogPrint "Limiting bootlist to 5 entries..."
+                bootlist_path=$(dmsetup deps $bootdev -o devname | awk -F: '{gsub (" ",""); gsub("\\(","/dev/",$2) ; gsub("\\)"," ",$2) ; print $2}' | cut -d" " -f-5)
+                LogPrint "bootlist will be $bootlist_path"
+                bootlist -m normal $bootlist_path
+                LogIfError "Unable to set bootlist. You will have to start in SMS to set it up manually."
+            else
+                LogPrint "bootlist will be $bootdev"
+                bootlist -m normal $bootdev
+            fi
         fi
         NOBOOTLOADER=
     fi

--- a/usr/share/rear/finalize/Linux-ppc64le/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/22_install_grub2.sh
@@ -46,7 +46,11 @@ if [[ -r "$LAYOUT_FILE" ]]; then
         chroot $TARGET_FS_ROOT /bin/bash --login -c "$grub_name-install $part"
         # Run bootlist only in PowerVM environment
         if ! grep -q "PowerNV" /proc/cpuinfo && ! grep -q "emulated by qemu" /proc/cpuinfo ; then
-            bootdev=`echo $part | sed -e 's/[0-9]*$//'`
+            #Using $LAYOUT_DEPS file to find the disk device containing the partition.
+            bootdev=$(awk '$1==PART { print $NF}' PART=$part $LAYOUT_DEPS)
+            if [[ -z $bootdev ]]; then
+                bootdev=`echo $part | sed -e 's/[0-9]*$//'`
+            fi
             LogPrint "Boot device is $bootdev."
 
             # Test if $bootdev is a multipath device


### PR DESCRIPTION
PowerPC bootlist supports a maximum of 5 entries. If more than 5 paths is given, bootlist is not set.
This is particulary true when boot device is multipathed.
`bootlist -m normal /dev/mapper/mpatha` will failed if `mpatha` has more than 5 paths.
=> We need to check and limit to 5 the number of path given to the bootlist command.