### PR TITLE
Fix LOGFILE setting

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -233,6 +233,16 @@ case "$WORKFLOW" in
         ;;
 esac
 
+# Set the variables v and verbose to be used in called programs
+# that support the '-v' or '--verbose' options like
+# "cp $v ..." or "rm $verbose ..." and so on:
+v=""
+verbose=""
+if test "$VERBOSE" ; then
+    v="-v"
+    verbose="--verbose"
+fi
+
 # Mark variables that are not meant to be changed later as constants (i.e. readonly).
 # Exceptions here:
 # CONFIG_DIR because "rear recover" sets it in /etc/rear/rescue.conf in the recovery system
@@ -290,22 +300,27 @@ hash -r
 # Make sure that we use only English:
 export LC_CTYPE=C LC_ALL=C LANG=C
 
-# Include default config:
+# Include default config before the LOGFILE value is set because
+# setting the right LOGFILE value requires values from default.conf
+# in particular the default LOGFILE value and the values of the
+# LOCKLESS_WORKFLOWS and SIMULTANEOUS_RUNNABLE_WORKFLOWS arrays:
 source $SHARE_DIR/conf/default.conf
 
-# Include functions:
-for script in $SHARE_DIR/lib/*.sh ; do
-    source $script
-done
-
+# Set the right LOGFILE value depending on whether or not
+# this currently running instance can run simultaneously with another instance:
+can_run_simultaneously=""
 # LOCKLESS_WORKFLOWS can run simultaneously with another instance by using a LOGFILE.lockless:
-if IsInArray "$WORKFLOW" "${LOCKLESS_WORKFLOWS[@]}" ; then
-    LOGFILE="$LOGFILE.lockless"
-else
-    # SIMULTANEOUS_RUNNABLE_WORKFLOWS are allowed to run simultaneously
-    # but cannot use LOGFILE.lockless instead they get a LOGFILE with PID
-    # see https://github.com/rear/rear/issues/1102
-    if  IsInArray "$WORKFLOW" "${SIMULTANEOUS_RUNNABLE_WORKFLOWS[@]}" ; then
+for lockless_workflow in "${LOCKLESS_WORKFLOWS[@]}" ; do
+    test "$WORKFLOW" = "$lockless_workflow" && LOGFILE="$LOGFILE.lockless"
+    can_run_simultaneously="yes"
+done
+# SIMULTANEOUS_RUNNABLE_WORKFLOWS are allowed to run simultaneously
+# but cannot use LOGFILE.lockless instead they get a LOGFILE with PID
+# see https://github.com/rear/rear/issues/1102
+# When a workflow is both in LOCKLESS_WORKFLOWS and in SIMULTANEOUS_RUNNABLE_WORKFLOWS
+# its right LOGFILE value is the one for SIMULTANEOUS_RUNNABLE_WORKFLOWS:
+for simultaneous_runnable_workflow in "${SIMULTANEOUS_RUNNABLE_WORKFLOWS[@]}" ; do
+    if test "$WORKFLOW" = "$simultaneous_runnable_workflow" ; then
         # Simultaneously runnable workflows require unique logfile names
         # so that the PID is interposed in the LOGFILE value from default.conf
         # which is used below as REAR_LOGFILE while the workflow is running
@@ -314,48 +329,50 @@ else
         # (in this case ${LOGFILE##*.} returns the whole $LOGFILE value):
         logfile_suffix=$( test "${LOGFILE##*.}" = "$LOGFILE" && echo 'log' || echo "${LOGFILE##*.}" )
         LOGFILE="${LOGFILE%.*}.$$.$logfile_suffix"
-    else
-        # When this currently running instance is not one of the LOCKLESS_WORKFLOWS
-        # and not one of the SIMULTANEOUS_RUNNABLE_WORKFLOWS
-        # then it cannot run simultaneously with another instance.
-        # In this case pidof is needed to test what running instances there are:
-        if ! has_binary pidof ; then
-            echo "ERROR: Required program 'pidof' missing, please check your PATH" >&2
+        can_run_simultaneously="yes"
+    fi
+done
+
+# When this currently running instance cannot run simultaneously with another instance
+# test that this currently running instance does not run simultaneously with another instance:
+if ! test "$can_run_simultaneously" ; then
+    # In this case pidof is needed to test what running instances there are:
+    if ! has_binary pidof ; then
+        echo "ERROR: Required program 'pidof' missing, please check your PATH" >&2
+        exit 1
+    fi
+    # For unknown reasons '-o %PPID' does not work for pidof at least in SLES11
+    # so that a manual test is done to find out if another pid != $$ is running:
+    for pid in $( pidof -x "$SCRIPT_FILE" ) ; do
+        if test "$pid" != $$ ; then
+            echo "ERROR: $PROGRAM is already running, not starting again" >&2
             exit 1
         fi
-        # For unknown reasons '-o %PPID' does not work for pidof at least in SLES11
-        # so that a manual test is done to find out if another pid != $$ is running:
-        for pid in $( pidof -x "$SCRIPT_FILE" ) ; do
-            if test "$pid" != $$ ; then
-                echo "ERROR: $PROGRAM is already running, not starting again" >&2
-                exit 1
-            fi
-        done
-    fi
+    done
 fi
 
 # Keep old log file:
 if test -r "$LOGFILE" ; then
-    mv -f "$LOGFILE" "$LOGFILE".old 2>&8
+    mv -f "$LOGFILE" "$LOGFILE".old 2>/dev/null
 fi
 mkdir -p $LOG_DIR
 
 exec 2>"$LOGFILE" || echo "ERROR: Could not create $LOGFILE" >&2
-# Keep our default $LOGFILE location in a seperate variable REAR_LOGFILE
+# Keep our currently used LOGFILE in a seperate variable REAR_LOGFILE
 # in case end-user overruled it in the local.conf file:
 readonly REAR_LOGFILE="$LOGFILE"
 
+# Include functions after LOGFILE and REAR_LOGFILE are set
+# because some functions use LOGFILE or REAR_LOGFILE:
+for script in $SHARE_DIR/lib/*.sh ; do
+    source $script
+done
+
+# Show initial startup messages:
 if test "$WORKFLOW" != "help" ; then
     LogPrint "$PRODUCT $VERSION / $RELEASE_DATE"
     Log "Command line options: $0 ${CMD_OPTS[@]}"
     LogPrint "Using log file: $REAR_LOGFILE"
-fi
-
-v=""
-verbose=""
-if test "$VERBOSE" ; then
-    v="-v"
-    verbose="--verbose"
 fi
 
 # In DEBUG mode keep by default the build area but that can be overridden in user config files

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -108,7 +108,9 @@ WORKFLOWS=("")
 # The LOCKLESS_WORKFLOWS array gets filled during runtime as needed by the various
 # usr/share/rear/lib/WORKFLOW-workflow.sh scripts. Currently the following workflows
 # add themselves to the LOCKLESS_WORKFLOWS array: checklayout dump help
-LOCKLESS_WORKFLOWS=("")
+# To make setting the right logfile name working in usr/sbin/rear
+# the lockless workflows must also be predefined here (cf. usr/sbin/rear):
+LOCKLESS_WORKFLOWS=( 'checklayout' 'dump' 'help' )
 # SIMULTANEOUS_RUNNABLE_WORKFLOWS are also allowed to run simultaneously
 # but cannot use LOGFILE.lockless as the LOCKLESS_WORKFLOWS.
 # Instead the SIMULTANEOUS_RUNNABLE_WORKFLOWS get a LOGFILE with PID

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -74,7 +74,7 @@ readonly MASTER_PID=$$
 exec 7>&1
 QuietAddExitTask "exec 7>&-"
 # USR1 is used to abort on errors, not using Print to always print to the original STDOUT, even if quiet
-builtin trap "echo '${MESSAGE_PREFIX}Aborting due to an error, check $LOGFILE for details' >&7 ; kill $MASTER_PID" USR1
+builtin trap "echo '${MESSAGE_PREFIX}Aborting due to an error, check $REAR_LOGFILE for details' >&7 ; kill $MASTER_PID" USR1
 
 # make sure nobody else can use trap
 function trap () {
@@ -155,7 +155,7 @@ BUG in $caller_source:
 '$@'
 --------------------
 Please report this issue at https://github.com/rear/rear/issues
-and include the relevant parts from $LOGFILE
+and include the relevant parts from $REAR_LOGFILE
 preferably with full debug information via 'rear -d -D $WORKFLOW'
 ===================="
 }


### PR DESCRIPTION
See
https://github.com/rear/rear/issues/1088#issuecomment-265507663

Now when rear errors out it shows the right logfile name, e.g.:
<pre>
Relax-and-Recover 1.19 / Git
Using log file: /root/rear/var/log/rear/rear-f79.16621.log
16621: ERROR: 
====================
BUG in /root/rear/usr/share/rear/init/default/030_update_recovery_system.sh:
'Test Error'
--------------------
Please report this issue at https://github.com/rear/rear/issues
and include the relevant parts from /root/rear/var/log/rear/rear-f79.16621.log
preferably with full debug information via 'rear -d -D mkbackuponly'
====================
Aborting due to an error, check /root/rear/var/log/rear/rear-f79.16621.log for details
Terminated
</pre>

The fix is mainly in usr/sbin/rear and it is a bit ugly
but from my point of view the whole logging code
in ReaR is currently ugly which results such ugly fixes.

From my point of view the whole logging in ReaR
should be simplified and cleaned up as I described in
https://github.com/rear/rear/issues/885
