### PR TITLE
Enhance logging and progress for running in parallel

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -124,11 +124,13 @@ function get_disk_used() {
 	let "$(stat -f -c 'used=(%b-%f)*%S' $1)"
 	echo $used
 }
-# while the backup runs in a sub-process, display some progress information to the user
-# ProgressInfo texts have a space at the end to get the 'OK' from ProgressStop shown separated
-case "$(basename ${BACKUP_PROG})" in
+
+# While the backup runs in a sub-process, display some progress information to the user.
+# ProgressInfo texts have a space at the end to get the 'OK' from ProgressStop shown separated.
+test "$PROGRESS_WAIT_SECONDS" || PROGRESS_WAIT_SECONDS=1
+case "$( basename $BACKUP_PROG )" in
 	(tar)
-		while sleep 1 ; kill -0 $BackupPID 2>&8; do
+		while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>&8; do
 			#blocks="$(stat -c %b ${backuparchive})"
 			#size="$((blocks*512))"
 			size="$(stat -c %s ${backuparchive}* | awk '{s+=$1} END {print s}')"
@@ -143,14 +145,14 @@ case "$(basename ${BACKUP_PROG})" in
 		# this should be good enough and in any case this is only some eye candy.
 		# TODO: Find a fast way to count the actual transfer data, preferrable getting the info from rsync.
 		let old_disk_used="$(get_disk_used "$backuparchive")"
-		while sleep 1 ; kill -0 $BackupPID 2>&8; do
+		while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>&8; do
 			let disk_used="$(get_disk_used "$backuparchive")" size=disk_used-old_disk_used
 			#echo -en "\e[2K\rArchived $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec]"
 			ProgressInfo "Archived $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec] "
 		done
 		;;
 	(*)
