### PR TITLE
Simplify reboot halt poweroff and shutdown in case of systemd

### DIFF
--- a/usr/share/rear/build/GNU/Linux/63_simplify_systemd_reboot_halt_poweroff_shutdown.sh
+++ b/usr/share/rear/build/GNU/Linux/63_simplify_systemd_reboot_halt_poweroff_shutdown.sh
@@ -1,0 +1,36 @@
+
+# In case of systemd simplify how reboot halt poweroff and shutdown works
+# to make it more fail-safe, cf. https://github.com/rear/rear/issues/953
+
+# Skip if systemd is not used:
+test -d $ROOTFS_DIR/usr/lib/systemd/system || return 0
+
+# Replace reboot halt and poweroff by simple scripts that run
+# "umount -a ; systemctl --force [reboot halt poweroff]"
+for command in reboot halt poweroff ; do
+cat <<EOF >$ROOTFS_DIR/bin/$command
+#!/bin/bash
+echo umounting all filesystems
+umount -vfar &>/dev/null
+echo $command in 3 seconds...
+sleep 3
+systemctl --force $command
+EOF
+done
+
+# Because there is no "systemctl shutdown" replace shutdown
+# by a more elaborated script that calls by default poweroff
+# but when '-r' or '--reboot' is specified it calls reboot and
+# when '-H' or '--halt' is specified it calls halt:
+cat <<'EOF' >$ROOTFS_DIR/bin/shutdown
+#!/bin/bash
+command=poweroff
+for arg in "$@" ; do
+    case "$arg" in
+        (-r|--reboot) command=reboot ;;
+        (-H|--halt)   command=halt ;;
+    esac
+done
+$command
+EOF
+

--- a/usr/share/rear/build/GNU/Linux/63_simplify_systemd_reboot_halt_poweroff_shutdown.sh
+++ b/usr/share/rear/build/GNU/Linux/63_simplify_systemd_reboot_halt_poweroff_shutdown.sh
@@ -32,7 +32,7 @@ cat <<EOF >$filename
 export LC_ALL=C LANG=C
 echo umounting all filesystems
 umount -vfar
-echo syncing disks... (waiting 3 seconds before $command)
+echo syncing disks... waiting 3 seconds before $command
 sync
 sleep 3
 systemctl --force $command

--- a/usr/share/rear/build/GNU/Linux/63_simplify_systemd_reboot_halt_poweroff_shutdown.sh
+++ b/usr/share/rear/build/GNU/Linux/63_simplify_systemd_reboot_halt_poweroff_shutdown.sh
@@ -3,8 +3,13 @@
 # simplifies how reboot halt poweroff and shutdown work in case of systemd
 # to make them more fail-safe, see https://github.com/rear/rear/issues/953
 
-# Skip if systemd is not used:
-test -d $ROOTFS_DIR/usr/lib/systemd/system || return 0
+# Skip if systemd is not used.
+# Because the scripts below need the systemctl executable and because
+# via prep/GNU/Linux/28_include_systemd.sh and build/GNU/Linux/10_copy_as_is.sh
+# systemctl gets only copied into the recovery system if systemd is used,
+# we can test here (i.e. after build/GNU/Linux/10_copy_as_is.sh had already run)
+# if /bin/systemctl exists in the recovery system:
+test -x $ROOTFS_DIR/bin/systemctl || return 0
 
 # Replace reboot halt and poweroff by simple scripts that basically run
 #   "umount -a ; sync ; systemctl --force [reboot halt poweroff]"

--- a/usr/share/rear/build/GNU/Linux/63_simplify_systemd_reboot_halt_poweroff_shutdown.sh
+++ b/usr/share/rear/build/GNU/Linux/63_simplify_systemd_reboot_halt_poweroff_shutdown.sh
@@ -11,7 +11,7 @@ for command in reboot halt poweroff ; do
 cat <<EOF >$ROOTFS_DIR/bin/$command
 #!/bin/bash
 echo umounting all filesystems
-umount -vfar &>/dev/null
+umount -vfar
 echo $command in 3 seconds...
 sleep 3
 systemctl --force $command


### PR DESCRIPTION
The new script
build/GNU/Linux/63_simplify_systemd_reboot_halt_poweroff_shutdown.sh
replaces in case of systemd in the rear recovery system
/bin/reboot /bin/halt /bin/poweroff and /bin/shutdown
by scripts that basically do
"umount -a" and "systemctl --force [reboot halt poweroff]"
to make reboot halt poweroff and shutdown work simpler
and more fail-safe, see https://github.com/rear/rear/issues/953
