### PR TITLE
Update 50_guess_bootloader.sh

### DIFF
--- a/usr/share/rear/prep/default/50_guess_bootloader.sh
+++ b/usr/share/rear/prep/default/50_guess_bootloader.sh
@@ -2,7 +2,8 @@
 # /var/lib/rear/recovery/bootloader
 if [[ -f /etc/sysconfig/bootloader ]]; then
     # openSUSE uses LOADER_TYPE, and others??
-    my_bootloader=$( grep ^LOADER_TYPE /etc/sysconfig/bootloader | cut -d= -f2 | sed -e 's/"//g' )
+    # getting values from sysconfig files is like sourcing shell scripts so that the last setting wins
+    my_bootloader=$( grep ^LOADER_TYPE /etc/sysconfig/bootloader | cut -d= -f2 | tail -n1 | sed -e 's/"//g' )
     if [[ ! -z "$my_bootloader" ]]; then
         echo "$my_bootloader" | tr '[a-z]' '[A-Z]' >$VAR_DIR/recovery/bootloader
         return


### PR DESCRIPTION
Added 'tail -n1' to get onyl the last value if there are more than one
and because getting values from sysconfig files is like sourcing
a shell script it is the last setting that matters, see
https://github.com/rear/rear/commit/c291991ace856a56843c6e45cb121af06829f82c#commitcomment-19500870
and
https://github.com/rear/rear/issues/1038

Cf.
http://stackoverflow.com/questions/2871930/how-to-retrieve-value-from-etc-sysconfig-in-python
that reads (excerpt):
  source /etc/sysconfig/FOO
  echo $MY_VALUE
and
http://ftp.novell.hu/pub/mirrors/ftp.novell.com/forge/library/SUSE%20Package%20Conventions/spc_sysconfig.html
that reads (excerpts):
  The configuration is easily readable by shell scripts
  The sysconfig files are plain text files.
  The setting is defined by pairs {VARIABLE,value} the following way,
  like shell variables:
  VARIABLE=”value”