### PR TITLE
Update 45_check_bootloader_files.sh

### DIFF
--- a/usr/share/rear/layout/save/default/45_check_bootloader_files.sh
+++ b/usr/share/rear/layout/save/default/45_check_bootloader_files.sh
@@ -8,7 +8,7 @@ myBOOTloader=$( cat $VAR_DIR/recovery/bootloader )
 case $myBOOTloader in
     EFI)  CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /boot/efi/EFI/*/grub*.cfg )
         ;;
-    GRUB) CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]}  /etc/grub.cfg /etc/grub2.cfg /boot/grub2/grub2.cfg /boot/grub/grub.cfg )
+    GRUB|GRUB2) CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /etc/grub.cfg /etc/grub2.cfg /boot/grub2/grub2.cfg /boot/grub/grub.cfg )
         ;;
     LILO) CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /etc/lilo.conf )
         ;;


### PR DESCRIPTION
In some cases (e.g. on some SLE12 systems)
the variable "myBOOTloader" could be also "GRUB2"
see https://github.com/rear/rear/issues/1038