### PR TITLE
Removed dead wrapup script add_galaxy_group

### DIFF
--- a/usr/share/rear/wrapup/rescue/default/600_add_galaxy_group.sh
+++ b/usr/share/rear/wrapup/rescue/default/600_add_galaxy_group.sh
@@ -1,7 +1,0 @@
-#
-# Galaxy uses a special group which we need to copy to the rescue system
-#
-
-# append group info to /etc/group if it is not root (0)
-galaxy_group=$(stat -c "%g" /opt/simpana/Base/Galaxy)
-test $galaxy_group -gt 0 && getent group $galaxy_group >>$ROOTFS_DIR/etc/group


### PR DESCRIPTION
Removed dead wrapup script
wrapup/rescue/default/600_add_galaxy_group.sh
the identical and right one is
rescue/GALAXY10/default/600_add_galaxy_group.sh
see https://github.com/rear/rear/issues/1124