### PR TITLE
Make NETFS_RESTORE_CAPABILITIES more fail safe

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1067,19 +1067,20 @@ NETFS_KEEP_OLD_BACKUP_COPY=
 # NETFS_RESTORE_CAPABILITIES is an array that contains those directories
 # where ReaR should save file capabilities via 'getcap -r' (during 'rear mkbackup') and
 # restore them for each file with file capabilities via 'setcap' (during 'rear recover').
-# The by default empty NETFS_RESTORE_CAPABILITIES means that
+# The special value NETFS_RESTORE_CAPABILITIES=( 'Yes' ) results that 'getcap -r /'
+# is used as fallback which could become unusable slow on systems with zillions of files
+# in particular when tons of stuff is mounted cf. https://github.com/rear/rear/issues/1283
+# In this case one must explicitly specify on what directories 'getcap -r' should be run.
+# NETFS_RESTORE_CAPABILITIES should usually contain those directories that are in the backup.
+# The default NETFS_RESTORE_CAPABILITIES=( 'No' ) means that
 # the backup program should save and restore file capabilities
 # (e.g. 'tar' via '--xattr' that is used by default in ReaR).
 # For backup program that do not support to save and restore file capabilities
 # the user can manually specify NETFS_RESTORE_CAPABILITIES as a workaround
 # cf. https://github.com/rear/rear/issues/1175
-# In this case NETFS_RESTORE_CAPABILITIES should usually contain those directories
-# that are in the backup but the root directory '/' should no be specified
-# because 'getcap -r /' needs a very log time to run
-# cf. https://github.com/rear/rear/issues/1283
-# Furthermore TMPDIR and ISO_DIR are automatically excluded
-# cf. rescue/NETFS/default/610_save_capabilities.sh
-NETFS_RESTORE_CAPABILITIES=()
+# Furthermore BUILD_DIR (i.e. usually /tmp/rear.XXXXXXXXXXXXXXX cf. TMPDIR above) and
+# ISO_DIR are automatically excluded cf. rescue/NETFS/default/610_save_capabilities.sh
+NETFS_RESTORE_CAPABILITIES=( 'No' )
 
 ##
 # BACKUP=RSYNC method

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1064,8 +1064,22 @@ NETFS_PREFIX="$HOSTNAME"
 # empty means only keep current backup
 NETFS_KEEP_OLD_BACKUP_COPY=
 
-# Specify if ReaR should try to backup capabilities (y/n) default (n).
-NETFS_RESTORE_CAPABILITIES=n
+# NETFS_RESTORE_CAPABILITIES is an array that contains those directories
+# where ReaR should save file capabilities via 'getcap -r' (during 'rear mkbackup') and
+# restore them for each file with file capabilities via 'setcap' (during 'rear recover').
+# The by default empty NETFS_RESTORE_CAPABILITIES means that
+# the backup program should save and restore file capabilities
+# (e.g. 'tar' via '--xattr' that is used by default in ReaR).
+# For backup program that do not support to save and restore file capabilities
+# the user can manually specify NETFS_RESTORE_CAPABILITIES as a workaround
+# cf. https://github.com/rear/rear/issues/1175
+# In this case NETFS_RESTORE_CAPABILITIES should usually contain those directories
+# that are in the backup but the root directory '/' should no be specified
+# because 'getcap -r /' needs a very log time to run
+# cf. https://github.com/rear/rear/issues/1283
+# Furthermore TMPDIR and ISO_DIR are automatically excluded
+# cf. rescue/NETFS/default/610_save_capabilities.sh
+NETFS_RESTORE_CAPABILITIES=()
 
 ##
 # BACKUP=RSYNC method

--- a/usr/share/rear/prep/GNU/Linux/310_include_cap_utils.sh
+++ b/usr/share/rear/prep/GNU/Linux/310_include_cap_utils.sh
@@ -4,7 +4,14 @@
 # Skip when the whole NETFS_RESTORE_CAPABILITIES array is empty.
 # For the 'test' one must have all array members as a single word i.e. "${name[*]}" because
 # the test should succeed when there is any non-empty array member, not necessarily the first one:
-test "${NETFS_RESTORE_CAPABILITIES[*]}" || return 0
+if ! test "${NETFS_RESTORE_CAPABILITIES[*]}" ; then
+    # Avoid a bug in the subsequent rescue/NETFS/default/600_store_NETFS_variables.sh script
+    # that would store a false NETFS_RESTORE_CAPABILITIES='()' into /etc/rear/rescue.conf
+    # when NETFS_RESTORE_CAPABILITIES=() but '()' is not an empty array but the string "()"
+    # cf. https://github.com/rear/rear/pull/1284#issuecomment-293246380
+    NETFS_RESTORE_CAPABILITIES=( 'No' )
+    return 0
+fi
 # Be backward compatible:
 is_false "$NETFS_RESTORE_CAPABILITIES" && return 0
 

