### PR TITLE
document that GRUB_RESCUE_USER is not supported for UEFI

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -985,7 +985,8 @@ USE_STATIC_NETWORKING=
 # whole current system with a recreated system where all files are restored from the backup.
 # To be on the safe side the GRUB_RESCUE functionality is disabled by default:
 GRUB_RESCUE=n
-# Optional password protection via GRUB_RESCUE_USER only works for GRUB2.
+# Optional password protection via GRUB_RESCUE_USER only works for GRUB2 with Legacy BIOS booting.
+# GRUB_RESCUE_USER is not supported for UEFI booting (cf. https://github.com/rear/rear/pull/954).
 # GRUB2 password protection requires an existing GRUB2 user with a password.
 # If the GRUB_RESCUE functionality is enabled (e.g. via GRUB_RESCUE=y in /etc/rear/local.conf)
 # a non-empty GRUB_RESCUE_USER can be optionally set to get GRUB2 password protection


### PR DESCRIPTION
and some changes to prepare 94_grub2_rescue.sh
for set -eu (cf. https://github.com/rear/rear/issues/700)
this enhances https://github.com/rear/rear/pull/954