### PR TITLE
Corrected bad test for UEFI partition check inside /boot.

### DIFF
--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -48,7 +48,7 @@ if grep -qw efivars /proc/mounts; then
 fi
 
 # next step, is case-sensitive checking /boot for case-insensitive /efi directory (we need it)
-if [[ -n $(find /boot -maxdepth 1 -iname efi -type d) ]]; then
+if [[ -z "$(find /boot -maxdepth 1 -iname efi -type d)" ]]; then
     return    # not found
 fi
 

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -48,9 +48,7 @@ if grep -qw efivars /proc/mounts; then
 fi
 
 # next step, is case-sensitive checking /boot for case-insensitive /efi directory (we need it)
-if [[ -z "$(find /boot -maxdepth 1 -iname efi -type d)" ]]; then
-    return    # not found
-fi
+test "$( find /boot -maxdepth 1 -iname efi -type d )" || return
 
 local esp_mount_point=""
 


### PR DESCRIPTION
Today I've accidentally found a small regression that can basically avoid ReaR to correctly setting **USING_UEFI_BOOTLOADER=1**.

With old code:
```
if [[ -n $(find /boot -maxdepth 1 -iname efi -type d) ]]; then
    return    # not found
fi
```
If _efi_ directory is found inside _/boot_  320_include_uefi_env.sh would prematurely return.

