### PR TITLE
Fixed non ASCII characters in scripts.

### DIFF
--- a/usr/share/rear/backup/DUPLICITY/default/50_make_duplicity_backup.sh
+++ b/usr/share/rear/backup/DUPLICITY/default/50_make_duplicity_backup.sh
@@ -1,7 +1,7 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included LICENSE for full text of license.
 
-if [ "$BACKUP_PROG" = "duply" ] && has_binary duply; then
+if [ "$BACKUP_PROG" = "duply" ] && has_binary duplyi ; then
     # we found the duply program; check if a profile was defined
     [[ -z "$DUPLY_PROFILE" ]] && return
 
@@ -15,29 +15,28 @@ if [ "$BACKUP_PROG" = "duply" ] && has_binary duply; then
 fi
 
 
-if [ "$BACKUP_PROG" = "duplicity" ]; then
+if [ "$BACKUP_PROG" = "duplicity" ] ; then
 
     # make backup using the DUPLICITY method with duplicity
-    # by falk hoeppner 
-    
+    # by falk hoeppner
+
     LogPrint "Creating $BACKUP_PROG archives on '$BACKUP_DUPLICITY_URL'"
-    
-    # using some new parameters from config.local 
+
+    # using some new parameters from config.local
     #
     # DUPLICITY_USER
     # DUPLICITY_HOST
     # DUPLICITY_PROTO
     # DUPLICITY_PATH
     # BACKUP_DUPLICITY_URL
-    
-    if [ -n $DUPLICITY_USER -a -n $DUPLICITY_HOST -a -n $DUPLICITY_PROTO -a -n $DUPLICITY_PATH ]
-    then 
+
+    if [ -n $DUPLICITY_USER -a -n $DUPLICITY_HOST -a -n $DUPLICITY_PROTO -a -n $DUPLICITY_PATH ] ; then
         BKP_URL="$BACKUP_DUPLICITY_URL"
         # ToDo: do some more plausibility checks !?
     else
         Error "Parameters for BACKUP_DUPLICITY_URL not set correctly, please look at config.local template"
     fi
-    
+
     # todo: check parameters
     DUP_OPTIONS="$BACKUP_DUPLICITY_OPTIONS"
     #
@@ -46,7 +45,7 @@ if [ "$BACKUP_PROG" = "duplicity" ]; then
     PASSPHRASE="$BACKUP_DUPLICITY_GPG_ENC_PASSPHRASE"
 
     echo "GPG_OPT = $GPG_OPT"
-    
+
     # EXCLUDES="${TMP_DIR}/backup_exclude.lst"
 
     # NMBRS=${#BACKUP_DUPLICITY_EXCLUDE[$@]}
@@ -58,57 +57,55 @@ if [ "$BACKUP_PROG" = "duplicity" ]; then
     #     echo "${BACKUP_DUPLICITY_EXCLUDE[$i]}" >> "${EXCLUDES}"
     # done
 
-    # runs without external file, but all the * in the excludelist 
+    # runs without external file, but all the * in the excludelist
     # will expanded :-(
     #
-    for EXDIR in ${BACKUP_DUPLICITY_EXCLUDE[@]}
-    do
+    for EXDIR in ${BACKUP_DUPLICITY_EXCLUDE[@]} ; do
         EXCLUDES="$EXCLUDES --exclude $EXDIR"
     done
 
     echo EXCLUDES = $EXCLUDES
-    
+
     # Setting the pass phrase to encrypt the backup files
     export PASSPHRASE
-    
+
     # check and create directory at backup-server
     # if the target-directory dont exist, duplicity will fail
-    # Note: this is only working if we use duplicity with ssh/rsync and the 
+    # Note: this is only working if we use duplicity with ssh/rsync and the
     # given user is allowed to create directories/files this way !!
     # maybe better done in an if or case statment
     #
     LogPrint "Checking backup-path at server ..."
     ssh ${DUPLICITY_USER}@${DUPLICITY_HOST} "test -d ${DUPLICITY_PATH}/${HOSTNAME} || mkdir -p ${DUPLICITY_PATH}/${HOSTNAME}"
-    
+
     # first remove everything older than $BACKUP_DUPLICITY_MAX_TIME
