### PR TITLE
Update 40_restore_backup.sh

### DIFF
--- a/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/40_restore_backup.sh
@@ -50,7 +50,8 @@ case "$BACKUP_PROG" in
                 # will be modified as well - see issue #952)
                 BASE=$BASEDIR/$(cat $BASEDIR/basebackup.txt)
             else
-                BASE=$BASEDIR/$(tar --test-label -f "$restorearchive")
+                #BASE=$BASEDIR/$(tar --test-label -f "$restorearchive")
+                BASE=$BASEDIR/$(cat $BASEDIR/basebackup.txt)
             fi
             if [ "$BASE" == "$LAST" ]; then
                 Log dd if=$BASE \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -


### PR DESCRIPTION
tar --test-label is not supported on Centos 5 who have tar version 1.15