### PR TITLE
Add yaboot.conf to the list of file for disk migration.

### DIFF
--- a/usr/share/rear/finalize/GNU/Linux/150_migrate_disk_devices_layout.sh
+++ b/usr/share/rear/finalize/GNU/Linux/150_migrate_disk_devices_layout.sh
@@ -15,6 +15,7 @@ for file in     [b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* [b]oot/grub/
 		[b]oot/grub2/{grub.conf,grub.cfg,menu.lst,device.map} \
                 [e]tc/sysconfig/grub [e]tc/sysconfig/bootloader \
                 [e]tc/lilo.conf \
+                [e]tc/yaboot.conf \
                 [e]tc/mtab [e]tc/fstab \
                 [e]tc/mtools.conf \
                 [e]tc/smartd.conf [e]tc/sysconfig/smartmontools \

--- a/usr/share/rear/layout/save/default/450_check_bootloader_files.sh
+++ b/usr/share/rear/layout/save/default/450_check_bootloader_files.sh
@@ -21,10 +21,13 @@ case $used_bootloader in
         CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /etc/elilo.conf )
         ;;
     (PPC)
-        CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /etc/lilo.conf /etc/yaboot.conf)
+        # PPC arch bootloader can be :
+        #  - LILO : SLES < 12
+        #  - YABOOT : RHEL < 7
+        #  - GRUB2 : SLES >= 12, RHEL >= 7, Ubuntu and other new Linux on POWER distro.
+        CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]} /etc/lilo.conf /etc/yaboot.conf /etc/grub.cfg /etc/grub2.cfg /boot/grub2/grub2.cfg /boot/grub/grub.cfg)
         ;;
     (*)
         BugError "Unknown bootloader ($used_bootloader) - ask for sponsoring to get this fixed"
         ;;
 esac
-


### PR DESCRIPTION
`yaboot.conf` is used by RHEL < 7 in POWER system.

Like `lilo.conf`, the variable `boot=` must be updated in case of disk migration.

We should also add lilo.conf & yaboot.conf files to `CHECK_CONFIG_FILES`. What do you think ?