### PR TITLE
Show OUTPUT_* variables in rear dump

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/usr/share/rear/lib/dump-workflow.sh
+++ b/usr/share/rear/lib/dump-workflow.sh
@@ -59,7 +59,7 @@ WORKFLOW_dump () {
 	esac
 
 	LogPrint "Output to $OUTPUT"
-	for opt in $(eval echo '${!'"$OUTPUT"'_*}') RESULT_MAILTO ; do
+	for opt in $(eval echo '${!'"$OUTPUT"'_*}' '${!OUTPUT_*}') RESULT_MAILTO ; do
 		LogPrint "$( printf "%40s = %s" "$opt" "$(eval 'echo "${'"$opt"'[@]}"')" )"
 	done
 


### PR DESCRIPTION
also show OUTPUT_* in rear dump, fixing #1337
(use Editorconfig to declare our coding style)