### PR TITLE
Use parted with B unit to be compatible with older parted.

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -171,7 +171,7 @@ PROGRESS_WAIT_SECONDS="1"
 BACKUP=REQUESTRESTORE
 OUTPUT=ISO
 
-# default cdrom size (in MB)
+# default cdrom size in MB (probably it is actually MiB?)
 CDROM_SIZE=20
 
 # The CHECK_CONFIG_FILES array lists files where changes
@@ -360,25 +360,28 @@ USB_DEVICE_FILESYSTEM_PARAMS=
 # which can be manually used otherwise by the user:
 USB_DEVICE_FILESYSTEM_PERCENTAGE=100
 
+# USB_PARTITION_ALIGN_BLOCK_SIZE specifies partitioning alignment in MiB
+# when formatting a medium via the format workflow.
+# The default alignment of 8 MiB is intended in particular for flash memory devices.
+# The partitioning tool can't figure out optimal alignment values for many flash memory devices.
+# The flashbench command helps determining "erase block size" a.k.a. "segment size"
+# a.k.a. "allocation unit size" for your particular flash memory device.
+# A too small value will result lower speed and less lifetime of your flash memory device.
+# A sufficiently big value will improve speed and lifetime of your flash memory device.
+# The default alignment of 8 MiB is intended in particular for flash memory devices:
+USB_PARTITION_ALIGN_BLOCK_SIZE="8"
+
 # When UEFI is used USB_UEFI_PART_SIZE specifies the size of the EFI system partition (ESP)
-# in MB when formatting a medium by the format workflow.
+# in MiB when formatting a medium by the format workflow.
 # If USB_UEFI_PART_SIZE is empty or invalid (i.e. not an unsigned integer larger than 0)
 # the user must interactively enter a valid value while running the format workflow.
 # The default value of 200 MiB should be sufficiently big and it is in compliance
-# with the 8 MiB partition alignment default value below ( 200 = 8 * 25 ):
+# with the 8 MiB partition alignment default value ( 200 = 8 * 25 ).
+# The value of USB_UEFI_PART_SIZE will be rounded to the nearest
+# USB_PARTITION_ALIGN_BLOCK_SIZE chunk:
 USB_UEFI_PART_SIZE="200"
 
-# When UEFI is used USB_PARTITION_ALIGN_BLOCK_SIZE specifies the boundaries
-# of where the EFI and 2nd partition (the 'REAR-000' labeled ReaR data partition)
-# are aligned to in MiB. The partitioning tool can't figure out optimal alignment
-# values for many flash memory devices. The flashbench command helps
-# determining "erase block size" a.k.a. "segment size" a.k.a. "allocation unit size" for
-# your flash device. A correct value will improve speed and lifetime of your flash memory.
-# The value of USB_UEFI_PART_SIZE will be rounded to the nearest
-# USB_PARTITION_ALIGN_BLOCK_SIZE chunk.
-USB_PARTITION_ALIGN_BLOCK_SIZE="8"
-
-# resulting files that should be copied onto the USB stick
+# Resulting files that should be copied onto the USB stick:
 USB_FILES=()
 
 # USB_SUFFIX specifies the last part of the backup directory on the USB medium.
@@ -1555,7 +1558,7 @@ UEFI_BOOTLOADER=""
 # Usually any bootloader should be able to load any initrd file but then
 # the initrd must be usable by the kernel which means a specially compressed initrd
 # may not always work, in particular not with older kernels.
-# When booting on ppc64 with the yaboot bootloader the initrd must be less than 32MB
+# When booting on ppc64 with the yaboot bootloader the initrd must be less than 32MB (or 32MiB?)
 # so that in this case the lzma compression could be even required
 # see https://github.com/rear/rear/issues/1142
 # In genaral a smaller initrd is loaded faster by the ReaR rescue/recovery system bootloader

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -59,7 +59,6 @@ else
     if ! parted -s $RAW_USB_DEVICE mklabel $USB_DEVICE_PARTED_LABEL >&2 ; then
         Error "Failed to create $USB_DEVICE_PARTED_LABEL partition table on '$RAW_USB_DEVICE'"
     fi
