### PR TITLE
use BACKUP_PROG_COMPRESS_OPTIONS as an array (issue904)

### DIFF
--- a/usr/share/rear/backup/NETFS/default/50_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/50_make_backup.sh
@@ -76,14 +76,14 @@ case "$(basename ${BACKUP_PROG})" in
 			--no-wildcards-match-slash --one-file-system \
 			--ignore-failed-read $BACKUP_PROG_OPTIONS \
 			$BACKUP_PROG_X_OPTIONS \
-			${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} $BACKUP_PROG_COMPRESS_OPTIONS \
+			${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
 			-X $TMP_DIR/backup-exclude.txt -C / -c -f - \
 			$(cat $TMP_DIR/backup-include.txt) $LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
 		$BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
 			--no-wildcards-match-slash --one-file-system \
 			--ignore-failed-read $BACKUP_PROG_OPTIONS \
 			$BACKUP_PROG_X_OPTIONS \
-			${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} $BACKUP_PROG_COMPRESS_OPTIONS \
+			${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
 			-X $TMP_DIR/backup-exclude.txt -C / -c -f - \
 			$(cat $TMP_DIR/backup-include.txt) $LOGFILE | $BACKUP_PROG_CRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $SPLIT_COMMAND
 	;;
@@ -99,11 +99,11 @@ case "$(basename ${BACKUP_PROG})" in
 	;;
 	(*)
 		Log "Using unsupported backup program '$BACKUP_PROG'"
-		Log $BACKUP_PROG $BACKUP_PROG_COMPRESS_OPTIONS \
+		Log $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
 			$BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
 			$BACKUP_PROG_OPTIONS $backuparchive \
 			$(cat $TMP_DIR/backup-include.txt) $LOGFILE > $backuparchive
-		$BACKUP_PROG $BACKUP_PROG_COMPRESS_OPTIONS \
+		$BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
 			$BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
 			$BACKUP_PROG_OPTIONS $backuparchive \
 			$(cat $TMP_DIR/backup-include.txt) $LOGFILE > $backuparchive

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -274,7 +274,14 @@ BACKUP_PROG_OPTIONS_CREATE_ARCHIVE=""
 # into a specific path (like tar -C $TARGET_FS_ROOT)
 BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE=""
 BACKUP_PROG_SUFFIX=".tar"
-BACKUP_PROG_COMPRESS_OPTIONS="--gzip"
+# BACKUP_PROG_COMPRESS_OPTIONS is an array so that one can use it to provide more complex values
+# e.g. to override the gzip default compression level (-6) via the tar '-I' option
+# like BACKUP_PROG_COMPRESS_OPTIONS=( -I 'gzip -9 -n -c' )
+# but using it with command options (as in 'gzip -9') fails with tar versions before 1.27
+# with a tar error message like "gzip -9: Cannot exec" because only since tar version 1.27
+# tar supports passing command line arguments to external commands, see
+# http://git.savannah.gnu.org/cgit/tar.git/plain/NEWS?id=release_1_27
+BACKUP_PROG_COMPRESS_OPTIONS=( --gzip )
 BACKUP_PROG_COMPRESS_SUFFIX=".gz"
 # Addons for encryption of the backup (currently only tar is supported)
 BACKUP_PROG_CRYPT_ENABLED=0

--- a/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
@@ -45,17 +45,17 @@ case "$BACKUP_PROG" in
             LAST="$restorearchive"
             BASE=$(dirname "$restorearchive")/$(tar --test-label -f "$restorearchive")
             if [ "$BASE" == "$LAST" ]; then
-                Log dd if=$BASE \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
-                dd if=$BASE | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
+                Log dd if=$BASE \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                dd if=$BASE | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
             else
-                Log dd if="$BASE" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
-                dd if="$BASE" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
-                Log dd if="$LAST" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
-                dd if="$LAST" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
+                Log dd if="$BASE" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                dd if="$BASE" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                Log dd if="$LAST" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                dd if="$LAST" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
             fi
         else
-            Log dd if=$restoreinput \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
-            dd if=$restoreinput | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS $BACKUP_PROG_COMPRESS_OPTIONS -C $TARGET_FS_ROOT/ -x -f -
+            Log dd if=$restoreinput \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+            dd if=$restoreinput | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
         fi
     ;;
     (rsync)
@@ -67,7 +67,7 @@ case "$BACKUP_PROG" in
     ;;
     (*)
         Log "Using unsupported backup program '$BACKUP_PROG'"
-        $BACKUP_PROG $BACKUP_PROG_COMPRESS_OPTIONS \
+        $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
             $BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE $TARGET_FS_ROOT \
             $BACKUP_PROG_OPTIONS $backuparchive
     ;;


### PR DESCRIPTION
Implemented enhancement https://github.com/rear/rear/issues/904

BACKUP_PROG_COMPRESS_OPTIONS is now an array
so that one can use it to provide more complex values.

E.g. to override the gzip default compression level (-6)
via the tar '-I' option like
BACKUP_PROG_COMPRESS_OPTIONS=( -I 'gzip -9 -n -c' )

But using it with command options (as in 'gzip -9')
fails with tar versions before 1.27 with a tar error
message like "gzip -9: Cannot exec" because only
since tar version 1.27 tar supports passing command
line arguments to external commands, see
http://git.savannah.gnu.org/cgit/tar.git/plain/NEWS?id=release_1_27
