### PR TITLE
Forbid BACKUP_URL=usb for BACKUP_TYPE=incremental/differential

### DIFF
--- a/doc/rear.8
+++ b/doc/rear.8
@@ -544,7 +544,11 @@ OUTPUT_URL=nfs://server/path/
 .\}
 .RE
 .sp
-When using BACKUP=NETFS and BACKUP_PROG=tar there is an option to select BACKUP_TYPE=incremental or BACKUP_TYPE=differential to let rear make incremental or differential backups until the next full backup day e\&.g\&. via FULLBACKUPDAY="Mon" is reached or when the last full backup is too old after FULLBACKUP_OUTDATED_DAYS has passed\&.
+When using BACKUP=NETFS and BACKUP_PROG=tar there is an option to select BACKUP_TYPE=incremental or BACKUP_TYPE=differential
+to let rear make incremental or differential backups until the next full backup day e\&.g\&. via FULLBACKUPDAY="Mon" is reached
+or when the last full backup is too old after FULLBACKUP_OUTDATED_DAYS has passed\&. Incremental or differential backup is
+currently only known to work with BACKUP_URL=nfs\&. Other BACKUP_URL schemes may work but at least BACKUP_URL=usb is known
+not to work with incremental or differential backup\&.
 .SH "CONFIGURATION"
 .sp
 To configure Relax\-and\-Recover you have to edit the configuration files in \fI/etc/rear/\fR\&. All \fI*\&.conf\fR files there are part of the configuration, but only \fIsite\&.conf\fR and \fIlocal\&.conf\fR are intended for the user configuration\&. All other configuration files hold defaults for various distributions and should not be changed\&.

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -386,6 +386,10 @@ When using +BACKUP=NETFS+ and BACKUP_PROG=tar there is an option to select
 incremental or differential backups until the next full backup day
 e.g. via +FULLBACKUPDAY="Mon"+ is reached or when the last full backup
 is too old after FULLBACKUP_OUTDATED_DAYS has passed.
+Incremental or differential backup is currently only known to work
+with +BACKUP_URL=nfs+. Other BACKUP_URL schemes may work but
+at least +BACKUP_URL=usb+ is known not to work with incremental
+or differential backup.
 
 == CONFIGURATION
 To configure Relax-and-Recover you have to edit the configuration files in

--- a/doc/user-guide/03-configuration.adoc
+++ b/doc/user-guide/03-configuration.adoc
@@ -133,6 +133,10 @@ When using +BACKUP=NETFS+ and +BACKUP_PROG=tar+ there is an option to select
 incremental or differential backups until the next full backup day
 e.g. via +FULLBACKUPDAY="Mon"+ is reached or when the last full backup
 is too old after FULLBACKUP_OUTDATED_DAYS has passed.
+Incremental or differential backup is currently only known to work
+with +BACKUP_URL=nfs+. Other BACKUP_URL schemes may work but
+at least +BACKUP_URL=usb+ is known not to work with incremental
+or differential backup.
 
 BACKUP=REQUESTRESTORE::
 No backup, just ask user to somehow restore the filesystems.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -493,6 +493,9 @@ BACKUP_INTEGRITY_CHECK=
 # Define BACKUP_TYPE.
 # By default BACKUP_TYPE is empty which means "rear mkbackup" will create a full backup.
 # Only with BACKUP=NETFS and BACKUP_PROG=tar one can also use incremental or differential backup:
+# Incremental or differential backup is currently only known to work with BACKUP_URL=nfs://.
+# Other BACKUP_URL schemes may work but at least BACKUP_URL=usb:///... is known not to work
+# with incremental or differential backup (see https://github.com/rear/rear/issues/1145).
 # Incremental or differential backup and NETFS_KEEP_OLD_BACKUP_COPY contradict each other so that
 # NETFS_KEEP_OLD_BACKUP_COPY must not be 'true' in case of incremental or differential backup
 # because NETFS_KEEP_OLD_BACKUP_COPY would move an already existing backup directory away

--- a/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
+++ b/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
@@ -51,6 +51,12 @@ set -e -u -o pipefail
 if ! test "NETFS" = "$BACKUP" -a "tar" = "$BACKUP_PROG" ; then
     Error "BACKUP_TYPE incremental or differential only works with BACKUP=NETFS and BACKUP_PROG=tar"
 fi
+# Incremental or differential backup is currently only known to work with BACKUP_URL=nfs://.
+# Other BACKUP_URL schemes may work but at least BACKUP_URL=usb:///... is known not to work
+# with incremental or differential backup (see https://github.com/rear/rear/issues/1145):
+if test "usb" = "$scheme" ; then
+    Error "BACKUP_TYPE incremental or differential does not work with BACKUP_URL=usb:///..."
+fi
 # Incremental or differential backup and keeping old backup contradict each other (mutual exclusive)
 # so that NETFS_KEEP_OLD_BACKUP_COPY must not be 'true' in case of incremental or differential backup:
 if test "$NETFS_KEEP_OLD_BACKUP_COPY" ; then


### PR DESCRIPTION
Incremental or differential backup is currently
only known to work with BACKUP_URL=nfs://.
Other BACKUP_URL schemes may work but at least
BACKUP_URL=usb:///... is known not to work with
incremental or differential backup, see
https://github.com/rear/rear/issues/1141
and
https://github.com/rear/rear/issues/1145
