### PR TITLE
Fix for long wait in dig, when DNS servers are not set.

### DIFF
--- a/usr/share/rear/rescue/GNU/Linux/990_sysreqs.sh
+++ b/usr/share/rear/rescue/GNU/Linux/990_sysreqs.sh
@@ -107,8 +107,7 @@ ip addr show | grep inet | grep -v 127.0.0. | sed -e "s/ brd.*//" -e "s/inet6//"
     # Only try to resolve hostnames if at least one DNS server is defined in /etc/resolv.conf
     # Missing DNS server causes every dig call to timeout after ~ 18 seconds, which
     # can sum up to several minutes when multiple IP addresses are in use.
-    # `grep -cv '\#.*nameserver.*$'` skips entries that are commented out
-    if hash dig 2>/dev/null && [ $(grep nameserver /etc/resolv.conf | grep -cv '\#.*nameserver.*$') -gt 0 ] ; then
+    if hash dig 2>/dev/null && [ $(grep -c '^[[:space:]]*nameserver' /etc/resolv.conf) -gt 0 ] ; then
         DNSname="$( dig +short -x ${ip%/*} )"
     else
         DNSname=""

--- a/usr/share/rear/rescue/GNU/Linux/990_sysreqs.sh
+++ b/usr/share/rear/rescue/GNU/Linux/990_sysreqs.sh
@@ -104,11 +104,8 @@ echo "  IP adresses:"
 # If "... DNS name" should not be output when there is no DNS name
 # a test whether or not <<$( dig +short -x ${ip%/*} )>> is empty would help.
 ip addr show | grep inet | grep -v 127.0.0. | sed -e "s/ brd.*//" -e "s/inet6//" -e "s/inet//" | while read ip ; do
-    # Only try to resolve hostnames if at least one DNS server is defined in /etc/resolv.conf
-    # Missing DNS server causes every dig call to timeout after ~ 18 seconds, which
-    # can sum up to several minutes when multiple IP addresses are in use.
-    if hash dig 2>/dev/null && [ $(grep -c '^[[:space:]]*nameserver' /etc/resolv.conf) -gt 0 ] ; then
-        DNSname="$( dig +short -x ${ip%/*} )"
+    if hash dig 2>/dev/null; then
+        DNSname="$( dig +time=1 +tries=1 +short -x ${ip%/*} )"
     else
         DNSname=""
     fi


### PR DESCRIPTION
When no DNS server is defined in _/etc/resolv.conf_, every call to `dig` in [990_sysreqs.sh](https://github.com/rear/rear/blob/master/usr/share/rear/rescue/GNU/Linux/990_sysreqs.sh#L107) takes ~18 s to timeout.
In summary, this caused on my SLES12 SP1 with two configured IP addresses to idle for 3 minutes:
```
...
2017-04-19 17:24:42 Including rescue/GNU/Linux/990_sysreqs.sh
2017-04-19 17:27:42 Finished running 'rescue' stage in 181 seconds
...
```

This fix skips call to `dig` if no DNS server is defined in _/etc/resolv.conf_

V.
