### PR TITLE
make TMPDIR work in compliance with Unix standards

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -29,6 +29,26 @@
 # * Some variables are actually bash arrays and should be treated with care.
 #   To set an empty array, use VAR=().
 
+##
+# TMPDIR
+#
+# Relax-and-Recover needs a (temporary) working area where it builds in particular
+# the rescue/recovery system ISO image (and perhaps even stores the backup archive).
+# The directory name of the working area is created in /usr/sbin/rear by calling
+#   mktemp -d -t rear.XXXXXXXXXXXXXXX
+# which usually results /tmp/rear.XXXXXXXXXXXXXXX or $TMPDIR/rear.XXXXXXXXXXXXXXX
+# the latter when the canonical Linux/Unix environment variable TMPDIR
+# is set in the environment where /usr/sbin/rear is called.
+# To have a specific working area directory prefix for Relax-and-Recover
+# specify in /etc/rear/local.conf something like
+#   export TMPDIR="/prefix/for/rear/working/directory"
+# where /prefix/for/rear/working/directory must already exist.
+# This is useful for example when there is not sufficient free space
+# in /tmp or $TMPDIR for the ISO image or even the backup archive.
+# TMPDIR cannot be set to a default value here, otherwise /usr/sbin/rear
+# would not work in compliance with the Linux/Unix standards regarding TMPDIR
+# see https://github.com/rear/rear/issues/968
+
 # You can override autodetection and specify the kernel for the rescue/recovery system:
 KERNEL_FILE=""
 # The kernel configuration is used to collect the kernel binary and modules.
@@ -1114,14 +1134,9 @@ WAIT_SECS=30
 # making the variable (y,Y,1) to enable
 BOOT_OVER_SAN=
 
-# the TMPDIR influences the mktemp command to define an alternative basedir instead of /tmp
-# useful in case /tmp is not large enough to contain ISO images and/or backup archives
-# be careful the directory must exist otherwise you will get an error by mktemp
-TMPDIR=""
-export TMPDIR    # the export is required so that mktemp can pickup the variable
-
 ####################
 # DRLM (Disaster Recovery Linux Manager) Variables
 
 # Specify if rear is managed from DRLM (y/n) [ default (n) ].
 DRLM_MANAGED=n
+


### PR DESCRIPTION
 i.e. no longer TMPDIR setting in default.conf
(only manually by te user if needed in local.conf)
issue https://github.com/rear/rear/issues/968