### PR TITLE
Initial support for multiple restore archives (issue1069)

### DIFF
--- a/doc/rear.8
+++ b/doc/rear.8
@@ -535,7 +535,7 @@ OUTPUT_URL=nfs://server/path/
 .\}
 .RE
 .sp
-When using BACKUP=NETFS there is an option to select a BACKUP_TYPE=incremental to have rear make incremental backups until the next full backup e\&.g\&. via FULLBACKUPDAY="Mon" is reached\&. The current implementation supports only to restore one full backup plus one single incremental backup so that currently BACKUP_TYPE=incremental actually implements a differential backup\&.
+When using BACKUP=NETFS and BACKUP_PROG=tar there is an option to select BACKUP_TYPE=incremental or BACKUP_TYPE=differential to let rear make incremental or differential backups until the next full backup day e\&.g\&. via FULLBACKUPDAY="Mon" is reached or when the last full backup is too old after FULLBACKUP_OUTDATED_DAYS has passed\&.
 .SH "CONFIGURATION"
 .sp
 To configure Relax\-and\-Recover you have to edit the configuration files in \fI/etc/rear/\fR\&. All \fI*\&.conf\fR files there are part of the configuration, but only \fIsite\&.conf\fR and \fIlocal\&.conf\fR are intended for the user configuration\&. All other configuration files hold defaults for various distributions and should not be changed\&.

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -370,11 +370,11 @@ BACKUP_URL=iso:///backup/
 OUTPUT_URL=nfs://server/path/
 ----
 
-When using +BACKUP=NETFS+ there is an option to select a +BACKUP_TYPE=incremental+
-to have +rear+ make incremental backups until the next full backup
-e.g. via +FULLBACKUPDAY="Mon"+ is reached. The current implementation supports only
-to restore one full backup plus one single incremental backup so that currently
-+BACKUP_TYPE=incremental+ actually implements a differential backup.
+When using +BACKUP=NETFS+ and BACKUP_PROG=tar there is an option to select
++BACKUP_TYPE=incremental+ or +BACKUP_TYPE=differential+ to let +rear+ make
+incremental or differential backups until the next full backup day
+e.g. via +FULLBACKUPDAY="Mon"+ is reached or when the last full backup
+is too old after FULLBACKUP_OUTDATED_DAYS has passed.
 
 == CONFIGURATION
 To configure Relax-and-Recover you have to edit the configuration files in

--- a/doc/user-guide/03-configuration.adoc
+++ b/doc/user-guide/03-configuration.adoc
@@ -121,11 +121,12 @@ BACKUP=BORG::
 Use BorgBackup (short Borg) a deduplicating backup program to restore the data.
 
 BACKUP=NETFS::
-Use Relax-and-Recover internal backup with tar or rsync (or similar). By adding the following settings in the configuration file -
-+BACKUP_TYPE=incremental+ and +FULLBACKUPDAY="Mon"+, incremental backups (only with +tar+!) will be activated.
-The current implementation supports only to restore one full backup plus one single incremental backup
-so that currently BACKUP_TYPE=incremental actually implements a differential backup.
-Please keep in mind to clean your old backups from time to time.
+Use Relax-and-Recover internal backup with tar or rsync (or similar).
+When using +BACKUP=NETFS+ and +BACKUP_PROG=tar+ there is an option to select
++BACKUP_TYPE=incremental+ or +BACKUP_TYPE=differential+ to let rear make
+incremental or differential backups until the next full backup day
+e.g. via +FULLBACKUPDAY="Mon"+ is reached or when the last full backup
+is too old after FULLBACKUP_OUTDATED_DAYS has passed.
 
 BACKUP=REQUESTRESTORE::
 No backup, just ask user to somehow restore the filesystems.
@@ -191,7 +192,9 @@ BACKUP_PROG=rsync::
 If you want to use rsync instead of tar (only for +BACKUP=NETFS+). Do not confuse this with the +BACKUP=RSYNC+ backup mechanism.
 
 NETFS_KEEP_OLD_BACKUP_COPY=y::
-If you want to keep the previous backup archive (by defining +BACKUP_TYPE=incremental+ the +NETFS_KEEP_OLD_BACKUP_COPY+ variable will be unset automatically)
+If you want to keep the previous backup archive.
+Incremental or differential backup and NETFS_KEEP_OLD_BACKUP_COPY contradict each other so that
++NETFS_KEEP_OLD_BACKUP_COPY+ must not be 'true' in case of incremental or differential backup.
 
 TMPDIR=/bigdisk::
 Define this variable in +/etc/rear/local.conf+ if directoru +/tmp+ is too small to contain the ISO image, e.g. when using

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -37,15 +37,16 @@ if [[ "$opath" ]]; then
     mkdir -p $v "${opath}" >&2
 fi
 
-# Disable BACKUP_PROG_CRYPT_OPTIONS by replacing the default value to cat in
-# case encryption is disabled
+# Disable BACKUP_PROG_CRYPT_OPTIONS by replacing the default with 'cat' when encryption is disabled
+# (by default encryption is disabled but the default BACKUP_PROG_CRYPT_OPTIONS is not 'cat'):
 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
-  # Note: encryption is only supported with tar
-  LogPrint "Encrypting archive with a key"
+    # Backup archive encryption is only supported with 'tar':
+    test "tar" = "$BACKUP_PROG" || Error "Backup archive encryption is only supported with BACKUP_PROG=tar"
+    LogPrint "Encrypting backup archive with key defined in variable \$BACKUP_PROG_CRYPT_KEY"
 else
-  LogPrint "Encrypting disabled"
-  BACKUP_PROG_CRYPT_OPTIONS="cat"
-  BACKUP_PROG_CRYPT_KEY=""
+    Log "Encrypting backup archive is disabled"
+    BACKUP_PROG_CRYPT_OPTIONS="cat"
+    BACKUP_PROG_CRYPT_KEY=""
 fi
 
 # Check if the backup needs to be splitted or not (on multiple ISOs)

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -77,14 +77,14 @@ case "$(basename ${BACKUP_PROG})" in
 		Log $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
 			--no-wildcards-match-slash --one-file-system \
 			--ignore-failed-read $BACKUP_PROG_OPTIONS \
