### PR TITLE
New REAR_INITRD_COMPRESSION to specify the compression of the recovery system initrd

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -54,7 +54,7 @@ if [[ -n "$ISO_MAX_SIZE" ]]; then
     # Computation of the real backup maximum size by excluding bootable files size on the first ISO (EFI, kernel, ramdisk)
     # Don't use that on max size less than 200MB which would result in too many backups
     if [[ $ISO_MAX_SIZE -gt 200 ]]; then
-        INITRD_SIZE=$(stat -c '%s' $TMP_DIR/initrd.cgz)
+        INITRD_SIZE=$(stat -c '%s' $TMP_DIR/$REAR_INITRD_FILENAME)
         KERNEL_SIZE=$(stat -c '%s' $KERNEL_FILE)
         # We add 15MB which is the average size of all isolinux binaries
         BASE_ISO_SIZE=$(((${INITRD_SIZE}+${KERNEL_SIZE})/1024/1024+15))

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1360,20 +1360,27 @@ USING_UEFI_BOOTLOADER=
 ##
 # REAR_INITRD_COMPRESSION
 #
-# What compression to use when creating the initramfs/initrd for Relax-and-Recover.
+# What compression to use when creating the initramfs/initrd for the ReaR rescue/recovery system.
 # By default and also as fallback an initrd.cgz with gzip default compression is created.
 # The default is known to work well in practice.
-# The ReaR initrd is loaded by possibly various bootloaders (normally syslinux).
+# The ReaR rescue/recovery system initrd is loaded by various bootloaders (normally syslinux).
 # Usually any bootloader should be able to load any initrd file but then
 # the initrd must be usable by the kernel which means a specially compressed initrd
 # may not always work, in particular not with older kernels.
+# When booting on ppc64 with the yaboot bootloader the initrd must be less than 32MB
+# so that in this case the lzma compression could be even required
+# see https://github.com/rear/rear/issues/1142
+# In genaral a smaller initrd is loaded faster by the ReaR rescue/recovery system bootloader
+# so that a small initrd could make the whole system recovery a bit faster.
 # With REAR_INITRD_COMPRESSION="fast"
-# an initrd.cgz with gzip --fast compression is created (fast speed but less compression).
+# an initrd.cgz with gzip --fast compression is created (fast creating but less compression).
 # With REAR_INITRD_COMPRESSION="best"
-# an initrd.cgz with gzip --best compression is created (best compression but slow speed).
+# an initrd.cgz with gzip --best compression is created (best gzip compression but slower creating).
 # With REAR_INITRD_COMPRESSION="lzma"
-# an initrd.xz with xz using the lzma compression is created
-# (see https://github.com/rear/rear/issues/1142).
+# an initrd.xz with xz using the lzma compression is created (very best compression but very slow).
+# An initrd.xz with lzma compression may not work in this or that case.
+# An initrd.xz with lzma compression is known not to work together with DRLM,
+# see https://github.com/rear/rear/pull/1182#issuecomment-275423441
 REAR_INITRD_COMPRESSION=""
 
 ##

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1358,6 +1358,25 @@ GRUB_RESCUE_USER=""
 USING_UEFI_BOOTLOADER=
 
 ##
