### PR TITLE
support of nvme disks in guess_bootloader script

### DIFF
--- a/usr/share/rear/prep/default/500_guess_bootloader.sh
+++ b/usr/share/rear/prep/default/500_guess_bootloader.sh
@@ -11,7 +11,7 @@ if [[ -f /etc/sysconfig/bootloader ]]; then
 fi
 for disk in /sys/block/* ; do
     blockd=${disk#/sys/block/}
-    if [[ $blockd = hd* || $blockd = sd* || $blockd = cciss* || $blockd = vd* || $blockd = xvd* ]] ; then
+    if [[ $blockd = hd* || $blockd = sd* || $blockd = cciss* || $blockd = vd* || $blockd = xvd* || $blockd = nvme* ]] ; then
         devname=$(get_device_name $disk)
 
         # Check if devname contains a PPC PreP boot partition (ID=0x41)


### PR DESCRIPTION
NVME disks are not handled by gues_bootloader script, causing an error later.
This is a simple fix that should do the job.