### PR TITLE
doc lz4 -1 changed to lz4 -l

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1515,8 +1515,18 @@ UEFI_BOOTLOADER=""
 # When booting on ppc64 with the yaboot bootloader the initrd must be less than 32MB
 # so that in this case the lzma compression could be even required
 # see https://github.com/rear/rear/issues/1142
-# In genaral a smaller initrd is loaded faster by the ReaR rescue/recovery system bootloader
+# In general a smaller initrd is loaded faster by the ReaR rescue/recovery system bootloader
 # so that a small initrd could make the whole system recovery a bit faster.
+# Except for lz4 which is ultra fast in decompressing.
+# An example:
+#       extraction time     creating        initrd size
+# ----- ------------------- --------------- --------------
+# lz4   0.248s              4-5 seconds     64 MiB
+# fast  3.111s              9 seconds       51 MiB
+# lzma  6.775s              173 seconds     34 MiB 
+# ----- ------------------- --------------- --------------
+# note: extraction time is an estimate, based on 'lsinitcpio -a' output
+#
 # With REAR_INITRD_COMPRESSION="fast"
 # an initrd.cgz with gzip --fast compression is created (fast creating but less compression).
 # With REAR_INITRD_COMPRESSION="best"
@@ -1524,7 +1534,7 @@ UEFI_BOOTLOADER=""
 # With REAR_INITRD_COMPRESSION="lzma"
 # an initrd.xz with xz using the lzma compression is created (very best compression but very slow).
 # With REAR_INITRD_COMPRESSION="lz4"
-# an initrd.lz4 with lz4 default -1 compression is created (fast speed but less compression).
+# an initrd.lz4 with lz4 -l compression is created (faster creating but less compression, compared to 'fast').
 # An initrd.xz with lzma or lz4 compression may not work in this or that case.
 # An initrd.xz with lzma or lz4 compression is known not to work together with DRLM prior to version 2.1.1
 # see https://github.com/rear/rear/pull/1182#issuecomment-275423441


### PR DESCRIPTION
lz4 -l is necessary for Linux kernel boot compatibility, a separate branch and patch has already been pull request for that change in code. This patch also updates the documentation for that change. And it includes a table with an example to show the real life trade offs for extraction time, creation time and size based on an example.