-    LogPrint "Creating ReaR data partition up to ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% of '$RAW_USB_DEVICE'"
     # Calculate byte value for the start of the subsequent ReaR data partition:
     data_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
     # rear_data_partition_number is used below and in the subsequent 350_label_usb_disk.sh script for the ReaR data partition:

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -6,40 +6,69 @@ umount $REAL_USB_DEVICE &>/dev/null
 
 LogPrint "Repartitioning '$RAW_USB_DEVICE'"
 
+# If not set use fallback value 100% (same as the default value in default.conf):
 test "$USB_DEVICE_FILESYSTEM_PERCENTAGE" || USB_DEVICE_FILESYSTEM_PERCENTAGE="100"
 
-if [[ "$EFI" == "y" ]]; then
+# If not set use fallback value 8 MiB (same as the default value in default.conf):
+test $USB_PARTITION_ALIGN_BLOCK_SIZE || USB_PARTITION_ALIGN_BLOCK_SIZE="8"
+# Block size must be an integer (test "1.5" -eq "1.5" fails with bash error "integer expression expected") but
+# that bash error is not logged to avoid that it looks as if there is a bash syntax error in the script code here:
+test "$USB_PARTITION_ALIGN_BLOCK_SIZE" -eq "$USB_PARTITION_ALIGN_BLOCK_SIZE" 2>/dev/null || USB_PARTITION_ALIGN_BLOCK_SIZE="8"
+# Block size must be 1 or greater:
+test $USB_PARTITION_ALIGN_BLOCK_SIZE -ge 1 || USB_PARTITION_ALIGN_BLOCK_SIZE="1"
+
+# Older parted versions do not support IEC binary units like MiB or GiB (cf. https://github.com/rear/rear/issues/1270)
+# so that parted is called with bytes 'B' as unit to be backward compatible:
+MiB_bytes=$(( 1024 * 1024 ))
+
+if [[ "$EFI" == "y" ]] ; then
     LogPrint "The --efi toggle was used with format - making an EFI bootable device '$RAW_USB_DEVICE'"
     # Prompt user for size of EFI system partition on USB disk if no valid value is specified:
     while ! [[ "$USB_UEFI_PART_SIZE" =~ ^[0-9]+$ && $USB_UEFI_PART_SIZE > 0 ]] ; do
         # When USB_UEFI_PART_SIZE is empty, do not tell about "Invalid EFI partition size value":
         test "$USB_UEFI_PART_SIZE" && echo "${MESSAGE_PREFIX}Invalid EFI system partition size value '$USB_UEFI_PART_SIZE' (must be unsigned integer larger than 0)"
-        echo -n "${MESSAGE_PREFIX}Enter size for EFI system partition on '$RAW_USB_DEVICE' in MB (plain 'Enter' defaults to 100 MB): "
+        echo -n "${MESSAGE_PREFIX}Enter size for EFI system partition on '$RAW_USB_DEVICE' in MiB (plain 'Enter' defaults to 200 MiB): "
         read USB_UEFI_PART_SIZE
-        # Plain 'Enter' defaults to 100 MB (same as the default value in default.conf):
-        test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="100"
+        # Plain 'Enter' defaults to 200 MiB (same as the default value in default.conf):
+        test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="200"
     done
     LogPrint "Creating GUID partition table (GPT) on '$RAW_USB_DEVICE'"
