### PR TITLE
Align backup on USB with backup on NFS

### DIFF
--- a/doc/rear.8
+++ b/doc/rear.8
@@ -551,7 +551,7 @@ OUTPUT_URL=nfs://server/path/
 .\}
 .RE
 .sp
-When using BACKUP=NETFS and BACKUP_PROG=tar there is an option to select BACKUP_TYPE=incremental or BACKUP_TYPE=differential to let rear make incremental or differential backups until the next full backup day e\&.g\&. via FULLBACKUPDAY="Mon" is reached or when the last full backup is too old after FULLBACKUP_OUTDATED_DAYS has passed\&. Incremental or differential backup is currently only known to work with BACKUP_URL=nfs\&. Other BACKUP_URL schemes may work but at least BACKUP_URL=usb is known not to work with incremental or differential backup\&.
+When using BACKUP=NETFS and BACKUP_PROG=tar there is an option to select BACKUP_TYPE=incremental or BACKUP_TYPE=differential to let rear make incremental or differential backups until the next full backup day e\&.g\&. via FULLBACKUPDAY="Mon" is reached or when the last full backup is too old after FULLBACKUP_OUTDATED_DAYS has passed\&. Incremental or differential backup is currently only known to work with BACKUP_URL=nfs\&. Other BACKUP_URL schemes may work but at least BACKUP_URL=usb requires USB_SUFFIX to be set to work with incremental or differential backup\&.
 .SH "CONFIGURATION"
 .sp
 To configure Relax\-and\-Recover you have to edit the configuration files in \fI/etc/rear/\fR\&. All \fI*\&.conf\fR files there are part of the configuration, but only \fIsite\&.conf\fR and \fIlocal\&.conf\fR are intended for the user configuration\&. All other configuration files hold defaults for various distributions and should not be changed\&.

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -388,8 +388,8 @@ e.g. via +FULLBACKUPDAY="Mon"+ is reached or when the last full backup
 is too old after FULLBACKUP_OUTDATED_DAYS has passed.
 Incremental or differential backup is currently only known to work
 with +BACKUP_URL=nfs+. Other BACKUP_URL schemes may work but
-at least +BACKUP_URL=usb+ is known not to work with incremental
-or differential backup.
+at least +BACKUP_URL=usb+ requires USB_SUFFIX to be set
+to work with incremental or differential backup.
 
 == CONFIGURATION
 To configure Relax-and-Recover you have to edit the configuration files in

--- a/doc/user-guide/03-configuration.adoc
+++ b/doc/user-guide/03-configuration.adoc
@@ -135,8 +135,8 @@ e.g. via +FULLBACKUPDAY="Mon"+ is reached or when the last full backup
 is too old after FULLBACKUP_OUTDATED_DAYS has passed.
 Incremental or differential backup is currently only known to work
 with +BACKUP_URL=nfs+. Other BACKUP_URL schemes may work but
-at least +BACKUP_URL=usb+ is known not to work with incremental
-or differential backup.
+at least +BACKUP_URL=usb+ requires USB_SUFFIX to be set
+to work with incremental or differential backup.
 
 BACKUP=REQUESTRESTORE::
 No backup, just ask user to somehow restore the filesystems.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -356,6 +356,23 @@ USB_UEFI_PART_SIZE="100"
 # resulting files that should be copied onto the USB stick
 USB_FILES=()
 
+# USB_SUFFIX specifies the last part of the backup directory on the USB medium.
+# When USB_SUFFIX is unset or empty, backup on USB works in its default mode which means
+# multiple timestamp backup directories of the form rear/HOSTNAME/YYYYMMDD.HHMM
+# plus automated rescue environments and backups cleanup via USB_RETAIN_BACKUP_NR.
+# In contrast when USB_SUFFIX is set, backup on USB works in compliance with how backup on NFS works
+# (i.e. BACKUP_URL=usb:... and BACKUP_URL=nfs:... behave compatible when USB_SUFFIX is set)
+# which means a fixed backup directory of the form rear/HOSTNAME/USB_SUFFIX on the USB medium
+# and no automated removal of backups or other stuff (regardless of USB_RETAIN_BACKUP_NR)
+# see https://github.com/rear/rear/issues/1164
+# Using multiple backups as described in doc/user-guide/11-multiple-backups.adoc
+# requires a fixed backup directory so that USB_SUFFIX must be set for multiple backups on USB
+# see https://github.com/rear/rear/issues/1160
+# Also BACKUP_TYPE incremental or differential requires a fixed backup directory
+# so that USB_SUFFIX must be set for incremental or differential backup on USB
+# see https://github.com/rear/rear/issues/1145
+USB_SUFFIX=""
+
 # Number of rescue environments/backups to retain on USB
 USB_RETAIN_BACKUP_NR=2
 
