### PR TITLE
First steps towards more reliably installing the right bootloader

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/21_install_grub.sh
+++ b/usr/share/rear/finalize/Linux-i386/21_install_grub.sh
@@ -5,112 +5,137 @@
 #  * We don't know what the first disk will be, so we cannot be sure the MBR
 #    is written to the correct disk(s). That's why we make all disks bootable.
 #
-#  * There is no guarantee that GRUB was the boot loader used originally. One
-#    solution is to save and restore the MBR for each disk, but this does not
-#    guarantee a correct boot-order, or even a working boot-lader config (eg.
-#    GRUB stage2 might not be at the exact same location)
+#  * There is no guarantee that GRUB was the boot loader used originally.
+#    One possible attempt would be to save and restore the MBR for each disk,
+#    but this does not guarantee a correct boot order,
+#    or even a working boot loader config
+#    (eg. GRUB stage2 might not be at the exact same location).
 
-# skip if another bootloader was installed
-if [[ -z "$NOBOOTLOADER" ]] ; then
+# Skip if another boot loader is already installed
+# (then $NOBOOTLOADER is not a true value cf. finalize/default/01_prepare_checks.sh):
+is_true $NOBOOTLOADER || return
+
+# For UEFI systems with grub legacy with should use efibootmgr instead:
+is_true $USING_UEFI_BOOTLOADER && return
+
+# If the BOOTLOADER variable (read by finalize/default/01_prepare_checks.sh)
+# is not "GRUB" (which means GRUB Legacy) skip this script (which is only for GRUB Legacy)
+# because finalize/Linux-i386/22_install_grub2.sh is for installing GRUB 2
+# and finalize/Linux-i386/22_install_elilo.sh is for installing elilo:
+test "GRUB" = "$BOOTLOADER" || return
+
+# If the BOOTLOADER variable is "GRUB" (which means GRUB Legacy)
+# do not unconditionally trust that because https://github.com/rear/rear/pull/589
+# reads (excerpt):
+#   Problems found:
+#   The 21_install_grub.sh checked for GRUB2 which is not part
+#   of the first 2048 bytes of a disk - only GRUB was present -
+#   thus the check for grub-probe/grub2-probe
+# and https://github.com/rear/rear/commit/079de45b3ad8edcf0e3df54ded53fe955abded3b
+# reads (excerpt):
+#    replace grub-install by grub-probe
+#    as grub-install also exist in legacy grub
+# so that it seems there are cases where actually GRUB 2 is used
+# but wrongly detected as "GRUB" so that another test is needed
+# to detected if actually GRUB 2 is used and that test is to
+# check if grub-probe or grub2-probe is installed because
+# grub-probe or grub2-probe is only installed in case of GRUB 2
+# and when GRUB 2 is installed we assume GRUB 2 is used as boot loader
+# so that then we skip this script (which is only for GRUB Legacy)
+# because finalize/Linux-i386/22_install_grub2.sh is for installing GRUB 2:
+if type -p grub-probe >&2 || type -p grub2-probe >&2 ; then
+    LogPrint "Skip installing GRUB Legacy boot loader because GRUB 2 is installed (grub-probe or grub2-probe exist)."
     return
 fi
 
-# for UEFI systems with grub legacy with should use efibootmgr instead
-is_true $USING_UEFI_BOOTLOADER && return # set to 1 means UEFI booting
+# The actual work:
+LogPrint "Installing GRUB Legacy boot loader:"
 
-# check the BOOTLOADER variable (read by 01_prepare_checks.sh script)
-if [[ "$BOOTLOADER" = "GRUB" ]]; then
-    if [[ $(type -p grub-probe) || $(type -p grub2-probe) ]]; then
-        # grub2 script should handle this instead
-        return
-    fi
-fi
+# Installing GRUB Legacy boot loader requires an executable "grub":
+type -p grub >&2 || Error "Cannot install GRUB Legacy boot loader because there is no 'grub' program."
 
