### PR TITLE
Increase default USB_UEFI_PART_SIZE from 100 to 200 MiB

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -351,7 +351,7 @@ USB_DEVICE_FILESYSTEM_PERCENTAGE=100
 # in MB when formatting a medium by the format workflow.
 # If USB_UEFI_PART_SIZE is empty or invalid (i.e. not an unsigned integer larger than 0)
 # the user must interactively enter a valid value while running the format workflow:
-USB_UEFI_PART_SIZE="100"
+USB_UEFI_PART_SIZE="200"
 
 # resulting files that should be copied onto the USB stick
 USB_FILES=()


### PR DESCRIPTION
100 MiB is too low. My first attempt to "rear -v mkrescue" an 64-bit kernel 4.9.11 fails with:
ERROR: Could not copy /tmp/rear.2wwzvo4iQ1W4LLK/tmp/initrd.cgz to /tmp/rear-efi.0sRzW//EFI/BOOT/initrd.cgz
Aborting due to an error, check /root/rear/var/log/rear/rear-d2.log for details.

The default 100 MiB is not a sensible value for an EFI boot partition nowadays:
# ls -lh /tmp/rear-efi.0sRzW/EFI/BOOT/
total 100M
-rwx------ 1 root root  79K Feb 22 22:59 BOOTX64.efi
-rwx------ 1 root root  96M Feb 22 22:59 initrd.cgz
-rwx------ 1 root root 4.7M Feb 19 14:49 kernel