### PR TITLE
Bareos support: add missing directory /var/run/bareos in recovery system

### DIFF
--- a/usr/share/rear/skel/BAREOS/var/run/bareos/.gitignore
+++ b/usr/share/rear/skel/BAREOS/var/run/bareos/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
we are using rear + bareos in our data center.
executing a test recovery revealed that bareos was requesting /var/run/bareos as a system's directory to exist. We've added it to the skel and it works now. We like to share this improvement.