-    parted -s $RAW_USB_DEVICE mklabel gpt >&2 || Error "Failed to create GPT partition table on '$RAW_USB_DEVICE'"
-    test $USB_PARTITION_ALIGN_BLOCK_SIZE || USB_PARTITION_ALIGN_BLOCK_SIZE="8" # MiB
-    # Block size must be an integer of 1 or greater (the first test checks for integer: test "1.5" -eq "1.5" fails with bash error "integer expression expected"):
-    test "$USB_PARTITION_ALIGN_BLOCK_SIZE" -eq "$USB_PARTITION_ALIGN_BLOCK_SIZE" 2>/dev/null || USB_PARTITION_ALIGN_BLOCK_SIZE="8" # MiB
-    test $USB_PARTITION_ALIGN_BLOCK_SIZE -ge 1 || USB_PARTITION_ALIGN_BLOCK_SIZE="1"
-    # Round UEFI partition size to nearest block size. This to make the 2nd partition also align to the block size:
-    USB_UEFI_PART_SIZE=$((($USB_UEFI_PART_SIZE + ($USB_PARTITION_ALIGN_BLOCK_SIZE / 2)) / $USB_PARTITION_ALIGN_BLOCK_SIZE * $USB_PARTITION_ALIGN_BLOCK_SIZE))
+    if ! parted -s $RAW_USB_DEVICE mklabel gpt >&2 ; then
+        Error "Failed to create GPT partition table on '$RAW_USB_DEVICE'"
+    fi
+    # Round UEFI partition size to nearest block size to make the 2nd partition (the ReaR data partition) also align to the block size:
+    USB_UEFI_PART_SIZE=$(( ( USB_UEFI_PART_SIZE + ( USB_PARTITION_ALIGN_BLOCK_SIZE / 2 ) ) / USB_PARTITION_ALIGN_BLOCK_SIZE * USB_PARTITION_ALIGN_BLOCK_SIZE ))
     LogPrint "Creating EFI system partition with size $USB_UEFI_PART_SIZE MiB aligned at $USB_PARTITION_ALIGN_BLOCK_SIZE MiB on '$RAW_USB_DEVICE'"
-    parted -s $RAW_USB_DEVICE mkpart primary ${USB_PARTITION_ALIGN_BLOCK_SIZE}Mib "$((${USB_PARTITION_ALIGN_BLOCK_SIZE} + ${USB_UEFI_PART_SIZE}))"Mib || Error "Failed to create EFI system partition on '$RAW_USB_DEVICE'"
-    LogPrint "Creating ReaR data partition up to ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% of '$RAW_USB_DEVICE'"
-    parted -s $RAW_USB_DEVICE mkpart primary "$((${USB_PARTITION_ALIGN_BLOCK_SIZE} + ${USB_UEFI_PART_SIZE}))"Mib ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2 || Error "Failed to create ReaR data partition on '$RAW_USB_DEVICE'"
-    # partition 1 is the EFI system partition (vfat partition) on which EFI/BOOT/BOOTX86.EFI resides
-    ParNr=2
+    # Calculate byte values:
+    efi_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
+    efi_partition_size_bytes=$(( USB_UEFI_PART_SIZE * MiB_bytes ))
+    # The end byte is the last byte that belongs to that partition so that one must be careful to use "start_byte + partition_size_in_bytes - 1":
+    efi_partition_end_byte=$(( efi_partition_start_byte + efi_partition_size_bytes - 1 ))
+    if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $efi_partition_start_byte $efi_partition_end_byte >&2 ; then
+        Error "Failed to create EFI system partition on '$RAW_USB_DEVICE'"
+    fi
+    # Calculate byte value for the start of the subsequent ReaR data partition:
+    data_partition_start_byte=$(( efi_partition_end_byte + 1 ))
+    # Partition 1 is the EFI system partition (vfat partition) on which EFI/BOOT/BOOTX86.EFI resides.
+    # ReaR_Data_Partition_Number is used below and in the subsequent 350_label_usb_disk.sh script for the ReaR data partition:
+    ReaR_Data_Partition_Number=2
 else
+    # If not set use fallback value 'msdos' (same as the default value in default.conf):
     test "msdos" = "$USB_DEVICE_PARTED_LABEL" -o "gpt" = "$USB_DEVICE_PARTED_LABEL" || USB_DEVICE_PARTED_LABEL="msdos"
     LogPrint "Creating partition table of type '$USB_DEVICE_PARTED_LABEL' on '$RAW_USB_DEVICE'"
