### PR TITLE
Allow multiple mkbackuponly or restoreonly running in parallel

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -302,21 +302,36 @@ done
 if IsInArray "$WORKFLOW" "${LOCKLESS_WORKFLOWS[@]}" ; then
     LOGFILE="$LOGFILE.lockless"
 else
-    # When this currently running instance is not one of the LOCKLESS_WORKFLOWS
-    # then it cannot run simultaneously with another instance
-    # in this case pidof is needed to test what running instances there are:
-    if ! has_binary pidof ; then
-        echo "ERROR: Required program 'pidof' missing, please check your PATH" >&2
-        exit 1
-    fi
-    # For unknown reasons '-o %PPID' does not work for pidof at least in SLES11
-    # so that a manual test is done to find out if another pid != $$ is running:
-    for pid in $( pidof -x "$SCRIPT_FILE" ) ; do
-        if test "$pid" != $$ ; then
-            echo "ERROR: $PROGRAM is already running, not starting again" >&2
+    # SIMULTANEOUS_RUNNABLE_WORKFLOWS are allowed to run simultaneously
+    # but cannot use LOGFILE.lockless instead they get a LOGFILE with PID
+    # see https://github.com/rear/rear/issues/1102
+    if  IsInArray "$WORKFLOW" "${SIMULTANEOUS_RUNNABLE_WORKFLOWS[@]}" ; then
+        # Simultaneously runnable workflows require unique logfile names
+        # so that the PID is interposed in the LOGFILE value from default.conf
+        # which is used below as REAR_LOGFILE while the workflow is running
+        # and at the end it gets copied to a possibly used-defined LOGFILE.
+        # The logfile_suffix also works for logfile names without '.*' suffix
+        # (in this case ${LOGFILE##*.} returns the whole $LOGFILE value):
+        logfile_suffix=$( test "${LOGFILE##*.}" = "$LOGFILE" && echo 'log' || echo "${LOGFILE##*.}" )
+        LOGFILE="${LOGFILE%.*}.$$.$logfile_suffix"
+    else
+        # When this currently running instance is not one of the LOCKLESS_WORKFLOWS
+        # and not one of the SIMULTANEOUS_RUNNABLE_WORKFLOWS
+        # then it cannot run simultaneously with another instance.
+        # In this case pidof is needed to test what running instances there are:
+        if ! has_binary pidof ; then
+            echo "ERROR: Required program 'pidof' missing, please check your PATH" >&2
             exit 1
         fi
-    done
+        # For unknown reasons '-o %PPID' does not work for pidof at least in SLES11
+        # so that a manual test is done to find out if another pid != $$ is running:
+        for pid in $( pidof -x "$SCRIPT_FILE" ) ; do
+            if test "$pid" != $$ ; then
+                echo "ERROR: $PROGRAM is already running, not starting again" >&2
+                exit 1
+            fi
+        done
+    fi
 fi
 
 # Keep old log file:
@@ -338,16 +353,10 @@ fi
 
 v=""
 verbose=""
-# Enable progress subsystem only in verbose mode, set some stuff that others can use:
 if test "$VERBOSE" ; then
-    source $SHARE_DIR/lib/progresssubsystem.nosh
     v="-v"
     verbose="--verbose"
 fi
-
-# Enable debug output of the progress pipe
-# (no readonly KEEP_BUILD_DIR because it is also set to 1 in build/default/980_verify_rootfs.sh):
-test "$DEBUG" && KEEP_BUILD_DIR=1 || true
 
 # Check if we are in recovery mode:
 test -e "/etc/rear-release" && RECOVERY_MODE="y" || true
@@ -381,10 +390,22 @@ done
 if test "$CONFIG_APPEND_FILES" ; then
     for config_append_file in $CONFIG_APPEND_FILES ; do
         # If what is specified on the command line starts with '/' an absolute path is meant