+# REAR_INITRD_COMPRESSION
+#
+# What compression to use when creating the initramfs/initrd for Relax-and-Recover.
+# By default and also as fallback an initrd.cgz with gzip default compression is created.
+# The default is known to work well in practice.
+# The ReaR initrd is loaded by possibly various bootloaders (normally syslinux).
+# Usually any bootloader should be able to load any initrd file but then
+# the initrd must be usable by the kernel which means a specially compressed initrd
+# may not always work, in particular not with older kernels.
+# With REAR_INITRD_COMPRESSION="fast"
+# an initrd.cgz with gzip --fast compression is created (fast speed but less compression).
+# With REAR_INITRD_COMPRESSION="best"
+# an initrd.cgz with gzip --best compression is created (best compression but slow speed).
+# With REAR_INITRD_COMPRESSION="lzma"
+# an initrd.xz with xz using the lzma compression is created
+# (see https://github.com/rear/rear/issues/1142).
+REAR_INITRD_COMPRESSION=""
+
+##
 # advanced handling of Relax-and-Recover result (boot image)
 ##
 # Relax-and-Recover can do something with the resulting files, here we say what

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -259,7 +259,7 @@ function make_syslinux_config {
 	syslinux_menu_help "Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)" \
 			"${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}"
 	echo "kernel kernel"
-	echo "append initrd=initrd.cgz root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE"
+	echo "append initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE"
 	if [ "$ISO_DEFAULT" == "manual" ] ; then
                echo "default rear"
                syslinux_menu "default"
@@ -272,7 +272,7 @@ function make_syslinux_config {
 	syslinux_menu_help "Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)" \
 			"${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}"
 	echo "kernel kernel"
-	echo "append initrd=initrd.cgz root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover"
+	echo "append initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover"
 
 	if [ "$ISO_DEFAULT" == "automatic" ] ; then
                echo "default rear-automatic"
@@ -451,7 +451,7 @@ default = "Relax-and-Recover (no Secure Boot)"
 
 image = kernel
     label = "Relax-and-Recover (no Secure Boot)"
-    initrd = initrd.cgz
+    initrd = $REAR_INITRD_FILENAME
 EOF
     [[ -n $KERNEL_CMDLINE ]] && cat << EOF
     append = "$KERNEL_CMDLINE"
@@ -486,14 +486,14 @@ menuentry "Relax-and-Recover (no Secure Boot)"  --class gnu-linux --class gnu --
      echo 'Loading kernel ...'
      linux /isolinux/kernel root=UUID=$root_uuid $KERNEL_CMDLINE
      echo 'Loading initial ramdisk ...'
-     initrd /isolinux/initrd.cgz
+     initrd /isolinux/$REAR_INITRD_FILENAME
 }
 
 menuentry "Relax-and-Recover (Secure Boot)"  --class gnu-linux --class gnu --class os {
      echo 'Loading kernel ...'
      linuxefi /isolinux/kernel root=UUID=$root_uuid $KERNEL_CMDLINE
      echo 'Loading initial ramdisk ...'
-     initrdefi /isolinux/initrd.cgz
+     initrdefi /isolinux/$REAR_INITRD_FILENAME
 }
 
 menuentry "Reboot" {

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -38,8 +38,8 @@ if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" ]]; then
         # copy initrd and kernel inside efi_boot image as
         cp -pL $v $KERNEL_FILE $TMP_DIR/mnt/EFI/BOOT/kernel >&2
         StopIfError "Could not copy kernel to UEFI"
-        cp $v $TMP_DIR/initrd.cgz $TMP_DIR/mnt/EFI/BOOT/initrd.cgz >&2
-        StopIfError "Could not copy initrd to UEFI"
+        cp $v $TMP_DIR/$REAR_INITRD_FILENAME $TMP_DIR/mnt/EFI/BOOT/$REAR_INITRD_FILENAME >&2
+        StopIfError "Could not copy $REAR_INITRD_FILENAME to UEFI"
         create_ebiso_elilo_conf > $TMP_DIR/mnt/EFI/BOOT/elilo.conf
         create_grub2_cfg > $TMP_DIR/mnt/EFI/BOOT/grub.cfg
     fi
@@ -52,7 +52,7 @@ timeout 5
 splashimage=/EFI/BOOT/splash.xpm.gz
 title Relax-and-Recover (no Secure Boot)
     kernel /isolinux/kernel
-    initrd /isolinux/initrd.cgz
+    initrd /isolinux/$REAR_INITRD_FILENAME
 
 EOF
 else

--- a/usr/share/rear/output/ISO/Linux-i386/800_create_isofs.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/800_create_isofs.sh
@@ -13,13 +13,12 @@ StopIfError "ISO_MKISOFS_BIN [$ISO_MKISOFS_BIN] not an executable !"
 if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" && $(basename ${UEFI_BOOTLOADER}) = "elilo.efi" ]]; then
    Log "Kernel is already present in virtual image, skipping"
 else
-   Log "Copying kernel"
-   #cp -pL $v $KERNEL_FILE $TMP_DIR/kernel >&2
+   Log "Copying kernel and initrd"
    cp -pL $v $KERNEL_FILE $TMP_DIR/isofs/isolinux/kernel >&2
-   cp $v $TMP_DIR/initrd.cgz $TMP_DIR/isofs/isolinux/initrd.cgz >&2
+   cp $v $TMP_DIR/$REAR_INITRD_FILENAME $TMP_DIR/isofs/isolinux/$REAR_INITRD_FILENAME >&2
 fi
 
-#ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel $TMP_DIR/initrd.cgz )
+#ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel $TMP_DIR/$REAR_INITRD_FILENAME )
 # in case the user populates this array manually we must not forget to copy
 # these files to our temporary isofs
 if test "${#ISO_FILES[@]}" -gt 0 ; then

--- a/usr/share/rear/output/ISO/Linux-ia64/300_create_bootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-ia64/300_create_bootimg.sh
@@ -12,7 +12,7 @@ mkdir $v -p $TMP_DIR/mnt/boot >&2
 cp -L $v "$ELILO_BIN" $TMP_DIR/mnt/boot >&2
 StopIfError "Could not find $ELILO_BIN"
 
-cp $v $TMP_DIR/initrd.cgz $TMP_DIR/mnt/boot
+cp $v $TMP_DIR/$REAR_INITRD_FILENAME $TMP_DIR/mnt/boot
 
 #VMLINUX_KERNEL=`find / -xdev -name "vmlinu*-${KERNEL_VERSION}"`
 #cp "${VMLINUX_KERNEL}" $TMP_DIR/mnt/boot/kernel
@@ -29,7 +29,7 @@ timeout=50
 
 image=kernel
 	label=rear
-	initrd=initrd.cgz
+	initrd=$REAR_INITRD_FILENAME
 	read-only
 	append="ramdisk=512000 $CONSOLE  rhgb selinux=0"
 EOF

--- a/usr/share/rear/output/ISO/Linux-ppc64/300_create_yaboot.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64/300_create_yaboot.sh
@@ -57,7 +57,7 @@ default=Relax-and-Recover
 
 image=kernel
 	label=Relax-and-Recover
-	initrd=initrd.cgz
+	initrd=$REAR_INITRD_FILENAME
 	append=" root=/dev/ram0 $KERNEL_CMDLINE"
 
 EOF

--- a/usr/share/rear/output/ISO/Linux-ppc64/310_create_grub2.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64/310_create_grub2.sh
@@ -26,7 +26,7 @@ set timeout=100
 
 menuentry "Relax-and-Recover" {
 	linux   /kernel root=/dev/ram0 $KERNEL_CMDLINE
-	initrd  /initrd.cgz
+	initrd  /$REAR_INITRD_FILENAME
 }
 EOF
 

--- a/usr/share/rear/output/ISO/Linux-ppc64/800_create_isofs.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64/800_create_isofs.sh
@@ -13,9 +13,9 @@ Log "Copying kernel"
 cp -pL $v $KERNEL_FILE $TMP_DIR/kernel >&2
 
 if [[ "$SUSE_STYLE" ]]; then
-  ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel initrd.cgz yaboot)
+  ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel $REAR_INITRD_FILENAME yaboot)
 else