@@ -494,8 +511,8 @@ BACKUP_INTEGRITY_CHECK=
 # By default BACKUP_TYPE is empty which means "rear mkbackup" will create a full backup.
 # Only with BACKUP=NETFS and BACKUP_PROG=tar one can also use incremental or differential backup:
 # Incremental or differential backup is currently only known to work with BACKUP_URL=nfs://.
-# Other BACKUP_URL schemes may work but at least BACKUP_URL=usb:///... is known not to work
-# with incremental or differential backup (see https://github.com/rear/rear/issues/1145).
+# Other BACKUP_URL schemes may work and at least BACKUP_URL=usb:///... requires USB_SUFFIX to be set
+# to work with incremental or differential backup (see https://github.com/rear/rear/issues/1145).
 # Incremental or differential backup and NETFS_KEEP_OLD_BACKUP_COPY contradict each other so that
 # NETFS_KEEP_OLD_BACKUP_COPY must not be 'true' in case of incremental or differential backup
 # because NETFS_KEEP_OLD_BACKUP_COPY would move an already existing backup directory away

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -373,7 +373,10 @@ USB_FILES=()
 # see https://github.com/rear/rear/issues/1145
 USB_SUFFIX=""
 
-# Number of rescue environments/backups to retain on USB
+# Number of older rescue environments or backups to retain on USB.
+# The default USB_RETAIN_BACKUP_NR=2 means that there is at most
+# the latest (current) rescue environment or backup plus
+# the second eldest and the third eldest (three all together):
 USB_RETAIN_BACKUP_NR=2
 
 # Define the default WORKFLOW for the udev handler (empty to disable)

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -103,10 +103,22 @@ fi
 
 # We generate a single syslinux.cfg for the current system
 Log "Creating $USB_PREFIX/syslinux.cfg"
+# FIXME: # type -a time
+#        time is a shell keyword
+#        time is /usr/bin/time
 time=$(basename $USB_REAR_DIR)
+if test $USB_SUFFIX ; then
+    # USB_SUFFIX specifies the last part of the backup directory on the USB medium
+    # and then basename $USB_REAR_DIR can be anything so that we use it as is:
+    menu_label="$time"
+else
+    # When USB_SUFFIX is unset, empty, or contains only blanks
+    # basename $USB_REAR_DIR is a timestamp of the form YYYYMMDD.HHMM
+    menu_label="${time:0:4}-${time:4:2}-${time:6:2} ${time:9:2}:${time:11:2}"
+fi
 syslinux_write <<EOF 4>"$USB_REAR_DIR/syslinux.cfg"
 label $HOSTNAME-$time
-    menu label ${time:0:4}-${time:4:2}-${time:6:2} ${time:9:2}:${time:11:2} $usb_label_workflow
+    menu label $menu_label $usb_label_workflow
     say $HOSTNAME-$time - Recover $HOSTNAME $usb_label_workflow ($time)
     text help
 Relax-and-Recover v$VERSION - $usb_label_workflow using kernel $(uname -r) ${IPADDR:+on $IPADDR}
