### PR TITLE
fix check_bootloader for POWER arch

### DIFF
--- a/usr/share/rear/layout/save/default/45_check_bootloader_files.sh
+++ b/usr/share/rear/layout/save/default/45_check_bootloader_files.sh
@@ -14,6 +14,8 @@ case $myBOOTloader in
         ;;
     ELILO) CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /etc/elilo.conf )
         ;;
+    PPC) CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /etc/lilo.conf /etc/yaboot.conf)
+        ;; 
       *) BugError "Unknown bootloader ($myBOOTloader) - ask for sponsoring to get this fixed"
         ;;
 esac

--- a/usr/share/rear/prep/default/50_guess_bootloader.sh
+++ b/usr/share/rear/prep/default/50_guess_bootloader.sh
@@ -12,6 +12,13 @@ for disk in /sys/block/* ; do
     blockd=${disk#/sys/block/}
     if [[ $blockd = hd* || $blockd = sd* || $blockd = cciss* || $blockd = vd* || $blockd = xvd* ]] ; then
         devname=$(get_device_name $disk)
+
+        # Check if devname contains a PPC PreP boot partition (ID=0x41)
+        if $(file -s $devname | grep ID=0x41 >/dev/null) ; then
+           echo "PPC" >$VAR_DIR/recovery/bootloader
+           return
+        fi
+
         dd if=$devname bs=512 count=4 | strings > $TMP_DIR/bootloader
         grep -q "EFI" $TMP_DIR/bootloader && {
         echo "EFI" >$VAR_DIR/recovery/bootloader
@@ -29,4 +36,3 @@ for disk in /sys/block/* ; do
         cat $TMP_DIR/bootloader >&2
    fi
 done
-


### PR DESCRIPTION
Since commit d15591e65461dfa43df6b7dbf23015d8e5598648, POWER arch based system is not able to run mkrescue.
=> `ERROR: BUG BUG BUG!  Unknown bootloader () - ask for sponsoring to get this fixed`

Here is a proposal to fix this.