### PR TITLE
do not list directories to backup twice in MANUAL_INCLUDE mode

### DIFF
--- a/usr/share/rear/backup/NETFS/default/400_create_include_exclude_files.sh
+++ b/usr/share/rear/backup/NETFS/default/400_create_include_exclude_files.sh
@@ -3,12 +3,17 @@
 for k in "${BACKUP_PROG_INCLUDE[@]}" ; do
 	test "$k" && echo "$k"
 done > $TMP_DIR/backup-include.txt
-# add the mountpoints that will be recovered to the backup include list
-while read mountpoint device junk ; do
-	if ! IsInArray "$mountpoint" "${EXCLUDE_MOUNTPOINTS[@]}" ; then
-		echo "$mountpoint"
-	fi
-done <"$VAR_DIR/recovery/mountpoint_device" >> $TMP_DIR/backup-include.txt
+
+# if we are in MANUAL_INCLUDE mode, there is no need to
+# include anything more. So skip this part if MANUAL_INCLUDE == "YES"
+if [ "${MANUAL_INCLUDE:-NO}" != "YES" ] ; then
+	# add the mountpoints that will be recovered to the backup include list
+	while read mountpoint device junk ; do
+		if ! IsInArray "$mountpoint" "${EXCLUDE_MOUNTPOINTS[@]}" ; then
+			echo "$mountpoint"
+		fi
+	done <"$VAR_DIR/recovery/mountpoint_device" >> $TMP_DIR/backup-include.txt
+fi
 
 # exclude list
 for k in "${BACKUP_PROG_EXCLUDE[@]}" ; do


### PR DESCRIPTION
In case we are running ```MANUAL_INCLUDE``` mode, there is no need
to add volumes, NOT explicitly excluded via ```EXCLUDE_MOUNTPOINTS```.

This will only add volumes added to ```BACKUP_PROG_INCLUDE``` to ```backup-include.txt```.

As this change is made in ```backup/NETFS/default/400_create_include_exclude_files.sh```, this change will also affect backup types BORG and RSYNC, as these also link to this file.

See also issue #1019.
