### PR TITLE
first steps to make GRUB_RESCUE work for GRUB2 on SLES12

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -940,7 +940,7 @@ USE_DHCLIENT=
 USE_STATIC_NETWORKING=
 
 ##
-# GRUB_RESCUE [ GRUB_RESCUE_PASSWORD [ GRUB_SUPERUSER ] GRUB_RESCUE_USER ]
+# GRUB_RESCUE [ GRUB_RESCUE_PASSWORD GRUB_RESCUE_USER ]
 #
 # Add a rear rescue/recovery system to the GRUB/GRUB2 bootloader of the currently running system.
 # It adds kernel and the rear initrd to the bootloader directory in the currently running system and
@@ -955,34 +955,30 @@ USE_STATIC_NETWORKING=
 # whole current system with a recreated system where all files are restored from the backup.
 # To be on the safe side the GRUB_RESCUE functionality is disabled by default:
 GRUB_RESCUE=n
-# If the GRUB_RESCUE functionality is explicity enabled (e.g. via GRUB_RESCUE=y in /etc/rear/local.conf)
-# a non-empty GRUB_RESCUE_PASSWORD can be set to get password protection for the GRUB2 menue entries.
-# This can be used to prevent accidental recovery.
-# When GRUB_RESCUE_PASSWORD is set it may result password protection for all GRUB2 menue entries
-# of the currently running system unless the '--unrestricted' option is set
-# for those GRUB2 menue entries that should not have password protection.
-# For GRUB2 instead of a plain text password one can specify the PBKDF2 hash of the password
+# Optional password protection via GRUB_RESCUE_PASSWORD plus GRUB_RESCUE_USER only works for GRUB2:
+# If the GRUB_RESCUE functionality is enabled (e.g. via GRUB_RESCUE=y in /etc/rear/local.conf)
+# a non-empty GRUB_RESCUE_PASSWORD can be optionally set to get GRUB2 password protection
+# for the 'Relax-and-Recover' GRUB2 menue entry.
+# Instead of a plain text password one can specify the PBKDF2 hash of the password
 # that is output by grub-mkpasswd-pbkdf2 (or grub2-mkpasswd-pbkdf2) as a very long string like
 #   GRUB_RESCUE_PASSWORD="grub.pbkdf2.sha512.10000.a1b2c3..."
-# The default GRUB_RESCUE_PASSWORD is empty which means that rear does not change
-# how GRUB2 password protection is already configured in the currently running system:
 GRUB_RESCUE_PASSWORD=""
-# When GRUB_RESCUE_PASSWORD is non-empty (i.e. when rear changes the GRUB2 password protection)
-# you can specify via GRUB_SUPERUSER which GRUB2 superuser can access GRUB2 menue entries.
-# The default GRUB_SUPERUSER is empty which means that rear does not change
-# how GRUB2 users are already configured in the currently running system:
-GRUB_SUPERUSER=""
 # GRUB2 password protection requires a GRUB2 user.
-# When GRUB_RESCUE_PASSWORD is non-empty (i.e. when rear changes the GRUB2 password protection)
-# a GRUB2 username is required that must exist as a configured GRUB2 user.
-# The default GRUB_RESCUE_USER is the same as the GRUB_SUPERUSER value
-# so that when a GRUB_SUPERUSER will be configured by rear that superuser
-# becomes by default the user that is used for the GRUB2 password protection.
-# Because by default GRUB_SUPERUSER is empty it means that when GRUB_RESCUE_PASSWORD is non-empty
-# you must explicitly also specify a valid existing GRUB2 user here as GRUB_RESCUE_USER:
-GRUB_RESCUE_USER="$GRUB_SUPERUSER"
-# When GRUB_RESCUE_PASSWORD is non-empty faulty settings for GRUB_SUPERUSER or GRUB_RESCUE_USER
-# may result that you can no longer boot your currently running system.
+# When GRUB_RESCUE_PASSWORD is non-empty a GRUB2 username is required
+# that must exist as an already configured GRUB2 user.
+# I.e. when GRUB_RESCUE_PASSWORD is non-empty you must explicitly
+# also specify a valid existing GRUB2 user as GRUB_RESCUE_USER.
+GRUB_RESCUE_USER=""
+# The former GRUB_SUPERUSER setup support in rear is dropped because
+# it can change the behaviour of the GRUB2 bootloader as a whole in unexpected ways and
+# rear is not meant to change the general GRUB2 configuration of the currently running system.
+# For background information see https://github.com/rear/rear/issues/703
+# starting at https://github.com/rear/rear/issues/703#issuecomment-235506494
+# To be backward compatible as far as possible rear uses a GRUB_SUPERUSER value
+# that might be set in /etc/rear/local.conf as fallback for GRUB_RESCUE_USER
+# if GRUB_RESCUE_PASSWORD is non-empty but GRUB_RESCUE_USER is empty.
+# Nevertheless it is recommended to no longer use GRUB_SUPERUSER and
+# only use GRUB_RESCUE_PASSWORD plus GRUB_RESCUE_USER if needed.
 
 ##
 # USING_UEFI_BOOTLOADER

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -940,7 +940,7 @@ USE_DHCLIENT=
 USE_STATIC_NETWORKING=
 
 ##
-# GRUB_RESCUE [ GRUB_RESCUE_PASSWORD GRUB_RESCUE_USER ]
+# GRUB_RESCUE [ GRUB_RESCUE_USER ]
 #
 # Add a rear rescue/recovery system to the GRUB/GRUB2 bootloader of the currently running system.
 # It adds kernel and the rear initrd to the bootloader directory in the currently running system and
@@ -949,36 +949,38 @@ USE_STATIC_NETWORKING=
 # changes the currently running system. It changes the currently running system even
 # in a critical way because it changes the bootloader of the currently running system.
 # The main reason for the GRUB_RESCUE functionality is to be quickly able to recover a system
