### PR TITLE
Split restoreonly workflow from recover workflow

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -455,7 +455,7 @@ else
 fi
 
 # Usually REAR_LOGFILE=/var/log/rear/rear-$HOSTNAME.log
-# The  REAR_LOGFILE name set by main script from LOGFILE in default.conf
+# The REAR_LOGFILE name set by main script from LOGFILE in default.conf
 # but later user config files are sourced in main script where LOGFILE can be set different
 # so that the user config LOGFILE setting is used as final logfile name:
 if test "$REAR_LOGFILE" != "$LOGFILE" ; then

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -333,7 +333,7 @@ readonly REAR_LOGFILE="$LOGFILE"
 if test "$WORKFLOW" != "help" ; then
     LogPrint "$PRODUCT $VERSION / $RELEASE_DATE"
     Log "Command line options: $0 ${CMD_OPTS[@]}"
-    test "$VERBOSE" && LogPrint "Using log file: $LOGFILE" || true
+    LogPrint "Using log file: $REAR_LOGFILE"
 fi
 
 v=""
@@ -454,7 +454,12 @@ else
     EXIT_CODE=1
 fi
 
+# Usually REAR_LOGFILE=/var/log/rear/rear-$HOSTNAME.log
+# The  REAR_LOGFILE name set by main script from LOGFILE in default.conf
+# but later user config files are sourced in main script where LOGFILE can be set different
+# so that the user config LOGFILE setting is used as final logfile name:
 if test "$REAR_LOGFILE" != "$LOGFILE" ; then
+    LogPrint "Saving $REAR_LOGFILE as $LOGFILE"
     cat "$REAR_LOGFILE" > "$LOGFILE"
 fi
 

--- a/usr/share/rear/backup/NETFS/default/400_create_include_exclude_files.sh
+++ b/usr/share/rear/backup/NETFS/default/400_create_include_exclude_files.sh
@@ -1,26 +1,33 @@
-# backup all local filesystems, as defined in mountpoint_device
 
-for k in "${BACKUP_PROG_INCLUDE[@]}" ; do
-	test "$k" && echo "$k"
+# Backup all that is explicitly specified in BACKUP_PROG_INCLUDE:
+for backup_include_item in "${BACKUP_PROG_INCLUDE[@]}" ; do
+    test "$backup_include_item" && echo "$backup_include_item"
 done > $TMP_DIR/backup-include.txt
 
-# if we are in MANUAL_INCLUDE mode, there is no need to
-# include anything more. So skip this part if MANUAL_INCLUDE == "YES"
-if [ "${MANUAL_INCLUDE:-NO}" != "YES" ] ; then
-	# add the mountpoints that will be recovered to the backup include list
-	while read mountpoint device junk ; do
-		if ! IsInArray "$mountpoint" "${EXCLUDE_MOUNTPOINTS[@]}" ; then
-			echo "$mountpoint"
-		fi
-	done <"$VAR_DIR/recovery/mountpoint_device" >> $TMP_DIR/backup-include.txt
+# Implicitly also backup all local filesystems as defined in mountpoint_device
+# except BACKUP_ONLY_INCLUDE or MANUAL_INCLUDE is set:
+if ! is_true "$BACKUP_ONLY_INCLUDE" ; then
+    if [ "${MANUAL_INCLUDE:-NO}" != "YES" ] ; then
+        # Add the mountpoints that will be recovered to the backup include list
+        # unless a mountpoint is excluded:
+        while read mountpoint device junk ; do
+            if ! IsInArray "$mountpoint" "${EXCLUDE_MOUNTPOINTS[@]}" ; then
+                echo "$mountpoint"
+            fi
+        done <"$VAR_DIR/recovery/mountpoint_device" >> $TMP_DIR/backup-include.txt
+    fi
 fi
 
-# exclude list
-for k in "${BACKUP_PROG_EXCLUDE[@]}" ; do
-	test "$k" && echo "$k"
+# Exclude all that is explicitly specified in BACKUP_PROG_EXCLUDE:
+for backup_exclude_item in "${BACKUP_PROG_EXCLUDE[@]}" ; do
+    test "$backup_exclude_item" && echo "$backup_exclude_item"
 done > $TMP_DIR/backup-exclude.txt
-# add also the excluded mount points to the backup exclude list
-for k in "${EXCLUDE_MOUNTPOINTS[@]}" ; do
-	test "$k" && echo "$k/"
-done >> $TMP_DIR/backup-exclude.txt
+
+# Implicitly also add excluded mountpoints to the backup exclude list
+# except BACKUP_ONLY_EXCLUDE is set:
+if ! is_true "$BACKUP_ONLY_EXCLUDE" ; then
+    for excluded_mountpoint in "${EXCLUDE_MOUNTPOINTS[@]}" ; do
+        test "$excluded_mountpoint" && echo "$excluded_mountpoint/"
+    done >> $TMP_DIR/backup-exclude.txt
+fi
 

