### PR TITLE
DRLM management and security improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ endif
 install-config:
 	@echo -e "\033[1m== Installing configuration ==\033[0;0m"
 	install -d -m0700 $(DESTDIR)$(sysconfdir)/rear/
+	install -d -m0700 $(DESTDIR)$(sysconfdir)/rear/cert/
 	-[[ ! -e $(DESTDIR)$(sysconfdir)/rear/local.conf ]] && \
 		install -Dp -m0600 etc/rear/local.conf $(DESTDIR)$(sysconfdir)/rear/local.conf
 	-[[ ! -e $(DESTDIR)$(sysconfdir)/rear/os.conf && -e etc/rear/os.conf ]] && \

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -37,6 +37,7 @@ binary-indep: build
 	# The DESTDIR Has To Be Exactly debian/rear
 	mkdir -vp \
 		debian/rear/etc/ \
+		debian/rear/etc/rear/cert/ \
 		debian/rear/usr/share/doc/ \
 		debian/rear/usr/sbin/ \
 		debian/rear/usr/share/ \

--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -193,6 +193,7 @@ OS_VERSION="13.2"
 %doc %{_mandir}/man8/rear.8*
 %config(noreplace) %{_sysconfdir}/cron.d/rear
 %config(noreplace) %{_sysconfdir}/rear/
+%config(noreplace) %{_sysconfdir}/rear/cert/
 %{_datadir}/rear/
 %{_localstatedir}/lib/rear/
 %{_sbindir}/rear

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1602,6 +1602,13 @@ WAIT_SECS=30
 BOOT_OVER_SAN=
 
 # ReaR default certificates location. ReaR will use it to store its required certificates. 
+# If used with '--capath $REAR_CAPATH' curl option (see: man curl) the following commands 
+# must be executed:   
+#   cd $REAR_CAPATH
+#   for file in *.crt *.pem; do ln -sf $file `openssl x509 -hash -noout -in $file`.0; done
+# If '--cacert $REAR_CAPATH/certname.crt' curl option (see: man curl) is used
+# there is no need to rehash. 
+# See http://stackoverflow.com/questions/9879688/difference-between-cacert-and-capath-in-curl
 REAR_CAPATH="/etc/rear/cert"
 
 ####################

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1601,9 +1601,30 @@ WAIT_SECS=30
 # making the variable (y,Y,1) to enable
 BOOT_OVER_SAN=
 
+# ReaR default certificates location. ReaR will use it to store its required certificates. 
+REAR_CAPATH="/etc/rear/cert"
+
 ####################
 # DRLM (Disaster Recovery Linux Manager) Variables
 
 # Specify if ReaR is managed from DRLM (y/n) [ default (n) ].
 DRLM_MANAGED=n
 
+# Specify the DRLM certificate location. DRLM can provide the certificate with it's 'instclient' workflow or you can get it from 
+# /etc/drlm/cert/*.crt on a DRLM server.
+# By default is defined with '--capath' curl option (see: man curl). Take care on using (-k|--insecure) only use it on trusted networks.   
+# DRLM use a RESTful API and in future more REST required options could be added.
+DRLM_REST_OPTS="--capath $REAR_CAPATH"
+
+# Specify DRLM Server name or ip address. This name must be the same as defined in CN of the certificate (DRLM server hostname by default). 
+# If is not possible because you're using other DRLM server for recovery or system migration, get the certificate from the new DRLM server 
+# or use (-k or --insecure) on DRLM_REST_OPTS.  
+DRLM_SERVER=""
+
+# Specify DRLM Client name. The hostname is used by default, but must be set to the DRLM client name if is different. 
+# The client hostname is the recommended but not mandatory.
+DRLM_ID="$HOSTNAME"
+
+# DRLM_REST_OPTS, DRLM_SERVER and DRLM_ID variables can be changed in /etc/rear/local.conf and also can be updated at runtime.
+#  e.g.
+#       rear recover SERVER=1.1.1.1 REST_OPTS="-k" ID=client01

--- a/usr/share/rear/init/default/010_set_drlm_env.sh
+++ b/usr/share/rear/init/default/010_set_drlm_env.sh
@@ -6,13 +6,30 @@ fi
 
 PROGS=( "${PROGS[@]}" curl )
 
