### PR TITLE
Update 15_migrate_uuid_tags.sh

### DIFF
--- a/usr/share/rear/finalize/GNU/Linux/15_migrate_lun_wwid.sh
+++ b/usr/share/rear/finalize/GNU/Linux/15_migrate_lun_wwid.sh
@@ -15,33 +15,33 @@ done < <(sort -u $LUN_WWID_MAP)
 Log "$SED_SCRIPT"
 
 # now run sed
-pushd $TARGET_FS_ROOT >&8
+pushd $TARGET_FS_ROOT >&2
 # the funny [] around the first letter make sure that shopt -s nullglob removes this file from the list if it does not exist
 # the files without a [] are mandatory, like fstab
-for file in 	[e]tc/elilo.conf \
-		          [e]tc/fstab 
-	do
+for file in [e]tc/elilo.conf \
+            [e]tc/fstab 
+        do
 
-  #[[ -d "$file" ]] && continue # skip directory
-	[[ ! -f "$file" ]] && continue # skip directory and file not found
-	# sed -i bails on symlinks, so we follow the symlink and patch the result
-	# on dead links we warn and skip them
-	# TODO: maybe we must put this into a chroot so that absolute symlinks will work correctly
-	if test -L "$file" ; then
-		if linkdest="$(readlink -f "$file")" ; then
-			# if link destination is residing on /proc we skip it silently
-			echo $linkdest | grep -q "^/proc" && continue
-			LogPrint "Patching '$linkdest' instead of '$file'"
-			file="$linkdest"
-		else
-			LogPrint "Not patching dead link '$file'"
-			continue
-		fi
-	fi
+        #[[ -d "$file" ]] && continue # skip directory
+        [[ ! -f "$file" ]] && continue # skip directory and file not found
+        # sed -i bails on symlinks, so we follow the symlink and patch the result
+        # on dead links we warn and skip them
+        # TODO: maybe we must put this into a chroot so that absolute symlinks will work correctly
+	    if test -L "$file" ; then
+            if linkdest="$(readlink -f "$file")" ; then
+                # if link destination is residing on /proc we skip it silently
+			    echo $linkdest | grep -q "^/proc" && continue
+			    LogPrint "Patching '$linkdest' instead of '$file'"
+			    file="$linkdest"
+		    else
+                LogPrint "Not patching dead link '$file'"
+			    continue
+			fi
+        fi
 
         LogPrint "Patching file '$file'"
-	sed -i "$SED_SCRIPT" "$file"
-	StopIfError "Patching '$file' with sed failed."
+        sed -i "$SED_SCRIPT" "$file"
+        StopIfError "Patching '$file' with sed failed."
 done
 
-popd >&8 
+popd >&2 

--- a/usr/share/rear/finalize/GNU/Linux/15_migrate_lun_wwid.sh
+++ b/usr/share/rear/finalize/GNU/Linux/15_migrate_lun_wwid.sh
@@ -1,0 +1,47 @@
+# migrate lun_wwid_mapping
+
+# skip if no mappings
+test -s "$LUN_WWID_MAP" || return 0
+
+Log "TAG-15-migrate-wwid: $LUN_WWID_MAP"
+
+# create the SED_SCRIPT
+SED_SCRIPT=""
+while read old_wwid new_wwid device ; do
+        SED_SCRIPT="$SED_SCRIPT;/${old_wwid}/s/${old_wwid}/${new_wwid}/g"
+done < <(sort -u $LUN_WWID_MAP)
+
+# debug line:
+Log "$SED_SCRIPT"
+
+# now run sed
+pushd $TARGET_FS_ROOT >&8
+# the funny [] around the first letter make sure that shopt -s nullglob removes this file from the list if it does not exist
+# the files without a [] are mandatory, like fstab
+for file in 	[e]tc/elilo.conf \
+		          [e]tc/fstab 
+	do
+
+  #[[ -d "$file" ]] && continue # skip directory
+	[[ ! -f "$file" ]] && continue # skip directory and file not found
+	# sed -i bails on symlinks, so we follow the symlink and patch the result
+	# on dead links we warn and skip them
+	# TODO: maybe we must put this into a chroot so that absolute symlinks will work correctly
+	if test -L "$file" ; then
+		if linkdest="$(readlink -f "$file")" ; then
+			# if link destination is residing on /proc we skip it silently
+			echo $linkdest | grep -q "^/proc" && continue
+			LogPrint "Patching '$linkdest' instead of '$file'"
+			file="$linkdest"
+		else
+			LogPrint "Not patching dead link '$file'"
+			continue
+		fi
+	fi
+
+        LogPrint "Patching file '$file'"
+	sed -i "$SED_SCRIPT" "$file"
+	StopIfError "Patching '$file' with sed failed."
+done
+
+popd >&8 

