### PR TITLE
Skip remount sync when systemd is used (issue1097)

### DIFF
--- a/usr/share/rear/finalize/default/900_remount_sync.sh
+++ b/usr/share/rear/finalize/default/900_remount_sync.sh
@@ -1,9 +1,29 @@
 #
-# remount everything with sync option
+# At the end of the recover WORKFLOW
+# remount all what is mounted below /mnt/local with sync option.
 #
-# user can still do stuff but rebooting without umount is not so tragic any more.
+# User can still do stuff after "rear recover" had finished
+# but rebooting without umount is not so tragic any more.
+# On the other hand remounting with sync option could become
+# in practice a major annoyance because it makes writing
+# anything below /mnt/local basically unusable slow,
+# see https://github.com/rear/rear/issues/1097
 #
+# Remounting with sync option is no longer needed when systemd is used because
+# when systemd is used reboot, halt, poweroff, and shutdown are replaced by
+# scripts that do umount plus sync to safely shut down the recovery system,
+# cf. https://github.com/rear/rear/pull/1011
+
+# Skip if not recover WORKFLOW:
+test "recover" = "$WORKFLOW" || return 0
+
+# Skip if systemd is used
+# systemctl gets copied into the recovery system as /bin/systemctl:
+test -x /bin/systemctl && return 0
+
+# Remount with sync option of all what is mounted below /mnt/local:
 while read mountpoint device mountby filesystem junk ; do
         mount -o remount,sync "${device}" $TARGET_FS_ROOT"$mountpoint"
         LogIfError "Remount sync of '${device}' failed"
 done < "${VAR_DIR}/recovery/mountpoint_device"
+

--- a/usr/share/rear/restore/default/050_remount_async.sh
+++ b/usr/share/rear/restore/default/050_remount_async.sh
@@ -3,12 +3,15 @@
 # otherwise the restore would be terribly slow.
 # Things may have been remounted with sync option in a preceding recover WORKFLOW
 # via finalize/default/900_remount_sync.sh
+# see also https://github.com/rear/rear/issues/1097
 #
-if test "restoreonly" = "$WORKFLOW" ; then
-    while read mountpoint device mountby filesystem junk ; do
-        if ! mount -o remount,async "${device}" $TARGET_FS_ROOT"$mountpoint" ; then
-            LogPrint "Remount async of '${device}' failed which can result very slow restore"
-        fi
-    done < "${VAR_DIR}/recovery/mountpoint_device"
-fi
+
+# Skip if not restoreonly WORKFLOW:
+test "restoreonly" = "$WORKFLOW" || return 0
+
+while read mountpoint device mountby filesystem junk ; do
+    if ! mount -o remount,async "${device}" $TARGET_FS_ROOT"$mountpoint" ; then
+        LogPrint "Remount async of '${device}' failed which can result very slow restore"
+    fi
+done < "${VAR_DIR}/recovery/mountpoint_device"
 

--- a/usr/share/rear/restore/default/995_remount_sync.sh
+++ b/usr/share/rear/restore/default/995_remount_sync.sh
@@ -1,17 +1,34 @@
 #
-# At the end of the restoreonly WORKFLOW remount everything again with sync option
-# so that the user can still do stuff but rebooting without umount is not so tragic any more
+# At the end of the restoreonly WORKFLOW
+# remount all what is mounted below /mnt/local with sync option.
 # cf. finalize/default/900_remount_sync.sh in the recover WORKFLOW
 #
-if test "restoreonly" = "$WORKFLOW" ; then
-    while read mountpoint device mountby filesystem junk ; do
-        if ! mount -o remount,sync "${device}" $TARGET_FS_ROOT"$mountpoint" ; then
-            LogPrint "Remount sync of '${device}' failed. Do not reboot without umount."
-            # Cf. /bin/reboot in the ReaR rescue/recovery system:
-            LogPrint "syncing disks and waiting 3 seconds..."
-            sync
-            sleep 3
-        fi
-    done < "${VAR_DIR}/recovery/mountpoint_device"
-fi
+# User can still do stuff after "rear recover" had finished
+# but rebooting without umount is not so tragic any more.
+# On the other hand remounting with sync option could become
+# in practice a major annoyance because it makes writing
+# anything below /mnt/local basically unusable slow,
+# see https://github.com/rear/rear/issues/1097
+#
+# Remounting with sync option is no longer needed when systemd is used because
+# when systemd is used reboot, halt, poweroff, and shutdown are replaced by
+# scripts that do umount plus sync to safely shut down the recovery system,
+# cf. https://github.com/rear/rear/pull/1011
+
+# Skip if not restoreonly WORKFLOW:
+test "restoreonly" = "$WORKFLOW" || return 0
+
+# Skip if systemd is used
+# systemctl gets copied into the recovery system as /bin/systemctl:
+test -x /bin/systemctl && return 0
+
+while read mountpoint device mountby filesystem junk ; do
+    if ! mount -o remount,sync "${device}" $TARGET_FS_ROOT"$mountpoint" ; then
+        LogPrint "Remount sync of '${device}' failed. Do not reboot without umount."
+        # Cf. /bin/reboot in the ReaR rescue/recovery system:
+        LogPrint "syncing disks and waiting 3 seconds..."
+        sync
+        sleep 3
+    fi
+done < "${VAR_DIR}/recovery/mountpoint_device"
 


### PR DESCRIPTION
Remounting all what is mounted below /mnt/local
with sync option is no longer needed when systemd is used
because when systemd is used reboot, halt, poweroff,
and shutdown are replaced by scripts that do umount
plus sync to safely shut down the recovery system,
see https://github.com/rear/rear/pull/1011
and https://github.com/rear/rear/issues/1097

Furthermore remounting with sync option could become
in practice a major annoyance because it makes writing
anything below /mnt/local basically unusable slow,
see https://github.com/rear/rear/issues/1097