--- a/usr/share/rear/prep/GNU/Linux/310_include_cap_utils.sh
+++ b/usr/share/rear/prep/GNU/Linux/310_include_cap_utils.sh
@@ -1,4 +1,10 @@
-# include utilities needed to set capabilities
-if is_true "$NETFS_RESTORE_CAPABILITIES" ; then
-    REQUIRED_PROGS=("${REQUIRED_PROGS[@]}" setcap getcap)
-fi
+
+# Include utilities needed to get and set capabilities:
+
+# Skip when the whole NETFS_RESTORE_CAPABILITIES array is empty.
+# For the 'test' one must have all array members as a single word i.e. "${name[*]}" because
+# the test should succeed when there is any non-empty array member, not necessarily the first one:
+test "${NETFS_RESTORE_CAPABILITIES[*]}" || return 0
+
+REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" getcap setcap )
+

--- a/usr/share/rear/prep/GNU/Linux/310_include_cap_utils.sh
+++ b/usr/share/rear/prep/GNU/Linux/310_include_cap_utils.sh
@@ -5,6 +5,8 @@
 # For the 'test' one must have all array members as a single word i.e. "${name[*]}" because
 # the test should succeed when there is any non-empty array member, not necessarily the first one:
 test "${NETFS_RESTORE_CAPABILITIES[*]}" || return 0
+# Be backward compatible:
+is_false "$NETFS_RESTORE_CAPABILITIES" && return 0
 
 REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" getcap setcap )
 

--- a/usr/share/rear/rescue/NETFS/default/600_store_NETFS_variables.sh
+++ b/usr/share/rear/rescue/NETFS/default/600_store_NETFS_variables.sh
@@ -1,4 +1,6 @@
-# store all NETFS* variables
-# I don't know why it does not work with the full declare -- var=value syntax
-# found out by experiment that I need to remove the declare -- stuff.
-declare -p ${!NETFS*} | sed -e 's/declare .. //' >>$ROOTFS_DIR/etc/rear/rescue.conf
+
+# Store all currently set NETFS* variables into /etc/rear/rescue.conf in the ReaR recovery system.
+echo "All set NETFS_* variables (cf. rescue/NETFS/default/600_store_NETFS_variables.sh):" >> $ROOTFS_DIR/etc/rear/rescue.conf
+set | grep '^NETFS_' >>$ROOTFS_DIR/etc/rear/rescue.conf
+echo "" >> $ROOTFS_DIR/etc/rear/rescue.conf
+

--- a/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
+++ b/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
@@ -7,7 +7,7 @@
 test "${NETFS_RESTORE_CAPABILITIES[*]}" || return 0
 
 # Save capapilities to /var/lib/rear/recovery/capabilities:
-echo /dev/null > $VAR_DIR/recovery/capabilities
+cat /dev/null > $VAR_DIR/recovery/capabilities
 
 # getcap and setcap are mandatory when NETFS_RESTORE_CAPABILITIES has a non-empty array member:
 has_binary getcap && has_binary setcap || Error "getcap and setcap are needed when NETFS_RESTORE_CAPABILITIES is non-empty"

--- a/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
+++ b/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
@@ -5,6 +5,8 @@
 # For the 'test' one must have all array members as a single word i.e. "${name[*]}" because
 # the test should succeed when there is any non-empty array member, not necessarily the first one:
 test "${NETFS_RESTORE_CAPABILITIES[*]}" || return 0
+# Be backward compatible:
+is_false "$NETFS_RESTORE_CAPABILITIES" && return 0
 
 # Save capapilities to /var/lib/rear/recovery/capabilities:
 cat /dev/null > $VAR_DIR/recovery/capabilities
@@ -15,6 +17,9 @@ has_binary getcap && has_binary setcap || Error "getcap and setcap are needed wh
 # Empty values must be avoided for egrep -v because egrep -v '' or egrep -v 'something|' matches all:
 exclude_directories="$BUILD_DIR"
 test "$ISO_DIR" && exclude_directories="$exclude_directories|$ISO_DIR"
+
+# Be backward compatible:
+is_true "$NETFS_RESTORE_CAPABILITIES" && NETFS_RESTORE_CAPABILITIES=( '/' )
 
 # The actual work:
 for directory in "${NETFS_RESTORE_CAPABILITIES[@]}" ; do

--- a/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
+++ b/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
@@ -12,7 +12,7 @@ echo /dev/null > $VAR_DIR/recovery/capabilities
 # getcap and setcap are mandatory when NETFS_RESTORE_CAPABILITIES has a non-empty array member:
 has_binary getcap && has_binary setcap || Error "getcap and setcap are needed when NETFS_RESTORE_CAPABILITIES is non-empty"
 
