### PR TITLE
Avoid to get devname & devsize when not needed (multipath)

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -248,13 +248,13 @@ Log "Saving disk partitions."
     for disk in /sys/block/* ; do
         blockd=${disk#/sys/block/}
         if [[ $blockd = hd* || $blockd = sd* || $blockd = cciss* || $blockd = vd* || $blockd = xvd* || $blockd = dasd* || $blockd = nvme* ]] ; then
-            devname=$(get_device_name $disk)
-            devsize=$(get_disk_size ${disk#/sys/block/})
 
             #Check if blockd is a path of a multipath device.
             if is_multipath_path ${blockd} ; then
                 Log "Ignoring $blockd: it is a path of a multipath device"
-            else
+            else    
+                devname=$(get_device_name $disk)
+                devsize=$(get_disk_size ${disk#/sys/block/})
                 disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")
 
                 echo "# Disk $devname"


### PR DESCRIPTION
Avoid to get devname and devsize if it is a multipath device.
 - In this section of script we get information devname and devsize; but
 those information will be dropped if the device is a multipath device.
 => test if it is a multipath device and get devname and devsize only when
 needed.