### PR TITLE
exclude tmpfs from df.txt and replace grep

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/510_current_disk_usage.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/510_current_disk_usage.sh
@@ -2,4 +2,4 @@
 # Public License. Refer to the included COPYING for full text of license.
 
 # Save the current disk usage (POSIX output format) in the rescue image
-df -Plh |grep -vE '^(encfs)' > $VAR_DIR/layout/config/df.txt
+df -Plh -x encfs -x tmpfs -x devtmpfs > $VAR_DIR/layout/config/df.txt


### PR DESCRIPTION
Gnu `df` at least since 2013 contains the -x option to "Exclude Certain File System Type":
`  -x, --exclude-type=TYPE   limit listing to file systems not of type TYPE`
There is no need to use `grep` to exclude file systems.

Also including `tmpfs` and `devtmpsfs` clutters the output. Exclude these file systems too.

Output before change:
```
Filesystem      Size  Used Avail Use% Mounted on
dev             3.9G     0  3.9G   0% /dev
run             3.9G  696K  3.9G   1% /run
/dev/sda2        20G  2.1G   18G  11% /
tmpfs           3.9G     0  3.9G   0% /dev/shm
tmpfs           3.9G     0  3.9G   0% /sys/fs/cgroup
tmpfs           3.9G     0  3.9G   0% /tmp
/dev/sda3       9.3G   17M  9.3G   1% /home
/dev/sda1      1022M   44M  979M   5% /boot
tmpfs           789M     0  789M   0% /run/user/0
```

Output after change:
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda2        20G  2.1G   18G  11% /
/dev/sda3       9.3G   17M  9.3G   1% /home
/dev/sda1      1022M   44M  979M   5% /boot
```
That makes the output readable.

FIXME: Non GNU `df` versions might lack support for option `-x`.