-# Needed for curl with NSS support
-LIBS=( 
+# Needed for curl (HTTPs)
+COPY_AS_IS=( ${COPY_AS_IS[@]} /etc/ssl/certs/* /etc/pki/* )
+
+LIBS=(
     "${LIBS[@]}"
-    /usr/lib*/libsoftokn3.so* 
-    /usr/lib*/libsqlite3.so* 
+    /lib*/libnsspem.so*
+    /usr/lib*/libnsspem.so*
+    /lib*/libfreebl*.so*
+    /usr/lib*/libfreebl*.so*
+    /lib*/libnss3.so*
+    /usr/lib*/libnss3.so*
+    /lib*/libnssutil3.so*
+    /usr/lib*/libnssutil3.so*
+    /lib*/libsoftokn3.so*
+    /usr/lib*/libsoftokn3.so*
+    /lib*/libsqlite3.so*
+    /usr/lib*/libsqlite3.so*
     /lib*/libfreeblpriv3.so*
     /usr/lib*/libfreeblpriv3.so*
+    /lib*/libssl.so*
+    /usr/lib*/libssl.so*
+    /lib*/libnssdbm3.so*
+    /usr/lib*/libnssdbm3.so*
 )
 
 drlm_import_runtime_config
+drlm_send_log

--- a/usr/share/rear/init/default/010_set_drlm_env.sh
+++ b/usr/share/rear/init/default/010_set_drlm_env.sh
@@ -4,8 +4,6 @@ if ! drlm_is_managed ; then
     return 0
 fi
 
-PROGS=( "${PROGS[@]}" curl )
-
 # Needed for curl (HTTPs)
 COPY_AS_IS=( ${COPY_AS_IS[@]} /etc/ssl/certs/* /etc/pki/* )
 

--- a/usr/share/rear/init/default/010_set_drlm_env.sh
+++ b/usr/share/rear/init/default/010_set_drlm_env.sh
@@ -1,8 +1,6 @@
 # Setting required environment for DRLM proper function
 
-if ! drlm_is_managed ; then
-    return 0
-fi
+is_true "$DRLM_MANAGED" || return 0
 
 # Needed for curl (HTTPs)
 COPY_AS_IS=( ${COPY_AS_IS[@]} /etc/ssl/certs/* /etc/pki/* )

--- a/usr/share/rear/lib/drlm-functions.sh
+++ b/usr/share/rear/lib/drlm-functions.sh
@@ -21,7 +21,7 @@ function drlm_import_runtime_config() {
     for arg in "${ARGS[@]}" ; do
         key=DRLM_"${arg%%=*}"
         val="${arg#*=}"
-        declare $key="$val"
+        eval $key='$val'
         Log "Setting $key=$val"
     done
 

--- a/usr/share/rear/lib/drlm-functions.sh
+++ b/usr/share/rear/lib/drlm-functions.sh
@@ -57,6 +57,6 @@ function drlm_send_log() {
 
     # send log file in real time to DRLM
     LogPrint "DRLM_MANAGED: Sending Logfile: '$RUNTIME_LOGFILE' to DRLM in real time ..."
-    tail -f --lines=5000 --pid=$$ $RUNTIME_LOGFILE | curl $verbose -T- -f -s -S $DRLM_REST_OPTS https://$DRLM_SERVER/client/$DRLM_ID/log/$WORKFLOW/$(date +%Y%m%d%H%M%S) &
+    tail -f --lines=5000 --pid=$$ $RUNTIME_LOGFILE | curl $verbose -T- -f -s -S $DRLM_REST_OPTS https://$DRLM_SERVER/clients/$DRLM_ID/log/$WORKFLOW/$(date +%Y%m%d%H%M%S) &
 
 }

--- a/usr/share/rear/lib/drlm-functions.sh
+++ b/usr/share/rear/lib/drlm-functions.sh
@@ -6,16 +6,6 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-function drlm_is_managed() {
-
-    if [[ "$DRLM_MANAGED" == "y" ]]; then
-        return 0
-    else
-        return 1
-    fi
-
-}
-
 function drlm_import_runtime_config() {
 
     for arg in "${ARGS[@]}" ; do
@@ -57,6 +47,6 @@ function drlm_send_log() {
 
     # send log file in real time to DRLM
     LogPrint "DRLM_MANAGED: Sending Logfile: '$RUNTIME_LOGFILE' to DRLM in real time ..."
-    tail -f --lines=5000 --pid=$$ $RUNTIME_LOGFILE | curl $verbose -T- -f -s -S $DRLM_REST_OPTS https://$DRLM_SERVER/clients/$DRLM_ID/log/$WORKFLOW/$(date +%Y%m%d%H%M%S) &
+    ( tail -f --lines=5000 --pid=$$ $RUNTIME_LOGFILE | curl $verbose -T- -f -s -S $DRLM_REST_OPTS https://$DRLM_SERVER/clients/$DRLM_ID/log/$WORKFLOW/$(date +%Y%m%d%H%M%S) ) &
 
 }

--- a/usr/share/rear/lib/drlm-functions.sh
+++ b/usr/share/rear/lib/drlm-functions.sh
@@ -26,14 +26,37 @@ function drlm_import_runtime_config() {
     done
 
     if ! has_binary curl ; then
-        Error "Need 'curl' to download DRLM dynamic configuration. Please install curl and try again."
+        Error "DRLM_MANAGED: Need 'curl' to download DRLM dynamic configuration. Please install curl and try again."
     fi
 
     if [[ "$DRLM_SERVER" && "$DRLM_REST_OPTS" && "$DRLM_ID" ]]; then
-        DRLM_CFG=$(curl $DRLM_REST_OPTS https://$DRLM_SERVER/clients/$DRLM_ID)
-        eval "$DRLM_CFG"
+        if [ "$CONFIG_APPEND_FILES" ]; then
+            for config_append_file in $CONFIG_APPEND_FILES ; do
+                LogPrint "DRLM_MANAGED: Loading configuration '$config_append_file' from DRLM ..."
+                local DRLM_CFG="/tmp/$config_append_file"
+                local http_response_code=$(curl $verbose -f -s -S -w '%{http_code}' $DRLM_REST_OPTS -o $DRLM_CFG https://$DRLM_SERVER/clients/$DRLM_ID/config/$config_append_file)
+                test "200" = "$http_response_code" || Error "DRLM_MANAGED: curl failed with HTTP response code '$http_response_code' trying to load '$config_append_file' from DRLM."
+                eval $(cat $DRLM_CFG)
+                rm $DRLM_CFG
+            done
+        else
+            LogPrint "DRLM_MANAGED: Loading configuration from DRLM ..."
+            local DRLM_CFG="/tmp/drlm_config"
+            local http_response_code=$(curl $verbose -f -s -S -w '%{http_code}' $DRLM_REST_OPTS -o $DRLM_CFG https://$DRLM_SERVER/clients/$DRLM_ID/config)
+            test "200" = "$http_response_code" || Error "DRLM_MANAGED: curl failed with HTTP response code '$http_response_code' trying to load configuration from DRLM."
+            eval $(cat $DRLM_CFG)
+            rm $DRLM_CFG
+        fi
     else
-        Error "ReaR only can be run from DRLM Server ('DRLM_MANAGED=y' is set)"
+        Error "DRLM_MANAGED: Please be sure DRLM_SERVER, DRLM_REST_OPTS and DRLM_ID are properly defined in local.conf or at set them at runtime (see: default.conf)"
     fi
+
+}
+
+function drlm_send_log() {
+
+    # send log file in real time to DRLM
+    LogPrint "DRLM_MANAGED: Sending Logfile: '$RUNTIME_LOGFILE' to DRLM in real time ..."
+    tail -f --lines=5000 --pid=$$ $RUNTIME_LOGFILE | curl $verbose -T- -f -s -S $DRLM_REST_OPTS https://$DRLM_SERVER/client/$DRLM_ID/log/$WORKFLOW/$(date +%Y%m%d%H%M%S) &
 
 }


### PR DESCRIPTION
This PR will improve DRLM and ReaR integration and solve a DRLM issue opened by @gdha (https://bugzilla.redhat.com/show_bug.cgi?id=1239003).

**brief description of changes:**
- add support for Multiple configs `rear -C confname` in DRLM (issue #1229)
- Solve issue https://github.com/brainupdaters/drlm/issues/42, now the connection is verified by default and properly documented in default.conf.
- Now ReaR logs will be sent in real time to DRLM.
- Improved error handling with DRLM RESTful API and keep backwards compatibility with previous versions of ReaR (since 1.17) on DRLM side.
- New default REAR_CAPATH="/etc/rear/cert" to store SSL certs used by ReaR. see default.conf

This code has been tested on RHEL/CentOS, SLES/OpenSUSE and Debian/Ubuntu.

