### PR TITLE
Only set host name in recovery when /etc/HOSTNAME (uppercase) exists

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/boot
+++ b/usr/share/rear/skel/default/etc/scripts/boot
@@ -34,10 +34,17 @@ cat /proc/mounts >/etc/mtab 2>/dev/null
 ip addr add 127.0.0.1/8 dev lo
 ip link set lo up
 
-# set hostname
-export HOSTNAME="$(cat /etc/HOSTNAME)" # set hostname in THIS shell
-hostname "$HOSTNAME" # set hostname in the system
+# After issue #1286 merges, 
+# /rescue/default/100_hostname.sh does (only) generate /RECOVERYFS/etc/hostname (lower case) 
+# for source systems that have the /etc/hostname file existing. (target: Arch Linux)
+# An Arch Linux recovery environment running already sets system and shell hostname using /etc/hostname.
+# There is no longer an /etc/HOSTNAME file for this target and no need to manually set the host name.
 
-echo Hostname set to $(uname -n)
+if [[ -e /etc/HOSTNAME ]] ; then
+    # set hostname
+    export HOSTNAME="$(cat /etc/HOSTNAME)" # set hostname in THIS shell
+    hostname "$HOSTNAME" # set hostname in the system
 
+    echo Hostname set to $(uname -n)
+fi
 


### PR DESCRIPTION
After merging issue #1286 this enhancement beautifies the recovery environment scripting, to not run unnecessary code for:
1. cases where /etc/HOSTNAME does not exist
2. things that the operating system already has taken care of.

Target: Arch Linux
Hostname set in /etc/hostname (lowercase)
Only that /etc/hostname file present, will already set the hostname in (1) system and (2) shell for Arch Linux, without the need for this script to set any of these 2.