### PR TITLE
Added SLE12-SP2-btrfs-example.conf (issue999)

### DIFF
--- a/usr/share/rear/conf/examples/SLE12-SP2-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-SP2-btrfs-example.conf
@@ -1,0 +1,73 @@
+# Begin example setup for SLE12-SP2 with default btrfs subvolumes.
+# Since SLE12-SP1 what is mounted at '/' is a btrfs snapshot subvolume
+# see https://github.com/rear/rear/issues/556
+# and since SLE12-SP2 btrfs quota via "snapper setup-quota" is needed
+# see https://github.com/rear/rear/issues/999
+# You must adapt "your.NFS.server.IP/path/to/your/rear/backup" at BACKUP_URL.
+# You must decide whether or not you want to have /home/* in the backup.
+# It depends on the size of your harddisk whether or not /home is by default
+# a btrfs subvolume or a separated xfs filesystem on a separated partition.
+# You may activate SSH_ROOT_PASSWORD and adapt the "password_on_the_rear_recovery_system".
+# For basic information see the SLE12-SP2 manuals.
+# Also see the support database article "SDB:Disaster Recovery"
+# at http://en.opensuse.org/SDB:Disaster_Recovery
+# In particular note:
+# There is no such thing as a disaster recovery solution that "just works".
+# Regarding btrfs snapshots:
+# Recovery of btrfs snapshot subvolumes is not possible.
+# Only recovery of "normal" btrfs subvolumes is possible.
+# On SLE12-SP1 and SP2 the only exception is the btrfs snapshot subvolume
+# that is mounted at '/' but that one is not recreated but instead
+# it is created anew from scratch during the recovery installation with the
+# default first btrfs snapper snapshot subvolume path "@/.snapshots/1/snapshot"
+# by the SUSE tool "installation-helper --step 1" (cf. below).
+# Other snapshots like "@/.snapshots/234/snapshot" are not recreated.
+# Create rear recovery system as ISO image:
+OUTPUT=ISO
+# Store the backup file via NFS on a NFS server:
+BACKUP=NETFS
+# BACKUP_OPTIONS variable contains the NFS mount options and
+# with 'mount -o nolock' no rpc.statd (plus rpcbind) are needed:
+BACKUP_OPTIONS="nfsvers=3,nolock"
+# If the NFS server is not an IP address but a hostname,
+# DNS must work in the rear recovery system when the backup is restored.
+BACKUP_URL=nfs://your.NFS.server.IP/path/to/your/rear/backup
+# Keep an older copy of the backup in a HOSTNAME.old directory
+# provided there is no '.lockfile' in the HOSTNAME directory:
+NETFS_KEEP_OLD_BACKUP_COPY=yes
+# Have all modules of the original system in the recovery system with the
+# same module loading ordering as in the original system by using the output of
+#   lsmod | tail -n +2 | cut -d ' ' -f 1 | tac | tr -s '[:space:]' ' '
+# as value for MODULES_LOAD (cf. https://github.com/rear/rear/issues/626):
+#MODULES_LOAD=( )
+# On SLE12-SP1 and SP2 with default btrfs subvolumes what is mounted at '/' is a btrfs snapshot subvolume
+# that is controlled by snapper so that snapper is needed in the recovery system.
+# In SLE12-SP1 and SP2 some btrfs subvolume directories (/var/lib/pgsql /var/lib/libvirt/images /var/lib/mariadb)
+# have the "no copy on write (C)" file attribute set so that chattr is required in the recovery system
+# and accordingly also lsattr is useful to have in the recovery system (but not strictly required):
+REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" snapper chattr lsattr )
+# Snapper setup by the recovery system uses /usr/lib/snapper/installation-helper
+# that is linked to all libraries where snapper is linked to
+# (except libdbus that is only needed by snapper).
+# "installation-helper --step 1" creates a snapper config based on /etc/snapper/config-templates/default
+COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib/snapper/installation-helper /etc/snapper/config-templates/default )
+# Files in btrfs subvolumes are excluded by 'tar --one-file-system'
+# so that such files must be explictly included to be in the backup.
+# Files in the following SLE12-SP1 and SP2 default btrfs subvolumes are
+# in the below example not included to be in the backup
+#   /.snapshots/*  /var/crash/*
+# but files in /home/* are included to be in the backup.
+# You may use a command like
+#   findmnt -t btrfs | cut -d ' ' -f 1 | cut -s -d '-' -f2 | egrep -v 'snapshots|crash' | sed -e "s/$/\/*'/" -e "s/^/'/" | tr '\n' ' '
+# to generate the values:
+BACKUP_PROG_INCLUDE=( '/var/cache/*' '/var/lib/mailman/*' '/var/tmp/*' '/var/lib/pgsql/*' '/usr/local/*' '/opt/*' '/var/lib/libvirt/images/*' '/boot/grub2/i386/*' '/var/opt/*' '/srv/*' '/boot/grub2/x86_64/*' '/var/lib/mariadb/*' '/var/spool/*' '/var/lib/mysql/*' '/tmp/*' '/home/*' '/var/log/*' '/var/lib/named/*' 'var/lib/machines/*' )
+# The following POST_RECOVERY_SCRIPT implements during "rear recover"
+# btrfs quota setup for snapper if that is used in the original system:
+POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | grep -q "^QGROUP.*[0-9]/[0-9]" ; then snapper --no-dbus -r $TARGET_FS_ROOT set-config QGROUP= ; snapper --no-dbus -r $TARGET_FS_ROOT setup-quota && echo snapper setup-quota done || echo snapper setup-quota failed ; else echo snapper setup-quota not used ; fi' )
+# This option defines a root password to allow SSH connection
+# whithout a public/private key pair
+#SSH_ROOT_PASSWORD="password_on_the_rear_recovery_system"
+# Let the rear recovery system run dhclient to get an IP address
+# instead of using the same IP address as the original system:
+#USE_DHCLIENT="yes"
+# End example setup for SLE12-SP1 with default btrfs subvolumes.


### PR DESCRIPTION
Added SLE12-SP2-btrfs-example.conf
with POST_RECOVERY_SCRIPT that implements btrfs quota
setup for snapper if that is used in the original system,
see https://github.com/rear/rear/issues/999