-  ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel initrd.cgz)
+  ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel $REAR_INITRD_FILENAME)
 fi
 Log "Starting '$ISO_MKISOFS_BIN'"
 LogPrint "Making ISO image"

--- a/usr/share/rear/output/ISO/Linux-ppc64le/300_create_grub2.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64le/300_create_grub2.sh
@@ -21,7 +21,7 @@ set timeout=100
 
 menuentry "Relax-and-Recover" {
 	linux   /kernel root=/dev/ram0 $KERNEL_CMDLINE
-	initrd  /initrd.cgz
+	initrd  /$REAR_INITRD_FILENAME
 }
 EOF
 

--- a/usr/share/rear/output/ISO/Linux-ppc64le/800_create_isofs.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64le/800_create_isofs.sh
@@ -12,7 +12,7 @@ StopIfError "ISO_MKISOFS_BIN [$ISO_MKISOFS_BIN] not an executable !"
 Log "Copying kernel"
 cp -pL $v $KERNEL_FILE $TMP_DIR/kernel >&2
 
-ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel initrd.cgz )
+ISO_FILES=( ${ISO_FILES[@]} $TMP_DIR/kernel $REAR_INITRD_FILENAME )
 Log "Starting '$ISO_MKISOFS_BIN'"
 LogPrint "Making ISO image"
 

--- a/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
+++ b/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
@@ -1,4 +1,4 @@
-# 80_copy_to_tftp.sh
+# 800_copy_to_tftp.sh
 #
 # copy kernel and initrd to TFTP server for Relax-and-Recover
 #
@@ -19,20 +19,20 @@ if [[ ! -z "$PXE_TFTP_URL" ]] ; then
     mkdir -m 755 -p $v "$BUILD_DIR/tftpbootfs/$OUTPUT_PREFIX_PXE" >&2
     StopIfError "Could not mkdir '$BUILD_DIR/tftpbootfs/$OUTPUT_PREFIX_PXE'"
     PXE_KERNEL="$OUTPUT_PREFIX_PXE/${PXE_TFTP_PREFIX}kernel"