-    parted -s $RAW_USB_DEVICE mklabel $USB_DEVICE_PARTED_LABEL >&2 || Error "Failed to create $USB_DEVICE_PARTED_LABEL partition table on '$RAW_USB_DEVICE'"
+    if ! parted -s $RAW_USB_DEVICE mklabel $USB_DEVICE_PARTED_LABEL >&2 ; then
+        Error "Failed to create $USB_DEVICE_PARTED_LABEL partition table on '$RAW_USB_DEVICE'"
+    fi
     LogPrint "Creating ReaR data partition up to ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% of '$RAW_USB_DEVICE'"
-    parted -s $RAW_USB_DEVICE mkpart primary 0 ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2 || Error "Failed to create ReaR data partition on '$RAW_USB_DEVICE'"
-    ParNr=1
+    # Calculate byte value for the start of the subsequent ReaR data partition:
+    data_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
+    # ReaR_Data_Partition_Number is used below and in the subsequent 350_label_usb_disk.sh script for the ReaR data partition:
+    ReaR_Data_Partition_Number=1
+fi
+LogPrint "Creating ReaR data partition up to ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% of '$RAW_USB_DEVICE'"
+# Older parted versions (at least GNU Parted 1.6.25.1 on SLE10) support the '%' unit (cf. https://github.com/rear/rear/issues/1270):
+if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $data_partition_start_byte ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2 ; then
+    Error "Failed to create ReaR data partition on '$RAW_USB_DEVICE'"
 fi
 
 # Choose correct boot flag for partition table (see issue #1153)
@@ -47,34 +76,42 @@ local boot_flag
 case "$USB_DEVICE_PARTED_LABEL" in
     "msdos")
         boot_flag="boot"
-    ;;
+        ;;
     "gpt")
         boot_flag="legacy_boot"
-    ;;
+        ;;
     *)
         Error "USB_DEVICE_PARTED_LABEL is incorrectly set, please check your settings."
-    ;;
+        ;;
 esac
 
 LogPrint "Setting '$boot_flag' flag on $RAW_USB_DEVICE"
-parted -s $RAW_USB_DEVICE set 1 $boot_flag on >&2 || Error "Could not make first partition bootable on '$RAW_USB_DEVICE'"
+if ! parted -s $RAW_USB_DEVICE set 1 $boot_flag on >&2 ; then
+    Error "Could not make first partition bootable on '$RAW_USB_DEVICE'"
+fi
 
 partprobe $RAW_USB_DEVICE
 # Wait until udev has had the time to kick in
 sleep 5
 
-if [[ "$EFI" == "y" ]]; then
+if [[ "$EFI" == "y" ]] ; then
     LogPrint "Creating vfat filesystem on EFI system partition on '${RAW_USB_DEVICE}1'"
-    mkfs.vfat $v -F 16 -n REAR-EFI ${RAW_USB_DEVICE}1 >&2 || Error "Failed to create vfat filesystem on '${RAW_USB_DEVICE}1'"
+    if ! mkfs.vfat $v -F 16 -n REAR-EFI ${RAW_USB_DEVICE}1 >&2 ; then
+        Error "Failed to create vfat filesystem on '${RAW_USB_DEVICE}1'"
+    fi
     # create link for EFI partition in /dev/disk/by-label
     partprobe $RAW_USB_DEVICE
     # Wait until udev has had the time to kick in
     sleep 5
 fi
 