-    if [ -z $BACKUP_DUPLICITY_MAX_TIME ]
-    then
-        BACKUP_DUPLICITY_MAX_TIME=2M  # Default: alte Backups nach 2 Monaten löschen
+    if [ -z $BACKUP_DUPLICITY_MAX_TIME ] ; then
+        # default: remove old backup after 2 month
+        BACKUP_DUPLICITY_MAX_TIME=2M
     fi
     LogPrint "Removing the old stuff from server with CMD:
     $DUPLICITY_PROG remove-older-than $BACKUP_DUPLICITY_MAX_TIME -v5 $BKP_URL/$HOSTNAME"
     $DUPLICITY_PROG remove-older-than $BACKUP_DUPLICITY_MAX_TIME -v5 $BKP_URL/$HOSTNAME >> ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log
-    
+
     # do the backup
     LogPrint "Running CMD: $DUPLICITY_PROG -v5 $DUP_OPTIONS --encrypt-key $GPG_KEY $GPG_OPT $EXCLUDES \
      / $BKP_URL/$HOSTNAME >> ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log "
     $DUPLICITY_PROG -v5 $DUP_OPTIONS --encrypt-key $GPG_KEY $GPG_OPT $EXCLUDES \
            / $BKP_URL/$HOSTNAME >> ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log 2>&1
-    
+
     RC_DUP=$?
-    
+
     sleep 1
     LOGAUSZUG=$(tail -n 18 ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log)
     LogPrint "${LOGAUSZUG}"
 
     # everyone should see this warning, even if not verbose
-    if [ $RC_DUP -gt 0 ] 
-    then 
+    if [ $RC_DUP -gt 0 ] ; then
         VERBOSE=1
         LogPrint "WARNING !
     There was an error during archive creation.
     Please check the archive and see '$LOGFILE' for more information.
-    
+
     Since errors are oftenly related to files that cannot be saved by
     $BACKUP_PROG, we will continue the $WORKFLOW process. However, you MUST
     verify the backup yourself before trusting it !

--- a/usr/share/rear/backup/DUPLICITY/default/50_make_duplicity_backup.sh
+++ b/usr/share/rear/backup/DUPLICITY/default/50_make_duplicity_backup.sh
@@ -1,7 +1,7 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included LICENSE for full text of license.
 
-if [ "$BACKUP_PROG" = "duply" ] && has_binary duplyi ; then
+if [ "$BACKUP_PROG" = "duply" ] && has_binary duply ; then
     # we found the duply program; check if a profile was defined
     [[ -z "$DUPLY_PROFILE" ]] && return
 

--- a/usr/share/rear/lib/mkrescue-functions.sh
+++ b/usr/share/rear/lib/mkrescue-functions.sh
@@ -172,9 +172,10 @@ FixSfdiskPartitionFile () {
 
 egrep -vi '(^warning|^dos)'  "$1" > "${TMP_DIR}/partitions.tmp"
 
-# If LANG is not set to C (it should be) and sfdisk is still producing French
-# comments like "N° table de partition de " then we should replace the "N"
-# with hash(#) sign.
+# If LANG is not set to C (it should be) and sfdisk is producing locale specific comments
+# for example in French something like "N<degree sign (U+00B0)> table de partition de "
+# where <degree sign (U+00B0)> means one unicode character (in UTF-8 two bytes 0xC2 0xB0)
+# then we should replace the "N" with hash(#) sign.
 sed -e 's/^N/#/' <"${TMP_DIR}/partitions.tmp" >"$1"
 rm -f $v "${TMP_DIR}/partitions.tmp" >&2
 }


### PR DESCRIPTION
Non-ASCII characters (e.g. UTF-8 characters) in scripts
are not wanted, see
https://github.com/rear/rear/issues/1018#issuecomment-251385721

Non-ASCII characters (e.g. UTF-8 characters) in scripts
might even cause failures on systems that do not
support non-POSIX/non-C locales (like UTF-8),
e.g. in the recovery system during "rear recover".

Currently non-ASCII characters were only used in
comments in the scripts but even that makes it at least
hard to read the comments in a non-ASCII locale
in particular because it is impossible to know
what encoding is meant by a sequence of bytes
that is a non-ASCII character, cf.
https://en.opensuse.org/SDB:Plain_Text_versus_Locale