-        # otherwise what is specified on the command line means a file in CONFIG_DIR:
+        # otherwise what is specified on the command line means a file in CONFIG_DIR.
+        # Files in CONFIG_DIR get automatically copied into the recovery system but
+        # other files are added to COPY_AS_IS to get them copied into the recovery system:
         case "$config_append_file" in
             (/*)
                 config_append_file_path="$config_append_file"
+                # If "-C foo" was specified on the command line but 'foo' does not exist
+                # try if 'foo.conf' exists and if yes, use that:
+                if test -r "$config_append_file_path" ; then
+                    COPY_AS_IS=( "${COPY_AS_IS[@]}" "$config_append_file_path" )
+                else if test -r "$config_append_file_path.conf" ; then
+                         COPY_AS_IS=( "${COPY_AS_IS[@]}" "$config_append_file_path.conf" )
+                     else
+                         Error "There is '-C $config_append_file' but neither '$config_append_file_path' nor '$config_append_file_path.conf' can be read."
+                     fi
+                fi
                 ;;
             (*)
                 config_append_file_path="$CONFIG_DIR/$config_append_file"
@@ -399,13 +420,23 @@ if test "$CONFIG_APPEND_FILES" ; then
                  LogPrint "Sourcing additional configuration file '$config_append_file_path.conf'"
                  Source "$config_append_file_path.conf"
              else
-                 Error "There is '-C $config_append_file' requested but neither '$config_append_file_path' nor '$config_append_file_path.conf' can be read."
+                 Error "There is '-C $config_append_file' but neither '$config_append_file_path' nor '$config_append_file_path.conf' can be read."
              fi
         fi
     done
 fi
+
 # Now SHARE_DIR CONFIG_DIR VAR_DIR LOG_DIR and KERNEL_VERSION should be set to a fixed value:
 readonly SHARE_DIR CONFIG_DIR VAR_DIR LOG_DIR KERNEL_VERSION
+
+# Enable progress subsystem only in verbose mode, set some stuff that others can use:
+if test "$VERBOSE" ; then
+    source $SHARE_DIR/lib/progresssubsystem.nosh
+fi
+
+# Enable debug output of the progress pipe
+# (no readonly KEEP_BUILD_DIR because it is also set to 1 in build/default/980_verify_rootfs.sh):
+test "$DEBUG" && KEEP_BUILD_DIR=1 || true
 
 SourceStage "init"
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -100,12 +100,25 @@ OS_VERSION=none
 # keep the build area after we are done ? (BOOL)
 KEEP_BUILD_DIR=""
 
-# no default workflows. This variable is filled in where the worklflows are defined
+# No default workflows. This variable is filled in where the workflows are defined
 # without the empty string as initial value WORKFLOWS and LOCKLESS_WORKFLOWS would
 # be unbound variables that would result an error exit if 'set -eu' is used:
 WORKFLOWS=("")
-# allow some workflows to not lock, also generates a separate log
+# Allow some workflows to not lock and use a separate logfile named 'LOGFILE.lockless'.
+# The LOCKLESS_WORKFLOWS array gets filled during runtime as needed by the various
+# usr/share/rear/lib/WORKFLOW-workflow.sh scripts. Currently the following workflows
+# add themselves to the LOCKLESS_WORKFLOWS array: checklayout dump help
 LOCKLESS_WORKFLOWS=("")
+# SIMULTANEOUS_RUNNABLE_WORKFLOWS are also allowed to run simultaneously
+# but cannot use LOGFILE.lockless as the LOCKLESS_WORKFLOWS.
+# Instead the SIMULTANEOUS_RUNNABLE_WORKFLOWS get a LOGFILE with PID
+# because simultaneously runnable workflows require unique logfile names
+# so that the PID is interposed in the LOGFILE value from default.conf above,
+# i.e. by default SIMULTANEOUS_RUNNABLE_WORKFLOWS use during runtime
+# a logfile named /var/log/rear/rear-$HOSTNAME.$$.log that gets
+# at the end copied to a final possibly used-defined LOGFILE,
+# see /usr/sbin/rear and https://github.com/rear/rear/issues/1102
+SIMULTANEOUS_RUNNABLE_WORKFLOWS=( 'mkbackuponly' 'restoreonly' )
 
 # default backup and output targets
 BACKUP=REQUESTRESTORE

--- a/usr/share/rear/lib/progresssubsystem.nosh
+++ b/usr/share/rear/lib/progresssubsystem.nosh
@@ -18,7 +18,6 @@ if tty -s <&1 ; then
         function ProgressInfo () {
             echo "${MESSAGE_PREFIX}$*"
         }
-
     else
         # If the 'plain' progress mode is not explicitly requested
         # (default/fallback behaviour when there is a tty on stdout)


### PR DESCRIPTION
New SIMULTANEOUS_RUNNABLE_WORKFLOWS variable
lists those workflows that are allowed to run simultaneously
but cannot use LOGFILE.lockless as the LOCKLESS_WORKFLOWS.
Instead the SIMULTANEOUS_RUNNABLE_WORKFLOWS
get a LOGFILE with PID because simultaneously runnable
workflows require unique logfile names, see
https://github.com/rear/rear/issues/1102

Additional enhancements and fixes in usr/sbin/rear:

CONFIG_APPEND_FILES that are not in CONFIG_DIR
get added to COPY_AS_IS to get them copied into the
recovery system.

Moved progress subsystem enablement
(i.e. source $SHARE_DIR/lib/progresssubsystem.nosh)
and enablement of debug output of the progress pipe
after the user config files had been read, because
otherwise a PROGRESS_MODE setting in a
user config file is not used when defining the
progress functions inprogresssubsystem.nosh