-		while sleep 1 ; kill -0 $BackupPID 2>&8; do
+		while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>&8; do
 			size="$(stat -c "%s" "$backuparchive")" || {
 				kill -9 $BackupPID
 				ProgressError

--- a/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
+++ b/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
@@ -66,12 +66,13 @@ check_remote_du() {
 # make sure that we don't fall for an old size info
 unset size
 # while the backup runs in a sub-process, display some progress information to the user
+test "$PROGRESS_WAIT_SECONDS" || PROGRESS_WAIT_SECONDS=1
 case "$(basename $BACKUP_PROG)" in
 
 	(rsync)
 		ofile=""
 		i=0
-		while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
+		while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null ; do
 			i=$((i+1))
 			[[ $i -gt 300 ]] && i=0
 			case $i in
@@ -101,7 +102,7 @@ case "$(basename $BACKUP_PROG)" in
 
 	(*)
 		ProgressInfo "Archiving"
-		while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
+		while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null ; do
 			ProgressStep
 		done
 		;;

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -74,7 +74,7 @@ readonly MASTER_PID=$$
 exec 7>&1
 QuietAddExitTask "exec 7>&-"
 # USR1 is used to abort on errors, not using Print to always print to the original STDOUT, even if quiet
-builtin trap "echo 'Aborting due to an error, check $LOGFILE for details' >&7 ; kill $MASTER_PID" USR1
+builtin trap "echo '${MESSAGE_PREFIX}Aborting due to an error, check $LOGFILE for details' >&7 ; kill $MASTER_PID" USR1
 
 # make sure nobody else can use trap
 function trap () {
@@ -109,7 +109,7 @@ function Error () {
     LogPrint "ERROR: $*"
     if has_binary caller ; then
         # Print stack strace in reverse order:
-        (   echo "=== Stack trace ==="
+        (   echo "==== ${MESSAGE_PREFIX}Stack trace ===="
             local c=0;
             while caller $((c++)) ; do
                 # nothing to do
@@ -117,8 +117,8 @@ function Error () {
             done | awk ' { l[NR]=$3":"$1" "$2 }
                          END { for (i=NR; i>0;) print "Trace "NR-i": "l[i--] }
                        '
-            echo "Message: $*"
-            echo "==================="
+            echo "${MESSAGE_PREFIX}Message: $*"
+            echo "== ${MESSAGE_PREFIX}End stack trace =="
         ) >&2
     fi
     LogToSyslog "ERROR: $*"
@@ -172,7 +172,7 @@ function Debug () {
 }
 
 function Print () {
-    test "$VERBOSE" && echo -e "$*" >&7 || true
+    test "$VERBOSE" && echo -e "${MESSAGE_PREFIX}$*" >&7 || true
 }
 
 # print if there is an error
@@ -195,9 +195,9 @@ fi
 
 function Log () {
     if test $# -gt 0 ; then
-        echo "$(Stamp)$*"
+        echo "${MESSAGE_PREFIX}$(Stamp)$*"
     else
-        echo "$(Stamp)$(cat)"
+        echo "${MESSAGE_PREFIX}$(Stamp)$(cat)"
     fi >&2
 }
 
@@ -246,6 +246,6 @@ ProgressInfo() {
 
 LogToSyslog() {
     # send a line to syslog or messages file with input string
-    logger -t rear -i "$*"
+    logger -t rear -i "${MESSAGE_PREFIX}$*"
 }
 

--- a/usr/share/rear/lib/progresssubsystem.nosh
+++ b/usr/share/rear/lib/progresssubsystem.nosh
@@ -1,38 +1,60 @@
-# call StartProgressSubsystem to get more detailed progress reports
-if tty -s <&1; then
-	ProgressStart() {
-		echo -en "\e[2K\r$*\e7"
-	}
 
-	ProgressStop() {
-		echo -e "\e8\e[KOK"
-	}
+####################### BEGIN Progress Indicator
+# Call StartProgressSubsystem to get more detailed progress reports:
+if tty -s <&1 ; then
+    # There is a tty on stdout.
+    if test "plain" = "$PROGRESS_MODE" ; then
+        # The 'plain' progress mode outputs the same content
+        # as below but without ANSI escape sequences:
+        function ProgressStart () {
+            echo "${MESSAGE_PREFIX}$*"
+        }
+        function ProgressStop () {
+            echo "${MESSAGE_PREFIX}OK"
+        }
+        function ProgressError () {
+            echo "${MESSAGE_PREFIX}FAILED"
+        }
+        function ProgressInfo () {
+            echo "${MESSAGE_PREFIX}$*"
+        }
 
-	ProgressError() {
-		echo -e "\e8\e[KFAILED"
-	}
-
-	ProgressStep() {
-		echo noop >&8
-	}
-
-	ProgressInfo() {
-		echo -en "\e[2K\r$*\e7"
-	}
-
+    else
+        # If the 'plain' progress mode is not explicitly requested
+        # (default/fallback behaviour when there is a tty on stdout)
+        # do progress animated display via ANSI escape sequences,
+        # see http://ascii-table.com/ansi-escape-sequences-vt-100.php
+        # for the ANSI escape sequences as they appear below:
+        #   Esc[2K : Clear entire line
+        #   Esc7   : Save cursor position and attributes
+        #   Esc8   : Restore cursor position and attributes
+        #   Esc[K  : Clear line from cursor right
+        function ProgressStart () {
+            echo -en "\e[2K\r${MESSAGE_PREFIX}$*\e7"
+        }
+        function ProgressStop () {
+            echo -e "\e8\e[K${MESSAGE_PREFIX}OK"
+        }
+        function ProgressError () {
+            echo -e "\e8\e[K${MESSAGE_PREFIX}FAILED"
+        }
+        function ProgressInfo () {
+            echo -en "\e[2K\r${MESSAGE_PREFIX}$*\e7"
+        }
+    fi
 else
-	# no tty, disable progress animated display altogether
-	ProgressStart() {
-		echo -n "$*  "
-	}
-
-	ProgressStop() {
-		echo -e "OK"
-	}
-
-	ProgressError() {
-		echo -e "FAILED"
-	}
+    # No tty on stdout, disable progress animated display altogether.
+    # The main difference to the 'plain' progress mode above is that
+    # there is no ProgressInfo when there is no tty on stdout:
+    function ProgressStart () {
+        echo -n "${MESSAGE_PREFIX}$*"
+    }
+    function ProgressStop () {
+        echo -e "${MESSAGE_PREFIX}OK"
+    }
+    function ProgressError () {
+        echo -e "${MESSAGE_PREFIX}FAILED"
+    }
 fi
 ####################### END Progress Indicator
 

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -137,14 +137,15 @@ for restoreinput in "${RESTORE_ARCHIVES[@]}" ; do
     # make sure that we don't fall for an old size info
     unset size
 
-    # While the backup runs in a sub-process, display some progress information to the user.
+    # While the backup restore runs in a sub-process, display some progress information to the user.
     # ProgressInfo texts have a space at the end to get the 'OK' from ProgressStop shown separated.
+    test "$PROGRESS_WAIT_SECONDS" || PROGRESS_WAIT_SECONDS=1
     ProgressStart "Restoring... "
     case "$BACKUP_PROG" in
         (tar)
             # Sleep one second to be on the safe side before testing that the backup sub-process is running and
             # avoid "kill: (BackupPID) - No such process" output when the backup sub-process has finished:
-            while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
+            while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null ; do
                 blocks="$( tail -1 "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log" | awk 'BEGIN { FS="[ :]" } /^block [0-9]+: / { print $2 }' )"
                 size="$((blocks*512))"
                 if [ -f ${TMP_DIR}/wait_dvd ] ; then
@@ -158,7 +159,7 @@ for restoreinput in "${RESTORE_ARCHIVES[@]}" ; do
             ;;
         (*)
             # Display some rather meaningless info to shows at least that restoring is still going on:
-            while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
+            while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null ; do
                 restore_seconds="$((SECONDS-starttime))"
                 ProgressInfo "Restoring for $restore_seconds seconds... "
             done

--- a/usr/share/rear/restore/RBME/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/RBME/default/400_restore_backup.sh
@@ -30,7 +30,8 @@ sleep 1 # Give the backup software a good chance to start working
 # make sure that we don't fall for an old size info
 unset size
 # while the restore runs in a sub-process, display some progress information to the user
-while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
+test "$PROGRESS_WAIT_SECONDS" || PROGRESS_WAIT_SECONDS=1
+while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null ; do
     size=$( df -P $TARGET_FS_ROOT | tail -1 | awk '{print $3}' )
     ProgressInfo "Restored $((size/1024)) MiB [avg $((size/(SECONDS-starttime))) KiB/sec]"
 done

--- a/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
+++ b/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
@@ -47,10 +47,11 @@ sleep 3 # Give the backup software a good chance to start working
 # make sure that we don't fall for an old size info
 unset size
 # while the restore runs in a sub-process, display some progress information to the user
+test "$PROGRESS_WAIT_SECONDS" || PROGRESS_WAIT_SECONDS=1
 case "$(basename $BACKUP_PROG)" in
 	(rsync)
 		
-		while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
+		while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null ; do
 			fsize=$(get_size "$(tail -2 "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log" | head -n 1)")
 			size=$((size+fsize))
 			ProgressInfo "Restored $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec]"
@@ -60,7 +61,7 @@ case "$(basename $BACKUP_PROG)" in
 	(*)
 
 		ProgressInfo "Restoring"
-		while sleep 1 ; kill -0 $BackupPID 2>/dev/null ; do
+		while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null ; do
 			ProgressStep
 		done
 		;;


### PR DESCRIPTION
Added support for a new variable MESSAGE_PREFIX
that is by default empty so that by default nothing changes
but the user can set it e.g. to MESSAGE_PREFIX="PID$$: "
to get the messages of ReaR output functions
prefixed with ${MESSAGE_PREFIX}.

Added support for a new variable PROGRESS_MODE that
can be PROGRESS_MODE="ANSI" (default/fallback behaviour)
or PROGRESS_MODE="plain" which outputs the same messages
as in default 'ANSI' mode but without ANSI escape sequences.

Added support for a new variable PROGRESS_WAIT_SECONDS
that specifies the number of seconds between progress messages
that are aoutput while a longer task (usually backup or restore) runs.
The default/fallback is 1 second to keep the current behaviour.

Setting at least MESSAGE_PREFIX="PID$$: "
and PROGRESS_MODE="plain" is needed to get
still usable (i.e. meaningful) output when multiple
"rear mkbackuponly" or "rear restoreonly" run in parallel.

Optionally setting PROGRESS_WAIT_SECONDS="5"
results much less progress messages but at the same time
it delays continuing after the task (e.g. backup or restore)
had finished by half that time on average up to at most
the whole amount of PROGRESS_WAIT_SECONDS.
