### PR TITLE
Include systemd/network to preserve Predictable Network Interface Names

### DIFF
--- a/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
+++ b/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
@@ -6,7 +6,12 @@ if ps ax | grep -v grep | grep -q systemd ; then
         upstart-udev-bridge )
     # cgroup stuff - not required for ReaR
     #PROGS=( "${PROGS[@]}" cg_annotate cgclear cgcreate cgget cgrulesengd cgset cgdelete cgclassify cgexec )
-    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* )
+
+    # 1- Depending to the distros, systemd directory/scripts can be located in /usr/lib or /lib
+    # 2- Need to add systemd/network subdir in order to preserve rules about network device naming
+    #    (predictable naming or persitant naming / like udev).
+    #    more info here: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* /usr/lib/systemd/network /lib/systemd/network )
     CLONE_GROUPS=( "${CLONE_GROUPS[@]}" input )
     Log "Including systemd (init replacement) tool-set to bootstrap Relax-and-Recover"
 fi


### PR DESCRIPTION
Some modern distros (like ubuntu16.04) use systemd to control inet naming. 
Those information are stored in `/lib/systemd/network` or `/usr/lib/systemd/network`.

For example, my system in Ubuntu16.04 uses Predictable interface name by default : **enp0s1**
*I'm not a big fan of Predictable interface name, but it seems to become the new standard (Fedora 25 / Ubuntu 16.04, CoreOS...)*

When I boot to the rescue image, the interface is renamed **eth0** => with **NO IP** because of name chaged.

I think we should add `/lib/systemd/network` or `/usr/lib/systemd/network` to the rescue image as we want to "replicate" network configuration from the original machine when booting on the rescue image.
If the user doesn't like the "Predictable naming", it could add `net.ifnames=0` or change the configuration file `/lib/systemd/network/99-default.link` (which will be saved in the rescue image)