### PR TITLE
Excluded private keys from recovery for curl https (see: PR #1267)

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -244,10 +244,18 @@ crc32c
 crc32c-intel
 )
 
-COPY_AS_IS=( ${COPY_AS_IS[@]:-} /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/termcap /etc/terminfo /lib*/terminfo /usr/share/terminfo /etc/netconfig /etc/mke2fs.conf /etc/*-release /etc/localtime /etc/magic /usr/share/misc/magic /etc/dracut.conf /etc/dracut.conf.d /usr/lib/dracut /sbin/modprobe.ksplice-orig /etc/sysctl.conf /etc/sysctl.d /etc/e2fsck.conf /etc/ssl/certs/* /etc/pki/* )
-
+COPY_AS_IS=( ${COPY_AS_IS[@]:-} /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/termcap /etc/terminfo /lib*/terminfo /usr/share/terminfo /etc/netconfig /etc/mke2fs.conf /etc/*-release /etc/localtime /etc/magic /usr/share/misc/magic /etc/dracut.conf /etc/dracut.conf.d /usr/lib/dracut /sbin/modprobe.ksplice-orig /etc/sysctl.conf /etc/sysctl.d /etc/e2fsck.conf )
+# Required by curl with https:
+# There are stored the distribution provided certificates
+# installed from packages, nothing confidential.
+# Usually the public verified certs, and not private keys.
+# The private keys are stored in /etc/ssl/private (not copied)
+# Private keys in /etc/pki/* are excluded (see below).
+COPY_AS_IS=( "${COPY_AS_IS[@]}" '/etc/ssl/certs/*' '/etc/pki/*' )
 # exclude /dev/shm/*, due to the way we use tar the leading / should be omitted
 COPY_AS_IS_EXCLUDE=( ${COPY_AS_IS_EXCLUDE[@]:-} dev/shm/\* )
+# Exclude private keys: /etc/pki/tls/private /etc/pki/CA/private and /etc/pki/nssdb/key*.db (cf. above):
+COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" '/etc/pki/tls/private' '/etc/pki/CA/private' '/etc/pki/nssdb/key*.db' )
 
 # some stuff for the Linux command line
 KERNEL_CMDLINE="$KERNEL_CMDLINE selinux=0"


### PR DESCRIPTION
brief description of changes:

Added excludes of SSL private keys in **/usr/share/rear/conf/GNU/Linux.conf** 

This code has been tested on RHEL/CentOS where curl has NSS support `/etc/pki/*`. SLES/opesSUSE and Debian/Ubuntu are ok with not including (/etc/ssl/private).