-for directory in "${NETWORKING_PREPARATION_COMMANDS[@]}" ; do
+for directory in "${NETFS_RESTORE_CAPABILITIES[@]}" ; do
     getcap -r $directory 2>/dev/null | egrep -v "$TMPDIR|$ISO_DIR" >> $VAR_DIR/recovery/capabilities
 done
 

--- a/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
+++ b/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
@@ -1,5 +1,18 @@
-# save all found capapilities to file 
 
-if is_true "$NETFS_RESTORE_CAPABILITIES" ; then
-	getcap -r / 2>/dev/null | grep -v $ISO_DIR > $VAR_DIR/recovery/capabilities || Log "Error while saving capabilities to file."
-fi
+# Save all found capapilities.
+
+# Skip when the whole NETFS_RESTORE_CAPABILITIES array is empty.
+# For the 'test' one must have all array members as a single word i.e. "${name[*]}" because
+# the test should succeed when there is any non-empty array member, not necessarily the first one:
+test "${NETFS_RESTORE_CAPABILITIES[*]}" || return 0
+
+# Save capapilities to /var/lib/rear/recovery/capabilities:
+echo /dev/null > $VAR_DIR/recovery/capabilities
+
+# getcap and setcap are mandatory when NETFS_RESTORE_CAPABILITIES has a non-empty array member:
+has_binary getcap && has_binary setcap || Error "getcap and setcap are needed when NETFS_RESTORE_CAPABILITIES is non-empty"
+
+for directory in "${NETWORKING_PREPARATION_COMMANDS[@]}" ; do
+    getcap -r $directory 2>/dev/null | egrep -v "$TMPDIR|$ISO_DIR" >> $VAR_DIR/recovery/capabilities
+done
+

--- a/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
+++ b/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
@@ -12,7 +12,12 @@ cat /dev/null > $VAR_DIR/recovery/capabilities
 # getcap and setcap are mandatory when NETFS_RESTORE_CAPABILITIES has a non-empty array member:
 has_binary getcap && has_binary setcap || Error "getcap and setcap are needed when NETFS_RESTORE_CAPABILITIES is non-empty"
 
+# Empty values must be avoided for egrep -v because egrep -v '' or egrep -v 'something|' matches all:
+exclude_directories="$BUILD_DIR"
+test "$ISO_DIR" && exclude_directories="$exclude_directories|$ISO_DIR"
+
+# The actual work:
 for directory in "${NETFS_RESTORE_CAPABILITIES[@]}" ; do
-    getcap -r $directory 2>/dev/null | egrep -v "$TMPDIR|$ISO_DIR" >> $VAR_DIR/recovery/capabilities
+    getcap -r $directory | egrep -v "$exclude_directories" >> $VAR_DIR/recovery/capabilities
 done
 

--- a/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
+++ b/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
@@ -22,6 +22,7 @@ test "$ISO_DIR" && exclude_directories="$exclude_directories|$ISO_DIR"
 is_true "$NETFS_RESTORE_CAPABILITIES" && NETFS_RESTORE_CAPABILITIES=( '/' )
 
 # The actual work:
+LogPrint "Saving file capabilities (NETFS_RESTORE_CAPABILITIES)"
 for directory in "${NETFS_RESTORE_CAPABILITIES[@]}" ; do
     getcap -r $directory | egrep -v "$exclude_directories" >> $VAR_DIR/recovery/capabilities
 done

--- a/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
+++ b/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
@@ -24,6 +24,8 @@ is_true "$NETFS_RESTORE_CAPABILITIES" && NETFS_RESTORE_CAPABILITIES=( '/' )
 # The actual work:
 LogPrint "Saving file capabilities (NETFS_RESTORE_CAPABILITIES)"
 for directory in "${NETFS_RESTORE_CAPABILITIES[@]}" ; do
-    getcap -r $directory | egrep -v "$exclude_directories" >> $VAR_DIR/recovery/capabilities
+    # Ignore stderr to avoid thousands of 'Failed to get capabilities of file'
+    # stderr messages for directories like /proc /sys /dev in case of 'getcap -r /':
+    getcap -r $directory 2>/dev/null | egrep -v "$exclude_directories" >> $VAR_DIR/recovery/capabilities
 done
 

--- a/usr/share/rear/restore/NETFS/default/510_set_capabilities.sh
+++ b/usr/share/rear/restore/NETFS/default/510_set_capabilities.sh
@@ -21,7 +21,7 @@ if ! test "$capabilities_file" ; then
     return 0
 fi
 
