### PR TITLE
Use "sort -un" to prevent duplicate entry in partitions file.

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -67,7 +67,7 @@ extract_partitions() {
     done
 
     # do a numeric sort to have the partitions in numeric order (see #352)
-    sort -n  $TMP_DIR/partitions_unsorted > $TMP_DIR/partitions
+    sort -un  $TMP_DIR/partitions_unsorted > $TMP_DIR/partitions
 
     if [[ ! -s $TMP_DIR/partitions ]] ; then
         Debug "No partitions found on $device."

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -67,6 +67,7 @@ extract_partitions() {
     done
 
     # do a numeric sort to have the partitions in numeric order (see #352)
+    # add a uniq sort "-u" to filter duplicated lines (see #1301) 
     sort -un  $TMP_DIR/partitions_unsorted > $TMP_DIR/partitions
 
     if [[ ! -s $TMP_DIR/partitions ]] ; then


### PR DESCRIPTION
 When using SLE12 with multipath, partition behind the multipath device are duplicated in disk layout file.
 This break the layout recreation during recovery.

 1) recovery will try to create twice the same partition
 2) flags are wrong (twice "primary" instead of "primary" "flag")

extract of layout generated:
```
multipath /dev/mapper/3600507680c82004cf8000000000000d8 /dev/sda,/dev/sdb,/dev/sdc,/dev/sdd,/dev/sde,/dev/sdf,/dev/sdg,/dev/sdh
part /dev/mapper/3600507680c82004cf8000000000000d8 7340032 2097152 primary primary /dev/mapper/3600507680c82004cf8000000000000d8-part1
part /dev/mapper/3600507680c82004cf8000000000000d8 7340032 2097152 primary primary /dev/mapper/3600507680c82004cf8000000000000d8-part1
part /dev/mapper/3600507680c82004cf8000000000000d8 2154823680 9441280 primary primary /dev/mapper/3600507680c82004cf8000000000000d8-part2
part /dev/mapper/3600507680c82004cf8000000000000d8 2154823680 9441280 primary primary /dev/mapper/3600507680c82004cf8000000000000d8-part2
part /dev/mapper/3600507680c82004cf8000000000000d8 21015560192 2164269056 primary primary /dev/mapper/3600507680c82004cf8000000000000d8-part3
part /dev/mapper/3600507680c82004cf8000000000000d8 21015560192 2164269056 primary primary /dev/mapper/3600507680c82004cf8000000000000d8-part3
part /dev/mapper/3600507680c82004cf8000000000000d8 30507257856 23179833344 primary primary /dev/mapper/3600507680c82004cf8000000000000d8-part4
part /dev/mapper/3600507680c82004cf8000000000000d8 30507257856 23179833344 primary primary /dev/mapper/3600507680c82004cf8000000000000d8-part4
```

extract of /tmp/rear.XXXXX/tmp/partition temporary file.
```
1 7340032 2097152 primary primary boot,prep boot,prep
1 7340032 2097152 primary primary boot,prep boot,prep
2 2154823680 9441280 primary primary none none
2 2154823680 9441280 primary primary none none
3 21015560192 2164269056 primary primary none none
3 21015560192 2164269056 primary primary none none
4 30507257856 23179833344 primary primary none none
4 30507257856 23179833344 primary primary none none
```
name and flags appear twice => this explain why flag are replaced by name in final layout file.

I don't currently find the "real" root cause for that. I think it is because SLE12 create symlink in /dev/mapper to keep partitions named with `_part` suffix (used in sles11) point to the same device than `-part` suffix used in SLE12...

```
sles12-143:/tmp/rear.txJkfqF92IeSAZv/tmp # ls -l /dev/mapper/
total 0
lrwxrwxrwx 1 root root       7 Apr 17 14:43 3600507680c82004cf8000000000000d8 -> ../dm-0
lrwxrwxrwx 1 root root       7 Apr 17 14:43 3600507680c82004cf8000000000000d8_part1 -> ../dm-1
lrwxrwxrwx 1 root root       7 Apr 17 14:43 3600507680c82004cf8000000000000d8-part1 -> ../dm-1
lrwxrwxrwx 1 root root       7 Apr 17 14:43 3600507680c82004cf8000000000000d8_part2 -> ../dm-2
lrwxrwxrwx 1 root root       7 Apr 17 14:43 3600507680c82004cf8000000000000d8-part2 -> ../dm-2
lrwxrwxrwx 1 root root       7 Apr 17 14:43 3600507680c82004cf8000000000000d8_part3 -> ../dm-3
lrwxrwxrwx 1 root root       7 Apr 17 14:43 3600507680c82004cf8000000000000d8-part3 -> ../dm-3
lrwxrwxrwx 1 root root       7 Apr 17 14:43 3600507680c82004cf8000000000000d8_part4 -> ../dm-4
lrwxrwxrwx 1 root root       7 Apr 17 14:43 3600507680c82004cf8000000000000d8-part4 -> ../dm-4
crw------- 1 root root 10, 236 Apr 17 14:43 control
```


Anyway, duplicates lines generated in `/tmp/rear.XXXXXXXX/partitions` should be easily solved by adding the parameter `-u` when sorting from `partitions_unsorted` file to `partition`

extract from `/tmp/rear.A8BIDrRDghtTw82/tmp/partitions_unsorted`
```
1 7340032 2097152
2 2154823680 9441280
3 21015560192 2164269056
4 30507257856 23179833344
1 7340032 2097152
2 2154823680 9441280
3 21015560192 2164269056
4 30507257856 23179833344
```
This will be cleaned by `sort -nu` .... then all the other files will be ok.

@gdha , @jsmeix , I need a review here.