### PR TITLE
Patch for newer versions of XFS with enabled CRC

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/130_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/130_include_filesystem_code.sh
@@ -80,7 +80,7 @@ function create_fs () {
                 tunefs="tune4fs"
             fi
             # Actually create the filesystem with initially correct UUID
-	    # (addresses Fedora/systemd problem, see issue 851)
+            # (addresses Fedora/systemd problem, see issue 851)
             # "mkfs -U" works at least since SLE11 but it may fail on older systems
             # e.g. on RHEL 5 mkfs does not support '-U' so that when "mkfs -U" fails
             # we assume it failed because of missing support for '-U' and
@@ -96,9 +96,9 @@ function create_fs () {
                   echo "    $tunefs -U $uuid $device >&2"
                   echo "fi"
                 ) >> "$LAYOUT_CODE"
-	    else
-		echo "mkfs -t ${fstype}${blocksize}${fragmentsize}${bytes_per_inode} $device >&2" >> "$LAYOUT_CODE"
-	    fi
+            else
+                echo "mkfs -t ${fstype}${blocksize}${fragmentsize}${bytes_per_inode} $device >&2" >> "$LAYOUT_CODE"
+            fi
             # Adjust tunable filesystem parameters on ext2/ext3/ext4 filesystems:
             # Set the label:
             if [ -n "$label" ] ; then
@@ -114,30 +114,19 @@ function create_fs () {
             # If available use wipefs to cleanup disk partition:
             test "$has_wipefs" && echo "$wipefs_command" >> "$LAYOUT_CODE"
 
-            local opts=""
-            local set_uuid_using_xfs_admin=0
-
             # Decide if mkfs.xfs or xfs_admin will set uuid.
             # Uuid set by xfs_admin will set incompatible flag on systems with
             # enabled CRC. This might cause ReaR failure during grub installation.
             # See: https://github.com/rear/rear/issues/1065
-            if [ -n "$uuid" ] ; then
-                # Check if option '-m uuid=<uuid>' is available in mkfs.xfs
-                if [ $(mkfs.xfs --help 2>&1 | grep "\-m" | grep -c uuid) -ne 0 ]; then
-                    opts="-m uuid=$uuid"
-                else
-                    # mkfs.xfs does not support uuid modification,
-                    # trigger xfs_admin to set uuid
-                    set_uuid_using_xfs_admin=1
-                fi
-            fi
-
-            # Actually create the filesystem (and set uuid if supported)
-            echo "mkfs.xfs -f $opts $device >&2" >> "$LAYOUT_CODE"
-
-            # Set UUID if needed
-            if [ $set_uuid_using_xfs_admin -eq 1 ]; then
-                echo "xfs_admin -U $uuid $device >&2" >> "$LAYOUT_CODE"
+            if [ -n "$uuid" ]; then
+                ( echo "if ! mkfs.xfs -f -m uuid=$uuid $device >&2; then"
+                  echo "    mkfs.xfs -f $device >&2"
+                  echo "    xfs_admin -U $uuid $device >&2"
+                  echo "fi"
+                ) >> "$LAYOUT_CODE"
+            else
+                # Actually create the filesystem
+                echo "mkfs.xfs -f $device >&2" >> "$LAYOUT_CODE"
             fi
 
             # Set the label:


### PR DESCRIPTION
See #1065.
If Self-Describing Metadata (CRC) is enabled on boot filesystem, and `xfs_admin` updates filesystem UUID, this sets incompatible flag (IF) to prevent older kernels to mount this filesystem.
Site effect of IF is that grub-install (resp. grub-probe) fails with _unknown filesystem_ message, which prevents ReaR to correctly install boot loader.