### PR TITLE
Set hostname in both /etc/hostname and /etc/HOSTNAME.

### DIFF
--- a/usr/share/rear/rescue/default/100_hostname.sh
+++ b/usr/share/rear/rescue/default/100_hostname.sh
@@ -8,5 +8,11 @@
 # For Arch Linux storing the host name in /etc/hostname (lowercase)
 # will set the host name in the recovery environment without any scripting.
 
+# If /etc/hostname exists => put hostname in $ROOTFS_DIR/etc/hostsname
+# Needed by Arch Linux
 [[ -e /etc/hostname ]] && echo $HOSTNAME >$ROOTFS_DIR/etc/hostname
+
+# If /etc/HOSTNAME exists => put hostname in $ROOTFS_DIR/etc/HOSTNAME
+# Used by most of the other Linux Distro.
+# SUSE 12 has both file, but seems to use /etc/HOSTNAME to setup hostname. (see #1316)
 [[ -e /etc/HOSTNAME ]] && echo $HOSTNAME >$ROOTFS_DIR/etc/HOSTNAME

--- a/usr/share/rear/rescue/default/100_hostname.sh
+++ b/usr/share/rear/rescue/default/100_hostname.sh
@@ -8,8 +8,5 @@
 # For Arch Linux storing the host name in /etc/hostname (lowercase)
 # will set the host name in the recovery environment without any scripting.
 
-if [[ -e /etc/hostname ]] ; then
-    echo $HOSTNAME >$ROOTFS_DIR/etc/hostname
-else
-    echo $HOSTNAME >$ROOTFS_DIR/etc/HOSTNAME
-fi
+[[ -e /etc/hostname ]] && echo $HOSTNAME >$ROOTFS_DIR/etc/hostname
+[[ -e /etc/HOSTNAME ]] && echo $HOSTNAME >$ROOTFS_DIR/etc/HOSTNAME

--- a/usr/share/rear/rescue/default/100_hostname.sh
+++ b/usr/share/rear/rescue/default/100_hostname.sh
@@ -8,11 +8,9 @@
 # For Arch Linux storing the host name in /etc/hostname (lowercase)
 # will set the host name in the recovery environment without any scripting.
 
-# If /etc/hostname exists => put hostname in $ROOTFS_DIR/etc/hostsname
-# Needed by Arch Linux
+# put hostname in $ROOTFS_DIR/etc/hostsname (Needed by Arch Linux)
 echo $HOSTNAME >$ROOTFS_DIR/etc/hostname
 
-# If /etc/HOSTNAME exists => put hostname in $ROOTFS_DIR/etc/HOSTNAME
-# Used by most of the other Linux Distro.
+# Put hostname in $ROOTFS_DIR/etc/HOSTNAME (used by most of the other Linux Distro.)
 # SUSE 12 has both file, but seems to use /etc/HOSTNAME to setup hostname. (see #1316)
 echo $HOSTNAME >$ROOTFS_DIR/etc/HOSTNAME

--- a/usr/share/rear/rescue/default/100_hostname.sh
+++ b/usr/share/rear/rescue/default/100_hostname.sh
@@ -10,9 +10,9 @@
 
 # If /etc/hostname exists => put hostname in $ROOTFS_DIR/etc/hostsname
 # Needed by Arch Linux
-[[ -e /etc/hostname ]] && echo $HOSTNAME >$ROOTFS_DIR/etc/hostname
+echo $HOSTNAME >$ROOTFS_DIR/etc/hostname
 
 # If /etc/HOSTNAME exists => put hostname in $ROOTFS_DIR/etc/HOSTNAME
 # Used by most of the other Linux Distro.
 # SUSE 12 has both file, but seems to use /etc/HOSTNAME to setup hostname. (see #1316)
-[[ -e /etc/HOSTNAME ]] && echo $HOSTNAME >$ROOTFS_DIR/etc/HOSTNAME
+echo $HOSTNAME >$ROOTFS_DIR/etc/HOSTNAME


### PR DESCRIPTION
Since 201921869e228d301cff7b4500c84e8cc165c539, SLE12 losts its hostname in recovery mode.

The reason seems to be because `/etc/hostname` file exists in SLE12, but only `/etc/HOSTNAME` is used to set hostname.

I propose the following simple change to solve this issue. 