-# from soft errors (like deleting all of /lib/) without digging out the rear recovery boot media.
+# from soft errors (like deleting all of /lib/) without digging out the rear recovery boot medium.
 # When booting that locally installed rear recovery system it does the same as when booting
-# the rear recovery system from an external rear boot media - i.e. "rear recover" replaces the
+# the rear recovery system from an external rear boot medium - i.e. "rear recover" replaces the
 # whole current system with a recreated system where all files are restored from the backup.
 # To be on the safe side the GRUB_RESCUE functionality is disabled by default:
 GRUB_RESCUE=n
-# Optional password protection via GRUB_RESCUE_PASSWORD plus GRUB_RESCUE_USER only works for GRUB2:
+# Optional password protection via GRUB_RESCUE_USER only works for GRUB2.
+# GRUB2 password protection requires an existing GRUB2 user with a password.
 # If the GRUB_RESCUE functionality is enabled (e.g. via GRUB_RESCUE=y in /etc/rear/local.conf)
-# a non-empty GRUB_RESCUE_PASSWORD can be optionally set to get GRUB2 password protection
+# a non-empty GRUB_RESCUE_USER can be optionally set to get GRUB2 password protection
 # for the 'Relax-and-Recover' GRUB2 menue entry.
-# Instead of a plain text password one can specify the PBKDF2 hash of the password
-# that is output by grub-mkpasswd-pbkdf2 (or grub2-mkpasswd-pbkdf2) as a very long string like
-#   GRUB_RESCUE_PASSWORD="grub.pbkdf2.sha512.10000.a1b2c3..."
-GRUB_RESCUE_PASSWORD=""
-# GRUB2 password protection requires a GRUB2 user.
-# When GRUB_RESCUE_PASSWORD is non-empty a GRUB2 username is required
-# that must exist as an already configured GRUB2 user.
-# I.e. when GRUB_RESCUE_PASSWORD is non-empty you must explicitly
-# also specify a valid existing GRUB2 user as GRUB_RESCUE_USER.
+# When GRUB_RESCUE_USER is non-empty it must specify an already configured GRUB2 user
+# except the special value 'unrestricted' is set via GRUB_RESCUE_USER="unrestricted"
+# which creates the 'Relax-and-Recover' GRUB2 menue entry so that it can be booted by anyone
+# which means anyone who can boot the currently running system can replace it via "rear recover".
+# When GRUB_RESCUE_USER is empty rear does not do a GRUB2 user related setup
+# so that the already existing GRUB2 users configuration determines
+# which users can boot the 'Relax-and-Recover' GRUB2 menue entry.
+# Usually this means anyone can boot 'Relax-and-Recover' which means anyone
+# who can boot the currently running system can replace it via "rear recover".
 GRUB_RESCUE_USER=""
-# The former GRUB_SUPERUSER setup support in rear is dropped because
-# it can change the behaviour of the GRUB2 bootloader as a whole in unexpected ways and
-# rear is not meant to change the general GRUB2 configuration of the currently running system.
-# For background information see https://github.com/rear/rear/issues/703
+# The former GRUB2 superuser setup support in rear via GRUB_SUPERUSER is dropped and
+# also the former GRUB2 password setup support in rear via GRUB_RESCUE_PASSWORD is dropped.
+# Both kind of setup can change the behaviour of the GRUB2 bootloader as a whole in unexpected ways
+# but rear is not meant to change the general GRUB2 configuration of the currently running system.
+# It works by default reasonably backward compatible when formerly a GRUB_SUPERUSER was used
+# which means a GRUB2 superuser was set up by rear in /etc/grub.d/01_users with GRUB_RESCUE_PASSWORD
+# so that the empty GRUB_RESCUE_USER results that the 'Relax-and-Recover' GRUB2 menue entry
+# can only be booted by the formerly set GRUB_SUPERUSER with the formerly set GRUB_RESCUE_PASSWORD.
+# For background information see https://github.com/rear/rear/pull/942
+# and https://github.com/rear/rear/issues/703
 # starting at https://github.com/rear/rear/issues/703#issuecomment-235506494
-# To be backward compatible as far as possible rear uses a GRUB_SUPERUSER value
-# that might be set in /etc/rear/local.conf as fallback for GRUB_RESCUE_USER
-# if GRUB_RESCUE_PASSWORD is non-empty but GRUB_RESCUE_USER is empty.
-# Nevertheless it is recommended to no longer use GRUB_SUPERUSER and
-# only use GRUB_RESCUE_PASSWORD plus GRUB_RESCUE_USER if needed.
 
 ##
 # USING_UEFI_BOOTLOADER

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -940,11 +940,11 @@ USE_DHCLIENT=
 USE_STATIC_NETWORKING=
 
 ##
-# GRUB_RESCUE
+# GRUB_RESCUE [ GRUB_RESCUE_PASSWORD [ GRUB_SUPERUSER ] GRUB_RESCUE_USER ]
 #
 # Add a rear rescue/recovery system to the GRUB/GRUB2 bootloader of the currently running system.
 # It adds kernel and the rear initrd to the bootloader directory in the currently running system and
-# adds a 'Relax and Recover' GRUB/GRUB2 menue entry to boot that locally installed rear rescue system.
+# adds a 'Relax-and-Recover' GRUB/GRUB2 menue entry to boot that locally installed rear rescue system.
 # Note that GRUB_RESCUE is the only functionality where "rear mkbackup" or "rear mkrescue"
 # changes the currently running system. It changes the currently running system even
 # in a critical way because it changes the bootloader of the currently running system.
@@ -956,15 +956,37 @@ USE_STATIC_NETWORKING=
 # To be on the safe side the GRUB_RESCUE functionality is disabled by default:
 GRUB_RESCUE=n
 # If the GRUB_RESCUE functionality is explicity enabled (e.g. via GRUB_RESCUE=y in /etc/rear/local.conf)