-LogPrint "Creating $USB_DEVICE_FILESYSTEM filesystem with label 'REAR-000' on '${RAW_USB_DEVICE}${ParNr}'"
-mkfs.$USB_DEVICE_FILESYSTEM -L REAR-000 ${USB_DEVICE_FILESYSTEM_PARAMS} ${RAW_USB_DEVICE}${ParNr} >&2 || Error "Failed to create $USB_DEVICE_FILESYSTEM filesystem on '${RAW_USB_DEVICE}${ParNr}'"
+LogPrint "Creating $USB_DEVICE_FILESYSTEM filesystem with label 'REAR-000' on '${RAW_USB_DEVICE}${ReaR_Data_Partition_Number}'"
+if ! mkfs.$USB_DEVICE_FILESYSTEM -L REAR-000 ${USB_DEVICE_FILESYSTEM_PARAMS} ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} >&2 ; then
+    Error "Failed to create $USB_DEVICE_FILESYSTEM filesystem on '${RAW_USB_DEVICE}${ReaR_Data_Partition_Number}'"
+fi
 
-LogPrint "Adjusting filesystem parameters on '${RAW_USB_DEVICE}${ParNr}'"
-tune2fs -c 0 -i 0 -o acl,journal_data,journal_data_ordered ${RAW_USB_DEVICE}${ParNr} >&2 || Error "Failed to adjust filesystem parameters on '${RAW_USB_DEVICE}${ParNr}'"
+LogPrint "Adjusting filesystem parameters on '${RAW_USB_DEVICE}${ReaR_Data_Partition_Number}'"
+if ! tune2fs -c 0 -i 0 -o acl,journal_data,journal_data_ordered ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} >&2 ; then
+    Error "Failed to adjust filesystem parameters on '${RAW_USB_DEVICE}${ReaR_Data_Partition_Number}'"
+fi
 

--- a/usr/share/rear/format/USB/default/350_label_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/350_label_usb_disk.sh
@@ -1,33 +1,48 @@
 
-if [[ "$EFI" == "Yes" ]] ; then
-    ReaR_Data_Partition_Number=2
+# TODO: Setting rear_data_partition_number again here looks duplicate because
+# it should have been already set in format/USB/default/300_format_usb_disk.sh
+# that was run just before this script:
+if is_true "$EFI" ; then
+    # Partition 1 is the EFI system partition (vfat partition).
+    # Partition 2 is the ReaR data partition:
+    rear_data_partition_number=2
 else
-    ReaR_Data_Partition_Number=1
+    rear_data_partition_number=1
 fi
+
+local rear_data_partition_device="$RAW_USB_DEVICE$rear_data_partition_number"
 
 # Artificial 'for' clause that is run only once
 # to be able to 'continue' with the code after it:
 for dummy in "once" ; do
+    # TODO: I <jsmeix@suse.de> wonder what the reason is why here
+    # a filesystem label REAR-000 is set via e2label or btrfs filesystem label
+    # versus before in format/USB/default/300_format_usb_disk.sh where a so called
+    # "volume label for the filesystem" (according to "man mkfs.ext[34]")
+    # was already set via mkfs.$USB_DEVICE_FILESYSTEM -L REAR-000
+    # is this duplicate here or are that different kind of labels?
     case "$ID_FS_TYPE" in
         ext*)
-            USB_LABEL="$( e2label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} )"
+            USB_LABEL="$( e2label $rear_data_partition_device )"
             test "REAR-000" = "$USB_LABEL" && continue
             LogPrint "Setting filesystem label to REAR-000"
-            if ! e2label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} REAR-000 ; then
-                Error "Could not label '${RAW_USB_DEVICE}${ReaR_Data_Partition_Number}' with REAR-000"
+            if ! e2label $rear_data_partition_device REAR-000 ; then
+                Error "Could not label $rear_data_partition_device with REAR-000"
             fi
-            USB_LABEL="$( e2label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} )"
+            USB_LABEL="$( e2label $rear_data_partition_device )"
             ;;
         btrfs)
-            USB_LABEL="$( btrfs filesystem label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} )"
+            USB_LABEL="$( btrfs filesystem label $rear_data_partition_device )"
             test "REAR-000" = "$USB_LABEL" && continue
             LogPrint "Setting filesystem label to REAR-000"
