### PR TITLE
Allow "grub PXE style" for non x86 platform. 

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -448,6 +448,12 @@ PXE_CREATE_LINKS=MAC
 # Should I remove old symlinks for this host ? [BOOL]
 PXE_REMOVE_OLD_LINKS=
 
+# Should I use PXE based on GRUB2 instead of PXE legacy. [BOOL] (default is no)
+# PXE based on GRUB2 can be used by none x86 platform (like POWER ppc64/ppc64le).
+# More information on the GRUB PXE setup can be found here :
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-installation-server-setup.html#sect-network-boot-setup-ppc-grub2
+PXE_CONFIG_GRUB_STYLE=
+
 # The way we start up in our PXE mode (keywords known are 'automatic', 'unattended', and empty)
 # 'automatic' is the auto_recover mode which means boot automatic with ReaR and execute a 'rear recover', but
 # when a question has to be answered (e.g. during migration mode) it will wait on an answer...

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -434,6 +434,10 @@ PXE_CONFIG_URL=
 # put this before the hostname on the PXE server
 PXE_CONFIG_PREFIX=rear-
 
+# TFPT IP server. needed to create grub menu when PXE_CONFIG_GRUB_STYLE=y
+# If not set, we gonna try to get TFTP IP from PXE_TFTP_URL
+PXE_TFTP_IP=
+
 # where should we put the TFTP files ? (legacy way)
 PXE_TFTP_PATH=/var/lib/rear/output
 # where should we put the TFTP files ? (URL style)

--- a/usr/share/rear/conf/examples/RHEL7-PPC64LE-Mulitpath-PXE-GRUB.conf
+++ b/usr/share/rear/conf/examples/RHEL7-PPC64LE-Mulitpath-PXE-GRUB.conf
@@ -1,0 +1,37 @@
+# Default is to create Relax-and-Recover rescue media as ISO image
+# set OUTPUT to change that
+# set BACKUP to activate an automated (backup and) restore of your data
+# Possible configuration values can be found in /usr/share/rear/conf/default.conf
+#
+# This file (local.conf) is intended for manual configuration. For configuration
+# through packages and other automated means we recommend creating a new
+# file named site.conf next to this file and to leave the local.conf as it is.
+# Our packages will never ship with a site.conf.
+
+AUTOEXCLUDE_MULTIPATH=n
+BOOT_OVER_SAN=y
+
+OUTPUT=PXE
+OUTPUT_PREFIX_PXE=$HOSTNAME
+
+PXE_CONFIG_GRUB_STYLE=y
+# On your TFTP server:
+# In your tftpboot dir execute the following command to create the netboot directory based on GRUB.
+# grub2-mknetdir --net-directory=/var/lib/tftpboot
+# config directory will be /var/lib/tftpboot/boot/grub2/powerpc-ieee1275
+# More information about setting up a PXE based on Grub on POWER : https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-installation-server-setup.html#sect-network-boot-setup-ppc-grub2
+PXE_CONFIG_URL="nfs://XX.YY.ZZ.AA/var/lib/tftpboot/boot/grub2/powerpc-ieee1275"
+PXE_CONFIG_PREFIX=grub.cfg-
+PXE_CREATE_LINKS=IP
+PXE_REMOVE_OLD_LINKS=y
+PXE_TFTP_URL="nfs://XX.YY.ZZ.AA/var/www/html/rear"
+PXE_CONFIG_URL=$PXE_TFTP_URL/$OUTPUT_PREFIX_PXE
+
+USE_STATIC_NETWORKING=y
+
+BACKUP=NETFS
+BACKUP_URL=nfs://XX.YY.ZZ.AA/NFS/rear
+#####################################
+## Optional
+## Reduce the size of initrd, but can be long and use more CPU (could help when booting PPC64 in POWERVM with TFTP)
+#REAR_INITRD_COMPRESSION=lzma

--- a/usr/share/rear/conf/examples/RHEL7-PPC64LE-Mulitpath-PXE-GRUB.conf
+++ b/usr/share/rear/conf/examples/RHEL7-PPC64LE-Mulitpath-PXE-GRUB.conf
@@ -20,12 +20,11 @@ PXE_CONFIG_GRUB_STYLE=y
 # grub2-mknetdir --net-directory=/var/lib/tftpboot
 # config directory will be /var/lib/tftpboot/boot/grub2/powerpc-ieee1275
 # More information about setting up a PXE based on Grub on POWER : https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-installation-server-setup.html#sect-network-boot-setup-ppc-grub2
-PXE_CONFIG_URL="nfs://XX.YY.ZZ.AA/var/lib/tftpboot/boot/grub2/powerpc-ieee1275"
+PXE_TFTP_IP=XX.YY.ZZ.AA
+PXE_CONFIG_URL="nfs://$PXE_TFTP_IP/var/lib/tftpboot/boot/grub2/powerpc-ieee1275"
 PXE_CREATE_LINKS=IP
 PXE_REMOVE_OLD_LINKS=y
