### PR TITLE
get_device_by_hwaddr made a bit more universal

### DIFF
--- a/usr/share/rear/lib/network-functions.sh
+++ b/usr/share/rear/lib/network-functions.sh
@@ -614,7 +614,7 @@ get_hwaddr ()
 
 get_device_by_hwaddr ()
 {
-    ip -o link | grep -v link/ieee802.11 | grep -i "$1" | awk -F ": " '{print $2}'
+    LANG=C ip -o link | grep -v link/ieee802.11 | grep -i "$1" | awk -F ": " '{print $2}'
 }
 
 need_hostname ()

--- a/usr/share/rear/lib/network-functions.sh
+++ b/usr/share/rear/lib/network-functions.sh
@@ -614,7 +614,7 @@ get_hwaddr ()
 
 get_device_by_hwaddr ()
 {
-    LANG=C ip -o link | grep -v link/ieee802.11 | awk -F ': ' -vIGNORECASE=1 "/$1/ { print \$2 }"
+    ip -o link | grep -v link/ieee802.11 | grep -i "$1" | awk -F ": " '{print $2}'
 }
 
 need_hostname ()


### PR DESCRIPTION
I've used more standard **grep -i** (instead of IGNORECASE) as mawk (used e.g. on Debian) doesn't know IGNORECASE. Which resulted this function not to find appropriate device.