### PR TITLE
Enhancement: find 64-bit systemd UEFI bootloader

### DIFF
--- a/usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
+++ b/usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
@@ -61,7 +61,12 @@ if [[ ! -f ${UEFI_BOOTLOADER} ]]; then
     UEFI_BOOTLOADER=$(find /boot/efi -name "elilo.efi" | tail -1)
 fi
 
-# triple check it
+# in case we have a 64-bit systemd bootloader not listed in efivars then we might be lucky with next statements
+if [[ ! -f ${UEFI_BOOTLOADER} ]]; then
+    UEFI_BOOTLOADER=$(find /boot/EFI -name "BOOTX64.EFI" | tail -1)
+fi
+
+# did we find a boot loader?
 if [[ ! -f ${UEFI_BOOTLOADER} ]]; then
 
     Error "Cannot find a proper UEFI_BOOTLOADER ($UEFI_BOOTLOADER). 


### PR DESCRIPTION
As seen on UEFI 64-bit Arch Linux distributions with efibootmgr package installed.
Upon "bootctl install" the .efi files are:
Copied "/usr/lib/systemd/boot/efi/systemd-bootx64.efi" to "/boot/EFI/systemd/systemd-bootx64.efi".
Copied "/usr/lib/systemd/boot/efi/systemd-bootx64.efi" to "/boot/EFI/BOOT/BOOTX64.EFI".

When system is booting withing having a listing in the UEFI boot menu (efivars) then the UEFI boot will most likely be booted using file /boot/EFI/BOOT/BOOTX64.EFI.