-    PXE_INITRD="$OUTPUT_PREFIX_PXE/${PXE_TFTP_PREFIX}initrd.cgz"
+    PXE_INITRD="$OUTPUT_PREFIX_PXE/$PXE_TFTP_PREFIX$REAR_INITRD_FILENAME"
     PXE_MESSAGE="$OUTPUT_PREFIX_PXE/${PXE_TFTP_PREFIX}message"
 else
     PXE_TFTP_LOCAL_PATH="$PXE_TFTP_PATH"
     # By default PXE_TFTP_PREFIX=$HOSTNAME. (see conf/default.conf)
     PXE_KERNEL="${PXE_TFTP_PREFIX}kernel"
-    PXE_INITRD="${PXE_TFTP_PREFIX}initrd.cgz"
+    PXE_INITRD="$PXE_TFTP_PREFIX$REAR_INITRD_FILENAME"
     PXE_MESSAGE="${PXE_TFTP_PREFIX}message"
     [[ ! -d "$PXE_TFTP_LOCAL_PATH" ]] && mkdir $v -m 750 "$PXE_TFTP_LOCAL_PATH" >&2
 fi
 
 
 cp -pL $v "$KERNEL_FILE" "$PXE_TFTP_LOCAL_PATH/$PXE_KERNEL" >&2
-cp -a $v "$TMP_DIR"/initrd.cgz "$PXE_TFTP_LOCAL_PATH/$PXE_INITRD" >&2
+cp -a $v "$TMP_DIR/$REAR_INITRD_FILENAME" "$PXE_TFTP_LOCAL_PATH/$PXE_INITRD" >&2
 echo "$VERSION_INFO" >"$PXE_TFTP_LOCAL_PATH/$PXE_MESSAGE"
 # files must be readable for others for PXE
 chmod 444 "$PXE_TFTP_LOCAL_PATH/$PXE_KERNEL"
@@ -65,16 +65,16 @@ fi
 
 
 if [[ ! -z "$PXE_TFTP_URL" ]] ; then
-    LogPrint "Copied kernel+initrd ($(du -shc $KERNEL_FILE "$TMP_DIR/initrd.cgz" | tail -n 1 | tr -s "\t " " " | cut -d " " -f 1 )) to $PXE_TFTP_URL"
+    LogPrint "Copied kernel+initrd $( du -shc $KERNEL_FILE "$TMP_DIR/$REAR_INITRD_FILENAME" | tail -n 1 | tr -s "\t " " " | cut -d " " -f 1 ) to $PXE_TFTP_URL"
     umount_url $PXE_TFTP_URL $BUILD_DIR/tftpbootfs
     rmdir $BUILD_DIR/tftpbootfs >&2
     if [[ $? -eq 0 ]] ; then
         RemoveExitTask "rm -Rf $v $BUILD_DIR/tftpbootfs >&2"
     fi
-    RESULT_FILES=( "${RESULT_FILES[@]}" )
 else
     # legacy way PXE_TFTP_PATH
-    LogPrint "Copied kernel+initrd ($(du -shc $KERNEL_FILE "$TMP_DIR/initrd.cgz" | tail -n 1 | tr -s "\t " " " | cut -d " " -f 1 )) to $PXE_TFTP_PATH"
+    LogPrint "Copied kernel+initrd $( du -shc $KERNEL_FILE "$TMP_DIR/$REAR_INITRD_FILENAME" | tail -n 1 | tr -s "\t " " " | cut -d " " -f 1 ) to $PXE_TFTP_PATH"
     # Add to result files
     RESULT_FILES=( "${RESULT_FILES[@]}" "$PXE_TFTP_LOCAL_PATH/$PXE_KERNEL" "$PXE_TFTP_LOCAL_PATH/$PXE_INITRD" "$PXE_TFTP_LOCAL_PATH/$PXE_MESSAGE" )
 fi
+

--- a/usr/share/rear/output/RAMDISK/Linux-i386/900_copy_ramdisk.sh
+++ b/usr/share/rear/output/RAMDISK/Linux-i386/900_copy_ramdisk.sh
@@ -10,7 +10,7 @@ local path=$( url_path $OUTPUT_URL )
 
 if [[ "$BACKUP" == "NETFS" ]] ; then
     cp $v -pLf $KERNEL_FILE $TMP_DIR/kernel-$RAMDISK_SUFFIX >&2
