### PR TITLE
Don't run yaboot if yaboot.conf is managed by lilo.

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64/600_install_yaboot.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/600_install_yaboot.sh
@@ -4,6 +4,16 @@
 # skip if yaboot conf is not found
 test -f $TARGET_FS_ROOT/etc/yaboot.conf || return
 
+# check if yaboot.conf is managed by lilo, if yes, return
+if test -f $TARGET_FS_ROOT/etc/lilo.conf; then
+    # if the word "initrd-size" is present in yaboot.conf, this mean it should be
+    # managed by lilo.
+    if grep -qw initrd-size $TARGET_FS_ROOT/etc/yaboot.conf; then
+        LogPrint "yaboot.conf found but seems to be managed by lilo."
+        return
+    fi
+fi
+
 # Reinstall yaboot boot loader
 LogPrint "Installing PPC PReP Boot partition."
 


### PR DESCRIPTION
Exit from executing yaboot, if yaboot bootloader is managed by lilo (could be the case on sles11 ppc64 when not using LVM).

Here is the content of yaboot.conf (sles11 ppc64 no LVM)
```
# header section
partition = 3
timeout = 80
default = SLES11_SP4_1
# image section
image = /boot/vmlinux-3.0.101-71-ppc64
        label = SLES11_SP4_1
        root = /dev/vda3
        append = "quiet sysrq=1 insmod=sym53c8xx insmod=ipr crashkernel=512M-:256M "
        initrd = /boot/initrd-3.0.101-71-ppc64
        # remove initrd-size= line if yaboot.conf is not updated by lilo
        initrd-size = 5817152
```