### PR TITLE
Enhanced udev device reload for systemd.

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/00-functions.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/00-functions.sh
@@ -1,12 +1,19 @@
 # helper functions
 # call udevtrigger
 my_udevtrigger() {
-        type -p udevadm >/dev/null && udevadm trigger $@ || udevtrigger $@
+    type -p udevadm >/dev/null && udevadm trigger $@ || udevtrigger $@
+    
+    # If systemd is running, this should help to rename devices
+    if [[ $(ps --no-headers -C systemd) ]]; then
+        sleep 1
+        my_udevsettle
+        udevadm trigger --action=add
+    fi
 }
 
 # call udevsettle
 my_udevsettle() {
-        type -p udevadm >/dev/null && udevadm settle --timeout=10 $@ || udevsettle $@
+    type -p udevadm >/dev/null && udevadm settle --timeout=10 $@ || udevsettle $@
 }
 
 # call udevinfo

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
@@ -124,6 +124,14 @@ if test -s /etc/rear/mappings/mac ; then
 	my_udevtrigger
 	sleep 1
 	my_udevsettle
+    
+    if [[ $(ps --no-headers -C systemd) ]]; then
+        # This might be not mandatory.
+        # It will release orphaned (old) device names in systemd
+        # Maybe it can be done by some less invazive command, but I didn't found it yet
+        systemctl daemon-reload
+    fi
+    
 	echo "done."
 fi
 


### PR DESCRIPTION
Hi guys, 

This should be fix for #958. (in case we confirm that **udevadm trigger** indeed doesn't rename devices under systemd)

Hope it helps.

V.