### PR TITLE
Borg as back end, now accepts options for repository encryption (take 2)

### DIFF
--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -95,6 +95,7 @@ BACKUP=BORG
 BORGBACKUP_HOST=<server_to_store_backup>
 BORGBACKUP_USERNAME=<user_to_run_backup>
 BORGBACKUP_REPO=</path/to/borg/repository>
+BORGBACKUP_ENC_TYPE="none"
 ----
  - Setting automatic retention strategy:
 (https://borgbackup.readthedocs.io/en/stable/usage.html#borg-prune)
@@ -107,8 +108,10 @@ BORGBACKUP_PRUNE_MONTHLY=
 BORGBACKUP_PRUNE_YEARLY=
 ----
 
+ - If not using BORGBACKUP_ENC_TYPE="none", you should initialize BORGBACKUP_REPO manually, as Borg repository encryption requires some user interaction. Be sure to read **ReaR with Borg and repository encryption** section to avoid possible problems during system backup/restore operations.
  - Executing `rear mkbackup` will create bootable ISO image of your system and start Borg backup process. It will also prune old backups if BORG_PRUNE* is set.
  - To recover your system, boot ISO and trigger `rear recover`, you will be prompted which archive to recover from Borg repository, once ReaR finished with layout configuration.
+
 ```
 ...
 Disk layout created.
@@ -128,6 +131,23 @@ Choose archive to recover from:
 
 ```
 
+=== ReaR with Borg and repository encryption
+
+Borg by default uses option "repokey" for repository initialization. This ensures that your repository is encrypted with your chosen pass-phrase.
+Having pass-phrase in place however requires user interaction every time you run `rear mkbackup/recover`,
+hence avoids running ReaR with Borg in non-interactive mode (e.g. using cron).
+
+**To start ReaR with Borg in non-interactive mode, you can choose one of the following:**
+
+ - Use BORGBACKUP_ENC_TYPE="none" (no repository encryption)
+ - Use BORGBACKUP_ENC_TYPE="repokey" (without pass-phrase - same as having BORGBACKUP_ENC_TYPE="none")
+ - Use BORGBACKUP_ENC_TYPE="keyfile" (without pass-phrase - repository will be encrypted with keyfile stored on client side in /$HOME/.config/borg/keys/)
+
+IMPORTANT: If using BORGBACKUP_ENC_TYPE="keyfile", don't forget to make your
+           encryption key available for case of restore!
+           (using `COPY_AS_IS_BORG=( "/root/.config/borg/keys/" )` is a option to consider)
+
+More information on Borg repository initialization/encryption: https://borgbackup.readthedocs.io/en/stable/usage.html#borg-init
 
 == Using Relax-and-Recover with USB storage devices
 Using USB devices with Relax-and-Recover can be appealing for several reasons:

--- a/usr/share/rear/backup/BORG/default/10_load_init_archives.sh
+++ b/usr/share/rear/backup/BORG/default/10_load_init_archives.sh
@@ -31,12 +31,20 @@ borg list $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO \
 # will be skipped.
 rc=$?
 
-# TODO: Add security options for Borg repository initialization ...
+# Prepare option for Borg encryption.
+# If user did not set anything in BORGBACKUP_ENC_TYPE,
+# Borg default encryption will be used.
+opt_encryption=""
+if [ ! -z $BORGBACKUP_ENC_TYPE ]; then
+    opt_encryption="--encryption $BORGBACKUP_ENC_TYPE"
+fi
+
 # This might be a Borg connection error, or missing repository.
 # If initialization succeeds, we can rule out connection problems.
 if [ $rc -ne 0 ]; then
     Log "Creating new Borg repository $BORGBACKUP_REPO on $BORGBACKUP_HOST"
-    borg init -e none $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO
+    borg init $opt_encryption \
+    $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO
     rc=$?
 fi
 

--- a/usr/share/rear/backup/BORG/default/80_prune_old_backups.sh
+++ b/usr/share/rear/backup/BORG/default/80_prune_old_backups.sh
@@ -32,6 +32,7 @@ if [ ! -z $prune_opts ]; then
     # Purge old archives according user settings.
     Log "Purging old Borg archives in repository $BORGBACKUP_REPO"
     borg prune -v --list ${prune_opts[@]} \
+    --prefix ${BORGBACKUP_ARCHIVE_PREFIX}_\
     $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO
     StopIfError "Failed to purge old backups"
 else

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -643,11 +643,18 @@ BORGBACKUP_ARCHIVE_PREFIX="rear"
 # Syntax: <compression_type,level>
 # compression_type: none, lz4, zlib, lzma
 # level: 0-9
-# "none" is default compression for Borg
+# Default: none
 # We agreed in #1037 to mirror its settings in ReaR as well.
 # "The reason why we default to no compression is that users have to make
 # an informed choice."
 BORGBACKUP_COMPRESSION=""
+# Borg encryption type
+# Types: none, keyfile, repokey
+# none: encryption is disabled (least trouble with setup, least security)
+# keyfile: passphrase and having-the-key (stored on client in /$HOME/.config/borg/keys/)
+# repokey: passphrase-only (stored on server BORGBACKUP_REPO/config)
+# Default: repokey
+BORGBACKUP_ENC_TYPE=""
 # Borg retention strategy
 BORGBACKUP_PRUNE_HOURLY=
 BORGBACKUP_PRUNE_DAILY=


### PR DESCRIPTION
- borg as back end, now accepts options for repository encryption.
- prune now only affects archives with BORGBACKUP_ARCHIVE_PREFIX