-# a non-empty GRUB_RESCUE password must also be set to prevent accidental recovery.
-# The default GRUB_RESCUE password is "REAR" (uppercase):
+# a non-empty GRUB_RESCUE_PASSWORD can be set to get password protection for the GRUB2 menue entries.
+# This can be used to prevent accidental recovery.
+# When GRUB_RESCUE_PASSWORD is set it may result password protection for all GRUB2 menue entries
+# of the currently running system unless the '--unrestricted' option is set
+# for those GRUB2 menue entries that should not have password protection.
 # For GRUB2 instead of a plain text password one can specify the PBKDF2 hash of the password
 # that is output by grub-mkpasswd-pbkdf2 (or grub2-mkpasswd-pbkdf2) as a very long string like
 #   GRUB_RESCUE_PASSWORD="grub.pbkdf2.sha512.10000.a1b2c3..."
-GRUB_RESCUE_PASSWORD="REAR"
-# In GRUB2 you can specify which users can properly access rear - here we only want superusers:
-GRUB_SUPERUSER="root"
+# The default GRUB_RESCUE_PASSWORD is empty which means that rear does not change
+# how GRUB2 password protection is already configured in the currently running system:
+GRUB_RESCUE_PASSWORD=""
+# When GRUB_RESCUE_PASSWORD is non-empty (i.e. when rear changes the GRUB2 password protection)
+# you can specify via GRUB_SUPERUSER which GRUB2 superuser can access GRUB2 menue entries.
+# The default GRUB_SUPERUSER is empty which means that rear does not change
+# how GRUB2 users are already configured in the currently running system:
+GRUB_SUPERUSER=""
+# GRUB2 password protection requires a GRUB2 user.
+# When GRUB_RESCUE_PASSWORD is non-empty (i.e. when rear changes the GRUB2 password protection)
+# a GRUB2 username is required that must exist as a configured GRUB2 user.
+# The default GRUB_RESCUE_USER is the same as the GRUB_SUPERUSER value
+# so that when a GRUB_SUPERUSER will be configured by rear that superuser
+# becomes by default the user that is used for the GRUB2 password protection.
+# Because by default GRUB_SUPERUSER is empty it means that when GRUB_RESCUE_PASSWORD is non-empty
+# you must explicitly also specify a valid existing GRUB2 user here as GRUB_RESCUE_USER:
+GRUB_RESCUE_USER="$GRUB_SUPERUSER"
+# When GRUB_RESCUE_PASSWORD is non-empty faulty settings for GRUB_SUPERUSER or GRUB_RESCUE_USER
+# may result that you can no longer boot your currently running system.
 
+##
+# USING_UEFI_BOOTLOADER
+#
 # UEFI (Secure booting) support is partly available in rear (at least for Fedora, RHEL)
 # SLES, openSUSE do not work out of the box due to issues with making an UEFI bootable ISO image.
 # SLES, openSUSE need the additional tool 'ebiso' to make an UEFI bootable ISO image

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -958,9 +958,12 @@ GRUB_RESCUE=n
 # If the GRUB_RESCUE functionality is explicity enabled (e.g. via GRUB_RESCUE=y in /etc/rear/local.conf)
 # a non-empty GRUB_RESCUE password must also be set to prevent accidental recovery.
 # The default GRUB_RESCUE password is "REAR" (uppercase):
+# For GRUB2 instead of a plain text password one can specify the PBKDF2 hash of the password
+# that is output by grub-mkpasswd-pbkdf2 (or grub2-mkpasswd-pbkdf2) as a very long string like
+#   GRUB_RESCUE_PASSWORD="grub.pbkdf2.sha512.10000.a1b2c3..."
 GRUB_RESCUE_PASSWORD="REAR"
 # In GRUB2 you can specify which users can properly access rear - here we only want superusers:
-GRUB_SUPERUSER="rearadmin"
+GRUB_SUPERUSER="root"
 
 # UEFI (Secure booting) support is partly available in rear (at least for Fedora, RHEL)
 # SLES, openSUSE do not work out of the box due to issues with making an UEFI bootable ISO image.

--- a/usr/share/rear/output/default/94_grub2_rescue.sh
+++ b/usr/share/rear/output/default/94_grub2_rescue.sh
@@ -1,146 +1,164 @@
+
 # This file is part of Relax and Recover, licensed under the GNU General
 # Public License. Refer to the included LICENSE for full text of license.
 
-### Add the rescue kernel and initrd to the local GRUB Legacy
-###
+# Add the rescue kernel and initrd to the local GRUB 2 bootloader.
 
-### Only do when explicitely enabled
-if ! is_true "$GRUB_RESCUE" ; then
-    return
-fi
+# Only do it when explicitly enabled:
+is_true "$GRUB_RESCUE" || return
 
-### Only do when system is not using GRUB Legacy
-[[ $(type -p grub-probe) || $(type -p grub2-probe) ]] || return
+# Only run this script when GRUB 2 is there
+# (grub-probe or grub2-probe only exist in GRUB 2)
+# in particular do not run this script when GRUB Legacy is used
+# (for GRUB Legacy output/default/94_grub_rescue.sh is run):
+type -p grub-probe >&2 || type -p grub2-probe >&2 || { LogPrint "Skipping GRUB_RESCUE setup for GRUB 2 (no GRUB 2 found)." return ; }
 
-if has_binary grub-mkpasswd-pbkdf2 ; then
-    grub_binary=$(get_path grub-mkpasswd-pbkdf2)
-elif has_binary grub2-mkpasswd-pbkdf2 ; then
-    grub_binary=$(get_path grub2-mkpasswd-pbkdf2)
-else
-    StopIfError "ERROR: no binary found for grub-mkpasswd-pbkdf2 or grub2-mkpasswd-pbkdf2"
-fi
+# Now GRUB_RESCUE is explicitly wanted and this script is the right one to set it up.
+LogPrint "Setting up GRUB_RESCUE: Adding Relax-and-Recover rescue system to the local GRUB 2 configuration."
+# Now error out whenever it cannot setup the GRUB_RESCUE functionality.
 