@@ -116,7 +128,7 @@ ${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BA
     append initrd=/$USB_PREFIX/initrd.cgz root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE
 
 label $HOSTNAME-$time
-    menu label ${time:0:4}-${time:4:2}-${time:6:2} ${time:9:2}:${time:11:2} $usb_label_workflow - AUTOMATIC RECOVER
+    menu label $menu_label $usb_label_workflow - AUTOMATIC RECOVER
     say $HOSTNAME-$time - Recover $HOSTNAME $usb_label_workflow ($time)
     text help
 Relax-and-Recover v$VERSION - $usb_label_workflow using kernel $(uname -r) ${IPADDR:+on $IPADDR}
@@ -175,6 +187,9 @@ EOF
     # TODO: Sort systems by name, but also sort timestamps in reverse order
     for file in $(cd $BUILD_DIR/outputfs; find rear/*/* -name syslinux.cfg); do
         dir=$(dirname $file)
+        # FIXME: # type -a time
+        #        time is a shell keyword
+        #        time is /usr/bin/time
         time=$(basename $dir)
         system=$(basename $(dirname $dir))
 

--- a/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
+++ b/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
@@ -52,10 +52,15 @@ if ! test "NETFS" = "$BACKUP" -a "tar" = "$BACKUP_PROG" ; then
     Error "BACKUP_TYPE incremental or differential only works with BACKUP=NETFS and BACKUP_PROG=tar"
 fi
 # Incremental or differential backup is currently only known to work with BACKUP_URL=nfs://.
-# Other BACKUP_URL schemes may work but at least BACKUP_URL=usb:///... is known not to work
-# with incremental or differential backup (see https://github.com/rear/rear/issues/1145):
+# Other BACKUP_URL schemes may work and at least BACKUP_URL=usb:///... needs special setup
+# to work with incremental or differential backup (see https://github.com/rear/rear/issues/1145):
 if test "usb" = "$scheme" ; then
-    Error "BACKUP_TYPE incremental or differential does not work with BACKUP_URL=usb:///..."
+    # When USB_SUFFIX is set the compliance mode is used where
+    # backup on USB works in compliance with backup on NFS which means
+    # a fixed backup directory where incremental or differential backups work.
+    # Use plain $USB_SUFFIX and not "$USB_SUFFIX" because when USB_SUFFIX contains only blanks
+    # test "$USB_SUFFIX" would result true because test " " results true:
+    test $USB_SUFFIX || Error "BACKUP_TYPE incremental or differential requires USB_SUFFIX for BACKUP_URL=usb"
 fi
 # Incremental or differential backup and keeping old backup contradict each other (mutual exclusive)
 # so that NETFS_KEEP_OLD_BACKUP_COPY must not be 'true' in case of incremental or differential backup:

--- a/usr/share/rear/prep/USB/default/060_set_usb_device.sh
+++ b/usr/share/rear/prep/USB/default/060_set_usb_device.sh
@@ -9,7 +9,24 @@ if [[ -z "$USB_DEVICE" ]] && [[ "$OUTPUT_URL" ]]; then
     esac
 fi
 
-USB_PREFIX="rear/$HOSTNAME/$(date +%Y%m%d.%H%M)"
+# Set USB_PREFIX:
+# Use plain $USB_SUFFIX and not "$USB_SUFFIX" because when USB_SUFFIX contains only blanks
+# test "$USB_SUFFIX" would result true because test " " results true:
+if test $USB_SUFFIX ; then
+    # When USB_SUFFIX is set the compliance mode is used which means
+    USB_PREFIX="rear/$HOSTNAME/$USB_SUFFIX"
+    # which results that backup on USB works in compliance with backup on NFS
+    # which means a fixed backup directory and no automated backups cleanup
+    # see https://github.com/rear/rear/issues/1164
+else
+    # When USB_SUFFIX is unset, empty, or contains only blanks
+    # the default mode for backup on USB is used which means
+    USB_PREFIX="rear/$HOSTNAME/$( date +%Y%m%d.%H%M )"
+    # which results multiple timestamp backup directories
+    # plus automated backups cleanup via USB_RETAIN_BACKUP_NR
+fi
+
+test "$USB_PREFIX" || USB_PREFIX="rear/$HOSTNAME/$(date +%Y%m%d.%H%M)"
 
 ### Change NETFS_PREFIX to USB_PREFIX if our backup URL is on USB
 if [[ "$BACKUP_URL" ]] ; then


### PR DESCRIPTION
The new config variable USB_SUFFIX
specifies the last part of the backup directory on the USB medium.
When USB_SUFFIX is unset or empty, backup on USB works
in its current default mode (i.e. backward compatible)
which means multiple timestamp backup directories
plus automated rescue environments and backups cleanup
via USB_RETAIN_BACKUP_NR.
When USB_SUFFIX is set, backup on USB works
in compliance with how backup on NFS works
which means a fixed backup directory and
no automated removal of any stuff
(regardless of USB_RETAIN_BACKUP_NR).
When  backup on USB behaves as backup on NFS
(i.e. when USB_SUFFIX is set) multiple backups and
incremental/differential backups also work on USB.
See
https://github.com/rear/rear/issues/1164
https://github.com/rear/rear/issues/1160
https://github.com/rear/rear/issues/1145
