### PR TITLE
Make it safe against wrong btrfs subvolumes on sles12 issue963

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_subvolumes_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_subvolumes_code.sh
@@ -213,10 +213,11 @@ btrfs_subvolumes_setup() {
             echo "# - creating snapshot of first root filesystem"
             echo "# - setting default subvolume"
             echo "if test -x $SLES12SP1SP2_installation_helper_executable"
-            echo "then $SLES12SP1SP2_installation_helper_executable --step 1 --device $device --description 'first root filesystem'"
+            echo "then LogPrint 'Running snapper/installation-helper:'"
+            echo "     $SLES12SP1SP2_installation_helper_executable --step 1 --device $device --description 'first root filesystem'"
             echo "else LogPrint '$SLES12SP1SP2_installation_helper_executable not executable may indicate an error with btrfs default subvolume setup for $subvolume_path on $device'"
             echo "fi"
-            echo " mount -t btrfs -o subvolid=0 $mountopts $device $target_system_mountpoint"
+            echo "mount -t btrfs -o subvolid=0 $mountopts $device $target_system_mountpoint"
             echo "# End step 1 of special SLES 12 SP1 btrfs default snapper snapshot subvolume setup"
             ) >> "$LAYOUT_CODE"
         else

--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_subvolumes_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_subvolumes_code.sh
@@ -108,7 +108,7 @@ btrfs_subvolumes_setup() {
             # which fails if it already exists.
             if test "$subvolume_path" = "@/.snapshots" ; then
                 info_message="No 'btrfs subvolume create' for '$subvolume_path' because it will be created by 'snapper/installation-helper --step 1' (which fails if that already exists)."
-                Log $info_message
+                LogPrint $info_message
                 echo "# $info_message" >> "$LAYOUT_CODE"
                 continue
             fi
@@ -121,7 +121,7 @@ btrfs_subvolumes_setup() {
             # to not let "rear recover" fail because of such kind of wrong btrfs subvolumes
             # and inform the user about that via 'LogPrint':
             if [[ "$subvolume_path" == "@/.snapshots/"* ]] ; then
-                info_message="Skipping subvolume setup for '$subvolume_path' because any normal btrfs subvolume under '.snapshots' is wrong (and 'snapper/installation-helper --step 1' fails if such a subvolume exists)."
+                info_message="Skipping subvolume setup for '$subvolume_path' because any btrfs subvolume under '.snapshots' would let 'snapper/installation-helper --step 1' fail."
                 LogPrint $info_message
                 echo "# $info_message" >> "$LAYOUT_CODE"
                 continue

--- a/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_subvolumes_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/13_include_mount_subvolumes_code.sh
@@ -32,9 +32,9 @@ btrfs_subvolumes_setup() {
     ###########################################
     # SLES 12 SP1 and SP2 special btrfs subvolumes setup detection:
     SLES12SP1SP2_btrfs_detection_string="@/.snapshots/"
-    if grep "^btrfsdefaultsubvol $device $mountpoint [0-9]* $SLES12SP1SP2_btrfs_detection_string" "$LAYOUT_FILE" ; then
-        info_message="Detected SLES 12 SP1 and SP2 special btrfs subvolumes setup because the default subvolume path contains '$SLES12SP1SP2_btrfs_detection_string'"
-        Log $info_message
+    if grep -q "^btrfsdefaultsubvol $device $mountpoint [0-9]* $SLES12SP1SP2_btrfs_detection_string" "$LAYOUT_FILE" ; then
+        info_message="Doing SLES12 special btrfs subvolumes setup because the default subvolume path contains '$SLES12SP1SP2_btrfs_detection_string'"
+        LogPrint $info_message
         echo "# $info_message" >> "$LAYOUT_CODE"
         # For SLES 12 SP1 a btrfsdefaultsubvol entry in disklayout.conf looks like
         #   btrfsdefaultsubvol /dev/sda2 / 259 @/.snapshots/1/snapshot

--- a/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/23_filesystem_layout.sh
@@ -270,7 +270,12 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
                     echo "# plus usually an entry in /etc/fstab to get it mounted automatically when booting."
                     echo "# Because any '@/.snapshots' subvolume would let 'snapper/installation-helper --step 1' fail"
                     echo "# such subvolumes are deactivated here to not let 'rear recover' fail:"
-                    echo "$subvolume_list" | grep "$snapper_base_subvolume" | sed -e "s/^/#$prefix /"
+                    if test -z "$snapshot_subvolumes_pattern" ; then
+                        # With an empty snapshot_subvolumes_pattern egrep -v '' would exclude all lines:
+                        echo "$subvolume_list" | grep "$snapper_base_subvolume" | sed -e "s/^/#$prefix /"
+                    else
+                        echo "$subvolume_list" | egrep -v "$snapshot_subvolumes_pattern" | grep "$snapper_base_subvolume" | sed -e "s/^/#$prefix /"
+                    fi
                 fi
                 # Output btrfs normal subvolumes:
                 if test -z "$subvolumes_exclude_pattern" ; then


### PR DESCRIPTION
Now snapper's own subvolumes are excluded from being
automatically recreated by listing them only as comments in
disklayout.conf during "rear mkbackup" (via 23_filesystem_layout.sh)
and furthermore if such subvolumes are active in disklayout.conf
they are skipped during "rear recover" plus LogPrint info for the user
(via 13_include_mount_subvolumes_code.sh).