-            if ! btrfs filesystem label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} REAR-000 ; then
-                Error "Could not label '${RAW_USB_DEVICE}${ReaR_Data_Partition_Number}' with REAR-000"
+            if ! btrfs filesystem label $rear_data_partition_device REAR-000 ; then
+                Error "Could not label $rear_data_partition_device with REAR-000"
             fi
-            USB_LABEL="$( btrfs filesystem label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} )"
+            USB_LABEL="$( btrfs filesystem label $rear_data_partition_device )"
             ;;
     esac
 done
-LogPrint "Device '${RAW_USB_DEVICE}${ReaR_Data_Partition_Number}' has label '$USB_LABEL'"
+
+# Report the final result to the user:
+LogPrint "Device $rear_data_partition_device has filesystem label '$USB_LABEL'"
 

--- a/usr/share/rear/format/USB/default/350_label_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/350_label_usb_disk.sh
@@ -1,28 +1,33 @@
-if [[ "$EFI" == "Yes" ]]; then
-    ParNr=2
+
+if [[ "$EFI" == "Yes" ]] ; then
+    ReaR_Data_Partition_Number=2
 else
-    ParNr=1
+    ReaR_Data_Partition_Number=1
 fi
 
-case "$ID_FS_TYPE" in
+# Artificial 'for' clause that is run only once
+# to be able to 'continue' with the code after it:
+for dummy in "once" ; do
+    case "$ID_FS_TYPE" in
+        ext*)
+            USB_LABEL="$( e2label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} )"
+            test "REAR-000" = "$USB_LABEL" && continue
+            LogPrint "Setting filesystem label to REAR-000"
+            if ! e2label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} REAR-000 ; then
+                Error "Could not label '${RAW_USB_DEVICE}${ReaR_Data_Partition_Number}' with REAR-000"
+            fi
+            USB_LABEL="$( e2label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} )"
+            ;;
+        btrfs)
+            USB_LABEL="$( btrfs filesystem label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} )"
+            test "REAR-000" = "$USB_LABEL" && continue
+            LogPrint "Setting filesystem label to REAR-000"
+            if ! btrfs filesystem label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} REAR-000 ; then
+                Error "Could not label '${RAW_USB_DEVICE}${ReaR_Data_Partition_Number}' with REAR-000"
+            fi
+            USB_LABEL="$( btrfs filesystem label ${RAW_USB_DEVICE}${ReaR_Data_Partition_Number} )"
+            ;;
+    esac
+done
+LogPrint "Device '${RAW_USB_DEVICE}${ReaR_Data_Partition_Number}' has label '$USB_LABEL'"
 
-	ext*)
-		USB_LABEL="$(e2label ${RAW_USB_DEVICE}${ParNr})"
-		if [[ "$USB_LABEL" != "REAR-000" ]]; then
-			LogPrint "Setting filesystem label to REAR-000"
-			e2label ${RAW_USB_DEVICE}${ParNr} REAR-000
-			StopIfError "Could not label '${RAW_USB_DEVICE}${ParNr}' with REAR-000"
-			USB_LABEL="$(e2label ${RAW_USB_DEVICE}${ParNr})"
-		fi
-		;;
-	btrfs)
-		USB_LABEL="$(btrfs filesystem label ${RAW_USB_DEVICE}${ParNr})"
-		if [[ "$USB_LABEL" != "REAR-000" ]]; then
-			LogPrint "Setting filesystem label to REAR-000"
-			btrfs filesystem label ${RAW_USB_DEVICE}${ParNr} REAR-000
-			StopIfError "Could not label '${RAW_USB_DEVICE}${ParNr}' with REAR-000"
-			USB_LABEL="$(btrfs filesystem label ${RAW_USB_DEVICE}${ParNr})"
-		fi
-		;;
-esac
-Log "Device '${RAW_USB_DEVICE}${ParNr}' has label $USB_LABEL"