-if [[ -z "$grub_binary" ]]; then
-    Log "Could not find grub-mkpasswd-pbkdf2 or grub2-mkpasswd-pbkdf2 binary."
-    return
-fi
+# Either grub-mkpasswd-pbkdf2 or grub2-mkpasswd-pbkdf2 is required:
+local grub_mkpasswd_binary=""
+has_binary grub-mkpasswd-pbkdf2 && grub_mkpasswd_binary=$(get_path grub-mkpasswd-pbkdf2)
+has_binary grub2-mkpasswd-pbkdf2 && grub_mkpasswd_binary=$(get_path grub2-mkpasswd-pbkdf2)
+test "$grub_mkpasswd_binary" || Error "Cannot setup GRUB_RESCUE: Neither grub-mkpasswd-pbkdf2 nor grub2-mkpasswd-pbkdf2 found."
 
 ### Use strings as grub --version syncs all disks
 #grub_version=$(get_version "grub --version")
-grub_version=$(strings $grub_binary | sed -rn 's/^[^0-9\.]*([0-9]+\.[-0-9a-z\.]+).*$/\1/p' | tail -n 1)
-if [[ ! "$grub_version" ]]; then
-    # only for grub-legacy we make special rear boot entry in menu.lst
-    return
-fi
+# FIXME:
+# This works with GRUB Legacy
+# e.g. on my <jsmeix@suse.de> SLES11 system:
+#   # strings /usr/sbin/grub | sed -rn 's/^[^0-9\.]*([0-9]+\.[-0-9a-z\.]+).*$/\1/p' | tail -n 1
+#   0.97
+#   # /usr/sbin/grub --version
+#   grub (GNU GRUB 0.97)
+#   # rpm -q grub
+#   grub-0.97-162.172.1
+# But it does no longer result the right version when grub_mkpasswd_binary is uesd
+# e.g. on my <jsmeix@suse.de> SLES12 system:
+#   # strings /usr/bin/grub2-mkpasswd-pbkdf2 | sed -rn 's/^[^0-9\.]*([0-9]+\.[-0-9a-z\.]+).*$/\1/p' | tail -n 1
+#   1.2.840.113549.1.1.12
+#   # /usr/bin/grub2-mkpasswd-pbkdf2 --version
+#   /usr/bin/grub2-mkpasswd-pbkdf2 (GRUB2) 2.02~beta2
+#   # rpm -q grub2
+#   grub2-2.02~beta2-69.1.x86_64
+# Because this works on my <jsmeix@suse.de> SLES12 system:
+#   # strings /usr/bin/grub2-mkpasswd-pbkdf2 | grep '^2\.' | head -n 1
+#   2.02~beta2
+# I <jsmeix@suse.de> simply use that for now until someone provides a better solution:
+local grub_version=$( strings $grub_mkpasswd_binary | grep '^2\.' | head -n 1 )
+test "$grub_version" || Error "Cannot setup GRUB_RESCUE: It seems '$grub_mkpasswd_binary' is of unsupported version 'grub_version'."
 
-[[ -r "$KERNEL_FILE" ]]
-StopIfError "Failed to find kernel, updating GRUB2 failed."
+# Ensure that kernel and initrd are there:
+test -r "$KERNEL_FILE" || Error "Cannot setup GRUB_RESCUE: Cannot read kernel file '$KERNEL_FILE'."
+test -r "$TMP_DIR/initrd.cgz" || Error "Cannot setup GRUB_RESCUE: Cannot read initrd '$TMP_DIR/initrd.cgz'."
 
-[[ -r "$TMP_DIR/initrd.cgz" ]]
-StopIfError "Failed to find initrd.cgz, updating GRUB2 failed."
-
+# Esure there is sufficient disk space in /boot for the local Relax-and-Recover rescue system:
 function total_filesize {
     stat --format '%s' $@ 2>&8 | awk 'BEGIN { t=0 } { t+=$1 } END { print t }'
 }
-
-available_space=$(df -Pkl /boot | awk 'END { print $4 * 1024 }')
-used_space=$(total_filesize /boot/rear-kernel /boot/rear-initrd.cgz)
-required_space=$(total_filesize $KERNEL_FILE $TMP_DIR/initrd.cgz)
-
+local available_space=$(df -Pkl /boot | awk 'END { print $4 * 1024 }')
+local used_space=$(total_filesize /boot/rear-kernel /boot/rear-initrd.cgz)
+local required_space=$(total_filesize $KERNEL_FILE $TMP_DIR/initrd.cgz)
 if (( available_space + used_space < required_space )) ; then
     required_MiB=$(( required_space / 1024 / 1024 ))
     available_MiB=$(( ( available_space + used_space ) / 1024 / 1024 ))
-    Error "Not enough disk space available in /boot for GRUB2 rescue image. Required: $required_MiB MiB. Available: $available_MiB MiB."
+    Error "Cannot setup GRUB_RESCUE: Not enough disk space in /boot for Relax-and-Recover rescue system. Required: $required_MiB MiB. Available: $available_MiB MiB."
 fi
 
+# Ensure a GRUB2 configuration file is found:
+local grub_conf=""
 if is_true $USING_UEFI_BOOTLOADER ; then
     # set to 1 means using UEFI
-    grub_conf="`dirname $UEFI_BOOTLOADER`/grub.cfg"
+    grub_conf="$( dirname $UEFI_BOOTLOADER )/grub.cfg"
 elif has_binary grub2-probe ; then
-    grub_conf=$(readlink -f /boot/grub2/grub.cfg)
+    grub_conf=$( readlink -f /boot/grub2/grub.cfg )
 else
