### PR TITLE
Support partitioning and formatting huge USB devices

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -304,11 +304,29 @@ ISO_DEFAULT=boothd
 #
 # NOTE: "USB" means any local block-storage device and includes also eSATA and other external disks
 
-# the device to use, set automatically by BACKUP=NETFS and BACKUP_URL=usb:///dev/sdb1
+# The device to use, set automatically by BACKUP=NETFS and BACKUP_URL=usb:///dev/sdb1
 USB_DEVICE=
 
-# default size of UEFI partition on USB disk in [MB]
+# Size of UEFI partition in MB when formatting a medium for use with ReaR via the format workflow:
 USB_UEFI_PART_SIZE=100
+
+# Filesystem to use when formatting a medium for use with ReaR via the format workflow.
+# Only ext3 and ext4 are supported by the format workflow.
+# The default ext3 should work up to a maximum medium size of about 4TB
+# while ext4 should work up to a maximum medium size of about 16TB.
+# For larger medium sizes set USB_DEVICE_FILESYSTEM_PERCENTAGE appropriately
+# so that what is used for ReaR partitions by the format workflow
+# does not exceed what works for the specified USB_DEVICE_FILESYSTEM:
+USB_DEVICE_FILESYSTEM=ext3
+
+# Percentage of the whole medium that is used for ReaR partitions
+# when formatting a medium via the format workflow.
+# A setting of less than 100 (i.e. less than the whole medium)
+# does not leave any existing data intact on the medium.
+# The format workflow deletes all existing data on the the whole medium.
+# A setting of less than 100 only leaves unused space on the medium
+# which can be manually used otherwise by the user:
+USB_DEVICE_FILESYSTEM_PERCENTAGE=100
 
 # resulting files that should be copied onto the USB stick
 USB_FILES=()

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -307,11 +307,19 @@ ISO_DEFAULT=boothd
 # The device to use, set automatically by BACKUP=NETFS and BACKUP_URL=usb:///dev/sdb1
 USB_DEVICE=
 
-# Size of UEFI partition in MB when formatting a medium for use with ReaR via the format workflow:
-USB_UEFI_PART_SIZE=100
+# The partition type that is used when formatting a medium for use with ReaR via the format workflow.
+# It can be 'msdos' to create a MBR partition table or 'gpt' to create a GUID partition table (GPT).
+# When UEFI is used the format workflow will create a GUID partition table in any case.
+# A MBR partition table limits the maximum usable storage space on the medium to 2TB.
+# For larger medium sizes use 'gpt'. If you must use a MBR partition table on a medium > 2TB
+# set USB_DEVICE_FILESYSTEM_PERCENTAGE appropriately so that what is used for ReaR does not exceed
+# what works with a MBR partition table but then you cannot use the remaining space on the medium:
+USB_DEVICE_PARTED_LABEL=msdos
 
-# Filesystem to use when formatting a medium for use with ReaR via the format workflow.
+# Filesystem to use for the 'REAR-000' labeled ReaR data partition
+# when formatting a medium for use with ReaR via the format workflow.
 # Only ext3 and ext4 are supported by the format workflow.
+# (An additional EFI system partition uses the vfat filesystem in any case.)
 # The default ext3 should work up to a maximum medium size of about 4TB
 # while ext4 should work up to a maximum medium size of about 16TB.
 # For larger medium sizes set USB_DEVICE_FILESYSTEM_PERCENTAGE appropriately
@@ -321,12 +329,20 @@ USB_DEVICE_FILESYSTEM=ext3
 
 # Percentage of the whole medium that is used for ReaR partitions
 # when formatting a medium via the format workflow.
+# When UEFI is used it specifies what is used by the format workflow for both partitions,
+# the EFI system partition (ESP) plus the 'REAR-000' labeled ReaR data partition.
 # A setting of less than 100 (i.e. less than the whole medium)
 # does not leave any existing data intact on the medium.
 # The format workflow deletes all existing data on the the whole medium.
 # A setting of less than 100 only leaves unused space on the medium
 # which can be manually used otherwise by the user:
 USB_DEVICE_FILESYSTEM_PERCENTAGE=100