--- a/usr/share/rear/backup/readme
+++ b/usr/share/rear/backup/readme
@@ -1,10 +1,10 @@
-00-09: initialization
-10-19: mount NETFS
-20-29: create prefix dir, etc.
-30-39: specials like SELinux (stop)
-40-49: create include/exclude files for backup
-50-59: backup itself
-60-69: specials like SELinux (start)
-70-79: umount NETFS
-80-89:
-90-99:
+000-099: initialization
+100-199: mount NETFS
+200-299: create prefix dir, etc.
+300-399: specials like SELinux (stop)
+400-499: create include/exclude files for backup
+500-599: backup itself
+600-699: specials like SELinux (start)
+700-799: umount NETFS
+800-899:
+900-999:

--- a/usr/share/rear/init/default/050_check_rear-recover_mode.sh
+++ b/usr/share/rear/init/default/050_check_rear-recover_mode.sh
@@ -1,5 +1,16 @@
-# When booted from ReaR image the only only workflow is 'recover' and
-# when booted from ReaR image /etc/rear-release is unique (does not exist otherwise):
-if [[ -f /etc/rear-release ]] && [[ "$WORKFLOW" != "recover" ]] ; then
-    Error "The workflow $WORKFLOW is not supported when booted from ReaR rescue image"
+# In the ReaR rescue/recovery system the only possible workflow is 'recover'
+# and its partial workflows 'layoutonly' 'restoreonly' 'finalizeonly'
+# cf. https://github.com/rear/rear/issues/987
+# and https://github.com/rear/rear/issues/1088
+# In the ReaR rescue/recovery system /etc/rear-release is unique (it does not exist otherwise):
+if test -f /etc/rear-release ; then
+    case "$WORKFLOW" in
+        (recover|layoutonly|restoreonly|finalizeonly)
+            LogPrint "Running workflow $WORKFLOW within the ReaR rescue/recovery system"
+            ;;
+        (*)
+            Error "The workflow $WORKFLOW is not supported in the ReaR rescue/recovery system"
+            ;;
+    esac
 fi
+