-    grub_conf=$(readlink -f /boot/grub/grub.cfg)
+    grub_conf=$( readlink -f /boot/grub/grub.cfg )
+fi
+test -w "$grub_conf" || Error "Cannot setup GRUB_RESCUE: GRUB 2 configuration '$grub_conf' cannot be modified."
+
+# Make a PBKDF2 hash of the GRUB_RESCUE_PASSWORD if it is not yet in this form:
+local grub_rescue_password_PBKDF2_hash=""
+if [[ "${GRUB_RESCUE_PASSWORD:0:11}" == 'grub.pbkdf2' ]] ; then
+    grub_rescue_password_PBKDF2_hash="$GRUB_RESCUE_PASSWORD"
+else
+    grub_rescue_password_PBKDF2_hash="$( echo -e "$GRUB_RESCUE_PASSWORD\n$GRUB_RESCUE_PASSWORD" | $grub_mkpasswd_binary | grep -o 'grub.pbkdf2.*' )"
+fi
+if [[ ! "${grub_rescue_password_PBKDF2_hash:0:11}" == 'grub.pbkdf2' ]] ; then
+    Error "Cannot setup GRUB_RESCUE: GRUB 2 password '${grub_rescue_password_PBKDF2_hash:0:40}...' seems to be not in the form of a PBKDF2_hash."
 fi
 
-[[ -w "$grub_conf" ]]
-StopIfError "GRUB2 configuration cannot be modified."
-
-if [[ ! "${GRUB_RESCUE_PASSWORD:0:11}" == 'grub.pbkdf2' ]]; then
-    Error "GRUB_RESCUE_PASSWORD needs to be set. Run grub2-mkpasswd-pbkdf2 to generate pbkdf2 hash"
-fi
-
-if [[ ! -f /etc/grub.d/01_users ]]; then
+if [[ ! -f /etc/grub.d/01_users ]] ; then
     echo "#!/bin/sh
 cat << EOF
 set superusers=\"$GRUB_SUPERUSER\"
-password_pbkdf2 $GRUB_SUPERUSER $GRUB_RESCUE_PASSWORD
+password_pbkdf2 $GRUB_SUPERUSER $grub_rescue_password_PBKDF2_hash
 EOF" > /etc/grub.d/01_users
 fi
 
-grub_pass_set=$(tail -n 4 /etc/grub.d/01_users | grep -E "cat|set superusers|password_pbkdf2|EOF" | wc -l)
-if [[ $grub_pass_set < 4 ]]; then
+grub_pass_set=$( tail -n 4 /etc/grub.d/01_users | grep -E "cat|set superusers|password_pbkdf2|EOF" | wc -l )
+if [[ $grub_pass_set < 4 ]] ; then
     echo "#!/bin/sh
 cat << EOF
 set superusers=\"$GRUB_SUPERUSER\"
-password_pbkdf2 $GRUB_SUPERUSER $GRUB_RESCUE_PASSWORD
+password_pbkdf2 $GRUB_SUPERUSER $grub_rescue_password_PBKDF2_hash
 EOF" > /etc/grub.d/01_users
 fi
 
-grub_super_set=$(grep 'set superusers' /etc/grub.d/01_users | cut -f2 -d '"')
-if [[ ! $grub_super_set == $GRUB_SUPERUSER ]]; then
+grub_super_set=$( grep 'set superusers' /etc/grub.d/01_users | cut -f2 -d '"' )
+if [[ ! $grub_super_set == $GRUB_SUPERUSER ]] ; then
     sed -i "s/set superusers=\"\S*\"/set superusers=\"$GRUB_SUPERUSER\"/" /etc/grub.d/01_users
-    sed -i "s/password_pbkdf2\s\S*\s\S*/password_pbkdf2 $GRUB_SUPERUSER $GRUB_RESCUE_PASSWORD/" /etc/grub.d/01_users
+    sed -i "s/password_pbkdf2\s\S*\s\S*/password_pbkdf2 $GRUB_SUPERUSER $grub_rescue_password_PBKDF2_hash/" /etc/grub.d/01_users
 fi
 
-grub_enc_password=$(grep "password_pbkdf2" /etc/grub.d/01_users | awk '{print $3}')
-if [[ ! $grub_enc_password == $GRUB_RESCUE_PASSWORD ]]; then
-    sed -i "s/password_pbkdf2\s\S*\s\S*/password_pbkdf2 $GRUB_SUPERUSER $GRUB_RESCUE_PASSWORD/" /etc/grub.d/01_users
+grub_enc_password=$( grep "password_pbkdf2" /etc/grub.d/01_users | awk '{print $3}' )
+if [[ ! $grub_enc_password == $grub_rescue_password_PBKDF2_hash ]] ; then
+    sed -i "s/password_pbkdf2\s\S*\s\S*/password_pbkdf2 $GRUB_SUPERUSER $grub_rescue_password_PBKDF2_hash/" /etc/grub.d/01_users
 fi
 
 # Ensure 01_users is added to the /boot/grub.d/
-if [[ ! -x /etc/grub.d/01_users ]]; then
+if [[ ! -x /etc/grub.d/01_users ]] ; then
     chmod 755 /etc/grub.d/01_users
 fi
 
-#Finding UUID of filesystem containing /boot
-grub_boot_uuid=$(df /boot | awk 'END {print $1}' | xargs blkid -s UUID -o value)
+# Finding UUID of filesystem containing /boot
+grub_boot_uuid=$( df /boot | awk 'END {print $1}' | xargs blkid -s UUID -o value )
 
-#Stop if $grub_boot_uuid is not a valid UUID
-blkid -U $grub_boot_uuid > /dev/null 2>&1
-StopIfError "$grub_boot_uuid is not a valid UUID"
+# Stop if $grub_boot_uuid is not a valid UUID
+blkid -U $grub_boot_uuid > /dev/null 2>&1 || Error "$grub_boot_uuid is not a valid UUID"
 
