### PR TITLE
Exit if TSM_RESULT_SAVE is false or PXE_TFTP_URL is defined.

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -781,7 +781,7 @@ TSM_RESTORE_PIT_DATE=
 # (Used internally)
 TSM_RESTORE_PIT_TIME=
 #
-# Tell if the result from mkrecover/backup (Rescue image: ISO image, PXE, kernel and initrd)
+# Tell if the result from mkbackup/mkrescue (Rescue image: ISO image, PXE, kernel and initrd)
 # should be saved via TSM.
 # You can disable these saving when the result is saved on an different way (ISO_URL, PXE_TFTP_URL....)
 # (y/n) default to y

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -781,8 +781,9 @@ TSM_RESTORE_PIT_DATE=
 # (Used internally)
 TSM_RESTORE_PIT_TIME=
 #
-# Should the result from mkrecover/backup saved via TSM
-# You can disable these saving when the result is saved on an different way (ISO_URL....)
+# Tell if the result from mkrecover/backup (Rescue image: ISO image, PXE, kernel and initrd)
+# should be saved via TSM.
+# You can disable these saving when the result is saved on an different way (ISO_URL, PXE_TFTP_URL....)
 # (y/n) default to y
 TSM_RESULT_SAVE=y
 

--- a/usr/share/rear/output/TSM/default/950_dsmc_save_result_files.sh
+++ b/usr/share/rear/output/TSM/default/950_dsmc_save_result_files.sh
@@ -8,7 +8,7 @@ fi
 
 # When PXE_TFTP_URL is defined, result files are directly copied on the remote
 # PXE/TFTP server, and the local files are deleted (800_copy_to_tftp.sh).
-# So, no need to backup RESULT_FILES when PXE_TFTP_UR is defined.
+# So, no need to backup RESULT_FILES when PXE_TFTP_URL is defined.
 [[ ! -z "$PXE_TFTP_URL" ]] && return
 
 [ ${#RESULT_FILES[@]} -gt 0 ]

--- a/usr/share/rear/output/TSM/default/950_dsmc_save_result_files.sh
+++ b/usr/share/rear/output/TSM/default/950_dsmc_save_result_files.sh
@@ -1,5 +1,13 @@
 # saving result files via TSM
 
+# If TSM_RESULT_SAVE is false, exit
+is_false $TSM_RESULT_SAVE && return
+
+# When PXE_TFTP_URL is defined, result files are directly copied on the remote
+# PXE/TFTP server, and the local files are deleted (800_copy_to_tftp.sh).
+# So, no need to backup RESULT_FILES when PXE_TFTP_UR is defined.
+[[ ! -z "$PXE_TFTP_URL" ]] && return
+
 [ ${#RESULT_FILES[@]} -gt 0 ]
 StopIfError "No files to copy (RESULT_FILES is empty)"
 
@@ -52,4 +60,3 @@ ret=$?
 # Error code 8 can be ignored
 [ "$ret" -eq 0 -o "$ret" -eq 8 ]
 StopIfError "Could not save result files with dsmc"
-

--- a/usr/share/rear/output/TSM/default/950_dsmc_save_result_files.sh
+++ b/usr/share/rear/output/TSM/default/950_dsmc_save_result_files.sh
@@ -1,7 +1,10 @@
 # saving result files via TSM
 
 # If TSM_RESULT_SAVE is false, exit
-is_false $TSM_RESULT_SAVE && return
+if is_false $TSM_RESULT_SAVE; then
+    Log "Result saving via TSM skipped"
+    return
+fi
 
 # When PXE_TFTP_URL is defined, result files are directly copied on the remote
 # PXE/TFTP server, and the local files are deleted (800_copy_to_tftp.sh).
@@ -43,11 +46,6 @@ if test -s $(get_template "RESULT_usage_$OUTPUT.txt") ; then
     cp $v $(get_template "RESULT_usage_$OUTPUT.txt") "$TSM_RESULT_FILE_PATH/README" >&2
     StopIfError "Could not copy '$(get_template RESULT_usage_$OUTPUT.txt)'"
     TSM_RESULT_FILES=( "${TSM_RESULT_FILES[@]}" "$TSM_RESULT_FILE_PATH"/README )
-fi
-
-if [[ "$TSM_RESULT_SAVE" = "n" ]]; then
-    Log "Result saving via TSM skipped"
-    return
 fi
 
 Log "Saving files '${TSM_RESULT_FILES[@]}' with dsmc"


### PR DESCRIPTION
Should fix #1342
 - No need to copy files if `TSM_RESULT_SAVE` is false
 - When `$PXE_TFTP_URL` is defined, results files are deleted by
 `800_copy_to_tftp.sh` ... So it produce an Error "No files to copy (RESULT_FILES is empty)"
 
