### PR TITLE
Add USB .hci_pci modules for broader hardware support

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -209,9 +209,13 @@ sr_mod
 ide_cd
 cdrom
 uhci_hcd
+uhci_pci
 ehci_hcd
+ehci_pci
 xhci_hcd
+xhci_pci
 ohci_hcd
+ohci_pci
 zlib
 zlib-inflate
 zlib-deflate


### PR DESCRIPTION
`mkrescue` on a source computer with both USB 2.0 and 3.0 port might run with the `xhci` module only.
When the (USB) boot device is used to start a USB 2.0 computer that requires the `ehci` module, both the `ehci_hcd` and `ehci_pci` modules, to boot with USB keyboard and mouse support. Tested with Arch Linux 4.9.11-1 on an Intel DE3815TYKHE (USB2+3 where `lsmod` only show the `xhci` module), then ReaR will not have keyboard support when booted on a machine with USB 2.0 only. After adding the 4 `(u|e|x|o)hci_pci` modules, the USB keyboard and mouse do function again with the USB 2.0 only mainboard. Also see https://github.com/rear/rear/issues/519#issuecomment-286579288