### PR TITLE
Make long SourceStage logging output better human scannable

### DIFF
--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -59,7 +59,9 @@ function SourceStage () {
     stage="$1"
     shift
     STARTSTAGE=$SECONDS
+    Log "======================"
     Log "Running '$stage' stage"
+    Log "======================"
     scripts=(
         $(
         cd $SHARE_DIR/$stage ;


### PR DESCRIPTION
Adding horizontal rulers around stage, so the human eye can quicker spot new stages in long output listings.