-    cp $v -pLf $TMP_DIR/initrd.cgz $TMP_DIR/initramfs-$RAMDISK_SUFFIX.img >&2
+    cp $v -pLf $TMP_DIR/$REAR_INITRD_FILENAME $TMP_DIR/initramfs-$RAMDISK_SUFFIX.img >&2
     # NETFS will copy things for us
     RESULT_FILES=( "${RESULT_FILES[@]}" $TMP_DIR/kernel-$RAMDISK_SUFFIX $TMP_DIR/initramfs-$RAMDISK_SUFFIX.img )
     return
@@ -25,23 +25,23 @@ case "$scheme" in
         LogPrint "Transferring kernel and initramfs to $path"
         mkdir -p $v $path >&2
         cp $v -pLf $KERNEL_FILE $path/kernel-$RAMDISK_SUFFIX >&2
-        cp $v -pLf $TMP_DIR/initrd.cgz $path/initramfs-$RAMDISK_SUFFIX.img >&2
+        cp $v -pLf $TMP_DIR/$REAR_INITRD_FILENAME $path/initramfs-$RAMDISK_SUFFIX.img >&2
         ;;
     (nfs|cifs|usb|davfs)
         LogPrint "Transferring kernel and initramfs to $OUTPUT_URL"
         mkdir -p $v $BUILD_DIR/outputfs/$NETFS_PREFIX/ >&2
         cp $v -pLf $KERNEL_FILE $BUILD_DIR/outputfs/$NETFS_PREFIX/kernel-$RAMDISK_SUFFIX >&2
-        cp $v -pLf $TMP_DIR/initrd.cgz $BUILD_DIR/outputfs/$NETFS_PREFIX/initramfs-$RAMDISK_SUFFIX.img >&2
+        cp $v -pLf $TMP_DIR/$REAR_INITRD_FILENAME $BUILD_DIR/outputfs/$NETFS_PREFIX/initramfs-$RAMDISK_SUFFIX.img >&2
         ;;
     (fish|ftp|ftps|hftp|http|https|sftp)
         LogPrint "Transferring kernel and initramfs to $OUTPUT_URL"
         lftp -c "open $OUTPUT_URL; mkdir $path; mput -O $path $KERNEL_FILE" || Error "Problem transferring kernel '$KERNEL_FILE' to $OUTPUT_URL"
-        lftp -c "open $OUTPUT_URL; mkdir $path; mput -O $path $TMP_DIR/initrd.cgz" || Error "Problem transferring ramdisk '$TMP_DIR/initrd.cgz' to $OUTPUT_URL"
+        lftp -c "open $OUTPUT_URL; mkdir $path; mput -O $path $TMP_DIR/$REAR_INITRD_FILENAME" || Error "Problem transferring ramdisk '$TMP_DIR/$REAR_INITRD_FILENAME' to $OUTPUT_URL"
         ;;
     (rsync)
         LogPrint "Transferring kernel and initramfs to $OUTPUT_URL"
         rsync -a $v "$KERNEL_FILE" "$OUTPUT_URL" || Error "Problem transferring kernel '$KERNEL_FILE' to $OUTPUT_URL"
