### PR TITLE
fix in documentation cifs credentials file name

### DIFF
--- a/doc/rear.8
+++ b/doc/rear.8
@@ -431,9 +431,9 @@ BACKUP_URL=\fBcifs://\fR
 .RS 4
 To backup to a Samba share (CIFS), use
 BACKUP_URL=cifs://cifs\-server\-name/share/path\&. To provide credentials for CIFS mounting use a
-\fI/etc/rear/\&.cifs\fR
+\fI/etc/rear/cifs\fR
 credentials file and define
-BACKUP_OPTIONS="cred=/etc/rear/\&.cifs"
+BACKUP_OPTIONS="cred=/etc/rear/cifs"
 and pass along:
 .sp
 .if n \{\

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -316,8 +316,8 @@ simply define +TAPE_DEVICE=/dev/nst0+
 BACKUP_URL=*cifs://*::
 To backup to a Samba share (CIFS), use
 +BACKUP_URL=cifs://cifs-server-name/share/path+. To provide credentials for
-CIFS mounting use a _/etc/rear/.cifs_ credentials file and define
-+BACKUP_OPTIONS="cred=/etc/rear/.cifs"+ and pass along:
+CIFS mounting use a _/etc/rear/cifs_ credentials file and define
++BACKUP_OPTIONS="cred=/etc/rear/cifs"+ and pass along:
 +
 ----
 username=_username_

--- a/doc/user-guide/03-configuration.adoc
+++ b/doc/user-guide/03-configuration.adoc
@@ -153,8 +153,8 @@ simply define +TAPE_DEVICE=/dev/nst0+
 BACKUP_URL=cifs://::
 To backup to a Samba share (CIFS), use
 +BACKUP_URL=cifs://cifs-server-name/share/path+. To provide credentials for
-CIFS mounting use a _/etc/rear/.cifs_ credentials file and define
-+BACKUP_OPTIONS="cred=/etc/rear/.cifs"+ and pass along:
+CIFS mounting use a _/etc/rear/cifs_ credentials file and define
++BACKUP_OPTIONS="cred=/etc/rear/cifs"+ and pass along:
 +
 ----
 username=_username_


### PR DESCRIPTION
fix manpage and other documentation
regarding cifs credentials filename that
should not be a dot file but a normal filename
see https://github.com/rear/rear/issues/924