### PR TITLE
Added required libs and files for curl with HTTPs by default

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -187,6 +187,26 @@ ${LIBS[@]:-}
 /lib*/rsyslog/*so
 
 /usr/lib*/syslog-ng/*
+
+### needed for curl HTTPS
+/lib*/libnsspem.so*
+/usr/lib*/libnsspem.so*
+/lib*/libfreebl*.so*
+/usr/lib*/libfreebl*.so*
+/lib*/libnss3.so*
+/usr/lib*/libnss3.so*
+/lib*/libnssutil3.so*
+/usr/lib*/libnssutil3.so*
+/lib*/libsoftokn3.so*
+/usr/lib*/libsoftokn3.so*
+/lib*/libsqlite3.so*
+/usr/lib*/libsqlite3.so*
+/lib*/libfreeblpriv3.so*
+/usr/lib*/libfreeblpriv3.so*
+/lib*/libssl.so*
+/usr/lib*/libssl.so*
+/lib*/libnssdbm3.so*
+/usr/lib*/libnssdbm3.so*
 )
 
 MODULES=(
@@ -221,7 +241,7 @@ crc32c
 crc32c-intel
 )
 
-COPY_AS_IS=( ${COPY_AS_IS[@]:-} /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/termcap /etc/terminfo /lib*/terminfo /usr/share/terminfo /etc/netconfig /etc/mke2fs.conf /etc/*-release /etc/localtime /etc/magic /usr/share/misc/magic /etc/dracut.conf /etc/dracut.conf.d /usr/lib/dracut /sbin/modprobe.ksplice-orig /etc/sysctl.conf /etc/sysctl.d /etc/e2fsck.conf )
+COPY_AS_IS=( ${COPY_AS_IS[@]:-} /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/termcap /etc/terminfo /lib*/terminfo /usr/share/terminfo /etc/netconfig /etc/mke2fs.conf /etc/*-release /etc/localtime /etc/magic /usr/share/misc/magic /etc/dracut.conf /etc/dracut.conf.d /usr/lib/dracut /sbin/modprobe.ksplice-orig /etc/sysctl.conf /etc/sysctl.d /etc/e2fsck.conf /etc/ssl/certs/* /etc/pki/* )
 
 # exclude /dev/shm/*, due to the way we use tar the leading / should be omitted
 COPY_AS_IS_EXCLUDE=( ${COPY_AS_IS_EXCLUDE[@]:-} dev/shm/\* )

--- a/usr/share/rear/init/default/010_set_drlm_env.sh
+++ b/usr/share/rear/init/default/010_set_drlm_env.sh
@@ -2,30 +2,5 @@
 
 is_true "$DRLM_MANAGED" || return 0
 
-# Needed for curl (HTTPs)
-COPY_AS_IS=( ${COPY_AS_IS[@]} /etc/ssl/certs/* /etc/pki/* )
-
-LIBS=(
-    "${LIBS[@]}"
-    /lib*/libnsspem.so*
-    /usr/lib*/libnsspem.so*
-    /lib*/libfreebl*.so*
-    /usr/lib*/libfreebl*.so*
-    /lib*/libnss3.so*
-    /usr/lib*/libnss3.so*
-    /lib*/libnssutil3.so*
-    /usr/lib*/libnssutil3.so*
-    /lib*/libsoftokn3.so*
-    /usr/lib*/libsoftokn3.so*
-    /lib*/libsqlite3.so*
-    /usr/lib*/libsqlite3.so*
-    /lib*/libfreeblpriv3.so*
-    /usr/lib*/libfreeblpriv3.so*
-    /lib*/libssl.so*
-    /usr/lib*/libssl.so*
-    /lib*/libnssdbm3.so*
-    /usr/lib*/libnssdbm3.so*
-)
-
 drlm_import_runtime_config
 drlm_send_log


### PR DESCRIPTION
This PR will add support for curl (HTTPS)
brief description of changes:

Added required LIBS and files to **/usr/share/rear/conf/GNU/Linux.conf** and remove them from **/usr/share/rear/init/default/010_set_drlm_env.sh**

This code has been tested on RHEL/CentOS, SLES/OpenSUSE and Debian/Ubuntu.