-#Creating REAR grub menu entry
+# Creating Relax-and-Recover grub menu entry
 echo "#!/bin/bash
 cat << EOF
-menuentry \"Relax and Recover\" --class os --users \"\" {
+menuentry \"Relax-and-Recover\" --class os --users \"\" {
         search --no-floppy --fs-uuid  --set=root $grub_boot_uuid
-        linux  /rear-kernel $KERNEL_CMDLINE
-        initrd /rear-initrd.cgz
-        password_pbkdf2 $GRUB_SUPERUSER $GRUB_RESCUE_PASSWORD
+        linux  /boot/rear-kernel $KERNEL_CMDLINE
+        initrd /boot/rear-initrd.cgz
+        password_pbkdf2 $GRUB_SUPERUSER $grub_rescue_password_PBKDF2_hash
 }
 EOF" > /etc/grub.d/45_rear
 
 chmod 755 /etc/grub.d/45_rear
 
-if [[ $( type -f grub2-mkconfig ) ]]; then
+if [[ $( type -f grub2-mkconfig ) ]] ; then
     grub2-mkconfig -o $TMP_DIR/grub.cfg
 else
     grub-mkconfig -o $TMP_DIR/grub.cfg
 fi
 
-[[ -s $TMP_DIR/grub.cfg ]]
-BugIfError "Modified GRUB2 is empty !"
+[[ -s $TMP_DIR/grub.cfg ]] || BugError "Modified GRUB 2 configuration is empty!"
 
-if ! diff -u $grub_conf $TMP_DIR/grub.cfg >&2; then
-    LogPrint "Modifying local GRUB configuration"
+if ! diff -u $grub_conf $TMP_DIR/grub.cfg >&2 ; then
+    LogPrint "Modifying local GRUB 2 configuration."
     cp -af $v $grub_conf $grub_conf.old >&2
     cat $TMP_DIR/grub.cfg >$grub_conf
 fi
 
-if [[ $(stat -L -c '%d' $KERNEL_FILE) == $(stat -L -c '%d' /boot/) ]]; then
+if [[ $(stat -L -c '%d' $KERNEL_FILE) == $(stat -L -c '%d' /boot/) ]] ; then
     # Hardlink file, if possible
     cp -pLlf $v $KERNEL_FILE /boot/rear-kernel >&2
-elif [[ $(stat -L -c '%s %Y' $KERNEL_FILE) == $(stat -L -c '%s %Y' /boot/rear-kernel 2>&8) ]]; then
+elif [[ $(stat -L -c '%s %Y' $KERNEL_FILE) == $(stat -L -c '%s %Y' /boot/rear-kernel 2>&8) ]] ; then
     # If existing file has exact same size and modification time, assume the same
     :
 else
@@ -149,5 +167,7 @@ else
 fi
 BugIfError "Unable to copy '$KERNEL_FILE' to /boot"
 
-cp -af $v $TMP_DIR/initrd.cgz /boot/rear-initrd.cgz >&2
-BugIfError "Unable to copy '$TMP_DIR/initrd.cgz' to /boot"
+cp -af $v $TMP_DIR/initrd.cgz /boot/rear-initrd.cgz >&2 || BugError "Unable to copy '$TMP_DIR/initrd.cgz' to /boot"
+
+LogPrint "Finished GRUB_RESCUE setup: Added 'Relax-and-Recover' GRUB 2 menu entry."
+

--- a/usr/share/rear/output/default/94_grub2_rescue.sh
+++ b/usr/share/rear/output/default/94_grub2_rescue.sh
@@ -146,7 +146,9 @@ local grub_rear_menu_entry_file="/etc/grub.d/45_rear"
     echo "cat << EOF"
     echo "menuentry \"Relax-and-Recover\" --class os --users \"\" {"
     echo "          search --no-floppy --fs-uuid  --set=root $grub_boot_uuid"
+    echo "          echo 'Loading kernel $boot_kernel_file ...'"
     echo "          linux  $boot_kernel_file $KERNEL_CMDLINE"
+    echo "          echo 'Loading initrd $boot_initrd_file (may take a while) ...'"
     echo "          initrd $boot_initrd_file"
   ) > $grub_rear_menu_entry_file
 if test "$grub_rescue_password_PBKDF2_hash" ; then

--- a/usr/share/rear/output/default/94_grub2_rescue.sh
+++ b/usr/share/rear/output/default/94_grub2_rescue.sh
@@ -51,19 +51,23 @@ test "$grub_version" || Error "Cannot setup GRUB_RESCUE: It seems '$grub_mkpassw
 
 # Ensure that kernel and initrd are there:
 test -r "$KERNEL_FILE" || Error "Cannot setup GRUB_RESCUE: Cannot read kernel file '$KERNEL_FILE'."
-test -r "$TMP_DIR/initrd.cgz" || Error "Cannot setup GRUB_RESCUE: Cannot read initrd '$TMP_DIR/initrd.cgz'."
+local initrd_file=$TMP_DIR/initrd.cgz
+test -r $initrd_file || Error "Cannot setup GRUB_RESCUE: Cannot read initrd '$initrd_file'."
 
 # Esure there is sufficient disk space in /boot for the local Relax-and-Recover rescue system:
 function total_filesize {
     stat --format '%s' $@ | awk 'BEGIN { t=0 } { t+=$1 } END { print t }'
 }
