### PR TITLE
Explain date prefixed backup archive

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -445,7 +445,10 @@ BACKUP_PROG_CRYPT_ENABLED=0
 BACKUP_PROG_CRYPT_KEY=""
 BACKUP_PROG_CRYPT_OPTIONS="/usr/bin/openssl des3 -salt -k "
 BACKUP_PROG_DECRYPT_OPTIONS="/usr/bin/openssl des3 -d -k "
-# one could also create a dynamic name, e.g. "backup_$( date -Iseconds )"
+# One can create a dynamic name like BACKUP_PROG_ARCHIVE="backup_$( date -Iseconds )"
+# in particular one can use BACKUP_PROG_ARCHIVE="$( date '+%Y-%m-%d-%H%M' )-F"
+# to get the same full backup file name for BACKUP_TYPE="" as what is used
+# for BACKUP_TYPE=incremental and/or BACKUP_TYPE=differential (see below):
 BACKUP_PROG_ARCHIVE="backup"
 BACKUP_PROG_EXCLUDE=( '/tmp/*' '/dev/shm/*' $VAR_DIR/output/\* )
 BACKUP_PROG_INCLUDE=( )


### PR DESCRIPTION
Added a explanatory comment to default.conf
what BACKUP_PROG_ARCHIVE to use
to get the same full backup file name for BACKUP_TYPE=""
as what would be used for BACKUP_TYPE=incremental
and/or BACKUP_TYPE=differential, see
https://github.com/rear/rear/issues/1074