### PR TITLE
Fixed ReaR versus rear spelling.

### DIFF
--- a/doc/user-guide/02-getting-started.adoc
+++ b/doc/user-guide/02-getting-started.adoc
@@ -154,4 +154,4 @@ git clone git@github.com:rear/rear.git
 
 Remember the general configuration file is found at +/usr/share/rear/conf/default.conf+. In that file you find all variables used by +rear+ which can be overruled by redefining these in the +/etc/rear/site.conf+ or +/etc/rear/local.conf+ files. Please do not modify the +default.conf+ file itself, but use the +site.conf+ or +local.conf+ for this purpose.
 
-NOTE: Important note about the configuration files inside rear. Treat these as Bash scripts! Rear will source these configuration files, and therefore, if you make any syntax error against Bash scripting rules rear will break.
+NOTE: Important note about the configuration files inside ReaR. Treat these as Bash scripts! ReaR will source these configuration files, and therefore, if you make any syntax error against Bash scripting rules ReaR will break.

--- a/doc/user-guide/03-configuration.adoc
+++ b/doc/user-guide/03-configuration.adoc
@@ -206,7 +206,7 @@ Define this variable in +/etc/rear/local.conf+ if directoru +/tmp+ is too small 
     OUTPUT_URL=nfs://lnx01/vol/lnx01/linux_images_dr
 
 The +TMPDIR+ is picked up by the +mktemp+ command to create the +BUILD_DIR+ under +/bigdisk/tmp/rear.XXXX+
-Please be aware, that directory +/bigdisk+ must exist, otherwise, rear will bail out when executing the +mktemp+ command.
+Please be aware, that directory +/bigdisk+ must exist, otherwise, +rear+ will bail out when executing the +mktemp+ command.
 The default value of +TMPDIR+ is an empty string, therefore, by default +BUILD_DIR+ is +/tmp/rear.XXXX+
 
 Another point of interest is the +ISO_DIR+ variable to choose another location of the ISO image instead of the default location (+/var/lib/rear/output+).

--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -25,7 +25,7 @@ BACKUP=[TSM|NSR|DP|NBU|GALAXY10|SEP|DUPLICITY|BACULA|BAREOS|RBME|FDRUPSTREAM]
 
 When using one of the above backup solution (commercial or open source) then there is no need to use +rear mkbackup+ as the backup workflow would be empty. Just use +rear mkrescue+
 
-Rear will incorporate the needed executables and libraries of your chosen backup solution into the rescue image of rear.
+ReaR will incorporate the needed executables and libraries of your chosen backup solution into the rescue image of ReaR.
 
 == Bootable ISO and storing archive on NFS/NAS
 To create an ISO rescue image and using a central NFS/NAS server to store the archive, you could define:

--- a/doc/user-guide/05-integration.adoc
+++ b/doc/user-guide/05-integration.adoc
@@ -63,13 +63,13 @@ The integration is done using our own _check_rear_ plugin for Nagios.
 #
 # Purpose: Checks if disaster recovery usb stick is up to date
 
-# Check if rear is installed
+# Check if ReaR is installed
 if [[ ! -x /usr/sbin/rear ]]; then
     echo "REAR IS NOT INSTALLED"
     exit 2
 fi
 
-# rear disk layout status can be identical or changed
+# ReaR disk layout status can be identical or changed
 # returncode: 0 = ok
 if ! /usr/sbin/rear checklayout; then
     echo "Disk layout has changed. Please insert Disaster Recovery USB stick into system !"

--- a/doc/user-guide/06-layout-configuration.adoc
+++ b/doc/user-guide/06-layout-configuration.adoc
@@ -662,5 +662,5 @@ logicaldrive <device> <slot nr>|<array name>|<logical drive name> raid=<raid lev
 The +/var/lib/rear/layout/disklayout.conf+ file is being used as input during +rear recover+ to create on-th-fly a script called +/var/lib/rear/layout/diskrestore.sh+.
 When something goes wrong during the recreation of partitions, volume groups you will be thrown in edit mode and you can make the modification needed. However, it is desirable to have a preview mode before doing the recovery so you can review the +diskrestore.sh+ script before doing any recovery. It is better to find mistakes, obsolete arguments and so on before then later, right?
 
-Gratien wrote a script to accomplish this (script is not part of rear) and is meant for debugging reasons only. For more details see http://www.it3.be/2016/06/08/rear-diskrestore/
+Gratien wrote a script to accomplish this (script is not part of ReaR) and is meant for debugging reasons only. For more details see http://www.it3.be/2016/06/08/rear-diskrestore/
 

--- a/doc/user-guide/09-design-concepts.adoc
+++ b/doc/user-guide/09-design-concepts.adoc
@@ -4,7 +4,7 @@
 Schlomo Schapiro, Gratien D'haese, Dag Wieers
 
 == The Workflow System
-Relax-and-Recover is built as a modular framework. A call of rear <command>
+Relax-and-Recover is built as a modular framework. A call of +rear <command>+
 will invoke the following general workflow:
 
   1. *Configuration:* Collect system information to assemble a correct
@@ -105,7 +105,7 @@ are indeed the same):
      onto '/var/log/rear/' in the recovered system.
 
 == FS layout
-Relax-and-Recover tries to be as much LSB compliant as possible. Therefore rear will be
+Relax-and-Recover tries to be as much LSB compliant as possible. Therefore ReaR will be
 installed into the usual locations:
 
 /etc/rear/::

--- a/doc/user-guide/10-integrating-external-backup.adoc
+++ b/doc/user-guide/10-integrating-external-backup.adoc
@@ -1,24 +1,24 @@
-= Integrating external backup programs into rear
+= Integrating external backup programs into ReaR
 
 Relax-and-Recover can be used only to restore the disk layout of your system and boot loader. However, that means you are responsible for taking backups. And, more important, to restore these before you reboot recovered system.
 
