### PR TITLE
Fixed example BACKUP_PROG_EXCLUDE and BACKUP_PROG_INCLUDE values

### DIFF
--- a/doc/user-guide/11-multiple-backups.adoc
+++ b/doc/user-guide/11-multiple-backups.adoc
@@ -117,7 +117,7 @@ BACKUP_URL=nfs://your.NFS.server.IP/path/to/your/rear/backup
 ----
 this_file_name=$( basename ${BASH_SOURCE[0]} )
 LOGFILE="$LOG_DIR/rear-$HOSTNAME-$WORKFLOW-${this_file_name%.*}.log"
-BACKUP_PROG_EXCLUDE=( /home/* /opt/* )
+BACKUP_PROG_EXCLUDE=( "${BACKUP_PROG_EXCLUDE[@]}" '/home/*' '/opt/*' )
 BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 ----
 
@@ -126,7 +126,7 @@ BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 this_file_name=$( basename ${BASH_SOURCE[0]} )
 LOGFILE="$LOG_DIR/rear-$HOSTNAME-$WORKFLOW-${this_file_name%.*}.log"
 BACKUP_ONLY_INCLUDE="yes"
-BACKUP_PROG_INCLUDE=( /home/* )
+BACKUP_PROG_INCLUDE=( '/home/*' )
 BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 ----
 
@@ -135,7 +135,7 @@ BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 this_file_name=$( basename ${BASH_SOURCE[0]} )
 LOGFILE="$LOG_DIR/rear-$HOSTNAME-$WORKFLOW-${this_file_name%.*}.log"
 BACKUP_ONLY_INCLUDE="yes"
-BACKUP_PROG_INCLUDE=( /opt/* )
+BACKUP_PROG_INCLUDE=( '/opt/*' )
 BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 ----
 
@@ -197,7 +197,7 @@ COPY_AS_IS=( "${COPY_AS_IS[@]}" "/borg/keys" )
 ----
 this_file_name=$( basename ${BASH_SOURCE[0]} )
 LOGFILE="$LOG_DIR/rear-$HOSTNAME-$WORKFLOW-${this_file_name%.*}.log"
-BACKUP_PROG_EXCLUDE=( /home/* )
+BACKUP_PROG_EXCLUDE=( "${BACKUP_PROG_EXCLUDE[@]}" '/home/*' )
 BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 BACKUP=NETFS
 BACKUP_OPTIONS="nfsvers=3,nolock"
@@ -210,7 +210,7 @@ this_file_name=$( basename ${BASH_SOURCE[0]} )
 LOGFILE="$LOG_DIR/rear-$HOSTNAME-$WORKFLOW-${this_file_name%.*}.log"
 BACKUP=BORG
 BACKUP_ONLY_INCLUDE="yes"
-BACKUP_PROG_INCLUDE=( /home/* )
+BACKUP_PROG_INCLUDE=( '/home/*' )
 BORGBACKUP_ARCHIVE_PREFIX="rear"
 BORGBACKUP_HOST="borg.server.name"
 BORGBACKUP_USERNAME="borg_server_username"
@@ -328,7 +328,7 @@ PROGRESS_WAIT_SECONDS="3"
 ----
 this_file_name=$( basename ${BASH_SOURCE[0]} )
 LOGFILE="$LOG_DIR/rear-$HOSTNAME-$WORKFLOW-${this_file_name%.*}-$$.log"
-BACKUP_PROG_EXCLUDE=( /home/* /opt/* )
+BACKUP_PROG_EXCLUDE=( "${BACKUP_PROG_EXCLUDE[@]}" '/home/*' '/opt/*' )
 BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 ----
 
@@ -337,7 +337,7 @@ BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 this_file_name=$( basename ${BASH_SOURCE[0]} )
 LOGFILE="$LOG_DIR/rear-$HOSTNAME-$WORKFLOW-${this_file_name%.*}-$$.log"
 BACKUP_ONLY_INCLUDE="yes"
-BACKUP_PROG_INCLUDE=( /home/* )
+BACKUP_PROG_INCLUDE=( '/home/*' )
 BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 ----
 
@@ -346,7 +346,7 @@ BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 this_file_name=$( basename ${BASH_SOURCE[0]} )
 LOGFILE="$LOG_DIR/rear-$HOSTNAME-$WORKFLOW-${this_file_name%.*}-$$.log"
 BACKUP_ONLY_INCLUDE="yes"
-BACKUP_PROG_INCLUDE=( /opt/* )
+BACKUP_PROG_INCLUDE=( '/opt/*' )
 BACKUP_PROG_ARCHIVE="backup-${this_file_name%.*}"
 ----
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -15,6 +15,9 @@
 # Use VAR=( "${VAR[@]}" "$var" ) to add a variable value to an array.
 # Whether or not the latter case works as intended depends on when and
 # how "$var" is set and evaluated by the Relax-and-Recover scripts.
+# In general using ${VAR[*]} is problematic and using ${VAR[@]} without
+# double-quotes is also problematic, see 'Arrays' in "man bash" and
+# see https://github.com/rear/rear/issues/1068 for some examples.
 #
 # Most variables can be set to an empty value VAR= which means that this
 # setting is off or set to some automatic mode.
@@ -73,13 +76,13 @@ KERNEL_CMDLINE=""
 # machine architecture, OS independant
 REAL_MACHINE="$( uname -m )"
 case "$REAL_MACHINE" in
-	(x86_64|i686|i586)
-		# all these behave exactly like i386. For 64bit we took care to handle the
-		# special cases within the 32bit scripts to prevent code duplication
-		MACHINE=i386
-		;;
-	(*)
-		MACHINE=$REAL_MACHINE
+    (x86_64|i686|i586)
+        # all these behave exactly like i386. For 64bit we took care to handle the
+        # special cases within the 32bit scripts to prevent code duplication
+        MACHINE=i386
+        ;;
+    (*)
+        MACHINE=$REAL_MACHINE
 esac
 
 # Architecture, e.g. Linux-i386
@@ -458,13 +461,15 @@ BACKUP_PROG_ARCHIVE="backup"
 # that is used e.g. in 'tar -X backup-exclude.txt' to get things excluded from the backup.
 # Proper quoting of the BACKUP_PROG_EXCLUDE array members is crucial to avoid bash expansions.
 # In /etc/rear/local.conf use BACKUP_PROG_EXCLUDE=( "${BACKUP_PROG_EXCLUDE[@]}" '/this/*' '/that/*' )
-# to add your particular items what should be excluded from your backup.
+# to specify your particular items that should be excluded from the backup in addition to what
+# gets excluded from the backup by default here (see also BACKUP_ONLY_EXCLUDE below):
 BACKUP_PROG_EXCLUDE=( '/tmp/*' '/dev/shm/*' "$VAR_DIR/output/*" )
 # BACKUP_PROG_INCLUDE is an array of strings that get written into a backup-include.txt file
 # that is used e.g. in 'tar -c $(cat backup-include.txt)' to get things included in the backup.
 # Proper quoting of the BACKUP_PROG_INCLUDE array members is crucial to avoid bash expansions.
-# In /etc/rear/local.conf use BACKUP_PROG_INCLUDE=( "${BACKUP_PROG_INCLUDE[@]}" '/this/*' '/that/*' )
-# to add your particular items what should be included in your backup.
+# In /etc/rear/local.conf use BACKUP_PROG_INCLUDE=( '/this/*' '/that/*' )
+# to specify your particular items that should be included in the backup in addition to what
+# gets included in the backup by default (see BACKUP_ONLY_INCLUDE below):
 BACKUP_PROG_INCLUDE=( )
 # When BACKUP_ONLY_INCLUDE is set to a 'true' value
 # only what is specified in BACKUP_PROG_INCLUDE will be in the backup

--- a/usr/share/rear/conf/examples/RHEL6-NETFS-of-NBU-master-example.conf
+++ b/usr/share/rear/conf/examples/RHEL6-NETFS-of-NBU-master-example.conf
@@ -15,5 +15,5 @@ BACKUP_URL=nfs://nfs-server-address/path/to/images
 NETFS_KEEP_OLD_BACKUP_COPY=y
 #
 # Exclude following content of the directories (merely log files), but do recreate the directories (albeit empty)
-BACKUP_PROG_EXCLUDE=( ${BACKUP_PROG_EXCLUDE[@]} '/usr/openv/tmp/*' '/nbu/logs/openv/logs/nbdisco/*' '/nbu/logs/openv/logs/nbsvcmon/*' '/nbu/logs/openv/logs/nbrmms/*' '/nbu/logs/openv/logs/nbsl/*' )
+BACKUP_PROG_EXCLUDE=( "${BACKUP_PROG_EXCLUDE[@]}" '/usr/openv/tmp/*' '/nbu/logs/openv/logs/nbdisco/*' '/nbu/logs/openv/logs/nbsvcmon/*' '/nbu/logs/openv/logs/nbrmms/*' '/nbu/logs/openv/logs/nbsl/*' )
 

--- a/usr/share/rear/conf/examples/SLE11-SLE12-SAP-HANA-UEFI-example.conf
+++ b/usr/share/rear/conf/examples/SLE11-SLE12-SAP-HANA-UEFI-example.conf
@@ -36,7 +36,7 @@ BACKUP_URL=nfs://your.NFS.server.IP/path/to/your/rear/backup
 NETFS_KEEP_OLD_BACKUP_COPY=yes
 # Make sure to exclude all SAP HANA related volume groups and mount points - modify next line with your HANA mount points:
 EXCLUDE_VG=( vgHANA-data-HC2 vgHANA-data-HC3 vgHANA-log-HC2 vgHANA-log-HC3 vgHANA-shared-HC2 vgHANA-shared-HC3 )
-BACKUP_PROG_EXCLUDE=( ${BACKUP_PROG_EXCLUDE[@]} '/hana/*' )
+BACKUP_PROG_EXCLUDE=( "${BACKUP_PROG_EXCLUDE[@]}" '/hana/*' )
 # This option defines a root password to allow SSH connection
 # whithout a public/private key pair
 #SSH_ROOT_PASSWORD="password_on_the_rear_recovery_system"


### PR DESCRIPTION
Fixed BACKUP_PROG_EXCLUDE and BACKUP_PROG_INCLUDE
example values in multiple backups documentation
and in example config files
(related to https://github.com/rear/rear/issues/1068)