--- a/usr/share/rear/format/USB/default/350_label_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/350_label_usb_disk.sh
@@ -40,6 +40,10 @@ for dummy in "once" ; do
             fi
             USB_LABEL="$( btrfs filesystem label $rear_data_partition_device )"
             ;;
+        (*)
+            # ID_FS_TYPE can be 'unknown', cf. format/USB/default/200_check_usb_layout.sh
+            return
+            ;;
     esac
 done
 

--- a/usr/share/rear/lib/format-workflow.sh
+++ b/usr/share/rear/lib/format-workflow.sh
@@ -10,37 +10,52 @@ WORKFLOW_format_DESCRIPTION="Format and label medium for use with ReaR"
 WORKFLOWS=( ${WORKFLOWS[@]} format )
 WORKFLOW_format () {
 
-    local DEVICE=""
+    local device_to_be_formatted=""
 
     # Parse options
     # (do not use OPTS here because that is readonly in the rear main script):
-    format_workflow_opts="$(getopt -n "$PROGRAM format" -o "efhy" -l "efi,force,help,yes" -- "$@")"
-    if (( $? != 0 )); then
-        echo "Try \`$PROGRAM format -- --help' for more information."
+    format_workflow_opts="$( getopt -n "$PROGRAM format" -o "efhy" -l "efi,force,help,yes" -- "$@" )"
+    if (( $? != 0 )) ; then
+        echo "Use '$PROGRAM format -- --help' for more information."
         exit 1
     fi
 
     eval set -- "$format_workflow_opts"
-    while true; do
+    while true ; do
         case "$1" in
-            (-e|--efi) EFI=y;;
-            (-f|--force) FORCE=y;;
-            (-h|--help) echo "Valid options are: -e/--efi, -f/--force or -y/--yes"; exit 1;;
-            (-y|--yes) YES=y;;
-            (--) shift; continue;;
-            ("") break;;
+            (-e|--efi)
+                EFI=y
+                ;;
+            (-f|--force)
+                FORCE=y
+                ;;
+            (-h|--help)
+                echo "Valid options are: -e/--efi, -f/--force or -y/--yes"
+                # TODO: Use proper exit codes cf. https://github.com/rear/rear/issues/1134
+                exit 1
+                ;;
+            (-y|--yes)
+                YES=y
+                ;;
+            (--)
+                shift
+                continue
+                ;;
+            ("")
+                break
+                ;;
             (/*)
-                if [[ "$DEVICE" ]]; then
-                    Error "Device $DEVICE already provided, only one argument is accepted"
-                else
-                    DEVICE=$1
-                fi;;
-            (*) Error "Argument $1 is not accepted.";;
+                test "$device_to_be_formatted" && Error "Device $device_to_be_formatted already provided, only one argument is accepted"
+                device_to_be_formatted=$1
+                ;;
+            (*)
+                Error "Argument $1 is not accepted."
+                ;;
         esac
         shift
     done
 
-    if [[ -z "$DEVICE" ]] ; then
+    if [[ -z "$device_to_be_formatted" ]] ; then
         test "$SIMULATE" || Error "No device provided as argument."
         # Simulation mode should work even without a device specified
         # see https://github.com/rear/rear/issues/1098#issuecomment-268973536
@@ -53,12 +68,12 @@ WORKFLOW_format () {
         return 0
     fi
 
-    if [[ -c "$DEVICE" ]]; then
+    if [[ -c "$device_to_be_formatted" ]] ; then
         OUTPUT=OBDR
-    elif [[ -b "$DEVICE" ]]; then
+    elif [[ -b "$device_to_be_formatted" ]] ; then
         OUTPUT=USB
     else
-        Error "Device $DEVICE is neither a character, nor a block device."
+        Error "Device $device_to_be_formatted is neither a character, nor a block device."
     fi
 
     SourceStage "format"


### PR DESCRIPTION
Use parted with bytes 'B' as unit in the format workflow
to be compatible with older parted, cf.
https://github.com/rear/rear/issues/1270
and further cleanups and enhancements
in the format workflow.