### PR TITLE
error out instead of bugerror for not implemented URI schemes

### DIFF
--- a/usr/share/rear/output/default/95_copy_result_files.sh
+++ b/usr/share/rear/output/default/95_copy_result_files.sh
@@ -1,10 +1,10 @@
 #
 # copy resulting files to network output location
 
-local scheme=$(url_scheme $OUTPUT_URL)
-local host=$(url_host $OUTPUT_URL)
-local path=$(url_path $OUTPUT_URL)
-local opath=$(output_path $scheme $path)
+local scheme=$( url_scheme $OUTPUT_URL )
+local host=$( url_host $OUTPUT_URL )
+local path=$( url_path $OUTPUT_URL )
+local opath=$( output_path $scheme $path )
 
 # if $opath is empty return silently (e.g. scheme tape)
 if [[ -z "$opath" || -z "$OUTPUT_URL" || "$scheme" == "obdr" || "$scheme" == "tape" ]]; then
@@ -17,40 +17,31 @@ case "$scheme" in
     (nfs|cifs|usb|file|sshfs|ftpfs|davfs)
         # if called as mkbackuponly then we just don't have any result files.
         if test "$RESULT_FILES" ; then
-            Log "Copying files '${RESULT_FILES[@]}' to $scheme location"
-            cp $v "${RESULT_FILES[@]}" "${opath}/" >&2
-            StopIfError "Could not copy files to $scheme location"
+            Log "Copying result files '${RESULT_FILES[@]}' to $opath at $scheme location"
+            cp $v "${RESULT_FILES[@]}" "${opath}/" >&2 || Error "Could not copy result files to $opath at $scheme location"
         fi
-        echo "$VERSION_INFO" >"${opath}/VERSION"
-        StopIfError "Could not create VERSION file on $scheme location"
-
-        cp $v $(get_template "RESULT_usage_$OUTPUT.txt") "${opath}/README" >&2
-        StopIfError "Could not copy usage file to $scheme location"
-
+        echo "$VERSION_INFO" >"${opath}/VERSION" || Error "Could not create ${opath}/VERSION file at $scheme location"
+        cp $v $( get_template "RESULT_usage_$OUTPUT.txt" ) "${opath}/README" >&2 || Error "Could not copy usage file to ${opath}/README at $scheme location"
         # REAR_LOGFILE=/var/log/rear/rear-$HOSTNAME.log (name set by main script)
-        cat "$REAR_LOGFILE" >"${opath}/rear.log"
-        StopIfError "Could not copy $REAR_LOGFILE to $scheme location"
+        cat "$REAR_LOGFILE" >"${opath}/rear.log" || Error "Could not copy $REAR_LOGFILE to ${opath}/rear.log at $scheme location"
     ;;
 
     (fish|ftp|ftps|hftp|http|https|sftp)
-    LogPrint "Copying files '${RESULT_FILES[*]}' to $scheme location"
+    LogPrint "Copying result files '${RESULT_FILES[*]}' to $scheme location"
     Log "lftp -c open $OUTPUT_URL; mput ${RESULT_FILES[*]}"
-    lftp -c "open $OUTPUT_URL; mput ${RESULT_FILES[*]}"
-    StopIfError "Problem transferring files to $OUTPUT_URL"
+    lftp -c "open $OUTPUT_URL; mput ${RESULT_FILES[*]}" || Error "Problem transferring result files to $OUTPUT_URL"
     ;;
 
     (rsync)
     [[ "$BACKUP" = "RSYNC" ]] && return 0   # output/RSYNC/default/90_copy_result_files.sh took care of it
-    LogPrint "Copying files '${RESULT_FILES[@]}' to $scheme location"
+    LogPrint "Copying result files '${RESULT_FILES[@]}' to $scheme location"
     Log "rsync -a $v ${RESULT_FILES[@]} ${host}:${path}"
-    rsync -a $v "${RESULT_FILES[@]}" "${host}:${path}"
-    StopIfError "Problem transferring files to $OUTPUT_URL"
+    rsync -a $v "${RESULT_FILES[@]}" "${host}:${path}" || Error "Problem transferring result files to $OUTPUT_URL"
     ;;
 
-    (*) BugError "Support for $scheme is not implemented yet."
+    (*) Error "Invalid scheme '$scheme' in '$OUTPUT_URL'."
     ;;
 esac
-
 
 Log "Saved $REAR_LOGFILE as rear.log"
 


### PR DESCRIPTION
see https://github.com/rear/rear/issues/931
and
some other fixes:
- first steps to be prepared for 'set -e' which means
  replaced COMMAND ; StopIfError
  with COMMAND || Error
- in output/PXE/default/82_copy_to_net.sh
  error out in case of "Problem transferring..."
  for each result file (before it only errors out
  in case of "Problem transferring..." for the last
  result file because the Errot was after the for loop)