-local available_space=$(df -Pkl /boot | awk 'END { print $4 * 1024 }')
-local used_space=$(total_filesize /boot/rear-kernel /boot/rear-initrd.cgz)
-local required_space=$(total_filesize $KERNEL_FILE $TMP_DIR/initrd.cgz)
+local boot_dir="/boot"
+local boot_kernel_file="$boot_dir/rear-kernel"
+local boot_initrd_file="$boot_dir/rear-initrd.cgz"
+local available_space=$( df -Pkl $boot_dir | awk 'END { print $4 * 1024 }' )
+local used_space=$( total_filesize $boot_kernel_file $boot_initrd_file )
+local required_space=$( total_filesize $KERNEL_FILE $initrd_file )
 if (( available_space + used_space < required_space )) ; then
     required_MiB=$(( required_space / 1024 / 1024 ))
     available_MiB=$(( ( available_space + used_space ) / 1024 / 1024 ))
-    Error "Cannot setup GRUB_RESCUE: Not enough disk space in /boot for Relax-and-Recover rescue system. Required: $required_MiB MiB. Available: $available_MiB MiB."
+    Error "Cannot setup GRUB_RESCUE: Not enough disk space in $boot_dir for Relax-and-Recover rescue system. Required: $required_MiB MiB. Available: $available_MiB MiB."
 fi
 
 # Ensure a GRUB2 configuration file is found:
@@ -72,19 +76,19 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     # set to 1 means using UEFI
     grub_conf="$( dirname $UEFI_BOOTLOADER )/grub.cfg"
 elif has_binary grub2-probe ; then
-    grub_conf=$( readlink -f /boot/grub2/grub.cfg )
+    grub_conf=$( readlink -f $boot_dir/grub2/grub.cfg )
 else
-    grub_conf=$( readlink -f /boot/grub/grub.cfg )
+    grub_conf=$( readlink -f $boot_dir/grub/grub.cfg )
 fi
 test -w "$grub_conf" || Error "Cannot setup GRUB_RESCUE: GRUB 2 configuration '$grub_conf' cannot be modified."
 
 # Set up GRUB 2 password protection if enabled:
+local grub_rescue_password_PBKDF2_hash=""
 if test "$GRUB_RESCUE_PASSWORD" ; then
     # When GRUB_RESCUE_USER is not specified, use by default GRUB_SUPERUSER (by default GRUB_SUPERUSER is empty):
     test "$GRUB_RESCUE_USER" || GRUB_RESCUE_USER="$GRUB_SUPERUSER"
     test "$GRUB_RESCUE_USER" || Error "Non-empty GRUB_RESCUE_PASSWORD requires that a GRUB_RESCUE_USER is specified."
     LogPrint "Setting up GRUB 2 password protection with GRUB 2 user '$GRUB_RESCUE_USER'".
-    local grub_rescue_password_PBKDF2_hash=""
     # Make a PBKDF2 hash of the GRUB_RESCUE_PASSWORD if it is not yet in this form:
     if [[ "${GRUB_RESCUE_PASSWORD:0:11}" == 'grub.pbkdf2' ]] ; then
         grub_rescue_password_PBKDF2_hash="$GRUB_RESCUE_PASSWORD"
@@ -96,8 +100,8 @@ if test "$GRUB_RESCUE_PASSWORD" ; then
         Error "Cannot setup GRUB_RESCUE: GRUB 2 password '${grub_rescue_password_PBKDF2_hash:0:40}...' seems to be not in the form of a PBKDF2_hash."
     fi
     # Set up a GRUB 2 superuser if enabled:
-    LogPrint "Setting up GRUB 2 superuser '$GRUB_SUPERUSER'."
     if test "$GRUB_SUPERUSER" ; then
+        LogPrint "Setting up GRUB 2 superuser '$GRUB_SUPERUSER'."
         local grub_users_file="/etc/grub.d/01_users"
         if [[ ! -f $grub_users_file ]] ; then
             ( echo "#!/bin/sh"
@@ -125,15 +129,15 @@ if test "$GRUB_RESCUE_PASSWORD" ; then
         if [[ ! $grub_enc_password == $grub_rescue_password_PBKDF2_hash ]] ; then
             sed -i "s/password_pbkdf2\s\S*\s\S*/password_pbkdf2 $GRUB_SUPERUSER $grub_rescue_password_PBKDF2_hash/" $grub_users_file
         fi
-        # Ensure the grub users file is executable:
+        # Ensure the GRUB 2 users file is executable:
         test -x $grub_users_file || chmod 755 $grub_users_file
     fi
 fi
 
-# Finding UUID of filesystem containing /boot
-grub_boot_uuid=$( df /boot | awk 'END {print $1}' | xargs blkid -s UUID -o value )
+# Finding UUID of filesystem containing boot_dir (i.e. /boot)
+grub_boot_uuid=$( df $boot_dir | awk 'END {print $1}' | xargs blkid -s UUID -o value )
 
-# Stop if $grub_boot_uuid is not a valid UUID
+# Stop if grub_boot_uuid is not a valid UUID
 blkid -U $grub_boot_uuid > /dev/null 2>&1 || Error "$grub_boot_uuid is not a valid UUID"
 
 # Creating Relax-and-Recover grub menu entry:
@@ -142,8 +146,8 @@ local grub_rear_menu_entry_file="/etc/grub.d/45_rear"
     echo "cat << EOF"
     echo "menuentry \"Relax-and-Recover\" --class os --users \"\" {"
     echo "          search --no-floppy --fs-uuid  --set=root $grub_boot_uuid"
-    echo "          linux  /boot/rear-kernel $KERNEL_CMDLINE"
-    echo "          initrd /boot/rear-initrd.cgz"
+    echo "          linux  $boot_kernel_file $KERNEL_CMDLINE"
+    echo "          initrd $boot_initrd_file"
   ) > $grub_rear_menu_entry_file
 if test "$grub_rescue_password_PBKDF2_hash" ; then
     # Specify GRUB 2 password protection if enabled:
@@ -155,36 +159,37 @@ fi
 chmod 755 $grub_rear_menu_entry_file
 
 # Generate a GRUB 2 configuration file:
+local generated_grub_conf="$TMP_DIR/grub.cfg"
 if [[ $( type -f grub2-mkconfig ) ]] ; then