-# Only for GRUB Legacy - GRUB2 will be handled by its own script
-if [[ -z "$(type -p grub)" ]]; then
-    return
-fi
-
-LogPrint "Installing GRUB boot loader"
 mount -t proc none $TARGET_FS_ROOT/proc
 
-if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]]; then
+if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]] ; then
 
     # Check if we find GRUB stage 2 where we expect it
-    [[ -d "$TARGET_FS_ROOT/boot" ]]
-    StopIfError "Could not find directory /boot"
-    [[ -d "$TARGET_FS_ROOT/boot/grub" ]]
-    StopIfError "Could not find directory /boot/grub"
-    [[ -r "$TARGET_FS_ROOT/boot/grub/stage2" ]]
-    StopIfError "Unable to find /boot/grub/stage2."
+    test -d "$TARGET_FS_ROOT/boot" || Error "Could not find directory /boot."
+    test -d "$TARGET_FS_ROOT/boot/grub" || Error "Could not find directory /boot/grub."
+    test -r "$TARGET_FS_ROOT/boot/grub/stage2" || Error "Unable to find /boot/grub/stage2."
 
     # Find exclusive partition(s) belonging to /boot
     # or / (if /boot is inside root filesystem)
-    if [[ "$(filesystem_name $TARGET_FS_ROOT/boot)" == "$TARGET_FS_ROOT" ]]; then
-        bootparts=$(find_partition fs:/)
+    if test "$TARGET_FS_ROOT" = "$( filesystem_name $TARGET_FS_ROOT/boot )" ; then
+        bootparts=$( find_partition fs:/ )
         grub_prefix=/boot/grub
     else
-        bootparts=$(find_partition fs:/boot)
+        bootparts=$( find_partition fs:/boot )
         grub_prefix=/grub
     fi
     # Should never happen
-    [[ "$bootparts" ]]
-    BugIfError "Unable to find any /boot partitions"
+    test "$bootparts" || BugError "Unable to find any /boot partitions."
 
     # Find the disks that need a new GRUB MBR
-    disks=$(grep '^disk \|^multipath ' $LAYOUT_FILE | cut -d' ' -f2)
-    [[ "$disks" ]]
-    StopIfError "Unable to find any disks"
+    disks=$( grep '^disk \|^multipath ' $LAYOUT_FILE | cut -d' ' -f2 )
+    test "$disks" || Error "Unable to find any disks."
 
-    for disk in $disks; do
+    for disk in $disks ; do
         # Use first boot partition by default
-        part=$(echo $bootparts | cut -d' ' -f1)
+        part=$( echo $bootparts | cut -d' ' -f1 )
 
         # Use boot partition that matches with this disk, if any
-        for bootpart in $bootparts; do
-            bootdisk=$(find_disk_and_multipath "$bootpart")
-            if [[ "$disk" == "$bootdisk" ]]; then
+        for bootpart in $bootparts ; do
+            bootdisk=$( find_disk_and_multipath "$bootpart" )
+            if test "$bootdisk" = "$disk" ; then
                 part=$bootpart
                 break
             fi
         done
 
         # Find boot-disk and partition number