--- a/usr/share/rear/finalize/GNU/Linux/15_migrate_uuid_tags.sh
+++ b/usr/share/rear/finalize/GNU/Linux/15_migrate_uuid_tags.sh
@@ -23,6 +23,7 @@ for file in 	[b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* \
 		[b]oot/grub2/{grub.conf,grub.cfg,menu.lst,device.map} \
 		[e]tc/sysconfig/grub [e]tc/sysconfig/bootloader \
 		[e]tc/lilo.conf \
+		[e]tc/elilo.conf \
 		[e]tc/mtab [e]tc/fstab \
 		[e]tc/mtools.conf \
 		[e]tc/smartd.conf [e]tc/sysconfig/smartmontools \

--- a/usr/share/rear/layout/prepare/default/01_prepare_files.sh
+++ b/usr/share/rear/layout/prepare/default/01_prepare_files.sh
@@ -6,6 +6,7 @@ LAYOUT_TODO="$VAR_DIR/layout/disktodo.conf"
 LAYOUT_CODE="$VAR_DIR/layout/diskrestore.sh"
 
 FS_UUID_MAP="$VAR_DIR/layout/fs_uuid_mapping"
+LUN_WWID_MAP="$VAR_DIR/layout/lun_wwid_mapping" 
 
 # Touchfiles for layout recreation.
 LAYOUT_TOUCHDIR="$TMP_DIR/touch"
@@ -22,6 +23,11 @@ if [ -e $CONFIG_DIR/disklayout.conf ] ; then
     cp $CONFIG_DIR/disklayout.conf $LAYOUT_FILE
     MIGRATION_MODE="true"
     LogPrint "$CONFIG_DIR/disklayout.conf exists, entering Migration mode."
+    
+    if [ -e $CONFIG_DIR/lun_wwid_mapping.conf ] ; then
+        cp $CONFIG_DIR/lun_wwid_mapping.conf $LUN_WWID_MAP
+		LogPrint "$CONFIG_DIR/lun_wwid_mapping.conf exists, creating lun_wwid_mapping"
+    fi
 fi
 
 if [ ! -e $LAYOUT_FILE ] ; then


### PR DESCRIPTION
Hello,
after migration fs_uuid for root partition wasn't changed in ELILO config file **/etc/elilo.conf**

e.g.

_image = /boot/vmlinuz-3.0.101-68-default
###Don't change this comment - YaST2 identifier: Original name: linux###
    label = Linux
    append = "LOCAL_BOOT=yes root=/dev/mapper/360002ac0000000000000000700015e10_part4 disk=/dev/mapper/360002ac0000000000000000700015e10 resume=/dev/mapper/360002ac0000000000000000700015e10_part5 n
osoftlockup intel_idle.max_cstate=0 processor.max_cstate=0 mce=ignore_ce idle=poll elevator=noop biosdevname=1 quiet"
    initrd = /boot/initrd-3.0.101-68-default
    **root = /dev/disk/by-uuid/c7c47b25-30d8-42bc-8ca8-13f939b5c7b8**
    description = "SAP Application"_