### PR TITLE
align supported distros documentation (issue1073)

### DIFF
--- a/doc/user-guide/01-introduction.adoc
+++ b/doc/user-guide/01-introduction.adoc
@@ -96,7 +96,7 @@ Relax-and-Recover has a wide range of features:
  - Syslinux boot menu
  - Storing rescue/backup logfile on rescue media
  - Restoring to different hardware
- - RHEL4, RHEL5, RHEL6 and RHEL7 support
+ - RHEL5, RHEL6 and RHEL7 support
  - SLES 11 and SLES 12 support
  - Debian and Ubuntu support
  - Various usability improvements

--- a/doc/user-guide/02-getting-started.adoc
+++ b/doc/user-guide/02-getting-started.adoc
@@ -57,15 +57,17 @@ Currently we aim to support the following distributions by testing them
 regularly:
 
  - Red Hat Enterprise Linux and derivatives: RHEL5, RHEL6 and RHEL7
- - SUSE SLES 11, 12
- - Ubuntu LTS: 10.04, 12.04, 13.* and 14.*
+ - SUSE Linux Enterprise Server 11 and 12
+ - Ubuntu LTS: 12, 13, 14 and 15
 
 Distributions dropped as supported:
 
  - Ubuntu LTS <12
+ - Fedora <21
+ - RHEL 3 and 4
+ - SLES 9 and 10
+ - openSUSE <11
  - Debian <6
- - RHEL 3, 4
- - Fedora <20
 
 Distributions known to be 'unsupported' are:
 


### PR DESCRIPTION
Aligned info about supported distros
in the documentation to what there is
in the current (i.e. ReaR 1.19) release notes.
If the supported distros changes for ReaR 2.0
that documentation needs to be adapted, see
https://github.com/rear/rear/issues/1073#issuecomment-270091799