-LogPrint "Restoring capabilities (NETFS_RESTORE_CAPABILITIES)"
+LogPrint "Restoring file capabilities (NETFS_RESTORE_CAPABILITIES)"
 while IFS="=" read file cap ; do
     file="${file% }"
     cap="${cap# }"

--- a/usr/share/rear/restore/NETFS/default/510_set_capabilities.sh
+++ b/usr/share/rear/restore/NETFS/default/510_set_capabilities.sh
@@ -1,13 +1,20 @@
-# restore capabilities if capabilities are in the backup
-	if is_true "$NETFS_RESTORE_CAPABILITIES" ; then
-		if test -s $VAR_DIR/recovery/capabilities ; then
-			Log "Restoring Capabilities."
-			while IFS="=" read file cap ; do
-				file="${file% }"
-				cap="${cap# }"
-				setcap "${cap}" "${TARGET_FS_ROOT}/${file}" 2>/dev/null || Log "Error while setting capabilties to \"${file}\""
-			done < <(cat $VAR_DIR/recovery/capabilities)
-		else
-			Log "No saved capabilities found"
-		fi
-	fi
+
+# Restore capabilities:
+
+# Skip when the whole NETFS_RESTORE_CAPABILITIES array is empty.
+# For the 'test' one must have all array members as a single word i.e. "${name[*]}" because
+# the test should succeed when there is any non-empty array member, not necessarily the first one:
+test "${NETFS_RESTORE_CAPABILITIES[*]}" || return 0
+
+# Report when NETFS_RESTORE_CAPABILITIES is non-empty but there is no capabilities file:
+if ! test -s $VAR_DIR/recovery/capabilities ; then
+    LogPrint "Cannot restore capabilities: No $VAR_DIR/recovery/capabilities or it is empty"
+fi
+
+LogPrint "Restoring capabilities (NETFS_RESTORE_CAPABILITIES)"
+while IFS="=" read file cap ; do
+    file="${file% }"
+    cap="${cap# }"
+    setcap "${cap}" "${TARGET_FS_ROOT}/${file}" 1>/dev/null || LogPrint "Error while setting capabilties to '$file'"
+done < <(cat $VAR_DIR/recovery/capabilities)
+

--- a/usr/share/rear/restore/NETFS/default/510_set_capabilities.sh
+++ b/usr/share/rear/restore/NETFS/default/510_set_capabilities.sh
@@ -5,10 +5,20 @@
 # For the 'test' one must have all array members as a single word i.e. "${name[*]}" because
 # the test should succeed when there is any non-empty array member, not necessarily the first one:
 test "${NETFS_RESTORE_CAPABILITIES[*]}" || return 0
+# Be backward compatible:
+is_false "$NETFS_RESTORE_CAPABILITIES" && return 0
+
+# Try to find a capabilities file.
+# Prefer the one in the recovery system ($VAR_DIR/recovery/capabilities) if exists
+# over the one that may have been restored from the backup ($TARGET_FS_ROOT/$VAR_DIR/recovery/capabilities):
+test -s $TARGET_FS_ROOT/$VAR_DIR/recovery/capabilities && capabilities_file="$TARGET_FS_ROOT/$VAR_DIR/recovery/capabilities"
+test -s $VAR_DIR/recovery/capabilities && capabilities_file="$VAR_DIR/recovery/capabilities"
 
 # Report when NETFS_RESTORE_CAPABILITIES is non-empty but there is no capabilities file:
-if ! test -s $VAR_DIR/recovery/capabilities ; then
+if ! test "$capabilities_file" ; then
     LogPrint "Cannot restore capabilities: No $VAR_DIR/recovery/capabilities or it is empty"
+    # Do not abort the whole 'rear recover' in this case:
+    return 0
 fi
 
 LogPrint "Restoring capabilities (NETFS_RESTORE_CAPABILITIES)"
@@ -16,5 +26,5 @@ while IFS="=" read file cap ; do
     file="${file% }"
     cap="${cap# }"
     setcap "${cap}" "${TARGET_FS_ROOT}/${file}" 1>/dev/null || LogPrint "Error while setting capabilties to '$file'"
-done < <(cat $VAR_DIR/recovery/capabilities)
+done < <(cat $capabilities_file)
 


### PR DESCRIPTION
Changed NETFS_RESTORE_CAPABILITIES
from a binary variable to an array that contains
those directories where ReaR should save and
restore file capabilities, see
https://github.com/rear/rear/issues/1283
and the related issue
https://github.com/rear/rear/issues/1175
This change is not backward compatible because now
NETFS_RESTORE_CAPABILITIES="yes"
does no longer work as expected.
I cannot enhance it so that
NETFS_RESTORE_CAPABILITIES="yes"
works as before which would mean to
run 'getcap -r /' as generic fallback
because that command is the reason for
https://github.com/rear/rear/issues/1283
which this pull request intends to fix.
