### PR TITLE
Adding libaio for multipath if BOOT_OVER_SAN true

### DIFF
--- a/usr/share/rear/prep/GNU/Linux/240_include_multipath_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/240_include_multipath_tools.sh
@@ -6,3 +6,9 @@ is_true "$BOOT_OVER_SAN" || return
 
 PROGS=( "${PROGS[@]}" multipath dmsetup kpartx multipathd scsi_id  )
 COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/multipath.conf /etc/multipath/* /lib*/multipath )
+
+# depending to the linux distro and arch, libaio can be located in different dir. (ex: /lib/powerpc64le-linux-gnu)
+for libdir in $(ldconfig -p | awk '/libaio.so/ { print $NF }' | xargs -n1 dirname | sort -u); do
+    libaio2add="$libaio2add $libdir/libaio*"
+done
+LIBS=( "${LIBS[@]}" $libaio2add )


### PR DESCRIPTION
 - same issue than #852. multipath need libaio.
 - Issue detected with Ubuntu.