### PR TITLE
Drop useless Abort choice in USB backup selection dialog

### DIFF
--- a/usr/share/rear/verify/USB/NETFS/default/540_choose_backup_archive.sh
+++ b/usr/share/rear/verify/USB/NETFS/default/540_choose_backup_archive.sh
@@ -46,16 +46,14 @@ for rear_run in $BUILD_DIR/outputfs/rear/$HOSTNAME/* ; do
 done
 
 # When there is no backup archive detected error out because in this case
-# it does not make sense to show a basically empty backup selection dialog
-# (strictly speaking a backup selection dialog with the only choice 'Abort').
+# it does not make sense to show a backup selection dialog without anything to choose.
 # For the 'test' one must have all array members as a single word i.e. "${name[*]}"
 # because it should succeed when there is any non-empty array member, not necessarily the first one:
 test "${backups[*]}" || Error "No '${BACKUP_PROG_ARCHIVE}${BACKUP_PROG_SUFFIX}${BACKUP_PROG_COMPRESS_SUFFIX}' detected in '$BUILD_DIR/outputfs/rear/$HOSTNAME/*'"
 
 # When there is only one backup archive detected use that and do not disrupt
 # "rear recover" or "rear restoreonly" with a backup selection dialog
-# because what else could the user chose except that one backup
-# (it is questionable why there is an 'Abort' choice below):
+# because what else could the user choose except that one backup:
 if test "1" = "${#backups[@]}" ; then
     backuparchive=${backups[0]}
     RESTORE_ARCHIVES=( "$backuparchive" )
@@ -72,8 +70,7 @@ LogPrint "Select a backup archive."
 # http://stackoverflow.com/questions/13195655/bash-set-x-without-it-being-printed
 # shows that when 'set -x' is set calling '{ set +x ; } 2>/dev/null' runs silently:
 { set +x ; } 2>/dev/null
-select choice in "${backup_times[@]}" "Abort" ; do
-    test "Abort" = "$choice" && Error "User chose to abort recovery."
+select choice in "${backup_times[@]}" ; do
     # trim blanks from reply
     n=( $REPLY )
     # bash arrays count from 0
@@ -82,7 +79,7 @@ select choice in "${backup_times[@]}" "Abort" ; do
         # direct output to stdout which is fd7 (see lib/_input-output-functions.sh)
         # and not using a Print function to always print to the original stdout
         # i.e. to the terminal wherefrom the user has started "rear recover":
-        echo "Invalid choice $REPLY, try again or abort." >&7
+        echo "Invalid choice $REPLY, try again (or press [Ctrl]+[C] to abort)." >&7
         continue
     fi
     backuparchive=${backups[$n]}


### PR DESCRIPTION
An "Abort" choice in any 'select' dialog is useless
because simple [Ctrl]+[C] also aborts ReaR.

Cf. https://github.com/rear/rear/issues/1166

With that change recovery with backup on USB
and aborting at the USB backup selection dialog
works as follows:
<pre>
RESCUE e205:~ # rear -d -D recover
...
Backup archive /tmp/rear.JAM8egDNTgZlexj/outputfs/rear/e205/20170117.1311/backup.tar.gz detected.
Backup archive /tmp/rear.JAM8egDNTgZlexj/outputfs/rear/e205/20170117.1324/backup.tar.gz detected.
Backup archive /tmp/rear.JAM8egDNTgZlexj/outputfs/rear/e205/20170117.1335/backup.tar.gz detected.
Select a backup archive.
1) 20170117.1311
2) 20170117.1324
3) 20170117.1335
#? 4
Invalid choice 4, try again (or press [Ctrl]+[C] to abort).
#? ^C
2017-01-18 09:22:29.979923804 Running exit tasks.
2017-01-18 09:22:29.982992270 Exit task 'umount -f -v '/tmp/rear.JAM8egDNTgZlexj/outputfs' >&2'
umount: /tmp/rear.JAM8egDNTgZlexj/outputfs (/dev/sdb1) unmounted
2017-01-18 09:22:29.994368475 Exit task 'rmdir -v /tmp/rear.JAM8egDNTgZlexj/outputfs >&2'
rmdir: removing directory, '/tmp/rear.JAM8egDNTgZlexj/outputfs'
2017-01-18 09:22:29.997847901 Exit task 'cleanup_build_area_and_end_program'
2017-01-18 09:22:30.000025643 Finished in 8 seconds
2017-01-18 09:22:30.002067549 Removing build area /tmp/rear.JAM8egDNTgZlexj
removed directory '/tmp/rear.JAM8egDNTgZlexj'
2017-01-18 09:22:30.011102008 End of program reached
2017-01-18 09:22:30.013068370 Exit task 'exec 8>&-'
2017-01-18 09:22:30.015225968 Exit task 'exec 7>&-'
2017-01-18 09:22:30.017316532 Exit task ''

RESCUE e205:~ # echo $?
130
</pre>

When there are no objections I will "just merge" it.
