### PR TITLE
Improve debian packaging

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -2,7 +2,7 @@ rear (1.18.1-1) stable; urgency=high
 
   * Add missing dependency isolinux
   * Add missing dependency dosfstools
-  * Switch to xorriso since Debian's genisofs does not seem to correctly
+  * Switch to xorriso since Debian's genisoimage does not seem to correctly
     handle UEFI ISO boot.
 
  -- Carlos Ramos <carragom@gmail.com> Fri, 29 Jul 2016 13:25:17 +0100

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,11 @@
+rear (1.18.1-1) stable; urgency=high
+
+  * Add missing dependency isolinux
+  * Add missing dependency dosfstools
+  * Switch to xorriso since Debian's genisofs does not seem to correctly
+    handle UEFI ISO boot.
+
+ -- Carlos Ramos <carragom@gmail.com> Fri, 29 Jul 2016 13:25:17 +0100
 rear (1.18-1) stable; urgency=high
 
   * new features

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,7 +8,7 @@ Package: rear
 Architecture: i386 ia64 amd64 ppc64el
 Provides: rear
 Build-Depends: debhelper
-Depends: syslinux[!ppc64el], ethtool, ${shlibs:Depends}, lsb-release, genisoimage, iproute, iputils-ping, binutils, parted, openssl, gawk, attr, ${misc:Depends}
+Depends: syslinux[!ppc64el], ethtool, ${shlibs:Depends}, lsb-release, xorriso, iproute, iputils-ping, isolinux, dosfstools, binutils, parted, openssl, gawk, attr, ${misc:Depends}
 Recommends: nfs-client, portmap
 Description: Relax and Recover is a bare metal disaster recovery and system
  migration framework. See http://relax-and-recover.org/ for all the details.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -199,7 +199,7 @@ ISO_MAX_SIZE=
 # for mkisofs/genisoimage on UEFI bootable systems
 # to use ebiso, specify ISO_MKISOFS_BIN=<full_path_to_ebiso>/ebiso
 # in /etc/rear/local.conf or /etc/rear/site.conv
-ISO_MKISOFS_BIN="$( type -p mkisofs || type -p genisoimage )"
+ISO_MKISOFS_BIN="$( type -p xorrisofs || type -p mkisofs || type -p genisoimage )"
 
 # which files to include in the ISO image
 ISO_FILES=()

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -199,6 +199,8 @@ ISO_MAX_SIZE=
 # for mkisofs/genisoimage on UEFI bootable systems
 # to use ebiso, specify ISO_MKISOFS_BIN=<full_path_to_ebiso>/ebiso
 # in /etc/rear/local.conf or /etc/rear/site.conv
+# xorisofs is now used as the preferred method for generating the iso image
+# with mkisofs and genisoimage as second and third option
 ISO_MKISOFS_BIN="$( type -p xorrisofs || type -p mkisofs || type -p genisoimage )"
 
 # which files to include in the ISO image


### PR DESCRIPTION
@jsmeix 

This should solve #828 and #696. In this pull priority is given to the `xorrisofs` binary over the other binaries (`mkisofs` and `genisoimage`).

Let me know what you guys think.
Cheers.