### PR TITLE
Adding a missing default directory and introducing a parameter

### DIFF
--- a/usr/share/rear/restore/BAREOS/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/BAREOS/default/40_restore_backup.sh
@@ -107,7 +107,12 @@ else
 		FILESET="fileset=\"$BAREOS_FILESET\""
 	fi
 
-        echo "restore client=$BAREOS_CLIENT $FILESET where=$TARGET_FS_ROOT select all done
+	if [ -n "$BAREOS_RESTOREJOB" ]
+	then
+		RESTOREJOB="restorejob=$BAREOS_RESTOREJOB"
+	fi
+
+        echo "restore client=$BAREOS_CLIENT $RESTOREJOB $FILESET where=$TARGET_FS_ROOT select all done
 
 " |     bconsole
 

--- a/usr/share/rear/skel/BAREOS/var/run/bareos/.gitignore
+++ b/usr/share/rear/skel/BAREOS/var/run/bareos/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
I am running rear + bareos in our environment. Each client has its own fileset, thus needed a specific restore job. I noticed that I need to add a parameter to tell rear which restore job to automatically start. 

I also noticed that a default folder was missing. I added this folder and rear + bareos work fine since quite a few months. It seems to be time to share this and offer this contribution. 