### PR TITLE
Remove duplicate pico from Linux.conf PROGS array

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -88,7 +88,6 @@ curl
 top
 iptraf
 joe
-pico
 getent
 id
 ldd


### PR DESCRIPTION
The PROGS array contains a redundant/duplicate "pico" configuration. Remove it.