### PR TITLE
Removed EXIT_CODE usage in case of Error functions.

### DIFF
--- a/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
+++ b/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
@@ -42,6 +42,6 @@ client=${BACULA_RESULT[9]}
 StopIfError "Bacula director not reachable."
 
 [ "$client" ]
-StopIfError 1 "Bacula client status unknown on director."
+StopIfError "Bacula client status unknown on director."
 
 Log "Bacula director = $director, client = $client"

--- a/usr/share/rear/prep/BAREOS/default/500_check_BAREOS_bconsole_results.sh
+++ b/usr/share/rear/prep/BAREOS/default/500_check_BAREOS_bconsole_results.sh
@@ -45,6 +45,6 @@ client=${BAREOS_RESULT[9]}
 StopIfError "Bareos director not reachable."
 
 [ "$client" ]
-StopIfError 1 "Bareos client status unknown on director."
+StopIfError "Bareos client status unknown on director."
 
 Log "Bareos director = $director, client = $client"

--- a/usr/share/rear/verify/BACULA/default/050_check_requirements.sh
+++ b/usr/share/rear/verify/BACULA/default/050_check_requirements.sh
@@ -29,6 +29,6 @@ else
    StopIfError "Bacula executable (bconsole) missing or not executable"
 
    [ -s /etc/bacula/bconsole.conf ]
-   StopIfError 1  "Bacula configuration file (bconsole.conf) missing"
+   StopIfError "Bacula configuration file (bconsole.conf) missing"
 
 fi

--- a/usr/share/rear/verify/BAREOS/default/050_check_requirements.sh
+++ b/usr/share/rear/verify/BAREOS/default/050_check_requirements.sh
@@ -29,6 +29,6 @@ else
    StopIfError "Bareos executable (bconsole) missing or not executable"
 
    [ -s /etc/bareos/bconsole.conf ]
-   StopIfError 1  "Bareos configuration file (bconsole.conf) missing"
+   StopIfError "Bareos configuration file (bconsole.conf) missing"
 
 fi


### PR DESCRIPTION
Removed EXIT_CODE usage from and for Error functions
(namely the Error and BugError functions) because
in this case rear kills itself that results exit code 143
so that setting EXIT_CODE for Error functions is useless,
see https://github.com/rear/rear/issues/1076