-However, we have successfully already integrated external backup programs within rear, such as Netbackup, EMC NetWorker, Tivoli Storage Manager, Data Protetctor to name a few commercial backup programs. Furthermore, open source external backup programs which are also working with rear are Bacula, Bareos, Duplicity and Borg to name the most known ones.
+However, we have successfully already integrated external backup programs within ReaR, such as Netbackup, EMC NetWorker, Tivoli Storage Manager, Data Protetctor to name a few commercial backup programs. Furthermore, open source external backup programs which are also working with ReaR are Bacula, Bareos, Duplicity and Borg to name the most known ones.
 
-Ah, my backup program which is the best of course, is not yet integrated within rear. How shall we proceed to make your backup program working with rear? This is a step by step approach.
+Ah, my backup program which is the best of course, is not yet integrated within ReaR. How shall we proceed to make your backup program working with ReaR? This is a step by step approach.
 
-The work-flow `mkrescue` is the only needed as `mkbackup` will not create any backup as it is done outside rear anyhow. Very important to know.
+The work-flow `mkrescue` is the only needed as `mkbackup` will not create any backup as it is done outside ReaR anyhow. Very important to know.
 
 == Think before coding
 
 Well, what does this mean? Is my backup program capable of making full backups of my root disks, including ACLs? And, as usual, did we test a restore of a complete system already? Can we do a restore via the command line, or do we need a graphical user interface to make this happen?
-If the CLI approach is working then this would be the preferred manor for rear. If on the other hand only GUI approach is possible, then can you initiate a push from the media server instead of the pull method (which we could program within rear)?
+If the CLI approach is working then this would be the preferred manor for ReaR. If on the other hand only GUI approach is possible, then can you initiate a push from the media server instead of the pull method (which we could program within ReaR)?
 
 So, most imprtant things to remember here are:
 
- * CLI - preferred method (and far the easiest one to integrate within rear) - pull method
- * GUI - as rear has no X Windows available (only command line) we cannot use the GUI within rear, however, GUI is still possible from another system (media server or backup server) and push out the restore to the recovered system. This method is similar to the REQUESTRESTORE BACKUP method.
+ * CLI - preferred method (and far the easiest one to integrate within ReaR) - pull method
+ * GUI - as ReaR has no X Windows available (only command line) we cannot use the GUI within ReaR, however, GUI is still possible from another system (media server or backup server) and push out the restore to the recovered system. This method is similar to the REQUESTRESTORE BACKUP method.
 
-What does rear need to have on board before we can initiate a restore from your backup program?
+What does ReaR need to have on board before we can initiate a restore from your backup program?
 
  * the executables (and libraries) from your backup program (only client related)
  * configuration files required by above executables?
@@ -28,7 +28,7 @@ What does rear need to have on board before we can initiate a restore from your 
 
 Do not make your life too difficult by re-invented the wheel. Have a look at existing integrations. How?
 
-Start with the default configuration file of rear:
+Start with the default configuration file of ReaR:
 
     $ cd /usr/share/rear/conf
     $ grep -r NBU *
@@ -40,8 +40,8 @@ Start with the default configuration file of rear:
 
 What does this learn you?
 
