### PR TITLE
Change default Permission on Files and Directory in tftpboot.

### DIFF
--- a/usr/share/rear/output/default/200_make_prefix_dir.sh
+++ b/usr/share/rear/output/default/200_make_prefix_dir.sh
@@ -10,5 +10,9 @@ local opath=$(output_path $scheme $path)
 # if $opath is empty return silently (e.g. scheme tape)
 [ -z "$opath" ] && return 0
 
-mkdir -p $v -m0750 "${opath}" >&2
+if [[ "$OUTPUT" == "PXE" && "$scheme" == "nfs" ]]; then
+    mkdir -p $v -m0755 "${opath}" >&2
+else
+    mkdir -p $v -m0750 "${opath}" >&2
+fi
 StopIfError "Could not mkdir '${opath}'"

--- a/usr/share/rear/output/default/200_make_prefix_dir.sh
+++ b/usr/share/rear/output/default/200_make_prefix_dir.sh
@@ -11,6 +11,7 @@ local opath=$(output_path $scheme $path)
 [ -z "$opath" ] && return 0
 
 if [[ "$OUTPUT" == "PXE" && "$scheme" == "nfs" ]]; then
+    # Need directory with read access to everyone for tftp use (nobody user)
     mkdir -p $v -m0755 "${opath}" >&2
 else
     mkdir -p $v -m0750 "${opath}" >&2

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -38,7 +38,7 @@ test "$RESULT_FILES" || return 0
 case "$scheme" in
     (nfs|cifs|usb|file|sshfs|ftpfs|davfs)
         Log "Copying result files '${RESULT_FILES[@]}' to $opath at $scheme location"
-        cp $v "${RESULT_FILES[@]}" "${opath}/" >&2 || Error "Could not copy result files to $opath at $scheme location"
+        cp -p $v "${RESULT_FILES[@]}" "${opath}/" >&2 || Error "Could not copy result files to $opath at $scheme location"
         ;;
     (fish|ftp|ftps|hftp|http|https|sftp)
         # FIXME: Verify if usage of $array[*] instead of "${array[@]}" is actually intended here
@@ -58,4 +58,3 @@ case "$scheme" in
         Error "Invalid scheme '$scheme' in '$OUTPUT_URL'."
         ;;
 esac
-

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -38,6 +38,9 @@ test "$RESULT_FILES" || return 0
 case "$scheme" in
     (nfs|cifs|usb|file|sshfs|ftpfs|davfs)
         Log "Copying result files '${RESULT_FILES[@]}' to $opath at $scheme location"
+        # Use cp -p (preserve option) to keep right access during copy to output directory.
+        # This is important when output is PXE because file are created in mode0444 [800_copy_to_tftp.sh]
+        # to be accessible by nobody user. 
         cp -p $v "${RESULT_FILES[@]}" "${opath}/" >&2 || Error "Could not copy result files to $opath at $scheme location"
         ;;
     (fish|ftp|ftps|hftp|http|https|sftp)


### PR DESCRIPTION
Files and directories created for PXE/TFTP are too restricted (500 or 400 with owner root) which prevent them to be accessible during tftp/bootp process.
This is mostly due to the default `umask 0077` set in `010_set_umask.sh`

before:
```
[root@rhel72be-177 rear]# ls -ld sles11sap-144
total 8
drwxr-x--- 2 root root 4096 Apr  4 16:15 sles11sap-144

[root@rhel72be-177 rear]# ls -l sles11sap-144
total 100880
-rw------- 1 root root      516 Apr  4 16:15 README
-rw------- 1 root root      540 Apr  4 16:15 rear-sles11sap-144
-rw------- 1 root root  2925256 Apr  4 16:15 rear-sles11sap-144.log
-r-------- 1 root root 36048732 Apr  4 16:15 sles11sap-144.initrd.cgz
-r-------- 1 root root 20806910 Apr  4 16:15 sles11sap-144.kernel
-r-------- 1 root root      294 Apr  4 16:15 sles11sap-144.message
-rw------- 1 root root      294 Apr  4 16:15 VERSION
```

I just propose two light modifications:
- Force creation of output directory `$opath` in 755 when `OUTPUT=PXE` and protocol is NFS.
- Use `cp -p` to preserve permission and avoid `umask 0077` permission.

after:
```
[root@rhel72be-177 rear]# ls -ld sles11sap-144
total 8
drwxr-xr-x 2 root root 4096 Apr  4 16:15 sles11sap-144

[root@rhel72be-177 rear]# ll sles11sap-144
total 101776
-rw------- 1 root root      516 Apr  4 16:12 README
-rw-r--r-- 1 root root      540 Apr  4 16:12 rear-sles11sap-144
-rw------- 1 root root  2925288 Apr  4 16:12 rear-sles11sap-144.log
-r--r--r-- 1 root root 36048256 Apr  4 16:12 sles11sap-144.initrd.cgz
-r--r--r-- 1 root root 20806910 Jun 24  2015 sles11sap-144.kernel
-r--r--r-- 1 root root      294 Apr  4 16:12 sles11sap-144.message
-rw------- 1 root root      294 Apr  4 16:12 VERSION
```