### PR TITLE
Initramfs need $PATH when running in chroot on sles11

### DIFF
--- a/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
@@ -83,7 +83,7 @@ local mkinitrd_binary=$( chroot $TARGET_FS_ROOT /bin/bash -c 'PATH=/sbin:/usr/sb
 if test $mkinitrd_binary ; then
     # mkinitrd calls other tool like find, xargs, wc ... without full PATH.
     # $PATH MUST BE SET for mkinitrd can run successfully.
-    if chroot $TARGET_FS_ROOT /bin/bash -c $'PATH=/sbin:/usr/sbin:/usr/bin:/bin' $mkinitrd_binary >&2 ; then
+    if chroot $TARGET_FS_ROOT /bin/bash -c "PATH=/sbin:/usr/sbin:/usr/bin:/bin $mkinitrd_binary" >&2 ; then
         LogPrint "Recreated initrd ($mkinitrd_binary)."
     else
         LogPrint "WARNING:

--- a/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
@@ -81,7 +81,9 @@ local mkinitrd_binary=$( chroot $TARGET_FS_ROOT /bin/bash -c 'PATH=/sbin:/usr/sb
 # and then "rear recover" cannot be aborted with the usual [Ctrl]+[C] keys.
 # Use plain $var because when var contains only blanks test "$var" results true because test " " results true:
 if test $mkinitrd_binary ; then
-    if chroot $TARGET_FS_ROOT $mkinitrd_binary >&2 ; then
+    # mkinitrd calls other tool like find, xargs, wc ... without full PATH.
+    # $PATH MUST BE SET for mkinitrd can run successfully.
+    if chroot $TARGET_FS_ROOT /bin/bash -c $'PATH=/sbin:/usr/sbin:/usr/bin:/bin' $mkinitrd_binary >&2 ; then
         LogPrint "Recreated initrd ($mkinitrd_binary)."
     else
         LogPrint "WARNING:
@@ -99,4 +101,3 @@ and decide yourself, whether the system will boot or not.
 fi
 
 umount $TARGET_FS_ROOT/proc $TARGET_FS_ROOT/sys
-


### PR DESCRIPTION

I just notice that initrd were not correctly created in sles11 since we change chroot usage (stop using loggin).

mkinitramfs call other tools (dirname, getent, perl ...) without a correctly configured $PATH, this operation failed.

Here is the way to reproduce it :

```
RESCUE sles11sap-144:~ # TARGET_FS_ROOT=/mnt/local
RESCUE sles11sap-144:~ # mount -t proc none $TARGET_FS_ROOT/proc
RESCUE sles11sap-144:~ # mount -t sysfs none $TARGET_FS_ROOT/sys
RESCUE sles11sap-144:~ # mkinitrd_binary=$( chroot $TARGET_FS_ROOT /bin/bash -c 'PATH=/sbin:/usr/sbin:/usr/bi
n:/bin type -P mkinitrd' )
RESCUE sles11sap-144:~ # chroot $TARGET_FS_ROOT $mkinitrd_binary 

Kernel image:   /boot/vmlinux-3.0.101-63-ppc64
Initrd image:   /boot/initrd-3.0.101-63-ppc64
/lib/mkinitrd/setup/01-prepare.sh: line 183: getent: command not found
/lib/mkinitrd/setup/01-splashy.sh: line 17: perl: command not found
/lib/mkinitrd/setup/01-splashy.sh: line 18: [: too many arguments
/lib/mkinitrd/setup/01-splashy.sh: line 24: file: command not found
/lib/mkinitrd/setup/01-splashy.sh: line 67: directfb-config: command not found
/lib/mkinitrd/setup/01-splashy.sh: line 55: dirname: command not found
cp: cannot stat `/usr/lib/libdirect-1.2.so.0': No such file or directory
/lib/mkinitrd/setup/01-splashy.sh: line 55: dirname: command not found
cp: cannot stat `/usr/lib/libdirectfb-1.2.so.0': No such file or directory
/lib/mkinitrd/setup/01-splashy.sh: line 55: dirname: command not found
cp: cannot stat `/usr/lib/libfusion-1.2.so.0': No such file or directory
/lib/mkinitrd/setup/01-splashy.sh: line 55: dirname: command not found
cp: cannot create regular file `/dev/shm/.wsptH6/mnt//usr/lib/libpng12.so.0': No such file or directory
/lib/mkinitrd/setup/01-splashy.sh: line 55: dirname: command not found
cp: cannot create regular file `/dev/shm/.wsptH6/mnt//usr/lib/libglib-2.0.so.0': No such file or directory
/lib/mkinitrd/setup/01-splashy.sh: line 55: dirname: command not found
cp: cannot stat `/usr/lib/libsplashy.so.1': No such file or directory
/lib/mkinitrd/setup/01-splashy.sh: line 55: dirname: command not found
cp: cannot stat `/usr/lib/libsplashycnf.so.1': No such file or directory
/lib/mkinitrd/setup/01-splashy.sh: line 55: dirname: command not found
/lib/mkinitrd/setup/01-splashy.sh: line 55: dirname: command not found
/lib/mkinitrd/setup/01-splashy.sh: line 55: dirname: command not found
/lib/mkinitrd/setup/01-splashy.sh: line 60: dirname: command not found
cp: cannot create regular file `/dev/shm/.wsptH6/mnt//etc/splashy/config.xml': No such file or directory
/lib/mkinitrd/setup/01-splashy.sh: line 60: dirname: command not found
cp: omitting directory `/usr/share/splashy/themes//default'
ln: target `/dev/shm/.wsptH6/mnt/etc/splashy/' is not a directory: No such file or directory
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/02-start.sh: line 63: wc: command not found
/lib/mkinitrd/setup/02-start.sh: line 63: [: -gt: unary operator expected
/lib/mkinitrd/setup/03-kms.sh: line 71: tr: command not found
/lib/mkinitrd/setup/01-prepare.sh: line 41: find: command not found
/lib/mkinitrd/setup/01-prepare.sh: line 41: xargs: command not found
/lib/mkinitrd/setup/01-prepare.sh: line 41: find: command not found
/lib/mkinitrd/setup/01-prepare.sh: line 41: xargs: command not found
/lib/mkinitrd/setup/01-prepare.sh: line 41: find: command not found
/lib/mkinitrd/setup/01-prepare.sh: line 41: xargs: command not found
/lib/mkinitrd/setup/01-prepare.sh: line 41: find: command not found
/lib/mkinitrd/setup/01-prepare.sh: line 41: xargs: command not found
```