### PR TITLE
Fixed REQUIRED_PROGS tests (related to issue1233)

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -476,15 +476,18 @@ fi
 SourceStage "init"
 
 # Check for requirements, do we have all required binaries?
-# Without the empty string as initial value MISSING_PROGS would be
-# an unbound variable that would result an error exit if 'set -eu' is used:
-MISSING_PROGS=("")
-for f in "${REQUIRED_PROGS[@]}" ; do
-    if ! has_binary "$f" ; then
-        MISSING_PROGS=( "${MISSING_PROGS[@]}" "$f" )
-    fi
+# For details see the comments in prep/default/950_check_missing_programs.sh
+# Without the empty string as initial value missing_progs ${missing_progs[*]} ${missing_progs[@]}
+# would all be unbound variables that would result an error exit if 'set -eu' is used:
+missing_progs=( '' )
+# Check for required binaries:
+for prog in "${REQUIRED_PROGS[@]}" ; do
+    has_binary "$prog" || missing_progs=( "${missing_progs[@]}" "$prog" )
 done
-test "$MISSING_PROGS" && Error "Cannot find required programs: ${MISSING_PROGS[@]}"
+# Detect when there is any non-empty array member (the first one is always empty, see above)
+# but the test should not succeed when there are only empty or blank array members
+# therefore 'echo -n' is interposed because its output is empty for only empty or blank arrays:
+test "$( echo -n ${missing_progs[*]} )" && Error "Cannot find required programs: ${missing_progs[@]}"
 
 readonly VERSION_INFO="
 $PRODUCT $VERSION / $RELEASE_DATE

--- a/usr/share/rear/prep/default/950_check_missing_programs.sh
+++ b/usr/share/rear/prep/default/950_check_missing_programs.sh
@@ -1,17 +1,25 @@
-# the main script all has the same piece of code (below), but
-# other prep scripts can also add binaries to the REQUIRED_PROGS array
+# The main script usr/sbin/rear has the same kind of code
+# but other prep scripts can add binaries to the REQUIRED_PROGS array
 # so we need to double check before leaving the prep stage.
 
-# check for requirements, do we have all required binaries ?
-# without the empty string as initial value MISSING_PROGS would be
-# an unbound variable that would result an error exit if 'set -eu' is used:
-declare -a MISSING_PROGS
-for f in "${REQUIRED_PROGS[@]}" ; do
-    if ! has_binary "$f" ; then
-        MISSING_PROGS=( "${MISSING_PROGS[@]}" "$f" )
-    fi
+# Without the empty string as initial value missing_progs ${missing_progs[*]} ${missing_progs[@]}
+# would all be unbound variables that would result an error exit if 'set -eu' is used:
+missing_progs=( '' )
+
+# Check for required binaries:
+for prog in "${REQUIRED_PROGS[@]}" ; do
+    has_binary "$prog" || missing_progs=( "${missing_progs[@]}" "$prog" )
 done
-if test -n "$MISSING_PROGS" ; then
-    Error "Cannot find required programs: ${MISSING_PROGS[@]}"
-fi
+
+# For the 'test' one must have all array members as a single word like "${arr[*]}" with double-quotes
+# because it should detect when there is any non-empty array member (not necessarily the first one)
+# but here the first array member is always the empty string because of missing_progs=( '' ) above
+# and test must have all as one argument (otherwise on gets 'bash: test: unary operator expected').
+# But on the other hand the test should not succeed when there are only empty or blank members
+# which would falsely succeed when the array is e.g. something like arr=( '' ' ' ) because then
+# "${arr[*]}" evaluates to "  " (the empty and blank members separated by the first character of IFS).
+# and test "${arr[*]}" results true for any non-empty argument (e.g. test " " results true).
+# Therefore 'echo -n' is interposed because the output of arr=( '' ' ' ) ; echo -n ${arr[*]}
+# is empty when the array has only empty or blank array members:
+test "$( echo -n ${missing_progs[*]} )" && Error "Cannot find required programs: ${missing_progs[@]}"
 


### PR DESCRIPTION
In
https://github.com/rear/rear/commit/463a2651af982723f843beccdf33f71a0352fa53
the fix for
usr/share/rear/prep/default/95_check_missing_programs.sh
made the REQUIRED_PROGS test therein work again
but the same code in usr/sbin/rear was not fixed
(with this pull request it gets fixed at both places).

But 'declare -a MISSING_PROGS' contradicted the intent
that is explained in the comment above in the code.

An empty array does not work witn 'set -u':
<pre>
# declare -a arr

# set -u

# echo $arr
-bash: arr: unbound variable

# echo ${arr[*]}
-bash: arr[*]: unbound variable

# echo ${arr[@]}
-bash: arr[@]: unbound variable

# echo "${arr[@]}"
-bash: arr[@]: unbound variable
</pre>
'declare -a arr' is the same as 'arr=()'.

One must have an array with at least one (empty) member.