- * you need to define a backup method name, e.g. `BACKUP=NBU` (must be unique within rear!)
- * define some new variables to automatically copy executables into the rear rescue image, and one to exclude stuff which is not required by the recovery (this means you have to play with it and fine-tune it)
+ * you need to define a backup method name, e.g. `BACKUP=NBU` (must be unique within ReaR!)
+ * define some new variables to automatically copy executables into the ReaR rescue image, and one to exclude stuff which is not required by the recovery (this means you have to play with it and fine-tune it)
  * finally, define a place holder array for your backup programs (is empty to start with).
 
 Now, you have defined a new BACKUP scheme name, right? As an example take the name BURP (http://burp.grke.org/).

--- a/usr/share/rear/backup/default/005_valid_backup_methods.sh
+++ b/usr/share/rear/backup/default/005_valid_backup_methods.sh
@@ -3,7 +3,7 @@
 # and error out when a BACKUP method is not found this way in default.conf
 # to ensure that the user cannot specify a non-working BACKUP in /etc/rear/local.conf
 # and to ensure that each implemented BACKUP method is mentioned in default.conf
-# to have a minimum documentation about what BACKUP methods are implemented in rear
+# to have a minimum documentation about what BACKUP methods are implemented in ReaR
 # see https://github.com/rear/rear/issues/914
 # and https://github.com/rear/rear/issues/159
 
@@ -15,6 +15,6 @@ for backup_method in $( grep 'BACKUP=' $SHARE_DIR/conf/default.conf | grep -v '_
 done
 
 if ! grep -q "$BACKUP" <<< $( echo ${valid_backup_methods[@]} ) ; then
-    Error "The BACKUP method '$BACKUP' is not known to rear."
+    Error "The BACKUP method '$BACKUP' is not known to ReaR."
 fi
 

--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -15,7 +15,7 @@ tar -v -X $TMP_DIR/copy-as-is-exclude \
 StopIfError "Could not copy files and directories"
 Log "Finished copying COPY_AS_IS"
 
-# fix rear directory if running from checkout
+# fix ReaR directory if running from checkout
 if [[ "$REAR_DIR_PREFIX" ]] ; then
     for dir in /usr/share/rear /var/lib/rear ; do
         ln $v -sf $REAR_DIR_PREFIX$dir $ROOTFS_DIR$dir>&8

--- a/usr/share/rear/build/GNU/Linux/610_verify_and_adjust_udev_systemd.sh
+++ b/usr/share/rear/build/GNU/Linux/610_verify_and_adjust_udev_systemd.sh
@@ -7,7 +7,7 @@ test -d $ROOTFS_DIR/usr/lib/systemd/system || return 0
 # ls /usr/lib/systemd/system/sockets.target.wants/
 #dbus.socket  systemd-initctl.socket  systemd-journald.socket  systemd-shutdownd.socket  udev-control.socket  udev-kernel.socket
 
-# in our rear skel directory we have:
+# in our ReaR skel directory we have:
 # ls sockets.target.wants/
 #dbus.socket    systemd-journald.socket  systemd-shutdownd.socket      systemd-udevd-kernel.socket  udev-kernel.socket
 #syslog.socket  systemd-logger.socket    systemd-udevd-control.socket  udev-control.socket

--- a/usr/share/rear/conf/Linux-ia64.conf
+++ b/usr/share/rear/conf/Linux-ia64.conf
@@ -18,7 +18,7 @@ dosfslabel
 dosfsck
 )
 
-# create an EFI rear boot directory on local disk for testing rescue image
+# create an EFI ReaR boot directory on local disk for testing rescue image
 # e.g. fs1:/EFI/rear (or under Linux mode /boot/efi/efi/rear)
 CREATE_LOCAL_EFI_DIR=true
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -124,22 +124,22 @@ CHECK_CONFIG_FILES=( '/etc/drbd/' '/etc/drbd.conf' '/etc/lvm/lvm.conf' '/etc/mul
 # and https://hackweek.suse.com/14/projects/1508
 #
 # The by default empty RECOVERY_UPDATE_URL means this functionality is not used so that
-# "rear recover" runs as usual without updating any files in the rear recovery system
+# "rear recover" runs as usual without updating any files in the ReaR recovery system
 # (i.e. with the recovery system as "rear mkbackup" or "rear mkrescue" had made it).
 #
 # If RECOVERY_UPDATE_URL is non-empty it points to a download location
 # wherefrom "rear recover" will first of all download a tar.gz archive and
-# extract that at the root directory '/' in the rear recovery system.
+# extract that at the root directory '/' in the ReaR recovery system.
 #
-# The intended purpose is to download and replace in the recovery system rear config files
+# The intended purpose is to download and replace in the recovery system ReaR config files
 # (usually the content of /etc/rear/ and /var/lib/rear/recovery/ and /var/lib/rear/layout/)
-# with updated rear config files.
+# with updated ReaR config files.
 #
-# But it is not limited to replace only rear config files in the recovery system.
+# But it is not limited to replace only ReaR config files in the recovery system.
 # Anything in the tar.gz archive will be extracted at '/' in the recovery system
 # (even if it destroys the recovery system) so that it can also be used to update
 # anything in the recovery system - provided one does the update carefully.
-# For example one should not replace currently running rear scripts.
+# For example one should not replace currently running ReaR scripts.
 #
 # Currently only a HTTP download location is supported like
 #   RECOVERY_UPDATE_URL="http://my_internal_server/$HOSTNAME.rear_config.tgz"
@@ -307,7 +307,7 @@ PXE_CREATE_LINKS=MAC
 PXE_REMOVE_OLD_LINKS=
 
 # The way we start up in our PXE mode (keywords known are 'automatic', 'unattended', and empty)
-# 'automatic' is the auto_recover mode which means boot automatic with rear and execute a 'rear recover', but
+# 'automatic' is the auto_recover mode which means boot automatic with ReaR and execute a 'rear recover', but
 # when a question has to be answered (e.g. during migration mode) it will wait on an answer...
 # 'unattended' should only used by EXPERTS and is meant to foresee in an automated recovery for testing
 # purposes only. If you do not know what I mean do not use it, or hire us ;-)
@@ -742,7 +742,7 @@ BEXTRACT_VOLUME=
 BEXTRACT_DEVICE=
 # If you have more than one restore job defined for a client, define it as
 # BAREOS_RESTORE_JOB=client-restore
-# You can leave it unset as rear will tell you when it is needed
+# You can leave it unset as ReaR will tell you when it is needed
 # BAREOS_RESTORE_JOB=
 #
 # If you have more than one fileset configured for your client, specify one here.
@@ -756,7 +756,7 @@ BEXTRACT_DEVICE=
 ##
 # DUPLICITY is a cloud based external backup method
 # The program duply is wrapper script around duplicity which makes it much easier to use
-# and script in rear - duply uses the concept of a profile (basically a script with vars
+# and script in ReaR - duply uses the concept of a profile (basically a script with vars
 # to define your settings - use it as "duply <profile> status" to see it in action)
 # By using DUPLY_PROFILE we will try an automatic restore, if duplicity directly is used
 # then you better add some restore script in the COPY_AS_IS array
@@ -782,7 +782,7 @@ DUPLY_PROFILE=""
 # DUPLICITY_HOST="<hostname|ip>"
 #
 # the protocol duplicity should use for backup/restore (must be rsync for this case)
-# duplicity supports much more (ssh, scp, ftp, ..) but this isnt test in rear yet
+# duplicity supports much more (ssh, scp, ftp, ..) but this isnt test in ReaR yet
 #
 # DUPLICITY_PROTO="rsync"
 #
@@ -843,7 +843,7 @@ NETFS_PREFIX="$HOSTNAME"
 # empty means only keep current backup
 NETFS_KEEP_OLD_BACKUP_COPY=
 
-# Specify if rear should try to backup capabilities (y/n) default (n).
+# Specify if ReaR should try to backup capabilities (y/n) default (n).
 NETFS_RESTORE_CAPABILITIES=n
 
 ##
@@ -902,7 +902,7 @@ REQUESTRESTORE_COMMAND=
 # BACKUP=RBME
 ##
 # This mode allows restoring a RBME backup from NFS shares.
-# As NFSv4 is not fully supported with rear (yet) it is safer to
+# As NFSv4 is not fully supported with ReaR (yet) it is safer to
 # use BACKUP_OPTIONS="nfsvers=3,nolock" in the local.conf file.
 # Also, do not forget to open the TCP/UDP ports on the NFS server (iptables)!
 
@@ -954,7 +954,7 @@ EXTERNAL_CHECK="ssh vms date >&8"
 #
 # See https://github.com/rear/rear/issues/779
 #
-# After backup restore rear should move away files or directories
+# After backup restore ReaR should move away files or directories
 # that should not have been restored - maily files or directories
 # that are created and maintained by system tools where
 # a restore from the backup results wrong/outdated
@@ -966,9 +966,9 @@ EXTERNAL_CHECK="ssh vms date >&8"
 # to /proc/self/mounts which should probably be restored to ensure
 # that link is available.
 #
-# rear will not remove any file (any user data is sacrosanct).
-# Instead rear moves those files away into a rear-specific directory
-# so that the admin can inspect that directory to see what rear thinks
+# ReaR will not remove any file (any user data is sacrosanct).
+# Instead ReaR moves those files away into a ReaR-specific directory
+# so that the admin can inspect that directory to see what ReaR thinks
 # should not have been restored:
 readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/moved_away_after_backup_restore/"
 #
@@ -1130,16 +1130,16 @@ NETWORKING_PREPARATION_COMMANDS=()
 ##
 # GRUB_RESCUE [ GRUB_RESCUE_USER ]
 #
-# Add a rear rescue/recovery system to the GRUB/GRUB2 bootloader of the currently running system.
-# It adds kernel and the rear initrd to the bootloader directory in the currently running system and
-# adds a 'Relax-and-Recover' GRUB/GRUB2 menue entry to boot that locally installed rear rescue system.
+# Add a ReaR rescue/recovery system to the GRUB/GRUB2 bootloader of the currently running system.
+# It adds kernel and the ReaR initrd to the bootloader directory in the currently running system and
+# adds a 'Relax-and-Recover' GRUB/GRUB2 menue entry to boot that locally installed ReaR rescue system.
 # Note that GRUB_RESCUE is the only functionality where "rear mkbackup" or "rear mkrescue"
 # changes the currently running system. It changes the currently running system even
 # in a critical way because it changes the bootloader of the currently running system.
 # The main reason for the GRUB_RESCUE functionality is to be quickly able to recover a system
-# from soft errors (like deleting all of /lib/) without digging out the rear recovery boot medium.
-# When booting that locally installed rear recovery system it does the same as when booting
-# the rear recovery system from an external rear boot medium - i.e. "rear recover" replaces the
+# from soft errors (like deleting all of /lib/) without digging out the ReaR recovery boot medium.
+# When booting that locally installed ReaR recovery system it does the same as when booting
+# the ReaR recovery system from an external ReaR boot medium - i.e. "rear recover" replaces the
 # whole current system with a recreated system where all files are restored from the backup.
 # To be on the safe side the GRUB_RESCUE functionality is disabled by default:
 GRUB_RESCUE=n
@@ -1153,18 +1153,18 @@ GRUB_RESCUE=n
 # except the special value 'unrestricted' is set via GRUB_RESCUE_USER="unrestricted"
 # which creates the 'Relax-and-Recover' GRUB2 menue entry so that it can be booted by anyone
 # which means anyone who can boot the currently running system can replace it via "rear recover".
-# When GRUB_RESCUE_USER is empty rear does not do a GRUB2 user related setup
+# When GRUB_RESCUE_USER is empty ReaR does not do a GRUB2 user related setup
 # so that the already existing GRUB2 users configuration determines
 # which users can boot the 'Relax-and-Recover' GRUB2 menue entry.
 # Usually this means anyone can boot 'Relax-and-Recover' which means anyone
 # who can boot the currently running system can replace it via "rear recover".
 GRUB_RESCUE_USER=""
-# The former GRUB2 superuser setup support in rear via GRUB_SUPERUSER is dropped and
-# also the former GRUB2 password setup support in rear via GRUB_RESCUE_PASSWORD is dropped.
+# The former GRUB2 superuser setup support in ReaR via GRUB_SUPERUSER is dropped and
+# also the former GRUB2 password setup support in ReaR via GRUB_RESCUE_PASSWORD is dropped.
 # Both kind of setup can change the behaviour of the GRUB2 bootloader as a whole in unexpected ways
-# but rear is not meant to change the general GRUB2 configuration of the currently running system.
+# but ReaR is not meant to change the general GRUB2 configuration of the currently running system.
 # It works by default reasonably backward compatible when formerly a GRUB_SUPERUSER was used
-# which means a GRUB2 superuser was set up by rear in /etc/grub.d/01_users with GRUB_RESCUE_PASSWORD
+# which means a GRUB2 superuser was set up by ReaR in /etc/grub.d/01_users with GRUB_RESCUE_PASSWORD
 # so that the empty GRUB_RESCUE_USER results that the 'Relax-and-Recover' GRUB2 menue entry
 # can only be booted by the formerly set GRUB_SUPERUSER with the formerly set GRUB_RESCUE_PASSWORD.
 # For background information see https://github.com/rear/rear/pull/942
@@ -1174,13 +1174,13 @@ GRUB_RESCUE_USER=""
 ##
 # USING_UEFI_BOOTLOADER
 #
-# UEFI (Secure booting) support is partly available in rear (at least for Fedora, RHEL)
+# UEFI (Secure booting) support is partly available in ReaR (at least for Fedora, RHEL)
 # SLES, openSUSE do not work out of the box due to issues with making an UEFI bootable ISO image.
 # SLES, openSUSE need the additional tool 'ebiso' to make an UEFI bootable ISO image
 # (via ISO_MKISOFS_BIN=/usr/bin/ebiso - see the ISO_MKISOFS_BIN variable above).
 # The next variable can explitly specify whether or not an UEFI bootloader should be used:
-# USING_UEFI_BOOTLOADER=   means let rear try to find it out by itself (default)
-# USING_UEFI_BOOTLOADER=0  means we do not want UEFI capable ISO and no efi tools in rear image
+# USING_UEFI_BOOTLOADER=   means let ReaR try to find it out by itself (default)
+# USING_UEFI_BOOTLOADER=0  means we do not want UEFI capable ISO and no efi tools in ReaR image
 # USING_UEFI_BOOTLOADER=1  means we want UEFI ISO image and all efi tools to recreate the secure boot
 # instead of '0' also any value that is recognized as 'no' by the is_false function can be used
 # instead of '1' also any value that is recognized as 'yes' by the is_true function can be used
@@ -1258,6 +1258,6 @@ BOOT_OVER_SAN=
 ####################
 # DRLM (Disaster Recovery Linux Manager) Variables
 
-# Specify if rear is managed from DRLM (y/n) [ default (n) ].
+# Specify if ReaR is managed from DRLM (y/n) [ default (n) ].
 DRLM_MANAGED=n
 

--- a/usr/share/rear/conf/examples/SLE11-SLE12-SAP-HANA-UEFI-example.conf
+++ b/usr/share/rear/conf/examples/SLE11-SLE12-SAP-HANA-UEFI-example.conf
@@ -7,21 +7,21 @@
 # In particular note:
 # There is no such thing as a disaster recovery solution that "just works".
 # SAP HANA on UEFI capable systems need EFI and DOS tools.
-# Installing DOS file system tools is optional as dosfslabel is not used within rear anymore thanks to issue #694
+# Installing DOS file system tools is optional as dosfslabel is not used within ReaR anymore thanks to issue #694
 #
 # Install EFI ISO creation tool:
-# For UEFI the ebiso package is required to use rear on SLES 11 and SLES 12.
+# For UEFI the ebiso package is required to use ReaR on SLES 11 and SLES 12.
 # The ebiso package is available at
 # http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/
 # For example to download the ebiso package for SLES 12 use a command like (the RPM package version and release numbers change):
 #   wget http://download.opensuse.org/repositories/Archiving:/Backup:/Rear/SLE_12/x86_64/ebiso-0.1.4-1.2.x86_64.rpm
 # and instal it with a command like:
 #   rpm -ivh ebiso-0.1.4-7.1.x86_64.rpm
-# Furthermore ebiso needs rear higher than 1.17.2 e.g. use a development snapshot release from
+# Furthermore ebiso needs ReaR higher than 1.17.2 e.g. use a development snapshot release from
 # http://download.opensuse.org/repositories/Archiving:/Backup:/Rear:/Snapshot/
-# Create rear recovery system as ISO image:
+# Create ReaR recovery system as ISO image:
 OUTPUT=ISO
-# Use ebiso to make an UEFI bootable ISO image of the rear recovery system:
+# Use ebiso to make an UEFI bootable ISO image of the ReaR recovery system:
 ISO_MKISOFS_BIN=/usr/bin/ebiso
 # Store the backup file via NFS on a NFS server:
 BACKUP=NETFS
@@ -29,7 +29,7 @@ BACKUP=NETFS
 # with 'mount -o nolock' no rpc.statd (plus rpcbind) are needed:
 BACKUP_OPTIONS="nfsvers=3,nolock"
 # If the NFS server is not an IP address but a hostname,
-# DNS must work in the rear recovery system when the backup is restored.
+# DNS must work in the ReaR recovery system when the backup is restored.
 BACKUP_URL=nfs://your.NFS.server.IP/path/to/your/rear/backup
 # Keep an older copy of the backup in a HOSTNAME.old directory
 # provided there is no '.lockfile' in the HOSTNAME directory:
@@ -40,7 +40,7 @@ BACKUP_PROG_EXCLUDE=( ${BACKUP_PROG_EXCLUDE[@]} '/hana/*' )
 # This option defines a root password to allow SSH connection
 # whithout a public/private key pair
 #SSH_ROOT_PASSWORD="password_on_the_rear_recovery_system"
-# Let the rear recovery system run dhclient to get an IP address
+# Let the ReaR recovery system run dhclient to get an IP address
 # instead of using the same IP address as the original system:
 #USE_DHCLIENT="yes"
 # End example setup for SAP HANA on UEFI capable systems.

--- a/usr/share/rear/conf/examples/SLE12-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-btrfs-example.conf
@@ -1,5 +1,5 @@
 # Begin example setup for SLE12 with default btrfs subvolumes.
-# This will not work with default btrfs on SLES12-SP1 because support for btrfs in rear
+# This will not work with default btrfs on SLES12-SP1 because support for btrfs in ReaR
 # explicitly excludes snapshot subvolumes but on SLES12-SP1 what is mounted at '/'
 # will be a btrfs snapshot subvolume (see https://github.com/rear/rear/issues/556).
 # You must adapt "your.NFS.server.IP/path/to/your/rear/backup" at BACKUP_URL.
@@ -15,7 +15,7 @@
 # Regarding btrfs snapshots:
 # Recovery of btrfs snapshot subvolumes is not possible.
 # Only recovery of "normal" btrfs subvolumes is possible.
-# Create rear recovery system as ISO image:
+# Create ReaR recovery system as ISO image:
 OUTPUT=ISO
 # Store the backup file via NFS on a NFS server:
 BACKUP=NETFS
@@ -23,7 +23,7 @@ BACKUP=NETFS
 # with 'mount -o nolock' no rpc.statd (plus rpcbind) are needed:
 BACKUP_OPTIONS="nfsvers=3,nolock"
 # If the NFS server is not an IP address but a hostname,
-# DNS must work in the rear recovery system when the backup is restored.
+# DNS must work in the ReaR recovery system when the backup is restored.
 BACKUP_URL=nfs://your.NFS.server.IP/path/to/your/rear/backup
 # Keep an older copy of the backup in a HOSTNAME.old directory
 # provided there is no '.lockfile' in the HOSTNAME directory:
@@ -38,7 +38,7 @@ BACKUP_PROG_INCLUDE=( '/home/*' '/var/tmp/*' '/var/spool/*' '/var/opt/*' '/var/l
 # This option defines a root password to allow SSH connection
 # whithout a public/private key pair
 #SSH_ROOT_PASSWORD="password_on_the_rear_recovery_system"
-# Let the rear recovery system run dhclient to get an IP address
+# Let the ReaR recovery system run dhclient to get an IP address
 # instead of using the same IP address as the original system:
 #USE_DHCLIENT="yes"
 # End example setup for SLE12 with default btrfs subvolumes.

--- a/usr/share/rear/init/default/030_update_recovery_system.sh
+++ b/usr/share/rear/init/default/030_update_recovery_system.sh
@@ -3,14 +3,14 @@
 
 # See https://github.com/rear/rear/issues/841
 
-# Currently updating rear is only supported during "rear recover"
+# Currently updating ReaR is only supported during "rear recover"
 # because "rear recover" is only run once in the recovery system and
 # afterwards the recovery system is shut down and the recovered system is booted.
 # Currently it is not tested what mess might happen for other workflows
 # that run many times in one same system like "rear mkbackup" in the normal system.
-# Furthermore it seems to make not much sense to update rear in the normal system
-# via this special built-in rear functionality because in the normal system
-# one can manually update rear as anything else.
+# Furthermore it seems to make not much sense to update ReaR in the normal system
+# via this special built-in ReaR functionality because in the normal system
+# one can manually update ReaR as anything else.
 test "$WORKFLOW" != "recover" && return
 
 # Without a RECOVERY_UPDATE_URL there is nothing to do:

--- a/usr/share/rear/init/default/050_check_rear-recover_mode.sh
+++ b/usr/share/rear/init/default/050_check_rear-recover_mode.sh
@@ -1,7 +1,5 @@
-# when booted from rear archive the only only workflow(s) are:
-# - recover
-
-# when booted from rear image then the file /etc/rear-release is unique and does not exist in production
+# When booted from ReaR image the only only workflow is 'recover' and
+# when booted from ReaR image /etc/rear-release is unique (does not exist otherwise):
 if [[ -f /etc/rear-release ]] && [[ "$WORKFLOW" != "recover" ]] ; then
-    Error "The workflow $WORKFLOW is not supported when booted from rear rescue image"
+    Error "The workflow $WORKFLOW is not supported when booted from ReaR rescue image"
 fi

--- a/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
@@ -53,9 +53,9 @@ if grep -q md /proc/mdstat &>/dev/null; then
     # so further parted commands with the disk will fail since the disk is busy now.
     # The /lib/udev/rules.d/65-md-incremental.rules detects anaconda (the Red Hat installer),
     # and if it find itself running under anaconda, it will not run.
-    # Accordingly also for other installers (in particular the rear installer)
+    # Accordingly also for other installers (in particular the ReaR installer)
     # this rule should not be there (and other Linux distros probably do not have it)
-    # which means removing it is the right solution to make rear work also for RHEL6:
+    # which means removing it is the right solution to make ReaR work also for RHEL6:
     if [ -e /lib/udev/rules.d/65-md-incremental.rules ] ; then
         rm -f /lib/udev/rules.d/65-md-incremental.rules || echo "rm 65-md-incremental.rules failed"
     fi

--- a/usr/share/rear/layout/prepare/GNU/Linux/130_include_mount_subvolumes_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/130_include_mount_subvolumes_code.sh
@@ -48,7 +48,7 @@ btrfs_subvolumes_setup() {
         SLES12SP1SP2_btrfs_subvolumes_setup="yes"
         # Because that very special btrfs default subvolume on SLES 12 SP1
         # has to be controlled by snapper it must be set up by snapper
-        # which means that snapper is needed in the rear recovery system.
+        # which means that snapper is needed in the ReaR recovery system.
         # For this special setup during installation a special SUSE tool
         # /usr/lib/snapper/installation-helper is used:
         SLES12SP1SP2_installation_helper_executable="/usr/lib/snapper/installation-helper"
@@ -310,7 +310,7 @@ btrfs_subvolumes_setup() {
         # "snapper improperly usurps control of the default subvolume from the user"
         # https://github.com/openSUSE/snapper/issues/178
         # https://features.opensuse.org/319292
-        # Regardless who or what is right or wrong here I like to have rear working fail-safe
+        # Regardless who or what is right or wrong here I like to have ReaR working fail-safe
         # because an admin could manually create any kind of awkward btrfs setup.
         # Therefore remounting is needed when the subvolume_mountpoint is '/'
         # but the subvolume_path is neither '/' nor the default subvolume.

--- a/usr/share/rear/lib/format-workflow.sh
+++ b/usr/share/rear/lib/format-workflow.sh
@@ -6,7 +6,7 @@
 # With the --efi toggle you get 2 partitions (vfat and ext3) so we are able
 # to make this USB UEFI bootable afterwards
 
-WORKFLOW_format_DESCRIPTION="format and label media for use with rear"
+WORKFLOW_format_DESCRIPTION="Format and label medium for use with ReaR"
 WORKFLOWS=( ${WORKFLOWS[@]} format )
 WORKFLOW_format () {
 

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -98,7 +98,7 @@ esac
 USB_REAR_DIR="$BUILD_DIR/outputfs/$USB_PREFIX"
 if [ ! -d "$USB_REAR_DIR" ]; then
     mkdir -p $v "$USB_REAR_DIR" >&8
-    StopIfError "Could not create USB rear dir [$USB_REAR_DIR] !"
+    StopIfError "Could not create USB ReaR dir [$USB_REAR_DIR] !"
 fi
 
 # We generate a single syslinux.cfg for the current system
@@ -148,7 +148,7 @@ for rear_run in $(ls -dt $BUILD_DIR/outputfs/rear/$HOSTNAME/*); do
     fi
 done
 
-# We generate a rear syslinux.cfg based on existing rear syslinux.cfg files.
+# We generate a ReaR syslinux.cfg based on existing ReaR syslinux.cfg files.
 Log "Creating /rear/syslinux.cfg"
 {
     syslinux_write <<EOF

--- a/usr/share/rear/output/default/940_grub_rescue.sh
+++ b/usr/share/rear/output/default/940_grub_rescue.sh
@@ -23,7 +23,7 @@ fi
 #grub_version=$(get_version "grub --version")
 grub_version=$(strings $grub_binary | sed -rn 's/^[^0-9\.]*([0-9]+\.[-0-9a-z\.]+).*$/\1/p' | tail -n 1)
 if version_newer "$grub_version" 1.0; then
-    # only for grub-legacy we make special rear boot entry in menu.lst
+    # only for grub-legacy we make special ReaR boot entry in menu.lst
     return
 fi
 
@@ -49,7 +49,7 @@ fi
 
 if is_true $USING_UEFI_BOOTLOADER ; then
     # set to 1 means using UEFI
-    # SLES uses elilo instead of grub-efi; we will return if that is the case (and do not add a rear rescue entry)
+    # SLES uses elilo instead of grub-efi; we will return if that is the case (and do not add a ReaR rescue entry)
     [[ "${UEFI_BOOTLOADER##*/}" = "elilo.efi" ]] && return
     grub_conf="`dirname $UEFI_BOOTLOADER`/grub.conf"
 else

--- a/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
+++ b/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
@@ -4,7 +4,7 @@ if ps ax | grep -v grep | grep -q systemd ; then
     PROGS=( "${PROGS[@]}" systemd agetty systemctl systemd-notify systemd-ask-password
         systemd-udevd systemd-journald journalctl dbus-uuidgen dbus-daemon dbus-send
         upstart-udev-bridge )
-    # cgroup stuff - not required for rear
+    # cgroup stuff - not required for ReaR
     #PROGS=( "${PROGS[@]}" cg_annotate cgclear cgcreate cgget cgrulesengd cgset cgdelete cgclassify cgexec )
     COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* )
     CLONE_GROUPS=( "${CLONE_GROUPS[@]}" input )

--- a/usr/share/rear/prep/README
+++ b/usr/share/rear/prep/README
@@ -1,4 +1,4 @@
-This is the preparation part of rear before starting the rescue build phase.
+This is the preparation part of ReaR before starting the rescue build phase.
 
 Please note that you should not put any scripts that reference
 $ROOTFS_DIR or $VAR_DIR/recovery into this section. Scripts for $ROOTFS_DIR

--- a/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
+++ b/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
@@ -38,7 +38,7 @@ if [ "${RSYNC_USER}" != "root" ]; then
         else
             # when using --fake-super we must have user_xattr mount options on the remote mntpt
             _mntpt=$(ssh ${RSYNC_USER}@${RSYNC_HOST} 'cd ${RSYNC_PATH}; df -P .' 2>/dev/null | tail -1 | awk '{print $6}')
-            ssh ${RSYNC_USER}@${RSYNC_HOST} "cd ${RSYNC_PATH} && touch .is_xattr_supported && setfattr -n user.comment -v 'File created by rear to test if this filesystems supports extended attributes.' .is_xattr_supported && getfattr -n user.comment .is_xattr_supported 1>/dev/null; find .is_xattr_supported -empty -delete"
+            ssh ${RSYNC_USER}@${RSYNC_HOST} "cd ${RSYNC_PATH} && touch .is_xattr_supported && setfattr -n user.comment -v 'File created by ReaR to test if this filesystems supports extended attributes.' .is_xattr_supported && getfattr -n user.comment .is_xattr_supported 1>/dev/null; find .is_xattr_supported -empty -delete"
             StopIfError "Remote file system $_mntpt does not have user_xattr mount option set!"
             #BACKUP_RSYNC_OPTIONS=( "${BACKUP_RSYNC_OPTIONS[@]}" --xattrs --rsync-path="""rsync --fake-super""" )
             # see issue #366 for explanation of removing --xattrs

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -8,20 +8,20 @@ if grep -qw 'noefi' /proc/cmdline; then
     return
 fi
 
-# by default the variable USING_UEFI_BOOTLOADER is empty which means rear will decide (this script)
+# by default the variable USING_UEFI_BOOTLOADER is empty which means ReaR will decide (this script)
 # except when the variable USING_UEFI_BOOTLOADER has an explicit 'false' value set:
 if is_false $USING_UEFI_BOOTLOADER ; then
     # we forced the variable to zero (in local.conf) so we do not want UEFI stuff
-    Log "We do not want UEFI capabilities in rear (USING_UEFI_BOOTLOADER=0)"
+    Log "We do not want UEFI capabilities in ReaR (USING_UEFI_BOOTLOADER=0)"
     return
 fi
-# FIXME: I <jsmeix@suse.de> wonder if rear should also decide via the code below
+# FIXME: I <jsmeix@suse.de> wonder if ReaR should also decide via the code below
 # if the variable USING_UEFI_BOOTLOADER has already an explicit 'true' value set.
 # I think if the variable USING_UEFI_BOOTLOADER has an explicit 'true' value set
 # but the code below returns before "it is safe to turn on USING_UEFI_BOOTLOADER=1"
 # then something is probably wrong because the user wants USING_UEFI_BOOTLOADER
 # but the tests in the code below seem to contradict what the user wants
-# so that probably rear should better abort here with an error and not
+# so that probably ReaR should better abort here with an error and not
 # blindly proceed and then fail later in arbitrary unpredictable ways
 # cf. https://github.com/rear/rear/issues/801#issuecomment-200353337
 # or is it also usually "safe to proceed with USING_UEFI_BOOTLOADER=1"

--- a/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
+++ b/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
@@ -323,10 +323,10 @@ else
     #
     # FIXME: Translate the following comment into globally comprehensible language (i.e. English!)
     # Anpassung HZD: Hat ein System bei einer SLES10 Installation zwei Bonding-Devices
-    # gibt es Probleme beim Boot mit der Rear-Iso-Datei. Der Befehl modprobe -o name ...
+    # gibt es Probleme beim Boot mit der ReaR-ISO-Datei. Der Befehl modprobe -o name ...
     # funkioniert nicht. Dadurch wird nur das erste bonding-Device koniguriert.
     # Die Konfiguration des zweiten Devices schlaegt fehl und dieses laesst sich auch nicht manuell
-    # nachinstallieren. Daher wurde diese script so angepasst, dass die Rear-Iso-Datei kein Bonding
+    # nachinstallieren. Daher wurde diese script so angepasst, dass die ReaR-ISO-Datei kein Bonding
     # konfiguriert, sondern die jeweiligen IP-Adressen einer Netzwerkkarte des Bondingdevices
     # zuordnet. Dadurch musste aber auch das script 350_routing.sh angepasst werden.
     #

--- a/usr/share/rear/rescue/GNU/Linux/990_sysreqs.sh
+++ b/usr/share/rear/rescue/GNU/Linux/990_sysreqs.sh
@@ -3,7 +3,7 @@
 # system in a remote DRP site
 # Output file: /var/lib/rear/sysreqs/Minimal_System_Requirements.txt
 # This is just for your information and the output is nowhere else
-# used by rear whatsoever.
+# used by ReaR whatsoever.
 
 test -d $VAR_DIR/sysreqs || mkdir -m 755 $VAR_DIR/sysreqs
 
@@ -26,7 +26,7 @@ if test -f /etc/SuSE-release ; then
 elif test -f /etc/redhat-release ; then
     cat /etc/redhat-release
 elif test -f /etc/rear/os.conf ; then
-    # The following 2 variables are listed as an example, and are already known by rear
+    # The following 2 variables are listed as an example, and are already known by ReaR
     # OS_VENDOR=RedHatEnterpriseServer
     # OS_VERSION=6
     echo "${OS_VENDOR} ${OS_VERSION}"

--- a/usr/share/rear/rescue/NSR/default/450_prepare_networker_startup.sh
+++ b/usr/share/rear/rescue/NSR/default/450_prepare_networker_startup.sh
@@ -14,4 +14,4 @@ if [ -f /usr/sbin/nsrexecd ]; then
 fi
 EOF
 chmod +x $ROOTFS_DIR/etc/scripts/system-setup.d/90-networker.sh
-Log "Created the EMC NetWorker nsrexecd start-up script (90-networker.sh) for Rear"
+Log "Created the EMC NetWorker nsrexecd start-up script (90-networker.sh) for ReaR"

--- a/usr/share/rear/restore/default/990_move_away_restored_files.sh
+++ b/usr/share/rear/restore/default/990_move_away_restored_files.sh
@@ -3,7 +3,7 @@
 #
 # See https://github.com/rear/rear/issues/779
 #
-# After backup restore rear should move away files or directories
+# After backup restore ReaR should move away files or directories
 # that should not have been restored - maily files or directories
 # that are created and maintained by system tools where
 # a restore from the backup results wrong/outdated
@@ -15,10 +15,10 @@
 # to /proc/self/mounts which should probably be restored to ensure
 # that link is available.
 #
-# rear will not remove any file (any user data is sacrosanct).
-# Instead rear moves those files away into a rear-specific directory
+# ReaR will not remove any file (any user data is sacrosanct).
+# Instead ReaR moves those files away into a ReaR-specific directory
 # (specified by BACKUP_RESTORE_MOVE_AWAY_DIRECTORY in default.conf)
-# so that the admin can inspect that directory to see what rear thinks
+# so that the admin can inspect that directory to see what ReaR thinks
 # should not have been restored.
 #
 # There is nothing hardcoded in the scripts.
@@ -67,7 +67,7 @@ for dummy in "once" ; do
             # * matches non-dot-files
             # .[!.]* matches dot-files except '.' and dot-dot-files
             # ..?* matches dot-dot-files (also dot-dot-...-dot-files) except '..'
-            # If all patterns match nothing the nullglob setting in rear let it expand to empty
+            # If all patterns match nothing the nullglob setting in ReaR let it expand to empty
             # which is o.k. because 'rm -f' does not care about non-existent arguments:
             rm -rf $file_relative/* $file_relative/.[!.]* $file_relative/..?*
         else


### PR DESCRIPTION
We use 'ReaR' as official abbreviation for Relax-and-Recover
and 'rear' to point to RPM packages or scripts, see
https://github.com/rear/rear/issues/1086 and
https://github.com/rear/rear/issues/1033