### PR TITLE
USE_STATIC_NETWORKING now really overrides USE_DHCLIENT.

### DIFF
--- a/usr/share/rear/prep/GNU/Linux/21_include_dhclient.sh
+++ b/usr/share/rear/prep/GNU/Linux/21_include_dhclient.sh
@@ -88,7 +88,7 @@ PROGS=( "${PROGS[@]}" arping ipcalc usleep "${dhclients[@]}" )
 # At this point we want DHCP client support and found a binary
 # check if binary was defined in /etc/rear/local.conf; if not append it to rescue.conf
 # as we need this variable at recovery time.
-if [[ ! -z "$USE_DHCLIENT" && -z "$USE_STATIC_NETWORKING" ]]; then
+if [ ! -z "$USE_DHCLIENT" ]; then
     REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" $DHCLIENT_BIN $DHCLIENT6_BIN )
     cat - <<EOF >> "$ROOTFS_DIR/etc/rear/rescue.conf"
 # The following 3 lines were added through 21_include_dhclient.sh

--- a/usr/share/rear/prep/GNU/Linux/21_include_dhclient.sh
+++ b/usr/share/rear/prep/GNU/Linux/21_include_dhclient.sh
@@ -88,7 +88,7 @@ PROGS=( "${PROGS[@]}" arping ipcalc usleep "${dhclients[@]}" )
 # At this point we want DHCP client support and found a binary
 # check if binary was defined in /etc/rear/local.conf; if not append it to rescue.conf
 # as we need this variable at recovery time.
-if [ ! -z "$USE_DHCLIENT" ]; then
+if [[ ! -z "$USE_DHCLIENT" && -z "$USE_STATIC_NETWORKING" ]]; then
     REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" $DHCLIENT_BIN $DHCLIENT6_BIN )
     cat - <<EOF >> "$ROOTFS_DIR/etc/rear/rescue.conf"
 # The following 3 lines were added through 21_include_dhclient.sh

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/58-start-dhclient.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/58-start-dhclient.sh
@@ -3,6 +3,10 @@
 # check if we have USE_DHCLIENT=y, if not then we run 60/62 scripts
 [[ -z "$USE_DHCLIENT"  ]] && return
 
+# with USE_STATIC_NETWORKING no networking setup via DHCP must happen
+# see default.conf: USE_STATIC_NETWORKING overrules USE_DHCLIENT
+test "$USE_STATIC_NETWORKING" && return
+
 # if 'noip' is gicen on boot prompt then skip dhcp start-up
 if [[ -e /proc/cmdline ]] ; then
     if grep -q 'noip' /proc/cmdline ; then


### PR DESCRIPTION
In default.conf we have comment:

> Say "y", "Yes" (or any not empty string) to enable static networking (overrules USE_DHCLIENT):

This is currently not true, because doesn't matter how is USE_STATIC_NETWORKING set, dhcp configuration will be triggered in rear recover.