+
+# When UEFI is used USB_UEFI_PART_SIZE specifies the size of the EFI system partition (ESP)
+# in MB when formatting a medium by the format workflow.
+# If USB_UEFI_PART_SIZE is empty or invalid (i.e. not an unsigned integer larger than 0)
+# the user must interactively enter a valid value while running the format workflow:
+USB_UEFI_PART_SIZE="100"
 
 # resulting files that should be copied onto the USB stick
 USB_FILES=()

--- a/usr/share/rear/format/USB/default/200_check_usb_layout.sh
+++ b/usr/share/rear/format/USB/default/200_check_usb_layout.sh
@@ -1,3 +1,4 @@
+
 [[ "$DEVICE" ]]
 StopIfError "USB device is not set."
 
@@ -33,7 +34,9 @@ fi
 [[ "$RAW_USB_DEVICE" && -b "$RAW_USB_DEVICE" ]]
 StopIfError "Unable to determine raw USB device for $REAL_USB_DEVICE"
 
-answer=""
+USB_format_answer=""
+
+test "ext3" = "$USB_DEVICE_FILESYSTEM" -o "ext4" = "$USB_DEVICE_FILESYSTEM" || USB_DEVICE_FILESYSTEM="ext3"
 
 file_output=$(file -sbL "$REAL_USB_DEVICE")
 ID_FS_TYPE=$(
@@ -55,11 +58,12 @@ ID_FS_TYPE=$(
 
 [[ "$ID_FS_TYPE" == btr* || "$ID_FS_TYPE" == ext* ]]
 if (( $? != 0 )) && [[ -z "$YES" ]]; then
-	echo "USB device $REAL_USB_DEVICE must be formatted with ext2/3/4 or btrfs file system"
-	echo -n "Please type Yes to format $REAL_USB_DEVICE in ext3 format: "
-	read answer
-	[ "$answer" == "Yes" ]
-	StopIfError "Abort USB format process by user"
+	echo "USB device $REAL_USB_DEVICE is not formatted with ext2/3/4 or btrfs filesystem"
+	echo -n "Type exactly 'Yes' to format $REAL_USB_DEVICE with $USB_DEVICE_FILESYSTEM filesystem: "
+	read USB_format_answer
+	[[ "$USB_format_answer" == "Yes" ]]
+	StopIfError "Abort USB format process by user (user input '$USB_format_answer' is not 'Yes')"
 elif [[ "$YES" ]]; then
-	answer="Yes"
+	USB_format_answer="Yes"
 fi
+

--- a/usr/share/rear/format/USB/default/200_check_usb_layout.sh
+++ b/usr/share/rear/format/USB/default/200_check_usb_layout.sh
@@ -58,8 +58,8 @@ ID_FS_TYPE=$(
 
 [[ "$ID_FS_TYPE" == btr* || "$ID_FS_TYPE" == ext* ]]
 if (( $? != 0 )) && [[ -z "$YES" ]]; then
-	echo "USB device $REAL_USB_DEVICE is not formatted with ext2/3/4 or btrfs filesystem"
-	echo -n "Type exactly 'Yes' to format $REAL_USB_DEVICE with $USB_DEVICE_FILESYSTEM filesystem: "
+	echo "${MESSAGE_PREFIX}USB device $REAL_USB_DEVICE is not formatted with ext2/3/4 or btrfs filesystem"
+	echo -n "${MESSAGE_PREFIX}Type exactly 'Yes' to format $REAL_USB_DEVICE with $USB_DEVICE_FILESYSTEM filesystem: "
 	read USB_format_answer
 	[[ "$USB_format_answer" == "Yes" ]]
 	StopIfError "Abort USB format process by user (user input '$USB_format_answer' is not 'Yes')"

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -13,8 +13,8 @@ if [[ "$EFI" == "y" ]]; then
     # Prompt user for size of EFI system partition on USB disk if no valid value is specified:
     while ! [[ "$USB_UEFI_PART_SIZE" =~ ^[0-9]+$ && $USB_UEFI_PART_SIZE > 0 ]] ; do
         # When USB_UEFI_PART_SIZE is empty, do not tell about "Invalid EFI partition size value":
-        test "$USB_UEFI_PART_SIZE" && echo "Invalid EFI system partition size value '$USB_UEFI_PART_SIZE' (must be unsigned integer larger than 0)"
-        echo -n "Enter size for EFI system partition on '$RAW_USB_DEVICE' in MB (plain 'Enter' defaults to 100 MB): "
+        test "$USB_UEFI_PART_SIZE" && echo "${MESSAGE_PREFIX}Invalid EFI system partition size value '$USB_UEFI_PART_SIZE' (must be unsigned integer larger than 0)"
+        echo -n "${MESSAGE_PREFIX}Enter size for EFI system partition on '$RAW_USB_DEVICE' in MB (plain 'Enter' defaults to 100 MB): "
         read USB_UEFI_PART_SIZE
         # Plain 'Enter' defaults to 100 MB (same as the default value in default.conf):
         test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="100"

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -6,64 +6,54 @@ umount $REAL_USB_DEVICE &>/dev/null
 
 LogPrint "Repartitioning '$RAW_USB_DEVICE'"
 
-echo "Yes" | parted -s $RAW_USB_DEVICE mklabel msdos >&2
-StopIfError "Could not create initial msdos partition table on '$REAL_USB_DEVICE'"
-
 test "$USB_DEVICE_FILESYSTEM_PERCENTAGE" || USB_DEVICE_FILESYSTEM_PERCENTAGE="100"
 
 if [[ "$EFI" == "y" ]]; then
-    LogPrint "The --efi toggle was used with format - make an EFI bootable device '$REAL_USB_DEVICE'"
-
-    # Prompt user for size of EFI partition on USB disk
-    # Pressing Enter (\n) will use USB_UEFI_PART_SIZE (default in default.conf) or fallback here:
-    test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="100"
-    echo -n "Enter size of EFI partition on '$REAL_USB_DEVICE' in MB [default $USB_UEFI_PART_SIZE MB]: "
-    read efi_part_size
-
-    # Check if user entered unsigned integer larger than 0
-    if [[ "${efi_part_size}" =~ ^[0-9]+$ && ${efi_part_size} > 0 ]]; then
-        USB_UEFI_PART_SIZE=${efi_part_size}
-        LogPrint "Creating EFI partition on '$REAL_USB_DEVICE' with size $USB_UEFI_PART_SIZE MB."
-    # We did not read anything, used defaults
-    elif [[ -z ${efi_part_size} ]]; then
-        LogPrint "Creating EFI partition on '$REAL_USB_DEVICE' with default size $USB_UEFI_PART_SIZE MB."
-    # User input was not correct ...
-    else
-        Error "Bad input for EFI partition size."
-    fi
-
-    echo "Yes" | parted -s $RAW_USB_DEVICE -- mklabel gpt mkpart primary 0 ${USB_UEFI_PART_SIZE}Mib mkpart primary ${USB_UEFI_PART_SIZE}Mib ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2
-
-    StopIfError "Could not create GPT partitions on '$REAL_USB_DEVICE'"
-    # partition 1 is the ESP (vfat partition) on which EFI/BOOT/BOOTX86.EFI resides
+    LogPrint "The --efi toggle was used with format - making an EFI bootable device '$RAW_USB_DEVICE'"
+    # Prompt user for size of EFI system partition on USB disk if no valid value is specified:
+    while ! [[ "$USB_UEFI_PART_SIZE" =~ ^[0-9]+$ && $USB_UEFI_PART_SIZE > 0 ]] ; do
+        # When USB_UEFI_PART_SIZE is empty, do not tell about "Invalid EFI partition size value":
+        test "$USB_UEFI_PART_SIZE" && echo "Invalid EFI system partition size value '$USB_UEFI_PART_SIZE' (must be unsigned integer larger than 0)"
+        echo -n "Enter size for EFI system partition on '$RAW_USB_DEVICE' in MB (plain 'Enter' defaults to 100 MB): "
+        read USB_UEFI_PART_SIZE
+        # Plain 'Enter' defaults to 100 MB (same as the default value in default.conf):
+        test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="100"
+    done
+    LogPrint "Creating GUID partition table (GPT) on '$RAW_USB_DEVICE'"
+    parted -s $RAW_USB_DEVICE mklabel gpt >&2 || Error "Failed to create GPT partition table on '$RAW_USB_DEVICE'"
+    LogPrint "Creating EFI system partition with size $USB_UEFI_PART_SIZE MB on '$RAW_USB_DEVICE'"
+    parted -s $RAW_USB_DEVICE mkpart primary 0 ${USB_UEFI_PART_SIZE}Mib || Error "Failed to create EFI system partition on '$RAW_USB_DEVICE'"
+    LogPrint "Creating ReaR data partition up to ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% on '$RAW_USB_DEVICE'"
+    parted -s $RAW_USB_DEVICE mkpart primary ${USB_UEFI_PART_SIZE}Mib ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2 || Error "Failed to create ReaR data partition on '$RAW_USB_DEVICE'"
+    # partition 1 is the EFI system partition (vfat partition) on which EFI/BOOT/BOOTX86.EFI resides
     ParNr=2
 else
-    echo "Yes" | parted -s $RAW_USB_DEVICE mkpart primary 0 ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2
-    StopIfError "Could not create a primary partition on '$REAL_USB_DEVICE'"
+    test "msdos" = "$USB_DEVICE_PARTED_LABEL" -o "gpt" = "$USB_DEVICE_PARTED_LABEL" || USB_DEVICE_PARTED_LABEL="msdos"
+    LogPrint "Creating partition table of type '$USB_DEVICE_PARTED_LABEL' on '$RAW_USB_DEVICE'"
+    parted -s $RAW_USB_DEVICE mklabel $USB_DEVICE_PARTED_LABEL >&2 || Error "Failed to create $USB_DEVICE_PARTED_LABEL partition table on '$RAW_USB_DEVICE'"
+    LogPrint "Creating ReaR data partition with size ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% on '$RAW_USB_DEVICE'"
+    parted -s $RAW_USB_DEVICE mkpart primary 0 ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2 || Error "Failed to create ReaR data partition on '$RAW_USB_DEVICE'"
     ParNr=1
 fi
 
-echo "Yes" | parted -s $RAW_USB_DEVICE set 1 boot on >&2
-StopIfError "Could not make primary partition bootable on '$REAL_USB_DEVICE'"
+parted -s $RAW_USB_DEVICE set 1 boot on >&2 || Error "Could not make first partition bootable on '$RAW_USB_DEVICE'"
 
 partprobe $RAW_USB_DEVICE
-
 # Wait until udev has had the time to kick in
 sleep 5
 
 if [[ "$EFI" == "y" ]]; then
-    LogPrint "Creating vfat filesystem on EFI system partition (ESP) '${RAW_USB_DEVICE}1'"
-    mkfs.vfat $v -F 16 -n REAR-EFI ${RAW_USB_DEVICE}1 >&2
-
+    LogPrint "Creating vfat filesystem on EFI system partition on '${RAW_USB_DEVICE}1'"
+    mkfs.vfat $v -F 16 -n REAR-EFI ${RAW_USB_DEVICE}1 >&2 || Error "Failed to create vfat filesystem on '${RAW_USB_DEVICE}1'"
     # create link for EFI partition in /dev/disk/by-label
     partprobe $RAW_USB_DEVICE
+    # Wait until udev has had the time to kick in
     sleep 5
 fi
 
-LogPrint "Creating $USB_DEVICE_FILESYSTEM filesystem on '${RAW_USB_DEVICE}${ParNr}'"
-mkfs.$USB_DEVICE_FILESYSTEM -L REAR-000 ${RAW_USB_DEVICE}${ParNr} >&2
-StopIfError "Could not format '${RAW_USB_DEVICE}${ParNr}' with $USB_DEVICE_FILESYSTEM filesystem"
+LogPrint "Creating $USB_DEVICE_FILESYSTEM filesystem with label 'REAR-000' on '${RAW_USB_DEVICE}${ParNr}'"
+mkfs.$USB_DEVICE_FILESYSTEM -L REAR-000 ${RAW_USB_DEVICE}${ParNr} >&2 || Error "Failed to create $USB_DEVICE_FILESYSTEM filesystem on '${RAW_USB_DEVICE}${ParNr}'"
 
-tune2fs -c 0 -i 0 -o acl,journal_data,journal_data_ordered ${RAW_USB_DEVICE}${ParNr} >&2
-StopIfError "Failed to change filesystem characteristics on '${RAW_USB_DEVICE}${ParNr}'"
+LogPrint "Adjusting filesystem parameters on '${RAW_USB_DEVICE}${ParNr}'"
+tune2fs -c 0 -i 0 -o acl,journal_data,journal_data_ordered ${RAW_USB_DEVICE}${ParNr} >&2 || Error "Failed to adjust filesystem parameters on '${RAW_USB_DEVICE}${ParNr}'"
 

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -23,7 +23,7 @@ if [[ "$EFI" == "y" ]]; then
     parted -s $RAW_USB_DEVICE mklabel gpt >&2 || Error "Failed to create GPT partition table on '$RAW_USB_DEVICE'"
     LogPrint "Creating EFI system partition with size $USB_UEFI_PART_SIZE MB on '$RAW_USB_DEVICE'"
     parted -s $RAW_USB_DEVICE mkpart primary 0 ${USB_UEFI_PART_SIZE}Mib || Error "Failed to create EFI system partition on '$RAW_USB_DEVICE'"
-    LogPrint "Creating ReaR data partition up to ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% on '$RAW_USB_DEVICE'"
+    LogPrint "Creating ReaR data partition up to ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% of '$RAW_USB_DEVICE'"
     parted -s $RAW_USB_DEVICE mkpart primary ${USB_UEFI_PART_SIZE}Mib ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2 || Error "Failed to create ReaR data partition on '$RAW_USB_DEVICE'"
     # partition 1 is the EFI system partition (vfat partition) on which EFI/BOOT/BOOTX86.EFI resides
     ParNr=2
@@ -31,7 +31,7 @@ else
     test "msdos" = "$USB_DEVICE_PARTED_LABEL" -o "gpt" = "$USB_DEVICE_PARTED_LABEL" || USB_DEVICE_PARTED_LABEL="msdos"
     LogPrint "Creating partition table of type '$USB_DEVICE_PARTED_LABEL' on '$RAW_USB_DEVICE'"
     parted -s $RAW_USB_DEVICE mklabel $USB_DEVICE_PARTED_LABEL >&2 || Error "Failed to create $USB_DEVICE_PARTED_LABEL partition table on '$RAW_USB_DEVICE'"
-    LogPrint "Creating ReaR data partition with size ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% on '$RAW_USB_DEVICE'"
+    LogPrint "Creating ReaR data partition up to ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% of '$RAW_USB_DEVICE'"
     parted -s $RAW_USB_DEVICE mkpart primary 0 ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2 || Error "Failed to create ReaR data partition on '$RAW_USB_DEVICE'"
     ParNr=1
 fi

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -1,63 +1,69 @@
-# $answer is filled by 200_check_usb_layout.sh
-if [[ "$answer" == "Yes" || "$FORCE" ]]; then
-    umount $REAL_USB_DEVICE >&8 2>&1
 
-    LogPrint "Repartition $RAW_USB_DEVICE"
+# $USB_format_answer is filled by 200_check_usb_layout.sh
+[[ "$USB_format_answer" == "Yes" || "$FORCE" ]] || return 0
 
-    echo "Yes" | parted -s $RAW_USB_DEVICE mklabel msdos >&2
-    StopIfError "Could not create msdos partitioning"
+umount $REAL_USB_DEVICE &>/dev/null
 
-    if [[ "$EFI" == "y" ]]; then
-        LogPrint "The --efi toggle was used with format - make an EFI bootable USB disk"
+LogPrint "Repartitioning '$RAW_USB_DEVICE'"
 
-        # Prompt user for size of EFI partition on USB disk
-        # Pressing Enter (\n) will use default value from default.conf
-        echo -n "Please enter size of EFI partition on USB device in MB [default ${USB_UEFI_PART_SIZE} MB]: "
-        read efi_part_size
+echo "Yes" | parted -s $RAW_USB_DEVICE mklabel msdos >&2
+StopIfError "Could not create initial msdos partition table on '$REAL_USB_DEVICE'"
 
-        # Check if user entered unsigned integer larger than 0
-        if [[ "${efi_part_size}" =~ ^[0-9]+$ && ${efi_part_size} > 0 ]]; then
-            USB_UEFI_PART_SIZE=${efi_part_size}
-            LogPrint "Creating EFI partition on USB device with size ${USB_UEFI_PART_SIZE} MB."
-        # We did not read anything, used defaults
-        elif [[ -z ${efi_part_size} ]]; then
-            LogPrint "Creating EFI partition on USB device with default size ${USB_UEFI_PART_SIZE} MB."
-        # User input was not correct ...
-        else
-            Error "Bad input for EFI partition size."
-        fi
+test "$USB_DEVICE_FILESYSTEM_PERCENTAGE" || USB_DEVICE_FILESYSTEM_PERCENTAGE="100"
 
-        echo "Yes" | parted -s $RAW_USB_DEVICE -- mklabel gpt mkpart primary 0 ${USB_UEFI_PART_SIZE}Mib mkpart primary ${USB_UEFI_PART_SIZE}Mib 100% >&2
+if [[ "$EFI" == "y" ]]; then
+    LogPrint "The --efi toggle was used with format - make an EFI bootable device '$REAL_USB_DEVICE'"
 
-        StopIfError "Could not create primary partitions on '$REAL_USB_DEVICE'"
-        # partition 1 is the ESP (vfat partition) on which EFI/BOOT/BOOTX86.EFI resides
-        ParNr=2
+    # Prompt user for size of EFI partition on USB disk
+    # Pressing Enter (\n) will use USB_UEFI_PART_SIZE (default in default.conf) or fallback here:
+    test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="100"
+    echo -n "Enter size of EFI partition on '$REAL_USB_DEVICE' in MB [default $USB_UEFI_PART_SIZE MB]: "
+    read efi_part_size
+
+    # Check if user entered unsigned integer larger than 0
+    if [[ "${efi_part_size}" =~ ^[0-9]+$ && ${efi_part_size} > 0 ]]; then
+        USB_UEFI_PART_SIZE=${efi_part_size}
+        LogPrint "Creating EFI partition on '$REAL_USB_DEVICE' with size $USB_UEFI_PART_SIZE MB."
+    # We did not read anything, used defaults
+    elif [[ -z ${efi_part_size} ]]; then
+        LogPrint "Creating EFI partition on '$REAL_USB_DEVICE' with default size $USB_UEFI_PART_SIZE MB."
+    # User input was not correct ...
     else
-        echo "Yes" | parted -s $RAW_USB_DEVICE mkpart primary 0 100% >&2
-        StopIfError "Could not create a primary partition on '$REAL_USB_DEVICE'"
-        ParNr=1
+        Error "Bad input for EFI partition size."
     fi
 
-    echo "Yes" | parted -s $RAW_USB_DEVICE set 1 boot on >&2
-    StopIfError "Could not make primary partition boot-able on '$REAL_USB_DEVICE'"
+    echo "Yes" | parted -s $RAW_USB_DEVICE -- mklabel gpt mkpart primary 0 ${USB_UEFI_PART_SIZE}Mib mkpart primary ${USB_UEFI_PART_SIZE}Mib ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2
 
-    partprobe $RAW_USB_DEVICE
-
-    # Wait until udev has had the time to kick in
-    sleep 5
-
-    if [[ "$EFI" == "y" ]]; then
-        LogPrint "Creating new vfat filesystem on ${RAW_USB_DEVICE}1"
-        mkfs.vfat $v -F 16 -n REAR-EFI ${RAW_USB_DEVICE}1 >&2
-
-        # create link for EFI partition in /dev/disk/by-label
-        partprobe $RAW_USB_DEVICE
-        sleep 5
-    fi
-    LogPrint "Creating new ext3 filesystem on ${RAW_USB_DEVICE}${ParNr}"
-    mkfs.ext3 -L REAR-000 ${RAW_USB_DEVICE}${ParNr} >&2
-    StopIfError "Could not format '${RAW_USB_DEVICE}${ParNr}' with ext3 layout"
-
-    tune2fs -c 0 -i 0 -o acl,journal_data,journal_data_ordered ${RAW_USB_DEVICE}${ParNr} >&2
-    StopIfError "Failed to change filesystem characteristics on '${RAW_USB_DEVICE}${ParNr}'"
+    StopIfError "Could not create GPT partitions on '$REAL_USB_DEVICE'"
+    # partition 1 is the ESP (vfat partition) on which EFI/BOOT/BOOTX86.EFI resides
+    ParNr=2
+else
+    echo "Yes" | parted -s $RAW_USB_DEVICE mkpart primary 0 ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2
+    StopIfError "Could not create a primary partition on '$REAL_USB_DEVICE'"
+    ParNr=1
 fi
+
+echo "Yes" | parted -s $RAW_USB_DEVICE set 1 boot on >&2
+StopIfError "Could not make primary partition bootable on '$REAL_USB_DEVICE'"
+
+partprobe $RAW_USB_DEVICE
+
+# Wait until udev has had the time to kick in
+sleep 5
+
+if [[ "$EFI" == "y" ]]; then
+    LogPrint "Creating vfat filesystem on EFI system partition (ESP) '${RAW_USB_DEVICE}1'"
+    mkfs.vfat $v -F 16 -n REAR-EFI ${RAW_USB_DEVICE}1 >&2
+
+    # create link for EFI partition in /dev/disk/by-label
+    partprobe $RAW_USB_DEVICE
+    sleep 5
+fi
+
+LogPrint "Creating $USB_DEVICE_FILESYSTEM filesystem on '${RAW_USB_DEVICE}${ParNr}'"
+mkfs.$USB_DEVICE_FILESYSTEM -L REAR-000 ${RAW_USB_DEVICE}${ParNr} >&2
+StopIfError "Could not format '${RAW_USB_DEVICE}${ParNr}' with $USB_DEVICE_FILESYSTEM filesystem"
+
+tune2fs -c 0 -i 0 -o acl,journal_data,journal_data_ordered ${RAW_USB_DEVICE}${ParNr} >&2
+StopIfError "Failed to change filesystem characteristics on '${RAW_USB_DEVICE}${ParNr}'"
+


### PR DESCRIPTION
To support partitioning and formatting a huge medium
by the format workflow there are new variables:
USB_DEVICE_FILESYSTEM specifies the filesystem
to use when formatting a medium via the format workflow.
USB_DEVICE_FILESYSTEM_PERCENTAGE specifies the
percentage of the whole medium that is used for ReaR partitions
when formatting a medium via the format workflow.
For details see conf/default.conf
Cf. https://github.com/rear/rear/issues/1105

