### PR TITLE
Fixed bug, with LOADER_TYPE=”grub2-efi"

### DIFF
--- a/usr/share/rear/build/GNU/Linux/10_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/10_copy_as_is.sh
@@ -30,9 +30,6 @@ mkdir $v -p $ROOTFS_DIR/etc/rear
 # if hidden file (.<filename>) is missing in $CONFIG_DIR
 cp $v -r $CONFIG_DIR/. $ROOTFS_DIR/etc/rear/ >&2
 
-#cp $v -r $CONFIG_DIR/* $ROOTFS_DIR/etc/rear/ >&2
-#cp $v -r $CONFIG_DIR/.[a-z]* $ROOTFS_DIR/etc/rear/ >&2
-
 COPY_AS_IS_EXELIST=()
 while read -r ; do
 	if [[ ! -d "$REPLY" && -x "$REPLY" ]]; then

--- a/usr/share/rear/layout/save/default/45_check_bootloader_files.sh
+++ b/usr/share/rear/layout/save/default/45_check_bootloader_files.sh
@@ -6,7 +6,7 @@
 myBOOTloader=$( cat $VAR_DIR/recovery/bootloader )
 
 case $myBOOTloader in
-    EFI)  CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /boot/efi/EFI/*/grub*.cfg )
+    EFI|GRUB2-EFI)  CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /boot/efi/EFI/*/grub*.cfg )
         ;;
     GRUB|GRUB2) CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /etc/grub.cfg /etc/grub2.cfg /boot/grub2/grub2.cfg /boot/grub/grub.cfg )
         ;;
@@ -15,7 +15,7 @@ case $myBOOTloader in
     ELILO) CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /etc/elilo.conf )
         ;;
     PPC) CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /etc/lilo.conf /etc/yaboot.conf)
-        ;; 
-      *) BugError "Unknown bootloader ($myBOOTloader) - ask for sponsoring to get this fixed"
+        ;;
+    *) BugError "Unknown bootloader ($myBOOTloader) - ask for sponsoring to get this fixed"
         ;;
 esac


### PR DESCRIPTION
When _/etc/sysconfig/bootloader_ have LOADER_TYPE=”grub2-efi", ReaR ends up with **"BUG! Unknown bootloader"**.

Related to issue: #1038 