### PR TITLE
Fix no hostname set in Arch Linux #1254

### DIFF
--- a/usr/share/rear/rescue/default/100_hostname.sh
+++ b/usr/share/rear/rescue/default/100_hostname.sh
@@ -5,4 +5,11 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-echo $HOSTNAME >$ROOTFS_DIR/etc/HOSTNAME
+# For Arch Linux storing the host name in /etc/hostname (lowercase)
+# will set the host name in the recovery environment without any scripting.
+
+if [[ -e /etc/hostname ]] ; then
+    echo $HOSTNAME >$ROOTFS_DIR/etc/hostname
+else
+    echo $HOSTNAME >$ROOTFS_DIR/etc/HOSTNAME
+fi


### PR DESCRIPTION
By storing the hostname in /etc/hostname (lowercase) Arch Linux will automatically set the host name in the recovery environment. See issue #1254