### PR TITLE
add /etc/multipath/* in rear ramdisk

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/280_multipath_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/280_multipath_layout.sh
@@ -26,7 +26,7 @@ done < <( dmsetup ls --target multipath )
 
 if grep -q ^multipath $DISKLAYOUT_FILE ; then
     PROGS=( "${PROGS[@]}" multipath kpartx multipathd )
-    COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/multipath.conf /lib*/multipath )
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/multipath.conf /etc/multipath/* /lib*/multipath )
 
     # depending to the linux distro and arch, libaio can be located in different dir. (ex: /lib/powerpc64le-linux-gnu)
     for libdir in $(ldconfig -p | awk '/libaio.so/ { print $NF }' | xargs -n1 dirname | sort -u); do


### PR DESCRIPTION
If multipathed devices are detected, add the content of `/etc/multipath` directory
into the ramdisk. This avoids some crash during recovery when multipathed
devices were renamed in `/etc/multipath/bindings.`

If no `/etc/multipath/binding` file is present in the ramdisk during recovery, system will detect and named multipath disk as `/dev/mapper/multipaha`, while rear trying to find a disk named `/dev/mapper/rootdisk` (this disk was named `rootdisk` in `/etc/multipath/binding` during backup.)

**=> Tested successfully on redhat7.2 (ppc64le)**

example of cutomized `/etc/multipath/binding` file where `mpatha` were renamed in `rootdisk`:
```
# Multipath bindings, Version : 1.0
# NOTE: this file is automatically maintained by the multipath program.
# You should not need to edit this file in normal circumstances.
#
# Format:
# alias wwid
#
rootdisk 3600507680c82004cf80000000000014c
```


Error message during restoration *when this patch is not applied* (note the `mpatha` device detected vs `rootdisk`):

```
2017-02-04 09:50:23 Including layout/prepare/GNU/Linux/210_load_multipath.sh
2017-02-04 09:50:23 Activating multipath
create: mpatha (3600507680c82004cf80000000000014c) undef IBM     ,2145            
size=50G features='0' hwhandler='0' wp=undef
|-+- policy='service-time 0' prio=50 status=undef
| |- 0:0:0:0 sda 8:0   undef ready running
| |- 0:0:1:0 sdb 8:16  undef ready running
| |- 1:0:0:0 sde 8:64  undef ready running
| `- 1:0:1:0 sdf 8:80  undef ready running
`-+- policy='service-time 0' prio=10 status=undef
  |- 0:0:2:0 sdc 8:32  undef ready running
  |- 0:0:3:0 sdd 8:48  undef ready running
  |- 1:0:2:0 sdg 8:96  undef ready running
  `- 1:0:3:0 sdh 8:112 undef ready running
2017-02-04 09:50:23 Including layout/prepare/default/250_compare_disks.sh
2017-02-04 09:50:23 Comparing disks.
2017-02-04 09:50:23 Disk configuration is identical, proceeding with restore.
2017-02-04 09:50:23 Including layout/prepare/default/270_overrule_migration_mode.sh
2017-02-04 09:50:23 Including layout/prepare/default/300_map_disks.sh
2017-02-04 09:50:23 Including layout/prepare/default/310_remove_exclusions.sh
2017-02-04 09:50:23 Including layout/prepare/default/320_apply_mappings.sh
2017-02-04 09:50:23 Including layout/prepare/default/400_autoresize_disks.sh
2017-02-04 09:50:23 Including layout/prepare/default/500_confirm_layout.sh
2017-02-04 09:50:23 Including layout/prepare/default/510_list_dependencies.sh
2017-02-04 09:50:23 Including layout/prepare/default/520_exclude_components.sh
2017-02-04 09:50:23 Including layout/prepare/default/540_generate_device_code.sh
2017-02-04 09:50:23 Disk label for /dev/mapper/rootdisk detected as msdos.
2017-02-04 09:50:23 Begin create_fs( fs:/ )
2017-02-04 09:50:23 Begin mount_fs( fs:/ )
2017-02-04 09:50:23 End mount_fs( fs:/ )
2017-02-04 09:50:23 End create_fs( fs:/ )
2017-02-04 09:50:23 Begin create_fs( fs:/boot )
2017-02-04 09:50:23 Begin mount_fs( fs:/boot )
2017-02-04 09:50:23 End mount_fs( fs:/boot )
2017-02-04 09:50:23 End create_fs( fs:/boot )
2017-02-04 09:50:23 Including layout/prepare/default/550_finalize_script.sh
2017-02-04 09:50:23 Including layout/prepare/default/600_show_unprocessed.sh
2017-02-04 09:50:23 Including layout/prepare/default/610_exclude_from_restore.sh
2017-02-04 09:50:23 Finished running 'layout/prepare' stage in 0 seconds
2017-02-04 09:50:23 Running 'layout/recreate' stage
2017-02-04 09:50:23 Including layout/recreate/default/100_ask_confirmation.sh
2017-02-04 09:50:23 Including layout/recreate/default/200_run_script.sh
2017-02-04 09:50:23 Start system layout restoration.
  /run/lvm/lvmetad.socket: connect failed: No such file or directory
  WARNING: Failed to connect to lvmetad. Falling back to internal scanning.
+++ create_component /dev/mapper/rootdisk multipath
+++ local device=/dev/mapper/rootdisk
+++ local type=multipath
+++ local touchfile=multipath--dev-mapper-rootdisk
+++ '[' -e /tmp/rear.jr8fwLGqQ0GKSHi/tmp/touch/multipath--dev-mapper-rootdisk ']'
+++ return 0
+++ LogPrint 'Creating partitions for disk /dev/mapper/rootdisk (msdos)'
+++ Log 'Creating partitions for disk /dev/mapper/rootdisk (msdos)'
+++ test 1 -gt 0
++++ Stamp
++++ date '+%Y-%m-%d %H:%M:%S '
+++ echo '2017-02-04 09:50:23 Creating partitions for disk /dev/mapper/rootdisk (msdos)'
2017-02-04 09:50:23 Creating partitions for disk /dev/mapper/rootdisk (msdos)
+++ Print 'Creating partitions for disk /dev/mapper/rootdisk (msdos)'
+++ test 1
+++ echo -e 'Creating partitions for disk /dev/mapper/rootdisk (msdos)'
+++ my_udevsettle
+++ has_binary udevadm
+++ for bin in '$@'
+++ type udevadm
+++ return 0
+++ udevadm settle
+++ parted -s /dev/mapper/rootdisk mklabel msdos
Error: Could not stat device /dev/mapper/rootdisk - No such file or directory.
2017-02-04 09:50:23 An error occurred during layout recreation.
