### PR TITLE
Allow yaboot bootlader creation even when yaboot.conf is missing (sles11 ppc64 with LVM)

### DIFF
--- a/usr/share/rear/finalize/SUSE_LINUX/ppc64/200_install_yaboot.sh
+++ b/usr/share/rear/finalize/SUSE_LINUX/ppc64/200_install_yaboot.sh
@@ -3,15 +3,19 @@ LogPrint "Installing PPC PReP Boot partition."
 
 # Find PPC PReP Boot partitions
 if test -f $TARGET_FS_ROOT/etc/yaboot.conf; then
-  part=$( awk -F '=' '/^boot=/ {print $2}' $TARGET_FS_ROOT/etc/yaboot.conf )
+    part=$( awk -F '=' '/^boot=/ {print $2}' $TARGET_FS_ROOT/etc/yaboot.conf )
+fi
 
-  if [ -n "$part" ]; then
+if [ -n "$part" ]; then
     LogPrint "Boot partion found: $part"
     chroot $TARGET_FS_ROOT /bin/bash --login -c "/sbin/lilo"
     bootdev=`echo $part | sed -e 's/[0-9]*$//'`
     LogPrint "Boot device is $bootdev."
     NOBOOTLOADER=
-  else
+else
+    # Allow Yaboot bootloader to be recreated even if there is no yaboot.conf
+    # (SLES11 ppc64 with /boot in LVM does not have /etc/yaboot.conf).
+    LogPrint "Scanning disks for PPC PReP Boot partition..."
     bootparts=`sfdisk -l 2>&8 | awk '/PPC PReP Boot/ {print $1}'`
     LogPrint "Boot partitions found: $bootparts."
     for part in $bootparts
@@ -25,8 +29,8 @@ if test -f $TARGET_FS_ROOT/etc/yaboot.conf; then
              done | sort | uniq`
     LogPrint "Boot device list is $bootdev."
     NOBOOTLOADER=
-  fi
-else
-  LogPrint "No bootloader configuration found. Install boot partition manually!"
 fi
 
+if [[ -n $NOBOOTLOADER ]]; then
+  LogPrint "No bootloader configuration found. Install boot partition manually!"
+fi

--- a/usr/share/rear/output/ISO/Linux-ppc64/300_create_yaboot.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64/300_create_yaboot.sh
@@ -6,7 +6,7 @@
 # Public License. Refer to the included COPYING for full text of license.
 
 ## other bootloader distro case
-if [[ ! -r /etc/yaboot.conf ]]
+if [[ ! -r /etc/yaboot.conf ]] && [[ ! -r /etc/lilo.conf ]]
 then
     return
 fi


### PR DESCRIPTION
Default LVM layout in SLES11sp4 put /boot in LVM (`/boot` is part of `/` which is a LV).
In this configuration, LILO does not create `/etc/yaboot.conf file`. (Yaboot configuration is directly created in the PPC PReP Boot Partition.)

Without `/etc/yaboot.conf`:   
+ ReaR ISO DVD is not bootable, 
+ and bootloader is not re-created at the end of the restoration process.

I propose the following changes to let LILO creates the bootloader even if `/etc/yaboot.conf` does not exist.

It seems those issues #820 #817 has the problem described here. (Sles11 with default LVM layout => no `/etc/yaboot.conf`).