-        bootdisk=$(find_disk_and_multipath "$part")
+        bootdisk=$( find_disk_and_multipath "$part" )
         partnr=${part#$bootdisk}
         partnr=${partnr#p}
-        partnr=$((partnr - 1))
+        partnr=$(( partnr - 1 ))
 
-        if [[ "$bootdisk" == "$disk" ]]; then
+        if test "$bootdisk" = "$disk" ; then
             # Best case scenario is to have /boot on disk with MBR booted
-            chroot $TARGET_FS_ROOT grub --batch --no-floppy >&2 <<EOF
+            if chroot $TARGET_FS_ROOT grub --batch --no-floppy >&2 <<EOF
 device (hd0) $disk
 root (hd0,$partnr)
 setup --stage2=/boot/grub/stage2 --prefix=$grub_prefix (hd0)
 quit
 EOF
+            then NOBOOTLOADER=""
+                 LogPrint "Installed GRUB Legacy boot loader with /boot on disk with MBR booted on 'device (hd0) $disk' with 'root (hd0,$partnr)'."
+            fi
         else
             # hd1 is a best effort guess, we cannot predict how numbering
             # changes when a disk fails.
-            chroot $TARGET_FS_ROOT grub --batch --no-floppy >&2 <<EOF
+            if chroot $TARGET_FS_ROOT grub --batch --no-floppy >&2 <<EOF
 device (hd0) $disk
 device (hd1) $bootdisk
 root (hd1,$partnr)
 setup --stage2=/boot/grub/stage2 --prefix=$grub_prefix (hd0)
 quit
 EOF
+            then NOBOOTLOADER=""
+                 LogPrint "Installed GRUB Legacy boot loader on hd1 as best effort guess on 'device (hd0) $disk' and 'device (hd1) $bootdisk' with 'root (hd1,$partnr)'."
+            fi
         fi
 
-        if (( $? == 0 )); then
-            NOBOOTLOADER=
-        fi
     done
 fi
 
-if [[ "$NOBOOTLOADER" ]]; then
+if test "$NOBOOTLOADER" ; then
     if chroot $TARGET_FS_ROOT grub-install '(hd0)' >&2 ; then
-        NOBOOTLOADER=
+        NOBOOTLOADER=""
+        LogPrint "Installed GRUB Legacy boot loader via 'grub-install (hd0)'."
     fi
 fi
 
+# This script is meant to get the GRUB Legacy boot loader installed:
+is_true $NOBOOTLOADER && Error "Failed to install GRUB Legacy boot loader."
+
 umount $TARGET_FS_ROOT/proc
+

--- a/usr/share/rear/finalize/default/01_prepare_checks.sh
+++ b/usr/share/rear/finalize/default/01_prepare_checks.sh
@@ -1,9 +1,21 @@
-# prepare some checks
-# we want to tell the user if we didn't install a boot loader. To accomplish this we set a variable
-# that is unset by all boot-loader installation scripts
+
+# Prepare some checks.
+
+# We want to tell the user if we did not install a boot loader.
+# To accomplish this we set the NOBOOTLOADER variable to a true value
+# that must be unset or set to an emptly value or set to a non-true value
+# (so that "is_true $NOBOOTLOADER" returns false, cf. lib/global-functions.sh)
+# by all boot-loader installation scripts after successfully installing a boot loader
+# (i.e. "is_true $NOBOOTLOADER || echo a boot loader is already installed"):
 NOBOOTLOADER=1
 
-# read the BOOTLOADER if it was defined
-if [[ -f $VAR_DIR/recovery/bootloader ]]; then
-    BOOTLOADER=$( cat $VAR_DIR/recovery/bootloader )
-fi
+# Try to read the BOOTLOADER value if /var/lib/rear/recovery/bootloader is not empty.
+# Currently (June 2016) the used BOOTLOADER values (grep for '$BOOTLOADER') are:
+#   GRUB  for GRUB Legacy
+#   GRUB2 for GRUB 2
+#   ELILO for elilo
+local bootloader_file="$VAR_DIR/recovery/bootloader"
+# The output is stored in an artificial bash array so that $BOOTLOADER is the first word:
+test -s $bootloader_file &&  BOOTLOADER=( $( grep -v '^[[:space:]]*#' $bootloader_file ) )
+test
+


### PR DESCRIPTION
Regarding installing GRUB Legacy as bootloader
overhauled finalize/Linux-i386/21_install_grub.sh and
improved finalie/default/01_prepare_checks.sh
(see issue https://github.com/rear/rear/issues/895)

It is still not fully reliably installing the right bootloader:
When GRUB 2 is installed in addition To GrubLegacy
it still prefers to install GRUB 2 as bootloader
even if the BOOTLOADER variable tells "GRUB"
(which means GRUB Legacy).

I.e. further work is needed...