-PXE_TFTP_IP=XX.YY.ZZ.AA
-PXE_TFTP_URL="nfs://XX.YY.ZZ.AA/var/www/html/rear"
-PXE_CONFIG_URL=$PXE_TFTP_URL/$OUTPUT_PREFIX_PXE
+PXE_TFTP_URL="nfs://$PXE_TFTP_IP/var/lib/tftpboot"
 
 USE_STATIC_NETWORKING=y
 

--- a/usr/share/rear/conf/examples/RHEL7-PPC64LE-Mulitpath-PXE-GRUB.conf
+++ b/usr/share/rear/conf/examples/RHEL7-PPC64LE-Mulitpath-PXE-GRUB.conf
@@ -12,7 +12,7 @@ AUTOEXCLUDE_MULTIPATH=n
 BOOT_OVER_SAN=y
 
 OUTPUT=PXE
-OUTPUT_PREFIX_PXE=$HOSTNAME
+OUTPUT_PREFIX_PXE=rear/$HOSTNAME
 
 PXE_CONFIG_GRUB_STYLE=y
 # On your TFTP server:
@@ -21,9 +21,9 @@ PXE_CONFIG_GRUB_STYLE=y
 # config directory will be /var/lib/tftpboot/boot/grub2/powerpc-ieee1275
 # More information about setting up a PXE based on Grub on POWER : https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-installation-server-setup.html#sect-network-boot-setup-ppc-grub2
 PXE_CONFIG_URL="nfs://XX.YY.ZZ.AA/var/lib/tftpboot/boot/grub2/powerpc-ieee1275"
-PXE_CONFIG_PREFIX=grub.cfg-
 PXE_CREATE_LINKS=IP
 PXE_REMOVE_OLD_LINKS=y
+PXE_TFTP_IP=XX.YY.ZZ.AA
 PXE_TFTP_URL="nfs://XX.YY.ZZ.AA/var/www/html/rear"
 PXE_CONFIG_URL=$PXE_TFTP_URL/$OUTPUT_PREFIX_PXE
 

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -612,3 +612,25 @@ function make_pxelinux_config {
     # end of function make_pxelinux_config
 }
 
