### PR TITLE
320_include_uefi_env made less case sensitive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ rear-*.tar.gz
 test/
 build-stamp
 /var
+etc/rear/site.conf

--- a/usr/share/rear/prep/default/310_include_uefi_tools.sh
+++ b/usr/share/rear/prep/default/310_include_uefi_tools.sh
@@ -5,8 +5,8 @@ if grep -qw 'noefi' /proc/cmdline; then
     return
 fi
 
-# next step, is checking /boot/efi directory (we need it)
-if [[ ! -d /boot/efi ]]; then
+# next step, is checking /boot/efi directory case-insensitive for the /EFI part (we need it)
+if [[ -n $(find /boot -maxdepth 1 -iname efi -type d) ]]; then
     return    # must be mounted
 fi
 

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -48,7 +48,7 @@ if grep -qw efivars /proc/mounts; then
 fi
 
 # next step, is case-sensitive checking /boot for case-insensitive /efi directory (we need it)
-if [[ -n find /boot -maxdepth 1 -iname efi -type d ]]; then
+if [[ -n `find /boot -maxdepth 1 -iname efi -type d` ]]; then
     # found
 else
     return    # not found

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -49,8 +49,6 @@ fi
 
 # next step, is case-sensitive checking /boot for case-insensitive /efi directory (we need it)
 if [[ -n `find /boot -maxdepth 1 -iname efi -type d` ]]; then
-    # found
-else
     return    # not found
 fi
 

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -48,17 +48,17 @@ if grep -qw efivars /proc/mounts; then
 fi
 
 # next step, is case-sensitive checking /boot for case-insensitive /efi directory (we need it)
-if [[ -n `find /boot -maxdepth 1 -iname efi -type d` ]]; then
+if [[ -n $(find /boot -maxdepth 1 -iname efi -type d) ]]; then
     return    # not found
 fi
 
 # next step, check filesystem partition type (vfat?)
 local efi_mount_point=""
 UEFI_FS_TYPE=$(awk '/\/boot\/efi/ { print $3 }' /proc/mounts)
-# if not mounted at /boot/efi, try /boot itself
+# if not mounted at /boot/efi, try /boot
 if [[ -z "$UEFI_FS_TYPE" ]]; then
     UEFI_FS_TYPE=$(awk '/\/boot/ { print $3 }' /proc/mounts)
-    [[ -z "$UEFI_FS_TYHPE" ]] && efi_mount_point='/\/boot/'
+    [[ -z "$UEFI_FS_TYPE" ]] && efi_mount_point='/\/boot/'
 else
     efi_mount_point='/\/boot\/efi/'
 fi

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -52,15 +52,15 @@ if [[ -n $(find /boot -maxdepth 1 -iname efi -type d) ]]; then
     return    # not found
 fi
 
+local esp_mount_point=""
+
 # next step, check filesystem partition type (vfat?)
-local efi_mount_point=""
-UEFI_FS_TYPE=$(awk '/\/boot\/efi/ { print $3 }' /proc/mounts)
+esp_mount_point='/\/boot\/efi/'
+UEFI_FS_TYPE=$(awk $esp_mount_point' { print $3 }' /proc/mounts)
 # if not mounted at /boot/efi, try /boot
 if [[ -z "$UEFI_FS_TYPE" ]]; then
-    UEFI_FS_TYPE=$(awk '/\/boot/ { print $3 }' /proc/mounts)
-    [[ -z "$UEFI_FS_TYPE" ]] && efi_mount_point='/\/boot/'
-else
-    efi_mount_point='/\/boot\/efi/'
+    esp_mount_point='/\/boot/'
+    UEFI_FS_TYPE=$(awk $esp_mount_point' { print $3 }' /proc/mounts)
 fi
 
 # ESP must be type vfat (under Linux)
@@ -72,4 +72,4 @@ fi
 USING_UEFI_BOOTLOADER=1
 LogPrint "Using UEFI Boot Loader for Linux (USING_UEFI_BOOTLOADER=1)"
 
-awk $efi_mount_point' { print $1 }' /proc/mounts >$VAR_DIR/recovery/bootdisk 2>/dev/null
+awk $esp_mount_point' { print $1 }' /proc/mounts >$VAR_DIR/recovery/bootdisk 2>/dev/null

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -1,7 +1,7 @@
 # in conf/default.conf we defined an empty variable USING_UEFI_BOOTLOADER
 # This script will try to guess if we're using UEFI or not, and if yes,
 # then add all the required executables, kernel modules, etc...
-# Most likely, only recent OSes will be UEFI capable, such as SLES11, RHEL6, Ubuntu 12.10, Fedora 18
+# Most likely, only recent OSes will be UEFI capable, such as SLES11, RHEL6, Ubuntu 12.10, Fedora 18, Arch Linux
 
 # If noefi is set, we can ignore UEFI altogether
 if grep -qw 'noefi' /proc/cmdline; then
@@ -47,13 +47,23 @@ if grep -qw efivars /proc/mounts; then
     SYSFS_DIR_EFI_VARS=/sys/firmware/efi/efivars
 fi
 
-# next step, is checking /boot/efi directory (we need it)
-if [[ ! -d /boot/efi ]]; then
-    return    # must be mounted
+# next step, is case-sensitive checking /boot for case-insensitive /efi directory (we need it)
+if [[ -n find /boot -maxdepth 1 -iname efi -type d ]]; then
+    # found
+else
+    return    # not found
 fi
 
 # next step, check filesystem partition type (vfat?)
+local efi_mount_point=""
 UEFI_FS_TYPE=$(awk '/\/boot\/efi/ { print $3 }' /proc/mounts)
+# if not mounted at /boot/efi, try /boot itself
+if [[ -z "$UEFI_FS_TYPE" ]]; then
+    UEFI_FS_TYPE=$(awk '/\/boot/ { print $3 }' /proc/mounts)
+    [[ -z "$UEFI_FS_TYHPE" ]] && efi_mount_point='/\/boot/'
+else
+    efi_mount_point='/\/boot\/efi/'
+fi
 
 # ESP must be type vfat (under Linux)
 if [[ "$UEFI_FS_TYPE" != "vfat" ]]; then
@@ -64,5 +74,4 @@ fi
 USING_UEFI_BOOTLOADER=1
 LogPrint "Using UEFI Boot Loader for Linux (USING_UEFI_BOOTLOADER=1)"
 
-awk '/\/boot\/efi/ { print $1 }' /proc/mounts >$VAR_DIR/recovery/bootdisk 2>/dev/null
-
+awk $efi_mount_point' { print $1 }' /proc/mounts >$VAR_DIR/recovery/bootdisk 2>/dev/null


### PR DESCRIPTION
and also allow `/boot` to be completely a VFAT file system, instead of just `/boot/efi` (rear/rear#1223)