### PR TITLE
Multipathing when BOOT_OVER_SAN=y

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -1,5 +1,7 @@
 
-if grep -q '^multipath' "$LAYOUT_FILE" ; then
+# Activating multipath if BOOT_OVER_SAN variable is true
+# or if multipath device are present in LAYOUT_FILE
+if grep -q '^multipath' "$LAYOUT_FILE" || is_true "$BOOT_OVER_SAN" ; then
     Log "Activating multipath"
     modprobe dm-multipath >&2
     multipath >&2

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -4,6 +4,7 @@
 if grep -q '^multipath' "$LAYOUT_FILE" || is_true "$BOOT_OVER_SAN" ; then
     Log "Activating multipath"
     modprobe dm-multipath >&2
+    [ ! -f /etc/multipath.conf ] && touch /etc/multipath.conf
     multipath >&2
     if [ $? -ne 0 ] ; then
         LogPrint "Failed to activate multipath. Please do this now:"

--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -64,6 +64,13 @@ while read source target junk ; do
         *rd[/!]c[0-9]d[0-9]|*cciss[/!]c[0-9]d[0-9]|*ida[/!]c[0-9]d[0-9]|*amiraid[/!]ar[0-9]|*emd[/!][0-9]|*ataraid[/!]d[0-9]|*carmel[/!][0-9])
             target="${target}p" # append p between main device and partitions
             ;;
+        *mapper[/!]*)
+            case $OS_VENDOR in
+                SUSE_LINUX)
+                    target="${target}_part"
+                ;;
+            esac
+        ;;
     esac
     sed -i -r "\|$replacement|s|$replacement([0-9]+)|$target\1|g" "$LAYOUT_FILE"
 done < "$MAPPING_FILE"

--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -67,10 +67,10 @@ while read source target junk ; do
         *mapper[/!]*)
             case $OS_VENDOR in
                 SUSE_LINUX)
-                    target="${target}_part"
+                    target="${target}_part" # append _part between main device and partitions
                 ;;
                 RedHatEnterpriseServer)
-                    target="${target}p"
+                    target="${target}p" # append p between main device and partitions
                 ;;
             esac
         ;;

--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -69,6 +69,9 @@ while read source target junk ; do
                 SUSE_LINUX)
                     target="${target}_part"
                 ;;
+                RedHatEnterpriseServer)
+                    target="${target}p"
+                ;;
             esac
         ;;
     esac

--- a/usr/share/rear/prep/GNU/Linux/240_include_multipath_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/240_include_multipath_tools.sh
@@ -1,7 +1,9 @@
 # 240_include_multipath_tools.sh
 # Boot Over SAN executables and other goodies
 
-[[ $BOOT_OVER_SAN != ^[yY1] ]] && return
+if ! is_true "$BOOT_OVER_SAN" ; then
+    return
+fi
 
 PROGS=( "${PROGS[@]}" multipath dmsetup kpartx multipathd scsi_id  )
-COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/multipath/bindings /etc/multipath/wwids /etc/multipath.conf )
+COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/multipath.conf /etc/multipath/* /lib*/multipath )


### PR DESCRIPTION
Force Loading multipath modules when `BOOT_OVER_SAN` is True.
Before this changes, multipath module was loaded only if multipath devices were present in `LAYOUT_FILE`. 
So, if you migrate from virtual machine (non-multipath) to `BOOT_OVER_SAN` system (usually multipathed), multipath is not loaded during recover/migration.

I propose to automatically the load of multipath modules during recovery when `BOOT_OVER_SAN` is True.

I also add `/lib*/multipath` which where missing when creating rescue image with `BOOT_OVER_SAN=y`