### PR TITLE
lz4 legacy format (Linux kernel compression)

### DIFF
--- a/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
+++ b/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
@@ -19,7 +19,7 @@ case "$REAR_INITRD_COMPRESSION" in
         # Create initrd.lz4 with lz4 default -1 compression (fast speed but less compression)
         REAR_INITRD_FILENAME="initrd.lz4"
         LogPrint "Creating recovery/rescue system initramfs/initrd $REAR_INITRD_FILENAME with lz4 compression"
-        if find . ! -name "*~" | cpio -H newc --create --quiet | lz4 > "$TMP_DIR/$REAR_INITRD_FILENAME" ; then
+        if find . ! -name "*~" | cpio -H newc --create --quiet | lz4 -l > "$TMP_DIR/$REAR_INITRD_FILENAME" ; then
             needed_seconds=$(( $( date +%s ) - start_seconds ))
             LogPrint "Created $REAR_INITRD_FILENAME with lz4 compression ($( stat -c%s $TMP_DIR/$REAR_INITRD_FILENAME ) bytes) in $needed_seconds seconds"
         else

--- a/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
+++ b/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
@@ -16,9 +16,10 @@ pushd "$ROOTFS_DIR" >/dev/null
 start_seconds=$( date +%s )
 case "$REAR_INITRD_COMPRESSION" in
     (lz4)
-        # Create initrd.lz4 with lz4 default -1 compression (fast speed but less compression)
+        # Create initrd.lz4 with lz4 -l compression (fast speed but less compression)
+        # -l = Legacy format (typically for Linux Kernel compression) 
         REAR_INITRD_FILENAME="initrd.lz4"
-        LogPrint "Creating recovery/rescue system initramfs/initrd $REAR_INITRD_FILENAME with lz4 compression"
+        LogPrint "Creating recovery/rescue system initramfs/initrd $REAR_INITRD_FILENAME with lz4 -l compression"
         if find . ! -name "*~" | cpio -H newc --create --quiet | lz4 -l > "$TMP_DIR/$REAR_INITRD_FILENAME" ; then
             needed_seconds=$(( $( date +%s ) - start_seconds ))
             LogPrint "Created $REAR_INITRD_FILENAME with lz4 compression ($( stat -c%s $TMP_DIR/$REAR_INITRD_FILENAME ) bytes) in $needed_seconds seconds"


### PR DESCRIPTION
Otherwise the initrd file will not boot the kernel, instead returning a Kernel Panic and

> initramfs unpacking failed: junk in compressed archive

`lsinitcpio -a` was helpful in spotting this issue: 

> ==> ERROR: Newer lz4 stream format detected! This may not boot!

More details at https://github.com/rear/rear/issues/1218#issuecomment-285813885