### PR TITLE
Multipath device mapping

### DIFF
--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -64,6 +64,13 @@ while read source target junk ; do
         *rd[/!]c[0-9]d[0-9]|*cciss[/!]c[0-9]d[0-9]|*ida[/!]c[0-9]d[0-9]|*amiraid[/!]ar[0-9]|*emd[/!][0-9]|*ataraid[/!]d[0-9]|*carmel[/!][0-9])
             target="${target}p" # append p between main device and partitions
             ;;
+        *mapper[/!]*)
+            case $OS_VENDOR in
+                SUSE_LINUX)
+                    target="${target}_part"
+                ;;
+            esac
+        ;;
     esac
     sed -i -r "\|$replacement|s|$replacement([0-9]+)|$target\1|g" "$LAYOUT_FILE"
 done < "$MAPPING_FILE"

--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -67,10 +67,21 @@ while read source target junk ; do
         *mapper[/!]*)
             case $OS_VENDOR in
                 SUSE_LINUX)
+                    # SUSE Linux put a "_part" between [mpath device name] and [part number].
+                    # For example /dev/mapper/3600507680c82004cf8000000000000d8_part1.
+                    # (verified in version 11 SP4 and 12 SP2).
                     target="${target}_part" # append _part between main device and partitions
                 ;;
                 RedHatEnterpriseServer)
-                    target="${target}p" # append p between main device and partitions
+                    # RHEL 7 and above seems to named partitions on multipathed devices with
+                    # [mpath device name] + [part number] like standard disk.
+                    # For example: /dev/mapper/mpatha1
+
+                    # But the scheme in RHEL 6 need a "p" between [mpath device name] and [part number].
+                    # For exemple: /dev/mapper/mpathap1
+                    if (( $OS_VERSION -lt 7 )) ; then
+                        target="${target}p" # append p between main device and partitions
+                    fi
                 ;;
             esac
         ;;

--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -67,10 +67,10 @@ while read source target junk ; do
         *mapper[/!]*)
             case $OS_VENDOR in
                 SUSE_LINUX)
-                    target="${target}_part"
+                    target="${target}_part" # append _part between main device and partitions
                 ;;
                 RedHatEnterpriseServer)
-                    target="${target}p"
+                    target="${target}p" # append p between main device and partitions
                 ;;
             esac
         ;;

--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -50,10 +50,16 @@ while read original replacement junk ; do
         *mapper[/!]*)
             case $OS_VENDOR in
                 SUSE_LINUX)
-                    # SUSE Linux put a "_part" between [mpath device name] and [part number].
-                    # For example /dev/mapper/3600507680c82004cf8000000000000d8_part1.
-                    # (verified in version 11 SP4 and 12 SP2).
+                # SUSE Linux SLE12 put a "-part" between [mpath device name] and [part number].
+                # For example /dev/mapper/3600507680c82004cf8000000000000d8-part1.
+                # But SLES11 uses a "_part" instead. (Let's assume it is the same for SLES10 )
+                if (( $OS_VERSION < 12 )) ; then
+                    # For SUSE before version 12
                     part_base="${original}_part" # append _part between main device and partitions
+                else
+                    # For SUSE 12 or above
+                    part_base="${original}-part" # append -part between main device and partitions
+                fi
                 ;;
                 RedHatEnterpriseServer)
                     # RHEL 7 and above seems to named partitions on multipathed devices with
@@ -88,10 +94,16 @@ while read source target junk ; do
         *mapper[/!]*)
             case $OS_VENDOR in
                 SUSE_LINUX)
-                    # SUSE Linux put a "_part" between [mpath device name] and [part number].
-                    # For example /dev/mapper/3600507680c82004cf8000000000000d8_part1.
-                    # (verified in version 11 SP4 and 12 SP2).
-                    target="${target}_part" # append _part between main device and partitions
+                    # SUSE Linux SLE12 put a "-part" between [mpath device name] and [part number].
+                    # For example /dev/mapper/3600507680c82004cf8000000000000d8-part1.
+                    # But SLES11 uses a "_part" instead. (Let's assume it is the same for SLES10 )
+                    if (( $OS_VERSION < 12 )) ; then
+                        # For SUSE before version 12
+                        target="${target}_part" # append _part between main device and partitions
+                    else
+                        # For SUSE 12 or above
+                        target="${target}-part" # append -part between main device and partitions
+                    fi
                 ;;
                 RedHatEnterpriseServer)
                     # RHEL 7 and above seems to named partitions on multipathed devices with

--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -69,6 +69,9 @@ while read source target junk ; do
                 SUSE_LINUX)
                     target="${target}_part"
                 ;;
+                RedHatEnterpriseServer)
+                    target="${target}p"
+                ;;
             esac
         ;;
     esac


### PR DESCRIPTION
Creating a set of rules based on OS type (RedHat, Suse) to set the suffix used between multipath disk name and partition number:

- RHEL < 7 => p
- RHEL >= 7 => ""
- SUSE < 12 => _part
- SUSE > 12 => -part

Can easily be updated with other Linux distro