--- a/usr/share/rear/lib/finalizeonly-workflow.sh
+++ b/usr/share/rear/lib/finalizeonly-workflow.sh
@@ -9,8 +9,8 @@ WORKFLOW_finalizeonly_DESCRIPTION="only finalize the recovery"
 WORKFLOWS=( ${WORKFLOWS[@]} finalizeonly )
 function WORKFLOW_finalizeonly () {
     SourceStage "setup"
-    # SourceStage "verify"
-    # SourceStage "layout/prepare"
+    SourceStage "verify"
+    SourceStage "layout/prepare"
     # SourceStage "layout/recreate"
     # SourceStage "restore"
     SourceStage "finalize"

--- a/usr/share/rear/lib/finalizeonly-workflow.sh
+++ b/usr/share/rear/lib/finalizeonly-workflow.sh
@@ -1,0 +1,19 @@
+# finalizeonly-workflow.sh
+#
+# finalizeonly workflow for Relax-and-Recover
+#
+# This file is part of Relax-and-Recover, licensed under the GNU General
+# Public License. Refer to the included COPYING for full text of license.
+
+WORKFLOW_finalizeonly_DESCRIPTION="only finalize the recovery"
+WORKFLOWS=( ${WORKFLOWS[@]} finalizeonly )
+function WORKFLOW_finalizeonly () {
+    SourceStage "setup"
+    # SourceStage "verify"
+    # SourceStage "layout/prepare"
+    # SourceStage "layout/recreate"
+    # SourceStage "restore"
+    SourceStage "finalize"
+    SourceStage "wrapup"
+}
+

--- a/usr/share/rear/lib/layoutonly-workflow.sh
+++ b/usr/share/rear/lib/layoutonly-workflow.sh
@@ -14,6 +14,6 @@ function WORKFLOW_layoutonly () {
     SourceStage "layout/recreate"
     # SourceStage "restore"
     # SourceStage "finalize"
-    SourceStage "wrapup"
+    # SourceStage "wrapup"
 }
 

--- a/usr/share/rear/lib/layoutonly-workflow.sh
+++ b/usr/share/rear/lib/layoutonly-workflow.sh
@@ -1,0 +1,19 @@
+# layoutonly-workflow.sh
+#
+# layoutonly workflow for Relax-and-Recover
+#
+# This file is part of Relax-and-Recover, licensed under the GNU General
+# Public License. Refer to the included COPYING for full text of license.
+
+WORKFLOW_layoutonly_DESCRIPTION="recreate only the disk layout"
+WORKFLOWS=( ${WORKFLOWS[@]} layoutonly )
+function WORKFLOW_layoutonly () {
+    SourceStage "setup"
+    # SourceStage "verify"
+    SourceStage "layout/prepare"
+    SourceStage "layout/recreate"
+    # SourceStage "restore"
+    # SourceStage "finalize"
+    SourceStage "wrapup"
+}
+

--- a/usr/share/rear/lib/restoreonly-workflow.sh
+++ b/usr/share/rear/lib/restoreonly-workflow.sh
@@ -1,0 +1,19 @@
+# restoreonly-workflow.sh
+#
+# restoreonly workflow for Relax-and-Recover
+#
+# This file is part of Relax-and-Recover, licensed under the GNU General
+# Public License. Refer to the included COPYING for full text of license.
+
+WORKFLOW_restoreonly_DESCRIPTION="restore only the backup"
+WORKFLOWS=( ${WORKFLOWS[@]} restoreonly )
+function WORKFLOW_restoreonly () {
+    SourceStage "setup"
+    SourceStage "verify"
+    # SourceStage "layout/prepare"
+    # SourceStage "layout/recreate"
+    SourceStage "restore"
+    # SourceStage "finalize"
+    SourceStage "wrapup"
+}
+

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -25,10 +25,10 @@ fi
 # so that the user config LOGFILE basename is used as final logfile name:
 final_logfile_name=$( basename $LOGFILE )
 cat "$REAR_LOGFILE" > "$TMP_DIR/$final_logfile_name" || Error "Could not copy $REAR_LOGFILE to $TMP_DIR/$final_logfile_name"
-LogPrint "Saving $REAR_LOGFILE as $final_logfile_name to network output location"
+LogPrint "Saving $REAR_LOGFILE as $final_logfile_name to $scheme location"
 
-# Add the README, VERSION and rear.log to the RESULT_FILES array
-RESULT_FILES=( "${RESULT_FILES[@]}" "$TMP_DIR/VERSION" "$TMP_DIR/README" "$TMP_DIR/rear.log" )
+# Add the README, VERSION and the final logfile to the RESULT_FILES array
+RESULT_FILES=( "${RESULT_FILES[@]}" "$TMP_DIR/VERSION" "$TMP_DIR/README" "$TMP_DIR/$final_logfile_name" )
 
 # For example for "rear mkbackuponly" there are usually no result files
 # that would need to be copied here to the network output location:

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -20,11 +20,12 @@ if test -s $(get_template "RESULT_usage_$OUTPUT.txt") ; then
 fi
 
 # Usually REAR_LOGFILE=/var/log/rear/rear-$HOSTNAME.log
-# The  REAR_LOGFILE name set by main script from LOGFILE in default.conf
+# The REAR_LOGFILE name set by main script from LOGFILE in default.conf
 # but later user config files are sourced in main script where LOGFILE can be set different
-# so that the user config LOGFILE setting is used as final logfile name:
-cat "$REAR_LOGFILE" > "$TMP_DIR/$LOGFILE" || Error "Could not copy $REAR_LOGFILE to $TMP_DIR/$LOGFILE"
-LogPrint "Saving $REAR_LOGFILE as $LOGFILE to network output location"
+# so that the user config LOGFILE basename is used as final logfile name:
+final_logfile_name=$( basename $LOGFILE )
+cat "$REAR_LOGFILE" > "$TMP_DIR/$final_logfile_name" || Error "Could not copy $REAR_LOGFILE to $TMP_DIR/$final_logfile_name"
+LogPrint "Saving $REAR_LOGFILE as $final_logfile_name to network output location"
 
 # Add the README, VERSION and rear.log to the RESULT_FILES array
 RESULT_FILES=( "${RESULT_FILES[@]}" "$TMP_DIR/VERSION" "$TMP_DIR/README" "$TMP_DIR/rear.log" )

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -19,9 +19,12 @@ if test -s $(get_template "RESULT_usage_$OUTPUT.txt") ; then
     StopIfError "Could not copy '$(get_template RESULT_usage_$OUTPUT.txt)'"
 fi
 
-# REAR_LOGFILE=/var/log/rear/rear-$HOSTNAME.log (name set by main script)
-cat "$REAR_LOGFILE" > "$TMP_DIR/rear.log" || Error "Could not copy $REAR_LOGFILE to $TMP_DIR/rear.log"
-Log "Saving $REAR_LOGFILE as rear.log"
+# Usually REAR_LOGFILE=/var/log/rear/rear-$HOSTNAME.log
+# The  REAR_LOGFILE name set by main script from LOGFILE in default.conf
+# but later user config files are sourced in main script where LOGFILE can be set different
+# so that the user config LOGFILE setting is used as final logfile name:
+cat "$REAR_LOGFILE" > "$TMP_DIR/$LOGFILE" || Error "Could not copy $REAR_LOGFILE to $TMP_DIR/$LOGFILE"
+LogPrint "Saving $REAR_LOGFILE as $LOGFILE to network output location"
 
 # Add the README, VERSION and rear.log to the RESULT_FILES array
 RESULT_FILES=( "${RESULT_FILES[@]}" "$TMP_DIR/VERSION" "$TMP_DIR/README" "$TMP_DIR/rear.log" )

--- a/usr/share/rear/rescue/default/910_copy_logfile.sh
+++ b/usr/share/rear/rescue/default/910_copy_logfile.sh
@@ -1,5 +1,10 @@
-# copy current unfinished logfile to initramfs for debug purpose
-
-Log "Copying logfile $LOGFILE into initramfs as '/tmp/rear-partial-$(date -Iseconds).log'"
+# Copy current unfinished logfile to initramfs for debug purpose.
+# Usually REAR_LOGFILE=/var/log/rear/rear-$HOSTNAME.log
+# The REAR_LOGFILE name set by main script from LOGFILE in default.conf
+# but later user config files are sourced in main script where LOGFILE can be set different
+# so that the user config LOGFILE basename (except a trailing '.log') is used as target logfile name:
+logfile_basename=$( basename $LOGFILE )
+LogPrint "Copying logfile $REAR_LOGFILE into initramfs as '/tmp/${logfile_basename%.*}-partial-$(date -Iseconds).log'"
 mkdir -p $v $ROOTFS_DIR/tmp >&2
-cp -a $v $LOGFILE $ROOTFS_DIR/tmp/rear-partial-$(date -Iseconds).log >&2
+cp -a $v $REAR_LOGFILE $ROOTFS_DIR/tmp/${logfile_basename%.*}-partial-$(date -Iseconds).log >&2
+

--- a/usr/share/rear/restore/default/050_remount_async.sh
+++ b/usr/share/rear/restore/default/050_remount_async.sh
@@ -1,0 +1,14 @@
+#
+# For the restoreonly WORKFLOW remount everything without sync option
+# otherwise the restore would be terribly slow.
+# Things may have been remounted with sync option in a preceding recover WORKFLOW
+# via finalize/default/900_remount_sync.sh
+#
+if test "restoreonly" = "$WORKFLOW" ; then
+    while read mountpoint device mountby filesystem junk ; do
+        if ! mount -o remount,async "${device}" $TARGET_FS_ROOT"$mountpoint" ; then
+            LogPrint "Remount async of '${device}' failed which can result very slow restore"
+        fi
+    done < "${VAR_DIR}/recovery/mountpoint_device"
+fi
+

--- a/usr/share/rear/restore/default/995_remount_sync.sh
+++ b/usr/share/rear/restore/default/995_remount_sync.sh
@@ -1,0 +1,17 @@
+#
+# At the end of the restoreonly WORKFLOW remount everything again with sync option
+# so that the user can still do stuff but rebooting without umount is not so tragic any more
+# cf. finalize/default/900_remount_sync.sh in the recover WORKFLOW
+#
+if test "restoreonly" = "$WORKFLOW" ; then
+    while read mountpoint device mountby filesystem junk ; do
+        if ! mount -o remount,sync "${device}" $TARGET_FS_ROOT"$mountpoint" ; then
+            LogPrint "Remount sync of '${device}' failed. Do not reboot without umount."
+            # Cf. /bin/reboot in the ReaR rescue/recovery system:
+            LogPrint "syncing disks and waiting 3 seconds..."
+            sync
+            sleep 3
+        fi
+    done < "${VAR_DIR}/recovery/mountpoint_device"
+fi
+

--- a/usr/share/rear/restore/readme
+++ b/usr/share/rear/restore/readme
@@ -1,12 +1,12 @@
 This is the "restore" tree of Relax-and-Recover
 -----------------------------------------------
-00-09	initialisation, e.g. copy dev-files needed for external backups progs
-10-19	do mounting if necessary (NETFS)
-20-29	user interaction scripts, e.g. do restore via 3th party software
-30-39	exec pre-exec scripts
-40-49	exec the restore itself
-50-59	exec the post-exec scripts
-60-69	reserved
-70-79	umount (NETFS)
-80-89	reserved
-90-99	finalisation scripts
+000-099 initialisation, e.g. copy dev-files needed for external backups progs
+100-199 do mounting if necessary (NETFS)
+200-299	user interaction scripts, e.g. do restore via 3th party software
+300-399	exec pre-exec scripts
+400-499	exec the restore itself
+500-599	exec the post-exec scripts
+600-699	reserved
+700-799	umount (NETFS)
+800-899	reserved
+900-999	finalisation scripts


### PR DESCRIPTION
Now there is a new restoreonly workflow
that is a part of the (unchanged) recover workflow
namely the part that does only restore a backup,
see https://github.com/rear/rear/issues/987
which is a prerequirement for
https://github.com/rear/rear/issues/1088
"support multiple backups".