+function make_pxelinux_config_grub {
+    # we use this function in case we are using $PXE_CONFIG_URL style of configuration and $PXE_CONFIG_GRUB_STYLE=y
+    # TODO First Draft. Need to complete with all other options (see make_pxelinux_config).
+    echo "menuentry 'Relax-and-Recover v$VERSION' {"
+    echo "insmod tftp"
+    echo "echo 'Network status: '"
+    echo "net_ls_cards"
+    echo "net_ls_addr"
+    echo "net_ls_routes"
+    echo "echo"
+    echo "echo \" Relax-and-Recover Rescue image\""
+    echo "echo \"---------------------------------\""
+    echo "echo \"build from host: $HOSTNAME ($OS_VENDOR $OS_VERSION $ARCH)\""
+    echo "echo \"kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)\""
+    echo "echo \"${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}\""
+    echo "echo"
+    echo "echo 'Loading kernel ...'"
+    echo "linux (tftp)/$PXE_KERNEL root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE"
+    echo "echo 'Loading initial ramdisk ...'"
+    echo "initrd (tftp)/$PXE_INITRD"
+    echo "}"
+}

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -613,10 +613,31 @@ function make_pxelinux_config {
 }
 
 function make_pxelinux_config_grub {
-    # we use this function in case we are using $PXE_CONFIG_URL style of configuration and $PXE_CONFIG_GRUB_STYLE=y
+    net_default_server_opt=""
+
+    # Be sure that TFTP Server IP is set with TFTP_SERVER_IP Variable.
+    # else set it based on PXE_TFTP_UR variable.
+    if [[ -z $PXE_TFTP_IP ]] ; then
+        if [[ -z $PXE_TFTP_URL ]] ; then
+            LogPrint "Can't find TFTP IP information. Variable TFTP_SERVER_IP or PXE_TFTP_URL with clear IP address must be set."
+            return
+        else
+            # Get IP address from PXE_TFTP_URL (ex:http://xx.yy.zz.aa:port/foo/bar)
+            PXE_TFTP_IP=$(echo "$PXE_TFTP_URL" | awk -F'[/:]' '{ print $4 }')
+        fi
+    fi
+
+    if [ ! -z $PXE_TFTP_IP ]; then
+        net_default_server_opt="set net_default_server=$PXE_TFTP_IP"
+    else
+        LogPrint "WARNING: No valid TFTP IP found. GRUB menu will be generated without net_default_server"
+    fi
+
+    # we use this function only when $PXE_CONFIG_URL is set and $PXE_CONFIG_GRUB_STYLE=y
     # TODO First Draft. Need to complete with all other options (see make_pxelinux_config).
     echo "menuentry 'Relax-and-Recover v$VERSION' {"
     echo "insmod tftp"
+    echo "$net_default_server_opt"
     echo "echo 'Network status: '"
     echo "net_ls_cards"
     echo "net_ls_addr"

--- a/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
+++ b/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
@@ -65,7 +65,7 @@ fi
 
 
 if [[ ! -z "$PXE_TFTP_URL" ]] ; then
-    LogPrint "Copied kernel+initrd $( du -shc $KERNEL_FILE "$TMP_DIR/$REAR_INITRD_FILENAME" | tail -n 1 | tr -s "\t " " " | cut -d " " -f 1 ) to $PXE_TFTP_URL"
+    LogPrint "Copied kernel+initrd $( du -shc $KERNEL_FILE "$TMP_DIR/$REAR_INITRD_FILENAME" | tail -n 1 | tr -s "\t " " " | cut -d " " -f 1 ) to $PXE_TFTP_URL/$OUTPUT_PREFIX_PXE"
     umount_url $PXE_TFTP_URL $BUILD_DIR/tftpbootfs
     rmdir $BUILD_DIR/tftpbootfs >&2
     if [[ $? -eq 0 ]] ; then
@@ -77,4 +77,3 @@ else
     # Add to result files
     RESULT_FILES=( "${RESULT_FILES[@]}" "$PXE_TFTP_LOCAL_PATH/$PXE_KERNEL" "$PXE_TFTP_LOCAL_PATH/$PXE_INITRD" "$PXE_TFTP_LOCAL_PATH/$PXE_MESSAGE" )
 fi
-

--- a/usr/share/rear/output/PXE/default/810_create_pxelinux_cfg.sh
+++ b/usr/share/rear/output/PXE/default/810_create_pxelinux_cfg.sh
@@ -61,9 +61,9 @@ fi
 # the client is looking at a file named "grub.cfg-01-<MAC>"
 # or grub.cfg-<IP in hex>. It is like PXE, but prefixed with "grub.cfg-"
 if is_true $PXE_CONFIG_GRUB_STYLE ; then
-    PXE_LINK_PREFIX="grub.cfg-"
+    pxe_link_prefix="grub.cfg-"
 else
-    PXE_LINK_PREFIX=""
+    pxe_link_prefix=""
 fi
 
 case "$PXE_CREATE_LINKS" in
@@ -80,9 +80,9 @@ case "$PXE_CREATE_LINKS" in
                 else
                 # if gethostip is not available on your platform (like ppc64),
                 # use awk to generate IP in hex mode.
-                    ln -sf $v "$PXE_CONFIG_FILE" $PXE_LINK_PREFIX$(printf '%02X' ${IP//./ }) >&2
+                    ln -sf $v "$PXE_CONFIG_FILE" $pxe_link_prefix$(printf '%02X' ${IP//./ }) >&2
                     # to capture the whole subnet as well
-    				ln -sf $v "$PXE_CONFIG_FILE" $PXE_LINK_PREFIX$(printf '%02X' ${IP//./ } | cut -c 1-6) >&2
+    				ln -sf $v "$PXE_CONFIG_FILE" $pxe_link_prefix$(printf '%02X' ${IP//./ } | cut -c 1-6) >&2
                 fi
 			done
 		;;

--- a/usr/share/rear/output/PXE/default/810_create_pxelinux_cfg.sh
+++ b/usr/share/rear/output/PXE/default/810_create_pxelinux_cfg.sh
@@ -73,7 +73,7 @@ case "$PXE_CREATE_LINKS" in
 			while read inet IP junk ; do
 				IP=${IP%/*}
                 # check if gethostip is available.
-                if type gethostip &>/dev/null ; then
+                if has_binary gethostip &>/dev/null ; then
     				ln -sf $v "$PXE_CONFIG_FILE" $(gethostip -x $IP) >&2
     				# to capture the whole subnet as well
     				ln -sf $v "$PXE_CONFIG_FILE" $(gethostip -x $IP | cut -c 1-6) >&2


### PR DESCRIPTION
Some non x86 platform (like ppc64/ppc64le) does not support native PXE boot. Some document recommend  to use GRUB as a PXE alternative. (https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-installation-server-setup.html#sect-network-boot-setup-ppc-grub2)

I would like to propose this possibility in ReaR as an addition to the standard PXE.
 - This alternative way to use "Grub PXE" server will be controlled by a new boolean variable : `PXE_CONFIG_GRUB_STYLE` 
 - a New `make_pxelinux_config_grub` function to create the grub compatible boot menu.
 - Like PXE, when the client is looking at its MAC address or IP (in hex) on the config directory of the TFTP server. But file should be like this : `grub.cfg-<MAC or IP>`.
 - `gethostip` is part of syslinux (which is not available on PPC, may be some tool limited to x86...) I use a workaround based on `printf` when `gethostip` is not available

Here is an example of a `local.conf`
```
OUTPUT=PXE
OUTPUT_PREFIX_PXE=rear/$HOSTNAME
PXE_CONFIG_GRUB_STYLE=y
PXE_CONFIG_URL="nfs://10.7.19.177/var/lib/tftpboot/boot/grub2/powerpc-ieee1275"
PXE_CREATE_LINKS=IP
PXE_REMOVE_OLD_LINKS=y
PXE_TFTP_URL="nfs://10.7.19.177/var/lib/tftpboot"

BACKUP=NETFS
BACKUP_URL="nfs://10.7.19.177/rear"
```

tested successfully with RedHat 6, RedHat 7, Sles 11, Sles 12 on ppc64/ppc64le

Like usual, feedback/review welcomed