### PR TITLE
Add (Linaro) flashbench to the list of PROGS

### DIFF
--- a/usr/share/rear/conf/Linux-i386.conf
+++ b/usr/share/rear/conf/Linux-i386.conf
@@ -11,4 +11,5 @@ partprobe
 lilo
 fdisk
 cfdisk
+flashbench
 )


### PR DESCRIPTION
Flash memory, especially SD Cards and USB flash drives, often comes without decent (NAND memory IC) specifications. As a result you have to figure the optimal partition alignment value a.k.a. Allocation Unit, a.k.a erase block size. That value is the smallest unit that a NAND flash can erase. The values range from 128KB to 64MB, typically 2MB. More info at [https://wiki.linaro.org/WorkingGroups/KernelArchived/Projects/FlashCardSurvey](https://wiki.linaro.org/WorkingGroups/KernelArchived/Projects/FlashCardSurvey) The `flashbench` tool helps to identify the real world Allocation Unit size for flash memory.