### PR TITLE
missing bareos-fd.conf error and could not start bareos-fd error 

### DIFF
--- a/usr/share/rear/verify/BAREOS/default/050_check_requirements.sh
+++ b/usr/share/rear/verify/BAREOS/default/050_check_requirements.sh
@@ -22,7 +22,7 @@ else
    [ -x /usr/sbin/bareos-fd ]
    StopIfError "Bareos executable (bareos-fd) missing or not executable"
 
-   [ -s /etc/bareos/bareos-fd.conf ]
+   [ -s /etc/bareos/bareos-fd.conf ] || [ -s /etc/bareos/bareos-fd.d/client/myself.conf ]
    StopIfError "Bareos configuration file (bareos-fd.conf) missing"
 
    [ -x /usr/sbin/bconsole ]

--- a/usr/share/rear/verify/BAREOS/default/100_start_bareos-fd.sh
+++ b/usr/share/rear/verify/BAREOS/default/100_start_bareos-fd.sh
@@ -13,7 +13,9 @@ if [ "$BEXTRACT_DEVICE" -o "$BEXTRACT_VOLUME" ]; then
 else
 
    ### Bareos support using bconsole
-   bareos-fd -u root -g bareos -c /etc/bareos/bareos-fd.conf
+   [ -f /etc/bareos/bareos-fd.conf ] && bareos-fd -u root -g bareos -c /etc/bareos/bareos-fd.conf
+   StopIfError "Cannot start bareos-fd file daemon"
+   [ -f /etc/bareos/bareos-fd.d/client/myself.conf ] && bareos-fd -u root -g bareos -c /etc/bareos
    StopIfError "Cannot start bareos-fd file daemon"
 
 fi


### PR DESCRIPTION
During recover time, this fixes the following errors:

* check for bareos-fd.conf failed for bareos 16.2 which uses /etc/bareos/bareos-fd.d/client/myself.conf 

* error starting bareos-fd due to the above error.