### PR TITLE
Applied corrections discussed in #1037

### DIFF
--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -83,7 +83,7 @@ TAPE_DEVICE=/dev/nst0
  - Setup ssh key infrastructure for user that will be running backup.
 Issuing following command must work without any password prompts or remote host identity confirmation:
 
-`ssh <BORG_USERNAME>@<BORG_HOST>`
+`ssh <BORGBACKUP_USERNAME>@<BORGBACKUP_HOST>`
 
  - Edit _local.conf_ / _site.conf_ as follows:
 [source,bash]
@@ -92,19 +92,19 @@ OUTPUT=ISO
 OUTPUT_URL=nfs://<server_to_store_iso>/<directory/to/store/iso>
 
 BACKUP=BORG
-BORG_HOST=<server_to_store_backup>
-BORG_USERNAME=<user_to_run_backup>
-BORG_REPO=</path/to/borg/repository>
+BORGBACKUP_HOST=<server_to_store_backup>
+BORGBACKUP_USERNAME=<user_to_run_backup>
+BORGBACKUP_REPO=</path/to/borg/repository>
 ----
  - Setting automatic retention strategy:
 (https://borgbackup.readthedocs.io/en/stable/usage.html#borg-prune)
 [source,bash]
 ----
-BORG_PRUNE_HOURLY=
-BORG_PRUNE_DAILY=
-BORG_PRUNE_WEEKLY=
-BORG_PRUNE_MONTHLY=
-BORG_PRUNE_YEARLY=
+BORGBACKUP_PRUNE_HOURLY=
+BORGBACKUP_PRUNE_DAILY=
+BORGBACKUP_PRUNE_WEEKLY=
+BORGBACKUP_PRUNE_MONTHLY=
+BORGBACKUP_PRUNE_YEARLY=
 ----
 
  - Executing `rear mkbackup` will create bootable ISO image of your system and start Borg backup process. It will also prune old backups if BORG_PRUNE* is set.

--- a/doc/user-guide/10-integrating-external-backup.adoc
+++ b/doc/user-guide/10-integrating-external-backup.adoc
@@ -2,7 +2,7 @@
 
 Relax-and-Recover can be used only to restore the disk layout of your system and boot loader. However, that means you are responsible for taking backups. And, more important, to restore these before you reboot recovered system.
 
-However, we have sucessfully already integrated external backup programs within rear, such as Netbackup, EMC NetWorker, Tivoli Storage Manager, Data Protetctor to name a few commercial backup programs. Furthermore, open source external backup programs which are also working with rear are, Bacula, Bareos, Duplicity and Borg to name the most known ones.
+However, we have successfully already integrated external backup programs within rear, such as Netbackup, EMC NetWorker, Tivoli Storage Manager, Data Protetctor to name a few commercial backup programs. Furthermore, open source external backup programs which are also working with rear are Bacula, Bareos, Duplicity and Borg to name the most known ones.
 
 Ah, my backup program which is the best of course, is not yet integrated within rear. How shall we proceed to make your backup program working with rear? This is a step by step approach.
 

--- a/usr/share/rear/backup/BORG/default/10_load_init_archives.sh
+++ b/usr/share/rear/backup/BORG/default/10_load_init_archives.sh
@@ -3,54 +3,56 @@
 #
 # 10_load_archives.sh
 
-# Check if BORG_ARCHIVE_PREFIX is correctly set
-# Using '_' could result to some unpleasant site effects,
+# Check if BORGBACKUP_ARCHIVE_PREFIX is correctly set.
+# Using '_' could result to some unpleasant side effects,
 # as this character is used as delimiter in latter `for' loop ...
-# Excluding other non aplhanum characeters is not really necessary,
+# Excluding other non alphanumeric characters is not really necessary,
 # however it looks safer to me.
 # I'm sure archive handling can be done better, but no time for it now ...
-if [[ $BORG_ARCHIVE_PREFIX =~ [^a-zA-Z0-9] ]] \
-|| [[ -z $BORG_ARCHIVE_PREFIX ]]; then
-    Error "BORG_ARCHIVE_PREFIX must be alphanumeric non emply value only"
+if [[ $BORGBACKUP_ARCHIVE_PREFIX =~ [^a-zA-Z0-9] ]] \
+|| [[ -z $BORGBACKUP_ARCHIVE_PREFIX ]]; then
+    Error "BORGBACKUP_ARCHIVE_PREFIX must be alphanumeric non-empty value only"
 fi
 
 # Do we have Borg binary?
 has_binary borg
 StopIfError "Could not find Borg binary"
 
-# Query Borg server for repoitory information and store it to archive_cache.
-# This should avoid repeatingly quering Borg server, which could be slow.
+# Query Borg server for repository information and store it to archive_cache.
+# This should avoid repeatingly querying Borg server, which could be slow.
 archive_cache=$TMP_DIR/borg_archive
-borg list $BORG_USERNAME@$BORG_HOST:$BORG_REPO 2> /dev/null > $archive_cache
+borg list $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO \
+2> /dev/null > $archive_cache
 
-# If $rc == 0 we have repository present, but it is empty
+# If $rc == 0 we have repository present, but it is empty.
 # In my tests, Borg returned RC = 2, when repository was non-existent or
-# due connection problems (bad hostname, etc ...)
+# due connection problems (bad hostname, etc ...).
 # If repository is present but empty, rc will be set to 0, and initialization
-# will be skipped
+# will be skipped.
 rc=$?
 
 # TODO: Add security options for Borg repository initialization ...
-# This might be an Borg connection error, or missing repository
-# If initialization succeedes, we can cast out connection problems
+# This might be a Borg connection error, or missing repository.
+# If initialization succeeds, we can rule out connection problems.
 if [ $rc -ne 0 ]; then
-    Log "Creating new Borg repository $BORG_REPO on $BORG_HOST"
-    borg init -e none $BORG_USERNAME@$BORG_HOST:$BORG_REPO
+    Log "Creating new Borg repository $BORGBACKUP_REPO on $BORGBACKUP_HOST"
+    borg init -e none $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO
     rc=$?
 fi
 
-# Borg repository initilization failed in previous step,
-# backup abort is inevitablee
+# Borg repository initialization failed in previous step,
+# backup abort is inevitable.
 if [ $rc -ne 0 ]; then
     Error "Could not initialize Borg repository"
 fi
 
-# Everything should be be OK now, we can extract information about archives
-# Lets find largest suffix in use, and increment it by 1
+# Everything should be be OK now, we can extract information about archives.
+# Let's find largest suffix in use, and increment it by 1.
 SUFFIX=0
 
 for i in \
-$(cat $archive_cache | grep "^$BORG_ARCHIVE_PREFIX_" | awk '{print $1}'); do
+$(cat $archive_cache | grep "^$BORGBACKUP_ARCHIVE_PREFIX_" | awk '{print $1}')
+do
     suffix_tmp=$(echo $i | cut -d "_" -f 2)
 
     if [ $suffix_tmp -gt $SUFFIX ]; then

--- a/usr/share/rear/backup/BORG/default/50_make_backup.sh
+++ b/usr/share/rear/backup/BORG/default/50_make_backup.sh
@@ -6,23 +6,25 @@
 include_list=()
 
 # Check if backup-include.txt (created by 40_create_include_exclude_files.sh),
-# really exists
+# really exists.
 if [ ! -r $TMP_DIR/backup-include.txt ]; then
-    Error "Cant find include list"
+    Error "Can't find include list"
 fi
 
-# Create Borg friendly include list
+# Create Borg friendly include list.
 for i in $(cat $TMP_DIR/backup-include.txt); do
     include_list+=("$i ")
 done
 
-Log "Creating archive ${BORG_ARCHIVE_PREFIX}_$SUFFIX \
-in repository $BORG_REPO on host $BORG_HOST"
+Log "Creating archive ${BORGBACKUP_ARCHIVE_PREFIX}_$SUFFIX \
+in repository $BORGBACKUP_REPO on host $BORGBACKUP_HOST"
 
-# Start actual Borg backup
+# Start actual Borg backup.
 borg create --one-file-system --verbose --stats \
---compression $BORG_COMPRESSION --exclude-from $TMP_DIR/backup-exclude.txt \
-$BORG_USERNAME@$BORG_HOST:$BORG_REPO::${BORG_ARCHIVE_PREFIX}_$SUFFIX \
+--compression $BORGBACKUP_COMPRESSION \
+--exclude-from $TMP_DIR/backup-exclude.txt \
+$BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO::\
+${BORGBACKUP_ARCHIVE_PREFIX}_$SUFFIX \
 ${include_list[@]}
 
 StopIfError "Failed to create backup"

--- a/usr/share/rear/backup/BORG/default/80_prune_old_backups.sh
+++ b/usr/share/rear/backup/BORG/default/80_prune_old_backups.sh
@@ -5,35 +5,36 @@
 
 prune_opts=()
 
-# Construct Borg arguments for archive purging
+# Construct Borg arguments for archive pruning.
 # No need to check config values of $BORG_PRUNE* family
-# Borg will boil out with error if values are wrong
-if [ ! -z $BORG_PRUNE_HOURLY ]; then
-    prune_opts+=("--keep-hourly=$BORG_PRUNE_HOURLY ")
+# Borg will bail out with error if values are wrong.
+if [ ! -z $BORGBACKUP_PRUNE_HOURLY ]; then
+    prune_opts+=("--keep-hourly=$BORGBACKUP_PRUNE_HOURLY ")
 fi
 
-if [ ! -z $BORG_PRUNE_DAILY ]; then
-    prune_opts+=("--keep-daily=$BORG_PRUNE_DAILY ")
+if [ ! -z $BORGBACKUP_PRUNE_DAILY ]; then
+    prune_opts+=("--keep-daily=$BORGBACKUP_PRUNE_DAILY ")
 fi
 
-if [ ! -z $BORG_PRUNE_WEEKLY ]; then
-    prune_opts+=("--keep-weekly=$BORG_PRUNE_WEEKLY ")
+if [ ! -z $BORGBACKUP_PRUNE_WEEKLY ]; then
+    prune_opts+=("--keep-weekly=$BORGBACKUP_PRUNE_WEEKLY ")
 fi
 
-if [ ! -z $BORG_PRUNE_MONTHLY ]; then
-    prune_opts+=("--keep-monthly=$BORG_PRUNE_MONTHLY ")
+if [ ! -z $BORGBACKUP_PRUNE_MONTHLY ]; then
+    prune_opts+=("--keep-monthly=$BORGBACKUP_PRUNE_MONTHLY ")
 fi
 
-if [ ! -z $BORG_PRUNE_YEARLY ]; then
-    prune_opts+=("--keep-yearly=$BORG_PRUNE_YEARLY ")
+if [ ! -z $BORGBACKUP_PRUNE_YEARLY ]; then
+    prune_opts+=("--keep-yearly=$BORGBACKUP_PRUNE_YEARLY ")
 fi
 
 if [ ! -z $prune_opts ]; then
-    # Purge old archives according user settings
-    Log "Purging old Borg archives in repository $BORG_REPO"
-    borg prune -v --list ${prune_opts[@]} $BORG_USERNAME@$BORG_HOST:$BORG_REPO
+    # Purge old archives according user settings.
+    Log "Purging old Borg archives in repository $BORGBACKUP_REPO"
+    borg prune -v --list ${prune_opts[@]} \
+    $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO
     StopIfError "Failed to purge old backups"
 else
-    # Purge is not set
-    Log "Purgining of old Borg archives not set, skipping"
+    # Purge is not set.
+    Log "Purging of old Borg archives not set, skipping"
 fi

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -630,29 +630,30 @@ COPY_AS_IS_BORG=( )
 # ReaR includes `borg' and `locale' automatically
 PROGS_BORG=( )
 # Borg server name
-BORG_HOST=
+BORGBACKUP_HOST=
 # Username for connection to Borg server
-BORG_USERNAME=
+BORGBACKUP_USERNAME=
 # Path to Borg repository on Borg server
-BORG_REPO=
+BORGBACKUP_REPO=
 # Prefix used by ReaR to name archives
 # WARNING:
-# Do not use '_' in BORG_ARCHIVE_PREFIX as it is used internally by ReaR.
-BORG_ARCHIVE_PREFIX="rear"
+# Do not use '_' in BORGBACKUP_ARCHIVE_PREFIX as it is used internally by ReaR.
+BORGBACKUP_ARCHIVE_PREFIX="rear"
 # Compression used by Borg
 # Syntax: <compression_type,level>
 # compression_type: none, lz4, zlib, lzma
 # level: 0-9
-BORG_COMPRESSION="zlib,9"
+# "none" is default compression for Borg
+# We agreed in #1037 to mirror its settings in ReaR as well.
+# "The reason why we default to no compression is that users have to make
+# an informed choice."
+BORGBACKUP_COMPRESSION="none"
 # Borg retention strategy
-BORG_PRUNE_HOURLY=
-BORG_PRUNE_DAILY=
-BORG_PRUNE_WEEKLY=
-BORG_PRUNE_MONTHLY=
-BORG_PRUNE_YEARLY=
-# SSH keys to use for connection to Borg server
-# NOT IMPLEMENTED YET!
-BORG_SSH_KEYS=
+BORGBACKUP_PRUNE_HOURLY=
+BORGBACKUP_PRUNE_DAILY=
+BORGBACKUP_PRUNE_WEEKLY=
+BORGBACKUP_PRUNE_MONTHLY=
+BORGBACKUP_PRUNE_YEARLY=
 
 ##
 # BACKUP=BAREOS stuff (bareos.org)

--- a/usr/share/rear/prep/BORG/default/10_prep_borg.sh
+++ b/usr/share/rear/prep/BORG/default/10_prep_borg.sh
@@ -3,15 +3,15 @@
 #
 # 10_prep_borg.sh
 
-# Create our own locales, used only for Borg restore
+# Create our own locales, used only for Borg restore.
 mkdir -p $ROOTFS_DIR/usr/lib/locale
 localedef -f UTF-8 -i en_US $ROOTFS_DIR/usr/lib/locale/rear.UTF-8
 StopIfError "Could not create locales"
 
-# Activate $COPY_AS_IS_BORG from default.conf
+# Activate $COPY_AS_IS_BORG from default.conf.
 COPY_AS_IS=( "${COPY_AS_IS[@]}" "${COPY_AS_IS_BORG[@]}" )
 
-# Activate $PROGS_BORG from default.conf
-# Avoid user to accidentelly override `borg' and `locale' and exclude them
-# from Relax-and-Recover rescue/recovery system
+# Activate $PROGS_BORG from default.conf.
+# Avoid user to accidentally override `borg' and `locale' and exclude them
+# from Relax-and-Recover rescue/recovery system.
 PROGS=( "${PROGS[@]}" "${PROGS_BORG[@]}" borg locale )

--- a/usr/share/rear/restore/BORG/default/30_load_archives.sh
+++ b/usr/share/rear/restore/BORG/default/30_load_archives.sh
@@ -6,31 +6,32 @@
 LogPrint "Starting Borg restore"
 
 # Do we have Borg binary?
-# Missing Borg binary should not happen as it is copyied by
-# backup/BORG/default/20_start_backup.sh
+# Missing Borg binary should not happen as it is copied by
+# backup/BORG/default/20_start_backup.sh.
 has_binary borg
 BugIfError "Could not find Borg binary"
 
-# Query Borg server for repoitory information and store it to archive_cache.
+# Query Borg server for repository information and store it to archive_cache.
 # This should avoid repeatingly quering Borg server, which could be slow.
 archive_cache=$TMP_DIR/borg_archive
-borg list $BORG_USERNAME@$BORG_HOST:$BORG_REPO > $archive_cache
+borg list \
+$BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO > $archive_cache
 StopIfError "Could not list Borg archive"
 
-# Store number of lines in archive_cache file for later use
+# Store number of lines in archive_cache file for later use.
 archive_cache_lines=$(wc -l $archive_cache | awk '{print $1}')
 
-# This means empty repository
+# This means empty repository.
 if [ $archive_cache_lines -eq 0 ]; then
-    Error "Borg repository $BORG_REPO on $BORG_HOST is empty"
+    Error "Borg repository $BORGBACKUP_REPO on $BORGBACKUP_HOST is empty"
 fi
 
-# Display list of archives in repository
-# Display header
+# Display list of archives in repository.
+# Display header.
 echo ""
 echo "=== Borg archives list ==="
-echo "Host:       $BORG_HOST"
-echo "Repository: $BORG_REPO"
+echo "Host:       $BORGBACKUP_HOST"
+echo "Repository: $BORGBACKUP_REPO"
 echo ""
 
 # Display archive_cache file content and prompt user for archive to restore.
@@ -40,16 +41,16 @@ echo ""
 while(true); do
     cat -n $archive_cache | awk '{print "["$1"]", $2,"\t"$3,$4,$5}'
 
-    # Show "Exit" option
+    # Show "Exit" option.
     echo ""
     echo "[$(($archive_cache_lines+1))]" Exit
     echo ""
 
-    # Read user input
+    # Read user input.
     echo -n "Choose archive to recover from: "
     read choice
 
-    # Evaluate user selection and save archive name to restore
+    # Evaluate user selection and save archive name to restore.
     # Valid pick
     if [[ $choice -ge 1 && $choice -le $archive_cache_lines ]]; then
         ARCHIVE=$(sed "$choice!d" $archive_cache | awk '{print $1}')

--- a/usr/share/rear/restore/BORG/default/40_restore_backup.sh
+++ b/usr/share/rear/restore/BORG/default/40_restore_backup.sh
@@ -3,19 +3,20 @@
 #
 # 20_start_restore.sh
 
-# Borg restores to cwd
-# Switch current working directory or die
+# Borg restores to cwd.
+# Switch current working directory or die.
 cd $TARGET_FS_ROOT
 StopIfError "Could not change directory to /mnt/local"
 
-# Start actual restore
+# Start actual restore.
 # Scope of LC_ALL is only within run of `borg extract'.
 # This avoids Borg problems with restoring UTF-8 encoded files names in archive
 # and should not interfere with remaining stages of rear recover.
-# This is still not the ideal sollution, but best I can think of so far :-/
+# This is still not the ideal solution, but best I can think of so far :-/.
 LogPrint "Recovering from Borg archive $ARCHIVE"
 LC_ALL=rear.UTF-8 \
-borg extract --sparse $BORG_USERNAME@$BORG_HOST:$BORG_REPO::$ARCHIVE
+borg extract --sparse \
+$BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO::$ARCHIVE
 StopIfError "Could not successfully finish Borg restore"
 
 LogPrint "Borg OS restore finished successfully"


### PR DESCRIPTION
Spelling corrections
BORG_* variables renamed to BORGBACKUP_* to avoid collisions with Borg.
When ReaR uses Borg as back end, it defaults to "none" compression to be aligned with Borg defaults.