### PR TITLE
Fix documentation regarding OUTPUT_URL=null

### DIFF
--- a/doc/rear.8
+++ b/doc/rear.8
@@ -316,12 +316,11 @@ Write the image using sshfs and the SSH protocol\&.
 .PP
 OUTPUT_URL=\fBnull\fR
 .RS 4
-Do not copy the ISO image from
-\fI/var/lib/rear/output/\fR
-to an external destination\&. Useful in combination with an
-\fIexternal\fR
-backup program, or when
-BACKUP_URL=iso://backup
+Do not copy the ISO image from \fI/var/lib/rear/output/\fR to a remote output location\&.
+OUTPUT_URL=null is useful when another program (e.g. an \fIexternal\fR backup program) is used to save the ISO image from the local system to a remote place,
+or with BACKUP_URL=iso:///backup when the backup is included in the ISO image to avoid a (big) copy of the ISO image at a remote output location\&.
+In the latter case the ISO image must be manually saved from the local system to a remote place\&.
+OUTPUT_URL=null is only supported together with BACKUP=NETFS\&.
 .RE
 .sp
 If you do not specify OUTPUT_URL variable then by default it will be aligned to what was defined by variable BACKUP_URL\&. And, the ISO image will then be copied to the same location as your backup of the system disk(s)\&.

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -215,8 +215,13 @@ OUTPUT_URL=*sshfs://*::
 Write the image using sshfs and the SSH protocol.
 
 OUTPUT_URL=*null*::
-Do not copy the ISO image from _/var/lib/rear/output/_ to an external destination.
-Useful in combination with an _external_ backup program, or when +BACKUP_URL=iso://backup+
+Do not copy the ISO image from _/var/lib/rear/output/_ to a remote output location.
++OUTPUT_URL=null+ is useful when another program (e.g. an _external_ backup program)
+is used to save the ISO image from the local system to a remote place,
+or with +BACKUP_URL=iso:///backup+ when the backup is included in the ISO image
+to avoid a (big) copy of the ISO image at a remote output location.
+In the latter case the ISO image must be manually saved from the local system to a remote place.
++OUTPUT_URL=null+ is only supported together with +BACKUP=NETFS+.
 
 If you do not specify +OUTPUT_URL+ variable then by default it will be aligned to what
 was defined by variable +BACKUP_URL+. And, the ISO image will then be copied to the same

--- a/doc/user-guide/03-configuration.adoc
+++ b/doc/user-guide/03-configuration.adoc
@@ -71,7 +71,13 @@ OUTPUT_URL=sshfs://::
 Write the image using sshfs and the SSH protocol.
 
 OUTPUT_URL=null::
-To avoid duplicate ISO images. Useful in combination with an _external_ backup program, or when +BACKUP_URL=iso://backup+
+Do not copy the ISO image from _/var/lib/rear/output/_ to a remote output location.
++OUTPUT_URL=null+ is useful when another program (e.g. an _external_ backup program)
+is used to save the ISO image from the local system to a remote place,
+or with +BACKUP_URL=iso:///backup+ when the backup is included in the ISO image
+to avoid a (big) copy of the ISO image at a remote output location.
+In the latter case the ISO image must be manually saved from the local system to a remote place.
++OUTPUT_URL=null+ is only supported together with +BACKUP=NETFS+.
 
 The default boot option of the created ISO is boothd / "boot from first harddisk". If you want to change this,
 e.g. because you integrate REAR into some automation process, you can change the default using

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -10,8 +10,11 @@
 # Do not change them here. Set them in your site.conf or local.conf file as needed.
 #
 # Some variables are actually bash arrays and should be treated with care.
-# Use VAR=( "${VAR[@]}" value ) to add a value to an array.
 # Use VAR=() to set an empty array.
+# Use VAR=( "${VAR[@]}" 'value' ) to add a fixed value to an array.
+# Use VAR=( "${VAR[@]}" "$var" ) to add a variable value to an array.
+# Whether or not the latter case works as intended depends on when and
+# how "$var" is set and evaluated by the Relax-and-Recover scripts.
 #
 # Most variables can be set to an empty value VAR= which means that this
 # setting is off or set to some automatic mode.
@@ -226,6 +229,7 @@ BACKUP_MOUNTCMD=
 BACKUP_UMOUNTCMD=
 
 # specify the location of the output
+# when OUTPUT_URL is not specified it inherits the BACKUP_URL value
 OUTPUT_URL=
 OUTPUT_OPTIONS=
 OUTPUT_MOUNTCMD=
@@ -450,7 +454,17 @@ BACKUP_PROG_DECRYPT_OPTIONS="/usr/bin/openssl des3 -d -k "
 # to get the same full backup file name for BACKUP_TYPE="" as what is used
 # for BACKUP_TYPE=incremental and/or BACKUP_TYPE=differential (see below):
 BACKUP_PROG_ARCHIVE="backup"
-BACKUP_PROG_EXCLUDE=( '/tmp/*' '/dev/shm/*' $VAR_DIR/output/\* )
+# BACKUP_PROG_EXCLUDE is an array of strings that get written into a backup-exclude.txt file
+# that is used e.g. in 'tar -X backup-exclude.txt' to get things excluded from the backup.
+# Proper quoting of the BACKUP_PROG_EXCLUDE array members is crucial to avoid bash expansions.
+# In /etc/rear/local.conf use BACKUP_PROG_EXCLUDE=( "${BACKUP_PROG_EXCLUDE[@]}" '/this/*' '/that/*' )
+# to add your particular items what should be excluded from your backup.
+BACKUP_PROG_EXCLUDE=( '/tmp/*' '/dev/shm/*' "$VAR_DIR/output/*" )
+# BACKUP_PROG_INCLUDE is an array of strings that get written into a backup-include.txt file
+# that is used e.g. in 'tar -c $(cat backup-include.txt)' to get things included in the backup.
+# Proper quoting of the BACKUP_PROG_INCLUDE array members is crucial to avoid bash expansions.
+# In /etc/rear/local.conf use BACKUP_PROG_INCLUDE=( "${BACKUP_PROG_INCLUDE[@]}" '/this/*' '/that/*' )
+# to add your particular items what should be included in your backup.
 BACKUP_PROG_INCLUDE=( )
 # When BACKUP_ONLY_INCLUDE is set to a 'true' value
 # only what is specified in BACKUP_PROG_INCLUDE will be in the backup


### PR DESCRIPTION
More explanatory documentation regarding OUTPUT_URL=null
see https://github.com/rear/rear/issues/734
Additionally more explanatory documentation in default.conf
about proper usage of quoting for BACKUP_PROG_INCLUDE
and BACKUP_PROG_EXCLUDE which is crucial to get
the intended results.