-        rsync -a $v "$TMP_DIR/initrd.cgz" "$OUTPUT_URL" || Error "Problem transferring ramdisk '$TMP_DIR/initrd.cgz' to $OUTPUT_URL"
+        rsync -a $v "$TMP_DIR/$REAR_INITRD_FILENAME" "$OUTPUT_URL" || Error "Problem transferring ramdisk '$TMP_DIR/$REAR_INITRD_FILENAME' to $OUTPUT_URL"
         ;;
     (*) Error "Invalid scheme '$scheme' in '$OUTPUT_URL'."
         ;;

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -125,7 +125,7 @@ Relax-and-Recover v$VERSION - $usb_label_workflow using kernel $(uname -r) ${IPA
 ${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}
     endtext
     kernel /$USB_PREFIX/kernel
-    append initrd=/$USB_PREFIX/initrd.cgz root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE
+    append initrd=/$USB_PREFIX/$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE
 
 label $HOSTNAME-$time
     menu label $menu_label $usb_label_workflow - AUTOMATIC RECOVER
@@ -135,7 +135,7 @@ Relax-and-Recover v$VERSION - $usb_label_workflow using kernel $(uname -r) ${IPA
 ${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}
     endtext
     kernel /$USB_PREFIX/kernel
-    append initrd=/$USB_PREFIX/initrd.cgz root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover
+    append initrd=/$USB_PREFIX/$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover
 
 EOF
 

--- a/usr/share/rear/output/USB/Linux-i386/830_copy_kernel_initrd.sh
+++ b/usr/share/rear/output/USB/Linux-i386/830_copy_kernel_initrd.sh
@@ -4,10 +4,10 @@
 cp -pL $v "$KERNEL_FILE" "$BUILD_DIR/outputfs/$USB_PREFIX/kernel" >&2
 StopIfError "Could not create $BUILD_DIR/outputfs/$USB_PREFIX/kernel"
 
-cp -p $v "$TMP_DIR/initrd.cgz" "$BUILD_DIR/outputfs/$USB_PREFIX/initrd.cgz" >&2
-StopIfError "Could not create $BUILD_DIR/outputfs/$USB_PREFIX/initrd.cgz"
+cp -p $v "$TMP_DIR/$REAR_INITRD_FILENAME" "$BUILD_DIR/outputfs/$USB_PREFIX/$REAR_INITRD_FILENAME" >&2
+StopIfError "Could not create $BUILD_DIR/outputfs/$USB_PREFIX/$REAR_INITRD_FILENAME"
 
-Log "Copied kernel and initrd.cgz to $USB_PREFIX"
+Log "Copied kernel and $REAR_INITRD_FILENAME to $USB_PREFIX"
 
 # Copy current unfinished logfile to USB dir for debug purpose.
 # Usually RUNTIME_LOGFILE=/var/log/rear/rear-$HOSTNAME.log
@@ -20,4 +20,4 @@ StopIfError "Could not copy $RUNTIME_LOGFILE to $BUILD_DIR/outputfs/$USB_PREFIX/
 LogPrint "Saved $RUNTIME_LOGFILE as $USB_PREFIX/$logfile_basename"
 
 # FIXME: This is meaningless ATM, RESULT_FILES should be put somewhere reliable and not on a temporary mounted media.
-#RESULT_FILES=( "${USB_FILES[@]}" "$USB_DIR/kernel" "$USB_DIR/initrd.cgz" )
+#RESULT_FILES=( "${USB_FILES[@]}" "$USB_DIR/kernel" "$USB_DIR/$REAR_INITRD_FILENAME" )

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -32,13 +32,13 @@ fi
 
 # Ensure that kernel and initrd are there:
 test -r "$KERNEL_FILE" || Error "Cannot setup GRUB_RESCUE: Cannot read kernel file '$KERNEL_FILE'."
-local initrd_file=$TMP_DIR/initrd.cgz
+local initrd_file=$TMP_DIR/$REAR_INITRD_FILENAME
 test -r $initrd_file || Error "Cannot setup GRUB_RESCUE: Cannot read initrd '$initrd_file'."
 
 # Some commonly needed values:
 local boot_dir="/boot"
 local boot_kernel_name="rear-kernel"
-local boot_initrd_name="rear-initrd.cgz"
+local boot_initrd_name="rear-$REAR_INITRD_FILENAME"
 local boot_kernel_file="$boot_dir/$boot_kernel_name"
 local boot_initrd_file="$boot_dir/$boot_initrd_name"
 local grub_config_dir="$boot_dir/grub${grub_num}"
@@ -247,7 +247,9 @@ else
     cp -pLf $v $KERNEL_FILE $boot_kernel_file >&2 || BugError "Unable to copy '$KERNEL_FILE' to '$boot_kernel_file'."
 fi
 
-# Provide the rear recovery system in initrd_file (i.e. TMP_DIR/initrd.cgz) as boot_initrd_file (i.e. /boot/rear-initrd.cgz):
+# Provide the rear recovery system in initrd_file (i.e. TMP_DIR/initrd.cgz or TMP_DIR/initrd.xz)
+# as boot_initrd_file (i.e. /boot/rear-initrd.cgz or /boot/rear-initrd.xz)
+# (regarding '.cgz' versus '.xz' see https://github.com/rear/rear/issues/1142)
 cp -af $v $initrd_file $boot_initrd_file >&2 || BugError "Unable to copy '$initrd_file' to '$boot_initrd_file'."
 
 LogPrint "Finished GRUB_RESCUE setup: Added '$grub_rear_menu_entry_name' GRUB 2 menu entry."

--- a/usr/share/rear/output/default/940_grub_rescue.sh
+++ b/usr/share/rear/output/default/940_grub_rescue.sh
@@ -30,16 +30,16 @@ fi
 [[ -r "$KERNEL_FILE" ]]
 StopIfError "Failed to find kernel, updating GRUB failed."
 
-[[ -r "$TMP_DIR/initrd.cgz" ]]
-StopIfError "Failed to find initrd.cgz, updating GRUB failed."
+[[ -r "$TMP_DIR/$REAR_INITRD_FILENAME" ]]
+StopIfError "Failed to find $REAR_INITRD_FILENAME, updating GRUB failed."
 
 function total_filesize {
     stat --format '%s' $@ 2>&8 | awk 'BEGIN { t=0 } { t+=$1 } END { print t }'
 }
 
 available_space=$(df -Pkl /boot | awk 'END { print $4 * 1024 }')
-used_space=$(total_filesize /boot/rear-kernel /boot/rear-initrd.cgz)
-required_space=$(total_filesize $KERNEL_FILE $TMP_DIR/initrd.cgz)
+used_space=$(total_filesize /boot/rear-kernel /boot/rear-$REAR_INITRD_FILENAME)
+required_space=$(total_filesize $KERNEL_FILE $TMP_DIR/$REAR_INITRD_FILENAME)
 
 if (( available_space + used_space < required_space )) ; then
     required_MiB=$(( required_space / 1024 / 1024 ))
@@ -83,7 +83,7 @@ END {
     print "title Relax-and-Recover"
     print "\tpassword $GRUB_RESCUE_PASSWORD"
     print "\tkernel /rear-kernel $KERNEL_CMDLINE"
-    print "\tinitrd /rear-initrd.cgz"
+    print "\tinitrd /rear-$REAR_INITRD_FILENAME"
 }
 EOF
 
@@ -108,5 +108,5 @@ else
 fi
 BugIfError "Unable to copy '$KERNEL_FILE' to /boot"
 
-cp -af $v $TMP_DIR/initrd.cgz /boot/rear-initrd.cgz >&2
-BugIfError "Unable to copy '$TMP_DIR/initrd.cgz' to /boot"
+cp -af $v $TMP_DIR/$REAR_INITRD_FILENAME /boot/rear-$REAR_INITRD_FILENAME >&2
+BugIfError "Unable to copy '$TMP_DIR/$REAR_INITRD_FILENAME' to /boot"

--- a/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
+++ b/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
@@ -1,16 +1,30 @@
-# 100_create_initramfs.sh
+# 900_create_initramfs.sh
 #
 # create initramfs for Relax-and-Recover
 #
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-LogPrint "Creating initramfs"
+LogPrint "Creating recovery/rescue system initramfs/initrd"
 
-pushd "$ROOTFS_DIR" >&8
-find . ! -name "*~"  |\
-	tee /dev/fd/8  |\
-	cpio -H newc --create --quiet  |\
-	gzip > "$TMP_DIR/initrd.cgz"
-StopIfError "Could not create initramfs archive"
-popd >&8
+pushd "$ROOTFS_DIR" >/dev/null
+# First try to create initrd.xz with the newer xz-lzma compression,
+# see https://github.com/rear/rear/issues/1142
+# The REAR_INITRD_FILENAME is needed in various subsequent scripts:
+REAR_INITRD_FILENAME="initrd.xz"
+if find . ! -name "*~" | cpio -H newc --create --quiet | xz --format=lzma --compress --stdout > "$TMP_DIR/$REAR_INITRD_FILENAME" ; then
+    LogPrint "Created $REAR_INITRD_FILENAME with xz-lzma compression ($( stat -c%s $TMP_DIR/$REAR_INITRD_FILENAME ) bytes)"
+else
+    REAR_INITRD_FILENAME="initrd.cgz"
+    # If it fails to create initrd.xz with xz-lzma compression
+    # fall back to the traditional way and create initrd.cgz with gzip compression,
+    # cf. "Dirty hacks welcome" at https://github.com/rear/rear/wiki/Coding-Style
+    if find . ! -name "*~" | cpio -H newc --create --quiet | gzip > "$TMP_DIR/$REAR_INITRD_FILENAME" ; then
+        LogPrint "Created $REAR_INITRD_FILENAME with gzip compression ($( stat -c%s $TMP_DIR/$REAR_INITRD_FILENAME ) bytes)"
+    else
+        # No need to clean up things (like 'popd') because Error exits directly:
+        Error "Failed to create recovery/rescue system initramfs/initrd"
+    fi
+fi
+popd >/dev/null
+

--- a/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
+++ b/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
@@ -7,6 +7,11 @@
 
 # The REAR_INITRD_FILENAME is needed in various subsequent scripts that install the bootloader
 # of the Relax-and-Recover recovery/rescue system during the subsequent 'output' stage.
+# REAR_INITRD_FILENAME contains the filename (i.e. basename) of ReaR's own initramfs/initrd
+# that contains the files of the Relax-and-Recover recovery/rescue system.
+# In contrast a variable that contains the filename of the initramfs/initrd of the system
+# where "rear mkbackup" runs would have to be named like SYSTEM_INITRD_FILENAME and/or
+# where "rear recover" runs like TARGET_SYSTEM_INITRD_FILENAME (cf. TARGET_FS_ROOT).
 pushd "$ROOTFS_DIR" >/dev/null
 case "$REAR_INITRD_COMPRESSION" in
     (lzma)

--- a/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
+++ b/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
@@ -5,7 +5,6 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-LogPrint "Creating recovery/rescue system initramfs/initrd"
 # The REAR_INITRD_FILENAME is needed in various subsequent scripts that install the bootloader
 # of the Relax-and-Recover recovery/rescue system during the subsequent 'output' stage.
 pushd "$ROOTFS_DIR" >/dev/null
@@ -13,6 +12,7 @@ case "$REAR_INITRD_COMPRESSION" in
     (lzma)
         # Create initrd.xz with xz and use the lzma compression, see https://github.com/rear/rear/issues/1142
         REAR_INITRD_FILENAME="initrd.xz"
+        LogPrint "Creating recovery/rescue system initramfs/initrd $REAR_INITRD_FILENAME with xz lzma compression"
         if find . ! -name "*~" | cpio -H newc --create --quiet | xz --format=lzma --compress --stdout > "$TMP_DIR/$REAR_INITRD_FILENAME" ; then
             LogPrint "Created $REAR_INITRD_FILENAME with xz lzma compression ($( stat -c%s $TMP_DIR/$REAR_INITRD_FILENAME ) bytes)"
         else
@@ -23,6 +23,7 @@ case "$REAR_INITRD_COMPRESSION" in
     (fast)
         # Create initrd.cgz with gzip --fast compression (fast speed but less compression)
         REAR_INITRD_FILENAME="initrd.cgz"
+        LogPrint "Creating recovery/rescue system initramfs/initrd $REAR_INITRD_FILENAME with gzip fast compression"
         if find . ! -name "*~" | cpio -H newc --create --quiet | gzip --fast > "$TMP_DIR/$REAR_INITRD_FILENAME" ; then
             LogPrint "Created $REAR_INITRD_FILENAME with gzip fast compression ($( stat -c%s $TMP_DIR/$REAR_INITRD_FILENAME ) bytes)"
         else
@@ -33,6 +34,7 @@ case "$REAR_INITRD_COMPRESSION" in
     (best)
         # Create initrd.cgz with gzip --best compression (best compression but slow speed)
         REAR_INITRD_FILENAME="initrd.cgz"
+        LogPrint "Creating recovery/rescue system initramfs/initrd $REAR_INITRD_FILENAME with gzip best compression"
         if find . ! -name "*~" | cpio -H newc --create --quiet | gzip --best > "$TMP_DIR/$REAR_INITRD_FILENAME" ; then
             LogPrint "Created $REAR_INITRD_FILENAME with gzip best compression ($( stat -c%s $TMP_DIR/$REAR_INITRD_FILENAME ) bytes)"
         else
@@ -44,6 +46,7 @@ case "$REAR_INITRD_COMPRESSION" in
         # Create initrd.cgz with gzip default compression by default and also as fallback
         # (no need to error out here if REAR_INITRD_COMPRESSION has an invalid value)
         REAR_INITRD_FILENAME="initrd.cgz"
+        LogPrint "Creating recovery/rescue system initramfs/initrd $REAR_INITRD_FILENAME with gzip default compression"
         if find . ! -name "*~" | cpio -H newc --create --quiet | gzip > "$TMP_DIR/$REAR_INITRD_FILENAME" ; then
             LogPrint "Created $REAR_INITRD_FILENAME with gzip default compression ($( stat -c%s $TMP_DIR/$REAR_INITRD_FILENAME ) bytes)"
         else


### PR DESCRIPTION
Now pack/GNU/Linux/900_create_initramfs.sh
first tries to create initrd.xz with the newer xz-lzma compression and
if that fails it falls back to creating initrd.cgz with gzip compression.
Because now two ReaR initrd filenames are used
initrd.xz versus initrd.cgz
the global variable REAR_INITRD_FILENAME is set
and used in various subsequent scripts where before
the filename initrd.cgz was hardcoded.
See https://github.com/rear/rear/issues/1142