-			$BACKUP_PROG_X_OPTIONS \
+			$BACKUP_PROG_CREATE_NEWER_OPTIONS \
 			${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
 			-X $TMP_DIR/backup-exclude.txt -C / -c -f - \
 			$(cat $TMP_DIR/backup-include.txt) $LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
 		$BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
 			--no-wildcards-match-slash --one-file-system \
 			--ignore-failed-read $BACKUP_PROG_OPTIONS \
-			$BACKUP_PROG_X_OPTIONS \
+			$BACKUP_PROG_CREATE_NEWER_OPTIONS \
 			${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
 			-X $TMP_DIR/backup-exclude.txt -C / -c -f - \
 			$(cat $TMP_DIR/backup-include.txt) $LOGFILE | $BACKUP_PROG_CRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $SPLIT_COMMAND

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -373,11 +373,18 @@ BACKUP_SELINUX_DISABLE=1
 # Enable integrity check of the backup archive (only with BACKUP=NETFS and BACKUP_PROG=tar)
 BACKUP_INTEGRITY_CHECK=
 # Define BACKUP_TYPE (default empty means full backup) or incremental (only with BACKUP=NETFS and BACKUP_PROG=tar).
+# Incremental backup and keeping old backup contradict each other (mutual exclusive)
+# so that NETFS_KEEP_OLD_BACKUP_COPY must not be 'true' in case of incremental backup
+# because NETFS_KEEP_OLD_BACKUP_COPY would move an already existing backup directory away
+# but for incremental backup an already existing backup directory must stay where it is
+# so that after the initial full backup the incremental backups can be stored therein.
 # The current implementation supports only to restore one full backup plus one single incremental backup
 # so that currently BACKUP_TYPE=incremental actually implements a differential backup,
 # see https://github.com/rear/rear/issues/974.
 BACKUP_TYPE=
 # Together with BACKUP_TYPE=incremental you could define on which weekday a full backup must be run.
+# If FULLBACKUPDAY is set a full backup will be done on that weekday in any case
+# (regardless if there already exists a full backup that was created on the same day).
 # For example use FULLBACKUPDAY=Mon where the weekday value must match the output of "date +%a" run in
 # the POSIX/C locale (/usr/sbin/rear sets that locale) i.e. it must be an English abbreviated weekday.
 # According to http://stackoverflow.com/questions/18919151/crontab-day-of-the-week-syntax

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -372,24 +372,41 @@ MANUAL_INCLUDE=NO
 BACKUP_SELINUX_DISABLE=1
 # Enable integrity check of the backup archive (only with BACKUP=NETFS and BACKUP_PROG=tar)
 BACKUP_INTEGRITY_CHECK=
-# Define BACKUP_TYPE (default empty means full backup) or incremental (only with BACKUP=NETFS and BACKUP_PROG=tar).
-# Incremental backup and keeping old backup contradict each other (mutual exclusive)
-# so that NETFS_KEEP_OLD_BACKUP_COPY must not be 'true' in case of incremental backup
+# Define BACKUP_TYPE.
+# By default BACKUP_TYPE is empty which means "rear mkbackup" will create a full backup.
+# Only with BACKUP=NETFS and BACKUP_PROG=tar one can also use incremental or differential backup:
+# Incremental or differential backup and NETFS_KEEP_OLD_BACKUP_COPY contradict each other so that
+# NETFS_KEEP_OLD_BACKUP_COPY must not be 'true' in case of incremental or differential backup
 # because NETFS_KEEP_OLD_BACKUP_COPY would move an already existing backup directory away
-# but for incremental backup an already existing backup directory must stay where it is
-# so that after the initial full backup the incremental backups can be stored therein.
-# The current implementation supports only to restore one full backup plus one single incremental backup
-# so that currently BACKUP_TYPE=incremental actually implements a differential backup,
-# see https://github.com/rear/rear/issues/974.
+# but for incremental or differential backup an already existing backup directory must stay there
+# so that after the initial full backup the incremental or differential backups can be stored therein.
+# BACKUP_TYPE=incremental means "rear mkbackup" creates at least one full backup (cf. FULLBACKUPDAY below)
+# plus optionally several incremental backups that get created by subsequent "rear mkbackup" runs
+# where each new incremental backup is based on the last existing incremental backup
+# so that "rear recover" will restore first the latest full backup that exists
+# plus all incremental backups in the ordering as they were made after the latest full backup.
+# BACKUP_TYPE=differential means "rear mkbackup" creates at least one full backup (cf. FULLBACKUPDAY below)
+# plus optionally several differential backups that get created by subsequent "rear mkbackup" runs
+# where each new differential backup is based on the last existing full backup
+# so that "rear recover" will restore first the latest full backup that exists
+# plus one single latest differential backup that was made after the latest full backup.
 BACKUP_TYPE=
-# Together with BACKUP_TYPE=incremental you could define on which weekday a full backup must be run.
-# If FULLBACKUPDAY is set a full backup will be done on that weekday in any case
-# (regardless if there already exists a full backup that was created on the same day).
-# For example use FULLBACKUPDAY=Mon where the weekday value must match the output of "date +%a" run in
-# the POSIX/C locale (/usr/sbin/rear sets that locale) i.e. it must be an English abbreviated weekday.
+# Together with BACKUP_TYPE=incremental or BACKUP_TYPE=differential
+# you could define on which weekdays "rear mkbackup" will create a full backup.
+# If FULLBACKUPDAY is set a full backup will be done on each of the weekdays in the FULLBACKUPDAY array
+# in any case (regardless if there already exists a full backup that was created on the same day).
+# For example FULLBACKUPDAY=( Sun Wed ) makes a full backup on each Sunday and Wednesday.
+# where the weekday values must match the output of "date +%a" run in the POSIX/C locale
+# (/usr/sbin/rear sets that locale) i.e. it must be an English abbreviated weekday.
 # According to http://stackoverflow.com/questions/18919151/crontab-day-of-the-week-syntax
 # here is a list of the English abbreviated weekday values: Sun Mon Tue Wed Thu Fri Sat
-FULLBACKUPDAY=
+FULLBACKUPDAY=()
+# Together with BACKUP_TYPE=incremental or BACKUP_TYPE=differential
+# you could define when an existing full backup is considered to be too old
+# so that "rear mkbackup" will create a new full backup.
+# By default an existing full backup is considered to be too old
+# when it is older than 7 days ago:
+FULLBACKUP_OUTDATED_DAYS="7"
 
 #
 # program files (find them in the path). These progs are optional,

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -396,7 +396,7 @@ BACKUP_TYPE=
 # If FULLBACKUPDAY is set a full backup will be done on each of the weekdays in the FULLBACKUPDAY array
 # in any case (regardless if there already exists a full backup that was created on the same day).
 # For example FULLBACKUPDAY=( Sun Wed ) makes a full backup on each Sunday and Wednesday.
-# where the weekday values must match the output of "date +%a" run in the POSIX/C locale
+# The weekday values must match the output of "date +%a" run in the POSIX/C locale
 # (/usr/sbin/rear sets that locale) i.e. it must be an English abbreviated weekday.
 # According to http://stackoverflow.com/questions/18919151/crontab-day-of-the-week-syntax
 # here is a list of the English abbreviated weekday values: Sun Mon Tue Wed Thu Fri Sat
@@ -404,6 +404,8 @@ FULLBACKUPDAY=()
 # Together with BACKUP_TYPE=incremental or BACKUP_TYPE=differential
 # you could define when an existing full backup is considered to be too old
 # so that "rear mkbackup" will create a new full backup.
+# ReaR does not remove any backup (the admin can do it deliberately and manually)
+# so that in particular too old backups are not removed.
 # By default an existing full backup is considered to be too old
 # when it is older than 7 days ago:
 FULLBACKUP_OUTDATED_DAYS="7"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -380,6 +380,12 @@ BACKUP_INTEGRITY_CHECK=
 # because NETFS_KEEP_OLD_BACKUP_COPY would move an already existing backup directory away
 # but for incremental or differential backup an already existing backup directory must stay there
 # so that after the initial full backup the incremental or differential backups can be stored therein.
+# With incremental or differential backup there is no need for NETFS_KEEP_OLD_BACKUP_COPY
+# because with incremental or differential backup all backup archives have a date prefix:
+# Full backups are of the form YYYY-MM-DD-HHMM-F.tar.gz where the 'F' denotes a full backup.
+# Incremental backups are of the form YYYY-MM-DD-HHMM-I.tar.gz where the 'I' denotes an incremental backup.
+# Differential backups are of the form YYYY-MM-DD-HHMM-D.tar.gz where the last 'D' denotes a differential backup.
+# Therefore all backup archives have different file names so that no old one gets overwritten.
 # BACKUP_TYPE=incremental means "rear mkbackup" creates at least one full backup (cf. FULLBACKUPDAY below)
 # plus optionally several incremental backups that get created by subsequent "rear mkbackup" runs
 # where each new incremental backup is based on the last existing incremental backup

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -26,19 +26,8 @@ Log "Saving $REAR_LOGFILE as rear.log"
 # Add the README, VERSION and rear.log to the RESULT_FILES array
 RESULT_FILES=( "${RESULT_FILES[@]}" "$TMP_DIR/VERSION" "$TMP_DIR/README" "$TMP_DIR/rear.log" )
 
-# For incremental backup also add latest_full_backup_date_file and latest_full_backup_filename_file
-# to the RESULT_FILES array if they exist (cf. prep/NETFS/default/070_set_backup_archive.sh):
-if test "incremental" = "$BACKUP_TYPE" ; then
-    for filename in timestamp.txt basebackup.txt ; do
-        test -f "$TMP_DIR/$filename" && RESULT_FILES=( "${RESULT_FILES[@]}" "$TMP_DIR/$filename" )
-    done
-fi
-
 # For example for "rear mkbackuponly" there are usually no result files
-# that would need to be copied here to the network output location.
-# But for incremental backup also "rear mkbackuponly" may cause result files
-# namely latest_full_backup_date_file and latest_full_backup_filename_file
-# if a full backup is made in case of incremental backup:
+# that would need to be copied here to the network output location:
 test "$RESULT_FILES" || return 0
 
 # The real work (actually copying resulting files to the network output location):

--- a/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
+++ b/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
@@ -168,9 +168,9 @@ if test "$latest_full_backup" ; then
             RESTORE_ARCHIVES=( $( find $backup_directory -name "$full_or_differential_backup_glob_regex" | sort | sed -n -e "/$latest_full_backup_file_name/,\$p" | sed -n -e '1p;$p' | sort -u ) )
             ;;
         (*)
-            # With bash >= 3 the BASH_SOURCE and BASH_LINENO variables are supported and
-            # even for older bash it should work sufficiently fail-safe when unset variables evaluate to empty:
-            BugError "Unexpected BACKUP_TYPE '$BACKUP_TYPE' in '$BASH_SOURCE' script at line '$BASH_LINENO'"
+            # With bash >= 3 the BASH_SOURCE variable is supported and
+            # even for older bash it should be fail-safe when unset variables evaluate to empty:
+            BugError "Unexpected BACKUP_TYPE '$BACKUP_TYPE' in '$BASH_SOURCE'"
             ;;
     esac
 else
@@ -230,9 +230,9 @@ case "$create_backup_type" in
         return
         ;;
     (*)
-        # With bash >= 3 the BASH_SOURCE and BASH_LINENO variables are supported and
-        # even for older bash it should work sufficiently fail-safe when unset variables evaluate to empty:
-        BugError "Unexpected create_backup_type '$create_backup_type' in '$BASH_SOURCE' script at line '$BASH_LINENO'"
+        # With bash >= 3 the BASH_SOURCE variable is supported and
+        # even for older bash it should be fail-safe when unset variables evaluate to empty:
+        BugError "Unexpected create_backup_type '$create_backup_type' in '$BASH_SOURCE'"
         ;;
 esac
 

--- a/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
+++ b/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
@@ -168,9 +168,9 @@ if test "$latest_full_backup" ; then
             RESTORE_ARCHIVES=( $( find $backup_directory -name "$full_or_differential_backup_glob_regex" | sort | sed -n -e "/$latest_full_backup_file_name/,\$p" | sed -n -e '1p;$p' | sort -u ) )
             ;;
         (*)
-            # With bash >= 3 the BASH_SOURCE BASH_LINENO BASH_COMMAND variables are supported and
+            # With bash >= 3 the BASH_SOURCE and BASH_LINENO variables are supported and
             # even for older bash it should work sufficiently fail-safe when unset variables evaluate to empty:
-            BugError "Unexpected BACKUP_TYPE '$BACKUP_TYPE' in '$BASH_SOURCE' script (line '$BASH_LINENO') at command: $BASH_COMMAND"
+            BugError "Unexpected BACKUP_TYPE '$BACKUP_TYPE' in '$BASH_SOURCE' script at line '$BASH_LINENO'"
             ;;
     esac
 else
@@ -230,9 +230,9 @@ case "$create_backup_type" in
         return
         ;;
     (*)
-        # With bash >= 3 the BASH_SOURCE BASH_LINENO BASH_COMMAND variables are supported and
+        # With bash >= 3 the BASH_SOURCE and BASH_LINENO variables are supported and
         # even for older bash it should work sufficiently fail-safe when unset variables evaluate to empty:
-        BugError "Unexpected create_backup_type '$create_backup_type' in '$BASH_SOURCE' script (line '$BASH_LINENO') at command: $BASH_COMMAND"
+        BugError "Unexpected create_backup_type '$create_backup_type' in '$BASH_SOURCE' script at line '$BASH_LINENO'"
         ;;
 esac
 

--- a/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
+++ b/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
@@ -34,8 +34,8 @@ esac
 
 local backup_directory=$BUILD_DIR/outputfs/$NETFS_PREFIX
 
-# Normal (i.e. non-incremental) backup:
-if [ "$BACKUP_TYPE" != "incremental" ] ; then
+# Normal (i.e. non-incremental/non-differential) backup:
+if ! test "incremental" = "$BACKUP_TYPE" -o "differential" = "$BACKUP_TYPE" ; then
     backuparchive="$backup_directory/$backup_file_name"
     # In case of normal (i.e. non-incremental) backup there is only one restore archive
     # and its name is the same as the backup archive (usually 'backup.tar.gz'):
@@ -44,19 +44,19 @@ if [ "$BACKUP_TYPE" != "incremental" ] ; then
     return
 fi
 
-# Incremental backup:
-# Incremental backup only works for the NETFS backup method
+# Incremental or differential backup:
+# Incremental or differential backup only works for the NETFS backup method
 # and only with the 'tar' backup program:
 if ! test "NETFS" = "$BACKUP" -a "tar" = "$BACKUP_PROG" ; then
-    Error "BACKUP_TYPE=incremental only works with BACKUP=NETFS and BACKUP_PROG=tar"
+    Error "BACKUP_TYPE incremental or differential only works with BACKUP=NETFS and BACKUP_PROG=tar"
 fi
-# Incremental backup and keeping old backup contradict each other (mutual exclusive)
-# so that NETFS_KEEP_OLD_BACKUP_COPY must not be 'true' in case of incremental backup:
+# Incremental or differential backup and keeping old backup contradict each other (mutual exclusive)
+# so that NETFS_KEEP_OLD_BACKUP_COPY must not be 'true' in case of incremental or differential backup:
 if test "$NETFS_KEEP_OLD_BACKUP_COPY" ; then
     NETFS_KEEP_OLD_BACKUP_COPY=""
-    LogPrint "Disabled NETFS_KEEP_OLD_BACKUP_COPY because BACKUP_TYPE=incremental does not work with that"
+    LogPrint "Disabled NETFS_KEEP_OLD_BACKUP_COPY because BACKUP_TYPE incremental or differential does not work with that"
 fi
-# For incremental backup some date values (weekday, YYYY-MM-DD, HHMM) are needed
+# For incremental or differential backup some date values (weekday, YYYY-MM-DD, HHMM) are needed
 # that must be consistent for one single point of the current time which means
 # one cannot call the 'date' command several times because then there would be
 # a small probability that e.g. weekday, YYYY-MM-DD, HHMM do not match
@@ -67,29 +67,37 @@ local current_date_output=( $( date '+%a %Y-%m-%d %H%M' ) )
 local current_weekday="${current_date_output[0]}"
 local current_yyyy_mm_dd="${current_date_output[1]}"
 local current_hhmm="${current_date_output[2]}"
-# The date 7 days ago is needed to check if the latest full backup is too old.
-# When the latest full backup is more than 7 days ago a new full backup is made.
+# The date FULLBACKUP_OUTDATED_DAYS ago is needed to check if the latest full backup is too old.
+# When the latest full backup is more than FULLBACKUP_OUTDATED_DAYS ago a new full backup is made.
 # This separated call of the 'date' command which is technically needed because is is
-# for another point in time (7 days ago) is run after the above call of the 'date'
+# for another point in time (e.g. 7 days ago) is run after the above call of the 'date'
 # command for the current time to be on the safe side when midnight passes in between
 # both 'date' commands which would then result that a new full backup is made
-# when the latest full backup is basically right now 7 days ago because the stored
-# date of the latest full backup is the current date at the time when it was made.
-# Example:
+# when the latest full backup is basically right now FULLBACKUP_OUTDATED_DAYS ago because
+# the stored date of the latest full backup is the current date at the time when it was made.
+# Example (assuming FULLBACKUP_OUTDATED_DAYS=7 ):
 # The latest full backup was made on Sunday January 10 in 2016 (just before midnight).
 # One week later this script runs again while midnight passes between the two 'date' calls
 # so that current_date_output[@]="Sun 2016-01-17 0000" (still Sunday January 17 in 2016)
-# and yyyymmdd_7_days_ago=20160111 (already Monday January 11 in 2016), then
+# and yyyymmdd_max_days_ago=20160111 (already Monday January 11 in 2016), then
 # Sunday January 10 is older than Monday January 11 so that a new full backup is made:
-local yyyymmdd_7_days_ago=$( date '+%Y%m%d' --date='7 days ago' )
-# The full backup file name is of the form YYYY-MM-DD-HHMM-F.tar.gz
+test "$FULLBACKUP_OUTDATED_DAYS" || FULLBACKUP_OUTDATED_DAYS="7"
+local yyyymmdd_max_days_ago=$( date '+%Y%m%d' --date="$FULLBACKUP_OUTDATED_DAYS days ago" )
+# Full backup file names are of the form YYYY-MM-DD-HHMM-F.tar.gz
 # where the 'F' denotes a full backup:
 local full_backup_marker="F"
-# The incremental backup file name is of the form YYYY-MM-DD-HHMM-I.tar.gz
+# Incremental backup file names are of the form YYYY-MM-DD-HHMM-I.tar.gz
 # where the 'I' denotes an incremental backup:
 local incremental_backup_marker="I"
+# Differential backup file names are of the form YYYY-MM-DD-HHMM-D.tar.gz
+# where the last 'D' denotes an differential backup:
+local differential_backup_marker="D"
+# Determine what kind of backup must be created, 'full' or 'incremental' or 'differential':
+local create_backup_type="full"
+# In case of incremental or differential backup the RESTORE_ARCHIVES contains
+# first the latest full backup file.
 # In case of incremental backup the RESTORE_ARCHIVES contains
-# first the latest full backup file and then each incremental backup
+# after the latest full backup file each incremental backup
 # in the ordering how they must be restored.
 # For example when the latest full backup was made on Sunday
 # plus each subsequent weekday a separated incremental backup was made,
@@ -97,29 +105,83 @@ local incremental_backup_marker="I"
 # first the full backup from Sunday has to be restored,
 # then the incremental backup from Monday, and
 # finally the incremental backup from Tuesday.
-# Here 'find /path/to/dir -name '*.tar.gz' | sort' is used because
+# In case of differential backup the RESTORE_ARCHIVES contains
+# after the latest full backup file the latest differential backup.
+# For example when the latest full backup was made on Sunday
+# plus each subsequent weekday a separated differential backup was made,
+# then during a "rear recover" on Wednesday morning
+# first the full backup from Sunday has to be restored,
+# and finally the differential backup from Tuesday
+# (i.e. the differential backup from Monday is skipped).
+# The date format YYYY-MM-DD that is used here is crucial.
+# It is the ISO 8601 format 'year-month-day' to specify a day of a year
+# that is accepted by 'tar' for the '--newer' option,
+# see the GNU tar manual section "Operating Only on New Files"
+# at https://www.gnu.org/software/tar/manual/html_node/after.html
+# and the GNU tar manual section "Calendar date items"
+# at https://www.gnu.org/software/tar/manual/html_node/Calendar-date-items.html#SEC124
+local date_glob_regex="[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"
+local date_time_glob_regex="$date_glob_regex-[0-9][0-9][0-9][0-9]"
+# Get the latest full backup (if exists):
+local full_backup_glob_regex="$date_time_glob_regex-$full_backup_marker$backup_file_suffix"
+# Here things like 'find /path/to/dir -name '*.tar.gz' | sort' are used because
 # one cannot use bash globbing via commands like 'ls /path/to/dir/*.tar.gz'
 # because /usr/sbin/rear sets the nullglob bash option which leads to plain 'ls'
 # when '/path/to/dir/*.tar.gz' matches nothing (i.e. when no backup file exists)
 # so that then plain 'ls' would result nonsense.
-# First get the latest full backup:
-local date_time_glob_regex="[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]-"
-local full_backup_glob_regex="$date_time_glob_regex$full_backup_marker$backup_file_suffix"
-local full_or_incremental_backup_glob_regex="$date_time_glob_regex[$full_backup_marker$incremental_backup_marker]$backup_file_suffix"
 local latest_full_backup=$( find $backup_directory -name "$full_backup_glob_regex" | sort | tail -n1 )
 if test "$latest_full_backup" ; then
-    # When a latest full backup is found use that plus all later incremental backups for restore:
+    # A latest full backup is found:
     local latest_full_backup_file_name=$( basename $latest_full_backup )
-    # The following command is a bit tricky:
-    # It lists all YYYY-MM-DD-HHMM-F.tar.gz and all YYYY-MM-DD-HHMM-I.tar.gz files in the backup directory and sorts them
-    # and finally it outputs only those that match the latest full backup file name and all what got sorted after that
-    # where it is mandatory that the backup file names sort by date (i.e. date must be the leading part of the backup file names):
-    RESTORE_ARCHIVES=( $( find $backup_directory -name "$full_or_incremental_backup_glob_regex" | sort | sed -n -e "/$latest_full_backup_file_name/,\$p" ) )
+    local latest_full_backup_date=$( echo $latest_full_backup_file_name | grep -o "$date_glob_regex" )
+    local yyyymmdd_latest_full_backup=$( echo $latest_full_backup_date | tr -d '-' )
+    # Check if the latest full backup is too old:
+    if test $yyyymmdd_latest_full_backup -lt $yyyymmdd_max_days_ago ; then
+         create_backup_type="full"
+        LogPrint "Latest full backup date '$latest_full_backup_date' is too old (more than $FULLBACKUP_OUTDATED_DAYS days ago), triggers new full backup"
+    else
+        # When a latest full backup is found that is not too old
+        # a BACKUP_TYPE (incremental or differential) backup will be created:
+        create_backup_type="$BACKUP_TYPE"
+        LogPrint "Latest full backup found ($latest_full_backup_file_name), doing $BACKUP_TYPE backup"
+    fi
+    # This script is also run during "rear recover" where RESTORE_ARCHIVES is needed:
+    case "$BACKUP_TYPE" in
+        (incremental)
+            # When a latest full backup is found use that plus all later incremental backups for restore:
+            # The following command is a bit tricky:
+            # It lists all YYYY-MM-DD-HHMM-F.tar.gz and all YYYY-MM-DD-HHMM-I.tar.gz files in the backup directory and sorts them
+            # and finally it outputs only those that match the latest full backup file name and incremental backups that got sorted after that
+            # where it is mandatory that the backup file names sort by date (i.e. date must be the leading part of the backup file names):
+            local full_or_incremental_backup_glob_regex="$date_time_glob_regex-[$full_backup_marker$incremental_backup_marker]$backup_file_suffix"
+            RESTORE_ARCHIVES=( $( find $backup_directory -name "$full_or_incremental_backup_glob_regex" | sort | sed -n -e "/$latest_full_backup_file_name/,\$p" ) )
+            ;;
+        (differential)
+            # For differential backup use the latest full backup plus the one latest differential backup for restore:
+            # The following command is a bit tricky:
+            # It lists all YYYY-MM-DD-HHMM-F.tar.gz and all YYYY-MM-DD-HHMM-D.tar.gz files in the backup directory and sorts them
+            # then it outputs only those that match the latest full backup file name and all differential backups that got sorted after that
+            # and then it outputs only the first line (i.e. the full backup) and the last line (i.e. the latest differential backup)
+            # but when no differential backup exists (i.e. when only the full backup exists) the first line is also the last line
+            # so that "sed -n -e '1p;$p'" outputs the full backup twice which is corrected by the final "sort -u":
+            local full_or_differential_backup_glob_regex="$date_time_glob_regex-[$full_backup_marker$differential_backup_marker]$backup_file_suffix"
+            RESTORE_ARCHIVES=( $( find $backup_directory -name "$full_or_differential_backup_glob_regex" | sort | sed -n -e "/$latest_full_backup_file_name/,\$p" | sed -n -e '1p;$p' | sort -u ) )
+            ;;
+        (*)
+            # With bash >= 3 the BASH_SOURCE BASH_LINENO BASH_COMMAND variables are supported and
+            # even for older bash it should work sufficiently fail-safe when unset variables evaluate to empty:
+            BugError "Unexpected BACKUP_TYPE '$BACKUP_TYPE' in '$BASH_SOURCE' script (line '$BASH_LINENO') at command: $BASH_COMMAND"
+            ;;
+    esac
 else
+    # If no latest full backup is found create one during "rear mkbackup":
+    create_backup_type="full"
+    LogPrint "No full backup (YYYY-MM-DD-HHMM-F.tar.gz) found, triggers full backup"
+    # This script is also run during "rear recover" where RESTORE_ARCHIVES is needed:
     # If no latest full backup is found (i.e. no file name matches the YYYY-MM-DD-HHMM-F.tar.gz form)
-    # fall back to what is done in case of normal (i.e. non-incremental) backup
+    # fall back to what is done in case of normal (i.e. non-incremental/non-differential) backup
     # and hope for the best (i.e. that a backup_directory/backup_file_name actually exists).
-    # In case of normal (i.e. non-incremental) backup there is only one restore archive
+    # In case of normal (i.e. non-incremental/non-differential) backup there is only one restore archive
     # and its name is the same as the backup archive (usually 'backup.tar.gz').
     # This is only a fallback setting to be more on the safe side for "rear recover".
     # Initially for the very fist run of incremental backup during "rear mkbackup"
@@ -127,81 +189,50 @@ else
     # according to the code below:
     RESTORE_ARCHIVES=( "$backup_directory/$backup_file_name" )
 fi
-# File that contains the YYYY-MM-DD date of the latest full backup.
-# If that file does not (yet) exist a full backup is done.
-# If that file already exists with a valid value (not too old), an incremental backup is done:
-local latest_full_backup_date_file_name="timestamp.txt"
-local latest_full_backup_date_file="$backup_directory/$latest_full_backup_date_file_name"
-# File that contains the filename of the latest full backup:
-local latest_full_backup_filename_file_name="basebackup.txt"
-local latest_full_backup_filename_file="$backup_directory/$latest_full_backup_filename_file_name"
-# A FULLBACKUPDAY value must match the 'date +%a' output (in current_weekday), see default.conf and
-# quoting FULLBACKUPDAY avoids "bash: ... unary operator expected" error message if FULLBACKUPDAY is empty:
-if [ $current_weekday = "$FULLBACKUPDAY" ] ; then
-    # When today's weekday is FULLBACKUPDAY do a full backup in any case:
-    LogPrint "Today's weekday ('$FULLBACKUPDAY') is full backup day"
-    # Remove latest_full_backup_date_file to trigger a new full backup:
-    rm -f $latest_full_backup_date_file
-else
-    # Today's weekday is not FULLBACKUPDAY (or FULLBACKUPDAY is empty):
-    if [ ! -f $latest_full_backup_date_file ] ; then
-        # When there is no latest_full_backup_date_file (e.g. initially)
-        # there is nothing special to do here, just tell the user about it:
-        LogPrint "No full backup date file (timestamp.txt) found, triggers full backup"
-    else
-        # There is a latest_full_backup_date_file.
-        # Check if the latest full backup is too old:
-        local latest_full_backup_date=$( cat $latest_full_backup_date_file )
-        local yyyymmdd_latest_full_backup=$( echo $latest_full_backup_date | tr -d '-' )
-        if [ $yyyymmdd_latest_full_backup -lt $yyyymmdd_7_days_ago ] ; then
-            # Trigger a new full backup when latest full backup date is more than 7 days ago:
-            LogPrint "Latest full backup date '$latest_full_backup_date' is too old (more than 7 days ago)"
-            # Remove latest_full_backup_date_file to trigger a new full backup:
-            rm -f $latest_full_backup_date_file
+# The actual work (setting the right variables but do not actually do anything at this point):
+case "$create_backup_type" in
+    (full)
+        local new_full_backup_file_name="$current_yyyy_mm_dd-$current_hhmm-$full_backup_marker$backup_file_suffix"
+        backuparchive="$backup_directory/$new_full_backup_file_name"
+        BACKUP_PROG_X_OPTIONS="$BACKUP_PROG_X_OPTIONS -V $new_full_backup_file_name"
+        LogPrint "Performing full backup using backup archive '$new_full_backup_file_name'"
+        return
+        ;;
+    (incremental)
+        local new_incremental_backup_file_name="$current_yyyy_mm_dd-$current_hhmm-$incremental_backup_marker$backup_file_suffix"
+        backuparchive="$backup_directory/$new_incremental_backup_file_name"
+        # Get the latest latest incremental backup that is based on the latest full backup (if exists):
+        local incremental_backup_glob_regex="$date_time_glob_regex-$incremental_backup_marker$backup_file_suffix"
+        # First get the latest full backup plus all later incremental backups (cf. how RESTORE_ARCHIVES is set in case of incremental backup)
+        # then grep only the incremental backups and from the incremental backups use only the last one (if exists):
+        local latest_incremental_backup=$( find $backup_directory -name "$full_or_incremental_backup_glob_regex" | sort | sed -n -e "/$latest_full_backup_file_name/,\$p" | grep "$incremental_backup_glob_regex" | tail -n1 )
+        if test "$latest_incremental_backup" ; then
+            # A latest incremental backup that is based on the latest full backup is found:
+            local latest_incremental_backup_file_name=$( basename $latest_incremental_backup )
+            LogPrint "Latest incremental backup found ($latest_incremental_backup_file_name) that is newer than the latest full backup"
+            local latest_incremental_backup_date=$( echo $latest_incremental_backup_file_name | grep -o "$date_glob_regex" )
+            BACKUP_PROG_X_OPTIONS="$BACKUP_PROG_X_OPTIONS --newer=$latest_incremental_backup_date -V $latest_incremental_backup_file_name"
+            LogPrint "Performing incremental backup for files newer than $latest_incremental_backup_date using backup archive '$new_incremental_backup_file_name'"
         else
-            # When latest_full_backup_date_file exists latest_full_backup_filename_file must also exist:
-            if [ ! -f $latest_full_backup_filename_file ] ; then
-                # Trigger a new full backup when latest_full_backup_filename_file is missing:
-                LogPrint "Latest full backup file name file (basebackup.txt) missing, triggering full backup"
-                # Remove latest_full_backup_date_file to trigger a new full backup:
-                rm -f $latest_full_backup_date_file
-            else
-                # When latest_full_backup_date_file and latest_full_backup_filename_file exist
-                # verify that the matching full backup file actually exists:
-                local latest_full_backup_filename=$( cat $latest_full_backup_filename_file )
-                local latest_full_backup_file="$backup_directory/$latest_full_backup_filename"
-                if [ ! -f $latest_full_backup_file] ; then
-                    # Trigger a new full backup when the latest full backup file is missing:
-                    LogPrint "Latest full backup file ($latest_full_backup_filename) not found, triggering full backup"
-                    # Remove latest_full_backup_date_file to trigger a new full backup:
-                    rm -f $latest_full_backup_date_file
-                else
-                    # When latest_full_backup_date_file and latest_full_backup_filename_file
-                    # and latest_full_backup_file exist, an incremental backup will be done.
-                    # There is nothing special to do here, just tell the user about it:
-                    LogPrint "Full backup files found (timestamp.txt, basebackup.txt, $latest_full_backup_filename), doing incremental backup"
-                fi
-            fi
+            # When there is not yet an incremental backup that is based on the latest full backup
+            # the new created incremental backup must be based on the latest full backup:
+            BACKUP_PROG_X_OPTIONS="$BACKUP_PROG_X_OPTIONS --newer=$latest_full_backup_date -V $latest_full_backup_file_name"
+            LogPrint "Performing incremental backup for files newer than $latest_full_backup_date using backup archive '$new_incremental_backup_file_name'"
         fi
-    fi
-fi
-# The actual work (setting the right stuff):
-if [ -f $latest_full_backup_date_file ] ; then
-    local incremental_backup_file_name="$current_yyyy_mm_dd-$current_hhmm-$incremental_backup_marker$backup_file_suffix"
-    backuparchive="$backup_directory/$incremental_backup_file_name"
-    BACKUP_PROG_X_OPTIONS="$BACKUP_PROG_X_OPTIONS --newer=$latest_full_backup_date -V $latest_full_backup_filename"
-    LogPrint "Performing incremental backup using backup archive '$incremental_backup_file_name'"
-else
-    local full_backup_file_name="$current_yyyy_mm_dd-$current_hhmm-$full_backup_marker$backup_file_suffix"
-    backuparchive="$backup_directory/$full_backup_file_name"
-    # Create latest_full_backup_date_file and latest_full_backup_filename_file in TMP_DIR because
-    # initially (i.e. for the very first run of "rear mkbackup") there is not yet the
-    # backup_directory (it is created later by output/default/200_make_prefix_dir.sh) and
-    # those files will later be copied into the backup_directory by output/default/950_copy_result_files.sh
-    # (see see https://github.com/rear/rear/pull/1066):
-    echo "$current_yyyy_mm_dd" >$TMP_DIR/$latest_full_backup_date_file_name
-    echo "$full_backup_file_name" >$TMP_DIR/$latest_full_backup_filename_file_name
-    BACKUP_PROG_X_OPTIONS="$BACKUP_PROG_X_OPTIONS -V $full_backup_file_name"
-    LogPrint "Performing full backup using backup archive '$full_backup_file_name'"
-fi
+        return
+        ;;
+    (differential)
+        local new_differential_backup_file_name="$current_yyyy_mm_dd-$current_hhmm-$differential_backup_marker$backup_file_suffix"
+        backuparchive="$backup_directory/$new_differential_backup_file_name"
+        BACKUP_PROG_X_OPTIONS="$BACKUP_PROG_X_OPTIONS --newer=$latest_full_backup_date -V $latest_full_backup_file_name"
+        LogPrint "Performing differential backup for files newer than $latest_full_backup_date using backup archive '$new_differential_backup_file_name'"
+
+        return
+        ;;
+    (*)
+        # With bash >= 3 the BASH_SOURCE BASH_LINENO BASH_COMMAND variables are supported and
+        # even for older bash it should work sufficiently fail-safe when unset variables evaluate to empty:
+        BugError "Unexpected create_backup_type '$create_backup_type' in '$BASH_SOURCE' script (line '$BASH_LINENO') at command: $BASH_COMMAND"
+        ;;
+esac
 

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -7,229 +7,178 @@ local opath=$(backup_path $scheme $path)
 
 mkdir -p "${BUILD_DIR}/outputfs/${NETFS_PREFIX}"
 
-# Disable BACKUP_PROG_CRYPT_OPTIONS by replacing the default value to cat in
-# case encryption is disabled
+# Disable BACKUP_PROG_DECRYPT_OPTIONS by replacing the default with 'cat' when encryption is disabled
+# (by default encryption is disabled but the default BACKUP_PROG_DECRYPT_OPTIONS is not 'cat'):
 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
-  LogPrint "Decrypting archive with key defined in variable \$BACKUP_PROG_CRYPT_KEY"
+    # Backup archive decryption is only supported with 'tar':
+    test "tar" = "$BACKUP_PROG" || Error "Backup archive decryption is only supported with BACKUP_PROG=tar"
+    LogPrint "Decrypting backup archive with key defined in variable \$BACKUP_PROG_CRYPT_KEY"
 else
-  LogPrint "Decrypting disabled"
-  BACKUP_PROG_DECRYPT_OPTIONS="cat"
-  BACKUP_PROG_CRYPT_KEY=""
+    Log "Decrypting backup archive is disabled"
+    BACKUP_PROG_DECRYPT_OPTIONS="cat"
+    BACKUP_PROG_CRYPT_KEY=""
 fi
 
-if [[ -f "${TMP_DIR}/backup.splitted" ]]; then
+# The RESTORE_ARCHIVES array contains the restore input files.
+# If it is not set, RESTORE_ARCHIVES is only one element which is the backup archive:
+test "$RESTORE_ARCHIVES" || RESTORE_ARCHIVES=( "$backuparchive" )
+
+# In case of 'tar' the backup restore prog needs to be feed by another program
+# if the backup is splitted and then restore input is not a file but a FIFO
+# i.e. RESTORE_ARCHIVES is then only one element which is the FIFO
+# In this case launch another subshell that runs the feeder program:
+if test -f "${TMP_DIR}/backup.splitted" ; then
     # for multiple ISOs
-    restoreinput=$FIFO
-else
-    restoreinput="$backuparchive"
-fi
+    RESTORE_ARCHIVES=( "$FIFO" )
+    (
+        # Give the subsequent subshell that runs the backup restore prog a good chance to start working:
+        sleep 1
+        Print ""
+        while read file ; do
+            name=${file%% *}
+            vol_name=${file##* }
+            file_path="${opath}/${name}"
 
-if [ "$BACKUP_TYPE" == "incremental" ]; then
-    LAST="$restorearchive"
-    BASEDIR=$(dirname "$restorearchive")
-    if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
-        # As the archive is encrypted we cannot use tar to find the label (which should be the same as the content of file basebackup.txt)
-        # If that is not the case the restore will fail (verification needed after a new full backup if the content of file basebackup.txt
-        # will be modified as well - see issue #952)
-        BASE=$BASEDIR/$(cat $BASEDIR/basebackup.txt)
-    else
-        BASE=$BASEDIR/$(tar --test-label -f "$restorearchive")
-    fi
-    if [ "$BASE" == "$LAST" ]; then
-        LogPrint "Restoring full backup $BACKUP_PROG archive from '$BASE'"
-    else
-        LogPrint "First restoring full backup $BACKUP_PROG archive from '$BASE'"
-        LogPrint "Then restoring incremental backup $BACKUP_PROG archive from '$restorearchive'"
-    fi
-else
-    LogPrint "Restoring $BACKUP_PROG archive from '$restorearchive'"
-fi
+            touch ${TMP_DIR}/wait_dvd
 
-ProgressStart "Preparing restore operation"
-(
-case "$BACKUP_PROG" in
-    # tar compatible programs here
-    (tar)
-        # Add the --selinux option to be safe with SELinux context restoration
-        ##if [[ ! $BACKUP_SELINUX_DISABLE =~ ^[yY1] ]]; then
-        if ! is_true "$BACKUP_SELINUX_DISABLE" ; then
-            if tar --usage | grep -q selinux;  then
-                BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --selinux"
-            fi
-        fi
-        if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
-            BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --exclude-from=$TMP_DIR/restore-exclude-list.txt "
-        fi
-        if [ "$BACKUP_TYPE" == "incremental" ]; then
-            if [ "$BASE" == "$LAST" ]; then
-                Log dd if=$BASE \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
-                dd if=$BASE | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
-            else
-                Log dd if="$BASE" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
-                dd if="$BASE" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
-                Log dd if="$LAST" \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
-                dd if="$LAST" | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
-            fi
-        else
-            Log dd if=$restoreinput \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
-            dd if=$restoreinput | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
-        fi
-    ;;
-    (rsync)
-        if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
-            BACKUP_RSYNC_OPTIONS=( "${BACKUP_RSYNC_OPTIONS[@]}" --exclude-from=$TMP_DIR/restore-exclude-list.txt )
-        fi
-        Log $BACKUP_PROG $v "${BACKUP_RSYNC_OPTIONS[@]}"  "$backuparchive"/ $TARGET_FS_ROOT/
-        $BACKUP_PROG  $v "${BACKUP_RSYNC_OPTIONS[@]}" "$backuparchive"/ $TARGET_FS_ROOT/
-    ;;
-    (*)
-        Log "Using unsupported backup program '$BACKUP_PROG'"
-        $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
-            $BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE $TARGET_FS_ROOT \
-            $BACKUP_PROG_OPTIONS $backuparchive
-    ;;
-esac >"${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log"
-# important trick: the backup prog is the last in each case entry and the case .. esac is the last command
-# in the (..) subshell. As a result the return code of the subshell is the return code of the backup prog!
-) &
-BackupPID=$!
-starttime=$SECONDS
-
-# Give the backup software a good chance to start working:
-sleep 1
-
-(
-# In case of a splitted backup
-if [[ -f "${TMP_DIR}/backup.splitted" ]]; then
-    Print ""
-    while read file; do
-        name=${file%% *}
-        vol_name=${file##* }
-        file_path="${opath}/${name}"
-
-        touch ${TMP_DIR}/wait_dvd
-
-        while ! [[ -f "$file_path" ]]; do
-            umount "${BUILD_DIR}/outputfs"
-            ProgressInfo "Please insert the media called $vol_name in your CD-ROM drive..."
-            sleep 2
-            drive=$(cat /proc/sys/dev/cdrom/info | grep -i "drive name:" | awk '{print $3 " " $4}')
-            for dev in $drive; do
-                label=$(blkid /dev/${dev} | awk 'BEGIN{FS="[=\"]"} {print $3}')
-                if [[ $label = $vol_name ]]; then
-                    LogPrint "\n${vol_name} detected in /dev/${dev} ..."
-                    mount /dev/${dev} "${BUILD_DIR}/outputfs"
-                fi
-            done
-        done
-
-        if [[ -f "$file_path" ]]; then
-            ##if [[ $BACKUP_INTEGRITY_CHECK =~ ^[yY1] && -f "${TMP_DIR}/backup.md5" ]] ; then
-            if is_true "$BACKUP_INTEGRITY_CHECK" && [[ -f "${TMP_DIR}/backup.md5" ]] ; then
-                LogPrint "Checking $name ..."
-                (cd $(dirname $backuparchive) && grep $name "${TMP_DIR}/backup.md5" | md5sum -c)
-                ret=$?
-                if [[ $ret -ne 0 ]]; then
-                    Error "Integrity check failed ! Restore aborted.
-If you want to bypass this check, disable the option in your Rear configuration."
-                    return
-                fi
-            fi
-            rm ${TMP_DIR}/wait_dvd
-            LogPrint "Processing $name ..."
-            dd if="${file_path}" of="$FIFO"
-        else
-            StopIfError "$name could not be found on the $vol_name media !"
-        fi
-
-    done < "${TMP_DIR}/backup.splitted"
-    kill -9 $(cat "${TMP_DIR}/cat_pid")
-    rm "${TMP_DIR}/cat_pid"
-    rm "${TMP_DIR}/backup.splitted"
-    rm "${TMP_DIR}/backup.md5"
-fi
-) &
-
-# make sure that we don't fall for an old size info
-unset size
-
-# While the backup runs in a sub-process, display some progress information to the user.
-# ProgressInfo texts have a space at the end to get the 'OK' from ProgressStop shown separated.
-case "$BACKUP_PROG" in
-    (tar)
-        ProgressInfo "Restoring... "
-        # Sleep one second to be on the safe side before testing that the backup sub-process is running
-        # and avoid "kill: (BackupPID) - No such process" output when the backup sub-process has finished:
-        while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
-            blocks="$(tail -1 "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log" | awk 'BEGIN { FS="[ :]" } /^block [0-9]+: / { print $2 }')"
-            size="$((blocks*512))"
-            if [ -f ${TMP_DIR}/wait_dvd ]; then
-                starttime=$((starttime+1))
-            else
-                restored_size_MiB=$((size/1024/1024))
-                restored_avg_KiB_per_sec=$((size/1024/(SECONDS-starttime)))
-                if [ "$BACKUP_TYPE" == "incremental" ]; then
-                    if [ "$BASE" == "$LAST" ]; then
-                        ProgressInfo "Restored full backup $restored_size_MiB MiB [avg $restored_avg_KiB_per_sec KiB/sec] "
-                    else
-                        # Avoid misleading restored_size_MiB output for only one backup archive - the last one
-                        # which is the (usually small) incremental backup archive.
-                        # TODO: Implement calculating right restored_size_MiB and restored_avg_KiB_per_sec values
-                        # both for restoring the initial full backup archive and the subsequent incremental backup archive.
-                        # Display any progress information to the user so that he knows things are going on
-                        # show restored_avg_KiB_per_sec output regardless whether or not iot is fully correct:
-                        ProgressInfo "Restoring with about $restored_avg_KiB_per_sec KiB/sec... "
+            while ! [[ -f "$file_path" ]] ; do
+                umount "${BUILD_DIR}/outputfs"
+                ProgressInfo "Please insert the media called $vol_name in your CD-ROM drive..."
+                sleep 2
+                drive=$( cat /proc/sys/dev/cdrom/info | grep -i "drive name:" | awk '{print $3 " " $4}' )
+                for dev in $drive; do
+                    label=$( blkid /dev/${dev} | awk 'BEGIN{FS="[=\"]"} {print $3}' )
+                    if [[ $label = $vol_name ]] ; then
+                        LogPrint "\n${vol_name} detected in /dev/${dev} ..."
+                        mount /dev/${dev} "${BUILD_DIR}/outputfs"
                     fi
+                done
+            done
+
+            if [[ -f "$file_path" ]] ; then
+                if is_true "$BACKUP_INTEGRITY_CHECK" && [[ -f "${TMP_DIR}/backup.md5" ]] ; then
+                    LogPrint "Checking $name ..."
+                    ( cd $( dirname $backuparchive ) && grep $name "${TMP_DIR}/backup.md5" | md5sum -c )
+                    ret=$?
+                    if [[ $ret -ne 0 ]] ; then
+                        Error "Integrity check failed. Restore aborted because BACKUP_INTEGRITY_CHECK is enabled."
+                        return
+                    fi
+                fi
+                rm ${TMP_DIR}/wait_dvd
+                LogPrint "Processing $name ..."
+                # The actual feeder program:
+                dd if="${file_path}" of="$FIFO"
+            else
+                StopIfError "$name could not be found on the $vol_name media !"
+            fi
+        done < "${TMP_DIR}/backup.splitted"
+
+        kill -9 $( cat "${TMP_DIR}/cat_pid" )
+        rm "${TMP_DIR}/cat_pid"
+        rm "${TMP_DIR}/backup.splitted"
+        rm "${TMP_DIR}/backup.md5"
+    ) &
+    BackupRestoreFeederPID=$!
+    Log "Launched backup restore feeder subshell (PID=$BackupRestoreFeederPID)"
+fi
+
+# The actual restoring:
+for restoreinput in "${RESTORE_ARCHIVES[@]}" ; do
+    LogPrint "Restoring from '$restoreinput'..."
+    # Launch a subshell that runs the backup restore prog:
+    (
+        case "$BACKUP_PROG" in
+            (tar)
+                # Add the --selinux option to be safe with SELinux context restoration
+                if ! is_true "$BACKUP_SELINUX_DISABLE" ; then
+                    if tar --usage | grep -q selinux ; then
+                        BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --selinux"
+                    fi
+                fi
+                if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
+                    BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --exclude-from=$TMP_DIR/restore-exclude-list.txt "
+                fi
+                Log dd if=$restoreinput \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                dd if=$restoreinput | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                ;;
+            (rsync)
+                if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
+                    BACKUP_RSYNC_OPTIONS=( "${BACKUP_RSYNC_OPTIONS[@]}" --exclude-from=$TMP_DIR/restore-exclude-list.txt )
+                fi
+                Log $BACKUP_PROG $v "${BACKUP_RSYNC_OPTIONS[@]}" "$restoreinput"/ $TARGET_FS_ROOT/
+                $BACKUP_PROG $v "${BACKUP_RSYNC_OPTIONS[@]}" "$restoreinput"/ $TARGET_FS_ROOT/
+                ;;
+            (*)
+                Log "Using unsupported backup restore program '$BACKUP_PROG'"
+                $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" $BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE $TARGET_FS_ROOT $BACKUP_PROG_OPTIONS $restoreinput
+                ;;
+        esac >"${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log"
+        # Important trick: The backup prog is the last command in each case entry and the case..esac is the last command
+        # in the (..) subshell. As a result the return code of the subshell is the return code of the backup prog.
+    ) &
+    BackupPID=$!
+    Log "Launched backup restore subshell (PID=$BackupPID)"
+
+    starttime=$SECONDS
+
+    # make sure that we don't fall for an old size info
+    unset size
+
+    # While the backup runs in a sub-process, display some progress information to the user.
+    # ProgressInfo texts have a space at the end to get the 'OK' from ProgressStop shown separated.
+    ProgressStart "Restoring... "
+    case "$BACKUP_PROG" in
+        (tar)
+            # Sleep one second to be on the safe side before testing that the backup sub-process is running and
+            # avoid "kill: (BackupPID) - No such process" output when the backup sub-process has finished:
+            while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
+                blocks="$( tail -1 "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log" | awk 'BEGIN { FS="[ :]" } /^block [0-9]+: / { print $2 }' )"
+                size="$((blocks*512))"
+                if [ -f ${TMP_DIR}/wait_dvd ] ; then
+                    starttime=$((starttime+1))
                 else
+                    restored_size_MiB=$((size/1024/1024))
+                    restored_avg_KiB_per_sec=$((size/1024/(SECONDS-starttime)))
                     ProgressInfo "Restored $restored_size_MiB MiB [avg $restored_avg_KiB_per_sec KiB/sec] "
                 fi
-            fi
-        done
-        ;;
-    (*)
-        ProgressInfo "Restoring... "
-        while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
-            ProgressStep
-        done
-        ;;
-esac
-ProgressStop
+            done
+            ;;
+        (*)
+            # Display some rather meaningless info to shows at least that restoring is still going on:
+            while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
+                restore_seconds="$((SECONDS-starttime))"
+                ProgressInfo "Restoring for $restore_seconds seconds... "
+            done
+            ;;
+    esac
+    ProgressStop
 
-transfertime="$((SECONDS-starttime))"
+    transfertime="$((SECONDS-starttime))"
 
+    # Get the return code from the backup restore subshell which is the return code of the backup prog (see "Important trick" above).
+    # In POSIX shells wait returns the exit code of the job even if it had already terminated when wait was started,
+    # see http://pubs.opengroup.org/onlinepubs/9699919799/utilities/wait.html that reads:
+    # "This volume of POSIX.1-2008 requires the implementation to keep the status
+    #  of terminated jobs available until the status is requested".
+    # Avoid messages like "[1]+ Done..." or "[1]+ Terminated...".
+    wait $BackupPID 2>/dev/null
+    backup_prog_return_code=$?
+    if test "0" != "$backup_prog_return_code" ; then
+        LogPrint "Backup restore program '$BACKUP_PROG' failed with return code '$backup_prog_return_code'. Check '$LOGFILE' and the restored system."
+        is_true "$BACKUP_INTEGRITY_CHECK" && Error "Integrity check failed. Restore aborted because BACKUP_INTEGRITY_CHECK is enabled."
+    fi
 
-# harvest return code from background job. The kill -0 $BackupPID loop above should
-# have made sure that this wait won't do any real "waiting" :-)
-wait $BackupPID
-backup_prog_rc=$?
-
-sleep 1
-test "$backup_prog_rc" -gt 0 && LogPrint "WARNING !
-There was an error (Nr. $backup_prog_rc) while restoring the archive.
-Please check '$LOGFILE' for more information. You should also
-manually check the restored system to see wether it is complete.
-"
-
-# TODO if size is not given then calculate it from backuparchive_size
-
-tar_message="$(tac $LOGFILE | grep -m1 '^Total bytes written: ')"
-if [ $backup_prog_rc -eq 0 -a "$tar_message" ] ; then
-    LogPrint "$tar_message in $transfertime seconds."
-elif [ "$size" ]; then
-    restored_size_MiB=$((size/1024/1024))
-    restored_avg_KiB_per_sec=$((size/1024/transfertime))
-    if [ "$BACKUP_TYPE" == "incremental" ]; then
-        if [ "$BASE" == "$LAST" ]; then
-            LogPrint "Restored full backup $restored_size_MiB MiB in $((transfertime)) seconds [avg $restored_avg_KiB_per_sec KiB/sec]"
-        else
-            # Showing a simpler text here to avoid misleading restored_size_MiB and restored_avg_KiB_per_sec output
-            # for only one backup archive - the last one which is the (usually small) incremental backup archive.
-            # TODO: Implement calculating right restored_size_MiB and restored_avg_KiB_per_sec values
-            # both for restoring the initial full backup archive and the subsequent incremental backup archive.
-            LogPrint "Restored full backup and incremental backup in $((transfertime)) seconds"
-        fi
-    else
+    # TODO if size is not given then calculate it from backuparchive_size
+    tar_message="$(tac $LOGFILE | grep -m1 '^Total bytes written: ')"
+    if test "$backup_prog_return_code" = "0" -a "$tar_message" ; then
+        LogPrint "$tar_message in $transfertime seconds."
+    elif [ "$size" ] ; then
+        restored_size_MiB=$((size/1024/1024))
+        restored_avg_KiB_per_sec=$((size/1024/transfertime))
         LogPrint "Restored $restored_size_MiB MiB in $((transfertime)) seconds [avg $restored_avg_KiB_per_sec KiB/sec]"
     fi
-fi
+
+done
+LogPrint "Restoring finished."
 

--- a/usr/share/rear/verify/NETFS/default/550_check_backup_archive.sh
+++ b/usr/share/rear/verify/NETFS/default/550_check_backup_archive.sh
@@ -24,7 +24,7 @@ for restoreinput in "${RESTORE_ARCHIVES[@]}" ; do
     test "$backuparchive_size" && LogPrint "Backup archive size is $backuparchive_size ${BACKUP_PROG_COMPRESS_SUFFIX:+(compressed)}"
 
     if is_true "$BACKUP_INTEGRITY_CHECK" && test -f $restoreinput.md5 ; then
-        if ! test -f "$backup_splitted_file ; then
+        if ! test -f "$backup_splitted_file" ; then
             LogPrint "Checking integrity of $restoreinput_filename"
             md5sum -c $restoreinput.md5 || Error "Integrity check failed. Restore aborted because BACKUP_INTEGRITY_CHECK is enabled."
         fi

--- a/usr/share/rear/verify/NETFS/default/550_check_backup_archive.sh
+++ b/usr/share/rear/verify/NETFS/default/550_check_backup_archive.sh
@@ -1,55 +1,33 @@
 # check wether the archive is actually there
 
-# Don't check when backup is on a tape device
-case $(url_scheme "$BACKUP_URL") in
-    (tape)
-        return 0
-        ;;
-esac
+# Do not check when the backup is on a tape device:
+test "tape" = "$( url_scheme "$BACKUP_URL" )" && return 0
 
-if [ "$BACKUP_TYPE" == "incremental" ]; then
-    LAST="$restorearchive"
-    BASEDIR=$(dirname "$restorearchive")
-    if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
-        # As the archive is encrypted we cannot use tar to find the label (which should be the same as the content of file basebackup.txt)
-        # If that is not the case the restore will fail (verification needed after a new full backup if the content of file basebackup.txt
-        # will be modified as well - see issue #952)
-        BASE=$BASEDIR/$(cat $BASEDIR/basebackup.txt)
+# The RESTORE_ARCHIVES array contains the restore input files.
+# If it is not set, RESTORE_ARCHIVES is only one element which is the backup archive:
+test "$RESTORE_ARCHIVES" || RESTORE_ARCHIVES=( "$backuparchive" )
+
+for restoreinput in "${RESTORE_ARCHIVES[@]}" ; do
+
+    local backup_splitted_file="$( dirname $restoreinput )/backup.splitted"
+    local restoreinput_filename="$( basename $restoreinput )"
+
+    test -s "$restoreinput" -o -d "$restoreinput" -o -f "$backup_splitted_file" || Error "Backup archive '$restoreinput_filename' not found."
+
+    LogPrint "Calculating backup archive size"
+    if test -f "$backup_splitted_file" ; then
+        cut -d ' ' -f2 "$backup_splitted_file" | awk '{s+=$1} END {print s/(1024*1024)"M"}' >$TMP_DIR/backuparchive_size
     else
-        BASE=$BASEDIR/$(tar --test-label -f "$restorearchive")
+        du -sh "$restoreinput" | cut -d ' ' -f1 >$TMP_DIR/backuparchive_size
     fi
-    if [ "$BASE" == "$LAST" ]; then
-        backuparchive="$BASE"
-    else
-        # Only simple tests in case of BACKUP_TYPE=incremental with a real BASE full backup plus one LAST incremental backup:
-        test -s "$BASE" || Error "Full backup '$BASE' not found (or empty)."
-        test -s "$LAST" || Error "Incremental backup '$LAST' not found (or empty)."
-        # Just return here to avoid misleading 'Calculating backup archive size' output for only one backup archive.
-        # TODO: Implement 'Calculating backup archive size' correctly for BACKUP_TYPE=incremental.
-        return 0
+    read backuparchive_size <$TMP_DIR/backuparchive_size
+    test "$backuparchive_size" && LogPrint "Backup archive size is $backuparchive_size ${BACKUP_PROG_COMPRESS_SUFFIX:+(compressed)}"
+
+    if is_true "$BACKUP_INTEGRITY_CHECK" && test -f $restoreinput.md5 ; then
+        if ! test -f "$backup_splitted_file ; then
+            LogPrint "Checking integrity of $restoreinput_filename"
+            md5sum -c $restoreinput.md5 || Error "Integrity check failed. Restore aborted because BACKUP_INTEGRITY_CHECK is enabled."
+        fi
     fi
-fi
-
-[ -s "$backuparchive" -o -d "$backuparchive" -o -f "$(dirname $backuparchive)/backup.splitted" ]
-StopIfError "Backup archive '$backuparchive' not found !"
-
-LogPrint "Calculating backup archive size"
-
-if [[ -f "$(dirname $backuparchive)/backup.splitted" ]]; then
-    cut -d ' ' -f2 "$(dirname $backuparchive)/backup.splitted" | awk '{s+=$1} END {print s/(1024*1024)"M"}' >$TMP_DIR/backuparchive_size
-else
-    du -sh "$restorearchive" | cut -d ' ' -f1 >$TMP_DIR/backuparchive_size
-fi
-StopIfError "Failed to determine backup archive size."
-
-read backuparchive_size <$TMP_DIR/backuparchive_size
-LogPrint "Backup archive size is $backuparchive_size${BACKUP_PROG_COMPRESS_SUFFIX:+ (compressed)}"
-
-if [[ $BACKUP_INTEGRITY_CHECK =~ ^[yY1] && -f ${backuparchive}.md5 ]] ; then
-    if [[ ! -f "$(dirname $backuparchive)/backup.splitted" ]]; then
-        LogPrint "Checking integrity of $(basename $backuparchive) ..."
-        (cd $(dirname $restorearchive) && md5sum -c ${restorearchive}.md5)
-        StopIfError "Integrity check failed !! \nIf you want to bypass this check please edit the configuration file (/etc/rear/local.conf) and unset BACKUP_INTEGRITY_CHECK."
-    fi
-fi
+done
 


### PR DESCRIPTION
See https://github.com/rear/rear/issues/1069

I introduced the new RESTORE_ARCHIVES() array that
contains the restore input files for 400_restore_backup.sh

I did major changes in 400_restore_backup.sh
so that it now launches a separated restore subshell together
with the progress stuff for each element in RESTORE_ARCHIVES.

Together with changes in 070_set_backup_archive.sh
it does now already restore real incremental backups
(i.e. one full backup plus several incremental backups).

For example assume during several "rear mkbackup"
the backup directory contains:
<pre>
2016-11-15-1502-F.tar.gz
2016-11-16-1057-I.tar.gz
2016-11-16-1100-I.tar.gz
2016-11-17-1324-F.tar.gz
2016-11-17-1348-I.tar.gz
2016-11-17-1354-I.tar.gz
2016-11-17-1451-I.tar.gz
</pre>
then "rear recover" will restore those backups:
<pre>
2016-11-17-1324-F.tar.gz
2016-11-17-1348-I.tar.gz
2016-11-17-1354-I.tar.gz
2016-11-17-1451-I.tar.gz
</pre>
i.e. the latest full backup plus all incremental backups
afterwards.
The "rear recover" output looks then like (excerpt):
<pre>
Restoring from '/tmp/rear.YKFtL4WiICTkRPF/outputfs/d108/2016-11-17-1324-F.tar.gz'...
Restored 2426 MiB [avg 70992 KiB/sec] OK
Restored 2426 MiB in 36 seconds [avg 69020 KiB/sec]
Restoring from '/tmp/rear.YKFtL4WiICTkRPF/outputfs/d108/2016-11-17-1348-I.tar.gz'...
Restored 11 MiB [avg 11288 KiB/sec] OK
Restored 11 MiB in 2 seconds [avg 5644 KiB/sec]
Restoring from '/tmp/rear.YKFtL4WiICTkRPF/outputfs/d108/2016-11-17-1354-I.tar.gz'...
Restoring... OK
Restoring from '/tmp/rear.YKFtL4WiICTkRPF/outputfs/d108/2016-11-17-1451-I.tar.gz'...
Restoring... OK
Restoring finished.
</pre>
Note that when the backup archive is very small
the current progress stuff in 400_restore_backup.sh
(I did not change its behaviour) does not show
any "Restored ... MiB [avg ... KiB/sec]" message
because it waits initially one second and during that
one second the restore had already finished.
