### PR TITLE
correcting rear return code handling

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -40,12 +40,12 @@ echo "* * * Rescue System is ready * * *"
 
 # Launch rear recover automatically
 if grep -q 'auto_recover' /proc/cmdline ; then
-        rear recover -v
-        
 	choices=(
 	    "View Relax-and-Recover log"
 	    "Go to Relax-and-Recover shell"
 	)
+	
+	rear recover -v
 	if [ $? -eq 0 ] ; then
 	    choices=(
 	    "${choices[@]}"


### PR DESCRIPTION
Moved rear invocation so that the assignment return code is not interfering with rear return code processing. I assume the original intention was to only provide the reboot option if rear reports success.