### PR TITLE
Typo in 22_install_grub2.sh for ppc64/ppc64le

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/22_install_grub2.sh
@@ -69,7 +69,7 @@ if [[ -r "$LAYOUT_FILE" ]]; then
     fi
 fi
 
-if [[ "NOBOOTLOADER" ]]; then
+if [[ "$NOBOOTLOADER" ]]; then
     LogIfError "No bootloader configuration found. Install boot partition manually"
 fi
 

--- a/usr/share/rear/finalize/Linux-ppc64le/22_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/22_install_grub2.sh
@@ -69,7 +69,7 @@ if [[ -r "$LAYOUT_FILE" ]]; then
     fi
 fi
 
-if [[ "NOBOOTLOADER" ]]; then
+if [[ "$NOBOOTLOADER" ]]; then
     LogIfError "No bootloader configuration found. Install boot partition manually"
 fi
 


### PR DESCRIPTION
"$" seems to be missing when checking NOBOOTLOADER variable.

Please confirm.