### PR TITLE
Added PRE-POST backup scripts

### DIFF
--- a/usr/share/rear/backup/default/01_pre_backup_script.sh
+++ b/usr/share/rear/backup/default/01_pre_backup_script.sh
@@ -1,5 +1,5 @@
 if test "$PRE_BACKUP_SCRIPT" ; then
     Log "Running PRE_BACKUP_SCRIPT '${PRE_BACKUP_SCRIPT[@]}'"
-    AddExitTask "$(eval "${POST_BACKUP_SCRIPT[@]}")"
+    AddExitTask "${POST_BACKUP_SCRIPT[@]}"
     eval "${PRE_BACKUP_SCRIPT[@]}"
 fi

--- a/usr/share/rear/backup/default/01_pre_backup_script.sh
+++ b/usr/share/rear/backup/default/01_pre_backup_script.sh
@@ -1,0 +1,5 @@
+if test "$PRE_BACKUP_SCRIPT" ; then
+    Log "Running PRE_BACKUP_SCRIPT '${PRE_BACKUP_SCRIPT[@]}'"
+    AddExitTask "$(eval "${POST_BACKUP_SCRIPT[@]}")"
+    eval "${PRE_BACKUP_SCRIPT[@]}"
+fi

--- a/usr/share/rear/backup/default/99_post_backup_script.sh
+++ b/usr/share/rear/backup/default/99_post_backup_script.sh
@@ -1,0 +1,5 @@
+if test "$POST_BACKUP_SCRIPT" ; then
+    Log "Running POST_BACKUP_SCRIPT '${POST_BACKUP_SCRIPT[@]}'"
+    RemoveExitTask "$(eval "${POST_BACKUP_SCRIPT[@]}")"
+    eval "${POST_BACKUP_SCRIPT[@]}"
+fi

--- a/usr/share/rear/backup/default/99_post_backup_script.sh
+++ b/usr/share/rear/backup/default/99_post_backup_script.sh
@@ -1,5 +1,5 @@
 if test "$POST_BACKUP_SCRIPT" ; then
     Log "Running POST_BACKUP_SCRIPT '${POST_BACKUP_SCRIPT[@]}'"
-    RemoveExitTask "$(eval "${POST_BACKUP_SCRIPT[@]}")"
+    RemoveExitTask "${POST_BACKUP_SCRIPT[@]}"
     eval "${POST_BACKUP_SCRIPT[@]}"
 fi

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1126,6 +1126,13 @@ POST_RECOVERY_SCRIPT=
 # Call this before Relax-and-Recover starts to do anything in the recover workflow. You have the rescue system but nothing else
 PRE_RECOVERY_SCRIPT=
 
+# PRE/POST Backup scripts will provide the ability to run certain tasks before and after a ReaR backup.
+# for example:
+#   If a small database running on local filesystem and dependant on a local service, you will maintain its data consistency. 
+#   Stopping it before backup and restarting again after. 
+#   In case of any error during backup, if POST tasks were defined, ReaR will run those POST tasks within ExitTasks Array.
+#   This will prevent that the database remain stopped.
+
 # Call this after Relax-and-Recover finished to do anything in the mkbackup/mkbackuponly workflow. 
 POST_BACKUP_SCRIPT=
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1118,12 +1118,19 @@ ELILO_BIN=
 #
 # NOTE: The scripts can be defined as an array to better handly spaces in parameters.
 # The scripts are called like this: eval "${PRE_RECOVERY_SCRIPT[@]}"
+
 # Call this after Rela-and-Recover did everything in the recover workflow.
 # Use $TARGET_FS_ROOT (by default '/mnt/local') to refer to the recovered system.
 POST_RECOVERY_SCRIPT=
 
-# call this before Relax-and-Recover starts to do anything in the recover workflow. You have the rescue system but nothing else
+# Call this before Relax-and-Recover starts to do anything in the recover workflow. You have the rescue system but nothing else
 PRE_RECOVERY_SCRIPT=
+
+# Call this after Relax-and-Recover finished to do anything in the mkbackup/mkbackuponly workflow. 
+POST_BACKUP_SCRIPT=
+
+# Call this before Relax-and-Recover starts to do anything in the mkbackup/mkbackuponly workflow. 
+PRE_BACKUP_SCRIPT=
 
 # some external backup software give you the opportunity to enter paths to exclude ...
 # we tend to use a timer in seconds we wait before continuing (we do not want to break the automated restores)


### PR DESCRIPTION
Hello,

Those changes add the capacity in rear to stop/start some services or run some required tasks previous to run backup (just like those exist for recovery), this can be useful in some scenarios if, for example, a small database that can be stopped and it's data will be consistent after OS recovery without human intervention.

I've tested and forced error between pre and post to check correct behaviour of Exit Tasks in case of any error during backup if, for example, some service stopped in PRE can be started by Exit Tasks array.

Following changed:

#      	new file:   usr/share/rear/backup/default/01_pre_backup_script.sh
<pre>
if test "$PRE_BACKUP_SCRIPT" ; then
    Log "Running PRE_BACKUP_SCRIPT '${PRE_BACKUP_SCRIPT[@]}'"
    AddExitTask "${POST_BACKUP_SCRIPT[@]}"
    eval "${PRE_BACKUP_SCRIPT[@]}"
fi
</pre>
#      	new file:   usr/share/rear/backup/default/99_post_backup_script.sh
<pre>
if test "$POST_BACKUP_SCRIPT" ; then
    Log "Running POST_BACKUP_SCRIPT '${POST_BACKUP_SCRIPT[@]}'"
    RemoveExitTask "${POST_BACKUP_SCRIPT[@]}"
    eval "${POST_BACKUP_SCRIPT[@]}"
fi
</pre>
#      	modified:   usr/share/rear/conf/default.conf
<pre>
# Call this after Relax-and-Recover finished to do anything in the mkbackup/mkbackuponly workflow.
POST_BACKUP_SCRIPT=

# Call this before Relax-and-Recover starts to do anything in the mkbackup/mkbackuponly workflow.
PRE_BACKUP_SCRIPT=
</pre>
 
# required configuration on /etc/rear/local.conf:

<pre>
PRE_BACKUP_SCRIPT="/path_to_scripts/pre_scr.sh"
POST_BACKUP_SCRIPT="/path_to_scripts/post_scr.sh"
</pre>


Kind regards,

Didac