### PR TITLE
Better documentation for BACKUP_TYPE=incremental

### DIFF
--- a/doc/rear-release-notes.txt
+++ b/doc/rear-release-notes.txt
@@ -62,8 +62,9 @@ functionality:
 
       □ GNU tar (BACKUP=NETFS, BACKUP_PROG=tar)
       □ GNU tar (BACKUP=NETFS, BACKUP_PROG=tar, BACKUP_TYPE=incremental,
-        FULLBACKUPDAY=”Mon”) for using incremental backups with a weekly full
-        backup. Be aware, old tar archives will not be removed automatically!
+        FULLBACKUPDAY=”Mon”) for using incremental (actually differential)
+        backups with a weekly full backup. Be aware, old tar archives will not be
+        removed automatically!
       □ GNU tar with openssl encryption (BACKUP=NETFS, BACKUP_PROG=tar,
         BACKUP_PROG_CRYPT_ENABLED=1)
       □ rsync on local devices (BACKUP=NETFS, BACKUP_PROG=rsync), such USB
@@ -705,8 +706,8 @@ As usual lots of bug fixes - see the issue tracker.
 
   • Add automatic recovery mode for Bareos - issue #311
 
-  • Add incremental backup type with GNU tar with weekly backups, define in /
-    etc/rear/local.conf the following (issue #294):
+  • Add incremental (actually differential) backup type with GNU tar with
+    weekly backups, define in /etc/rear/local.conf the following (issue #294):
 
      BACKUP=NETFS
      BACKUP_TYPE=incremental
@@ -1313,10 +1314,14 @@ BACKUP_OPTIONS="rw,relatime,seclabel,user_xattr,acl,barrier=1,data=ordered"
 Issue Description: Is incremental backup possible?
 
 With our default settings (BACKUP=NETFS and BACKUP_PROG=tar) we support
-incremental backups when we add the following extra variables:
+a simple form of incremental backups when we add the following extra variables:
 
 BACKUP_TYPE=incremental
 FULLBACKUPDAY="Mon"
+
+The current implementation supports only to restore one full backup plus one single
+incremental backup so that currently BACKUP_TYPE=incremental actually implements
+a differential backup (cf. https://github.com/rear/rear/issues/974).
 
 Issue Description: ERROR: FindStorageDrivers called but STORAGE_DRIVERS is
 empty

--- a/doc/rear.8
+++ b/doc/rear.8
@@ -518,7 +518,7 @@ OUTPUT_URL=nfs://server/path/
 .\}
 .RE
 .sp
-When using BACKUP=NETFS there is an option to select a BACKUP_TYPE=incremental to have rear make incrementals until the next FULLBACKUPDAY="Mon" has reached\&.
+When using BACKUP=NETFS there is an option to select a BACKUP_TYPE=incremental to have rear make incremental backups until the next full backup e.g. via FULLBACKUPDAY="Mon" is reached\&. The current implementation supports only to restore one full backup plus one single incremental backup so that currently BACKUP_TYPE=incremental actually implements a differential backup\&.
 .SH "CONFIGURATION"
 .sp
 To configure Relax\-and\-Recover you have to edit the configuration files in \fI/etc/rear/\fR\&. All \fI*\&.conf\fR files there are part of the configuration, but only \fIsite\&.conf\fR and \fIlocal\&.conf\fR are intended for the user configuration\&. All other configuration files hold defaults for various distributions and should not be changed\&.

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -368,7 +368,10 @@ OUTPUT_URL=nfs://server/path/
 ----
 
 When using +BACKUP=NETFS+ there is an option to select a +BACKUP_TYPE=incremental+
- to have +rear+ make incrementals until the next +FULLBACKUPDAY="Mon"+ has reached.
+to have +rear+ make incremental backups until the next full backup
+e.g. via +FULLBACKUPDAY="Mon"+ is reached. The current implementation supports only
+to restore one full backup plus one single incremental backup so that currently
++BACKUP_TYPE=incremental+ actually implements a differential backup.
 
 == CONFIGURATION
 To configure Relax-and-Recover you have to edit the configuration files in

--- a/doc/user-guide/03-configuration.adoc
+++ b/doc/user-guide/03-configuration.adoc
@@ -119,8 +119,10 @@ Use CommVault Galaxy 10 (or Simpana 10)
 
 BACKUP=NETFS::
 Use Relax-and-Recover internal backup with tar or rsync (or similar)
-+BACKUP_TYPE=incremental+ and +FULLBACKUPDAY="Mon"+, activates incremental Backups (only with +tar+!).
-Please keep in mind to clean your old Backups from time to time.
++BACKUP_TYPE=incremental+ and +FULLBACKUPDAY="Mon"+, activates incremental backups (only with +tar+!).
+The current implementation supports only to restore one full backup plus one single incremental backup
+so that currently BACKUP_TYPE=incremental actually implements a differential backup.
+Please keep in mind to clean your old backups from time to time.
 
 BACKUP=REQUESTRESTORE::
 No backup, just ask user to somehow restore the filesystems

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1,33 +1,43 @@
 # Relax and Recover
 #
-# default configuration. Everything used should be set to a sane default here
-#
+# Default configuration.
+
 #    Relax-and-Recover is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
 #    the Free Software Foundation; either version 2 of the License, or
 #    (at your option) any later version.
-
+#
 #    Relax-and-Recover is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #    GNU General Public License for more details.
-
+#
 #    You should have received a copy of the GNU General Public License
 #    along with Relax-and-Recover; if not, write to the Free Software
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-#
 
-# PLEASE NOTE:
+# Here we define and describe all configuration variables and set them to a default.
 #
-# * Here we define and describe ALL configuration variables and set them to a sane
-#   default. Please do NOT change them here, but rather copy them to site.conf or
-#   local.conf
-# * Most variables can be set to an empty value (VAR=) which means that this
-#   setting is off or set to some automatic mode.
-# * Boolean variables can be set to anything as we only check wether the variable
-#   is not empty.
-# * Some variables are actually bash arrays and should be treated with care.
-#   To set an empty array, use VAR=().
+# Do not change them here. Set them in your site.conf or local.conf file as needed.
+#
+# Some variables are actually bash arrays and should be treated with care.
+# Use VAR=( "${VAR[@]}" value ) to add a value to an array.
+# Use VAR=() to set an empty array.
+#
+# Most variables can be set to an empty value VAR= which means that this
+# setting is off or set to some automatic mode.
+#
+# Boolean variables can be set to anything as we only check wether the variable
+# is not empty so that both VAR=yes and VAR=no evaluate to boolean "true".
+# To set a boolean variable to "false" set it to an empty value.
+#
+# A few variables have ternary semantics:
+# - unset or empty value
+# - explicit true value like True T true t Yes Y yes y 1
+# - explicit false value like False F false f No N no n 0
+# (see the is_true and is_false functions in lib/global-functions.sh).
+#
+# In case of doubt inspect the scripts how exactly a particular variable works.
 
 ##
 # TMPDIR
@@ -361,7 +371,10 @@ MANUAL_INCLUDE=NO
 BACKUP_SELINUX_DISABLE=1
 # Enable integrity check of the backup archive (only with BACKUP=NETFS and BACKUP_PROG=tar)
 BACKUP_INTEGRITY_CHECK=
-# define BACKUP_TYPE (default empty [full]) or incremental - only with BACKUP=NETFS and BACKUP_PROG=tar
+# Define BACKUP_TYPE (default empty means full backup) or incremental (only with BACKUP=NETFS and BACKUP_PROG=tar).
+# The current implementation supports only to restore one full backup plus one single incremental backup
+# so that currently BACKUP_TYPE=incremental actually implements a differential backup,
+# see https://github.com/rear/rear/issues/974.
 BACKUP_TYPE=
 # Together with BACKUP_TYPE=incremental you could define on which day in the week a full backup must be run
 # Therefore, use FULLBACKUPDAY=Mon (or whatever day you prefer - use the "date +%a" syntax)


### PR DESCRIPTION
See https://github.com/rear/rear/issues/974
in particular see
https://github.com/rear/rear/issues/974#issuecomment-248895101

Additionally I dared to enhance the general comment
in default.conf about how to use our variable types
(as far as I see BACKUP_PROG_CRYPT_ENABLED
has ternary semantics because both is_true and is_false
is used for that variable).