-    grub2-mkconfig -o $TMP_DIR/grub.cfg || Error "Failed to generate GRUB 2 configuration file (using grub2-mkconfig)."
+    grub2-mkconfig -o $generated_grub_conf || Error "Failed to generate GRUB 2 configuration file (using grub2-mkconfig)."
 else
-    grub-mkconfig -o $TMP_DIR/grub.cfg || Error "Failed to generate GRUB 2 configuration file (using grub-mkconfig)."
+    grub-mkconfig -o $generated_grub_conf || Error "Failed to generate GRUB 2 configuration file (using grub-mkconfig)."
 fi
-test -s $TMP_DIR/grub.cfg || BugError "Generated empty GRUB 2 configuration file '$TMP_DIR/grub.cfg'"
+test -s $generated_grub_conf || BugError "Generated empty GRUB 2 configuration file '$generated_grub_conf'."
 
 # Modifying local GRUB 2 configuration if it was actually changed:
-if ! diff -u $grub_conf $TMP_DIR/grub.cfg >&2 ; then
+if ! diff -u $grub_conf $generated_grub_conf >&2 ; then
     LogPrint "Modifying local GRUB 2 configuration."
     cp -af $v $grub_conf $grub_conf.old >&2
-    cat $TMP_DIR/grub.cfg >$grub_conf
+    cat $generated_grub_conf >$grub_conf
 fi
 
-# Provide the kernel as /boot/rear-kernel
-if [[ $( stat -L -c '%d' $KERNEL_FILE ) == $( stat -L -c '%d' /boot/ ) ]] ; then
+# Provide the kernel as boot_kernel_file (i.e. /boot/rear-kernel):
+if [[ $( stat -L -c '%d' $KERNEL_FILE ) == $( stat -L -c '%d' $boot_dir/ ) ]] ; then
     # Hardlink file, if possible:
-    cp -pLlf $v $KERNEL_FILE /boot/rear-kernel >&2
-elif [[ $( stat -L -c '%s %Y' $KERNEL_FILE ) == $( stat -L -c '%s %Y' /boot/rear-kernel ) ]] ; then
-    # If an already existing /boot/rear-kernel has exact same size and modification time
+    cp -pLlf $v $KERNEL_FILE $boot_kernel_file >&2
+elif [[ $( stat -L -c '%s %Y' $KERNEL_FILE ) == $( stat -L -c '%s %Y' $boot_kernel_file ) ]] ; then
+    # If an already existing boot_kernel_file has exact same size and modification time
     # as the current KERNEL_FILE, assume both are the same and do nothing:
     :
 else
-    # In all other cases, replace /boot/rear-kernel with the current KERNEL_FILE:
-    cp -pLf $v $KERNEL_FILE /boot/rear-kernel >&2
+    # In all other cases, replace boot_kernel_file with the current KERNEL_FILE:
+    cp -pLf $v $KERNEL_FILE $boot_kernel_file >&2
 fi
-BugIfError "Unable to copy '$KERNEL_FILE' to /boot"
+BugIfError "Unable to copy '$KERNEL_FILE' to '$boot_kernel_file'."
 
-# Provide the rear recovery system in TMP_DIR/initrd.cgz as /boot/rear-initrd.cgz
-cp -af $v $TMP_DIR/initrd.cgz /boot/rear-initrd.cgz >&2 || BugError "Unable to copy '$TMP_DIR/initrd.cgz' to /boot"
+# Provide the rear recovery system in initrd_file (i.e. TMP_DIR/initrd.cgz) as boot_initrd_file (i.e. /boot/rear-initrd.cgz):
+cp -af $v $initrd_file $boot_initrd_file >&2 || BugError "Unable to copy '$initrd_file' to '$boot_initrd_file'."
 
 LogPrint "Finished GRUB_RESCUE setup: Added 'Relax-and-Recover' GRUB 2 menu entry."
 


### PR DESCRIPTION
see https://github.com/rear/rear/issues/938
starting at https://github.com/rear/rear/issues/938#issuecomment-234899163

In its current state it somewhat works for me with
<pre>
GRUB_RESCUE=y
GRUB_RESCUE_PASSWORD="rear"
GRUB_SUPERUSER="root"
</pre>
as follows
<pre>
# usr/sbin/rear -d -D mkbackup
Relax-and-Recover 1.18 / Git
Using log file: /root/rear/var/log/rear/rear-f121.log
Creating disk layout
Creating root filesystem layout
Copying files and directories
Copying binaries and libraries
Copying kernel modules
Creating initramfs
Making ISO image
Wrote ISO image: /root/rear/var/lib/rear/output/rear-f121.iso (38M)
Setting up GRUB_RESCUE: Adding Relax-and-Recover rescue system to the local GRUB 2 configuration.
Modifying local GRUB 2 configuration.
Finished GRUB_RESCUE setup: Added 'Relax-and-Recover' GRUB 2 menu entry.
Copying resulting files to nfs location
Encrypting disabled
Creating tar archive '/tmp/rear.U1YlM2T4tHDaHBW/outputfs/f121/backup.tar.gz'
Archived 1316 MiB [avg 7246 KiB/sec]OK
Archived 1316 MiB in 187 seconds [avg 7207 KiB/sec]
</pre>

Now I have an additional GRUB 2 menue entry "Relax-and-Recover"
and when I select it I get asked for username (I enter root) and
password (I enter rear) and then the rear recovery system starts
where I can log in as root (without password) and therein I could
run "rear recover" but I did not yet test that.

In its current state what does not look o.k. for me is 
that now I get the GRUB 2 password dialog also for
the default SLES12 boot entry.

This is an unexpected change compared to before
where I could boot the default SLES12 without
a GRUB 2 password dialog.

I.e. I need to find out how to set up GRUB 2 so that
its password dialog happens only for the "Relax-and-Recover"
boot menue entry...
