### PR TITLE
do not show experimental workflows in rear help workflow

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -514,12 +514,12 @@ fi
 # but later user config files are sourced where LOGFILE can be set different
 # so that the user config LOGFILE is used as final logfile name:
 if test "$RUNTIME_LOGFILE" != "$LOGFILE" ; then
-    LogPrint "Saving $RUNTIME_LOGFILE as $LOGFILE"
+    test "$WORKFLOW" != "help" && LogPrint "Saving $RUNTIME_LOGFILE as $LOGFILE"
     cat "$RUNTIME_LOGFILE" > "$LOGFILE"
 fi
 
 if test $EXIT_CODE -eq 0 ; then
-    LogToSyslog "DONE: rc=$EXIT_CODE"
+    test "$WORKFLOW" != "help" && LogToSyslog "DONE: rc=$EXIT_CODE"
 fi
 
 exit $EXIT_CODE

--- a/usr/share/rear/lib/finalizeonly-workflow.sh
+++ b/usr/share/rear/lib/finalizeonly-workflow.sh
@@ -5,7 +5,7 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-WORKFLOW_finalizeonly_DESCRIPTION="only finalize the recovery"
+test "$VERBOSE" && WORKFLOW_finalizeonly_DESCRIPTION="only finalize the recovery (does not yet work)"
 WORKFLOWS=( ${WORKFLOWS[@]} finalizeonly )
 # The finalizeonly workflow is a part (a strict subset) of the recover workflow
 # by skipping those part of the recover workflow that are not needed

--- a/usr/share/rear/lib/help-workflow.sh
+++ b/usr/share/rear/lib/help-workflow.sh
@@ -37,16 +37,10 @@ for workflow in ${WORKFLOWS[@]} ; do
     # is only defined if "$VERBOSE" is set - currently (18. Nov. 2015) for those
     # WORKFLOW_savelayout_DESCRIPTION WORKFLOW_shell_DESCRIPTION WORKFLOW_udev_DESCRIPTION
     # so that an empty default is used to avoid that ${!description} is an unbound variable:
-    if test -n "${!description:-}" ; then
-        printf " %-16s%s\n" $workflow "${!description:-}"
-    fi
+    test "${!description:-}" && printf " %-16s%s\n" $workflow "${!description:-}"
 done
 
-if test -z "$VERBOSE" ; then
-    echo "Use 'rear -v help' for more advanced commands."
-fi
-
-EXIT_CODE=1
+test "$VERBOSE" || echo "Use 'rear -v help' for more advanced commands."
 
 }
 

--- a/usr/share/rear/lib/layoutonly-workflow.sh
+++ b/usr/share/rear/lib/layoutonly-workflow.sh
@@ -5,7 +5,7 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-WORKFLOW_layoutonly_DESCRIPTION="only recreate the disk layout"
+test "$VERBOSE" && WORKFLOW_layoutonly_DESCRIPTION="only recreate the disk layout (experimental)"
 WORKFLOWS=( ${WORKFLOWS[@]} layoutonly )
 # The layoutonly workflow is a part (a strict subset) of the recover workflow
 # by skipping those part of the recover workflow that are not needed


### PR DESCRIPTION
Do not show experimental workflows in help workflow
namely layoutonly and finalizeonly and let the
help workflow exit with zero exit code, cf
https://github.com/rear/rear/issues/1089#issuecomment-266984698

Additionally suppress some messages in usr/sbin/rear
in case of the help workflow namely the verbose
LogPrint whereto the log file gets copied
"Saving $RUNTIME_LOGFILE as $LOGFILE"
and the final LogToSyslog.
