### PR TITLE
Patch for issue #1269 where mawk incorrectly calculated size of partition

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
@@ -211,7 +211,7 @@ EOF
 
         # round starting size to next multiple of 4096
         # 4096 is a good match for most device's block size
-        start=$( echo "$start" | awk '{printf "%u", $1+4096-($1%4096);}')
+        start=$(( $start + 4096 - ( $start % 4096 ) ))
 
         # Get the partition number from the name
         local number=$(get_partition_number "$partition")

--- a/usr/share/rear/layout/prepare/default/400_autoresize_disks.sh
+++ b/usr/share/rear/layout/prepare/default/400_autoresize_disks.sh
@@ -73,7 +73,7 @@ while read type device size junk ; do
             name=${data%|*}
             partition_size=${data#*|}
 
-            new_size=$(echo "$partition_size $resizeable_space $available_space" | awk '{ printf "%d", ($1/$2)*$3; }')
+            new_size=$(( ( $partition_size / $resizeable_space ) * $available_space ))
 
             (( new_size > 0 ))
             BugIfError "Partition $name resized to a negative number."


### PR DESCRIPTION
This patch corrects problems with mawk, which allowed maximum integer 0x7FFFFFFF (2147483647) when "%d" conversion specification format was used.
This caused that maximum allowed partition size was limited to ~2GB.