### PR TITLE
Typo in 600_store_NETFS_variables.sh ?

### DIFF
--- a/usr/share/rear/rescue/NETFS/default/600_store_NETFS_variables.sh
+++ b/usr/share/rear/rescue/NETFS/default/600_store_NETFS_variables.sh
@@ -1,6 +1,5 @@
 
 # Store all currently set NETFS* variables into /etc/rear/rescue.conf in the ReaR recovery system.
-echo "All set NETFS_* variables (cf. rescue/NETFS/default/600_store_NETFS_variables.sh):" >> $ROOTFS_DIR/etc/rear/rescue.conf
+echo "# All set NETFS_* variables (cf. rescue/NETFS/default/600_store_NETFS_variables.sh):" >> $ROOTFS_DIR/etc/rear/rescue.conf
 set | grep '^NETFS_' >>$ROOTFS_DIR/etc/rear/rescue.conf
 echo "" >> $ROOTFS_DIR/etc/rear/rescue.conf
-


### PR DESCRIPTION
Error message when booting on recovery image:
```
ET: Registered protocol family 15
Registering the dns_resolver key type
registered taskstats version 1
Freeing unused kernel memory: 5376k freed
INIT: version 2.86 booting
Hostname set to sles11sap-144
/etc/rear/rescue.conf: line 9: syntax error near unexpected token `('
/etc/rear/rescue.conf: line 9: `All set NETFS_* variables (cf. rescue/NETFS/default/600_store_NETFS_variables.sh):'

Configuring Relax-and-Recover rescue system

Running 00-functions.sh...
Running 01-run-ldconfig.sh...
Running 10-console-setup.sh...
Loading /etc/dumpkeys.out
```

It seems "# " is missing in `usr/share/rear/rescue/NETFS/default/600_store_NETFS_variables.sh`