### PR TITLE
document incremental/differential backup timing granularity

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -574,6 +574,29 @@ BACKUP_INTEGRITY_CHECK=
 # where each new differential backup is based on the last existing full backup
 # so that "rear recover" will restore first the latest full backup that exists
 # plus one single latest differential backup that was made after the latest full backup.
+# Incremental and differential backup is implemented via the 'tar' option '--newer=YYYY-MM-DD'
+# so that only files whose modification or status change timestamp is newer than YYYY-MM-DD
+# get included in the incremental or differential backup.
+# In particular files that have been deleted since the last backup are not recognized this way
+# so that such files will get falsely restored during "rear recover".
+# Because of '--newer=YYYY-MM-DD' the timing granularity for incremental and differential backup
+# is one day and the differentiating time is at 00:00 on YYYY-MM-DD.
+# This means in particular for a series of incremental backups that happen each day at e.g. 05:00
+# that all files with modification or status change timestamp between 00:00 and 05:00
+# get included in two subsequent incremental backups, e.g. in 2017-11-22-0500-I.tar.gz
+# and in 2017-11-23-0500-I.tar.gz because 2017-11-23-0500-I.tar.gz includes all files
+# that are newer than 2017-11-22 at 00:00 (the date of the last incremental backup at 00:00)
+# see https://github.com/rear/rear/issues/1285 for details.
+# In general regarding advanced backup functionality (like incremental and differential backup):
+# ReaR is primarily a disaster recovery tool to recreate the basic system after a disaster happened.
+# ReaR is is neither a backup software nor a backup management software and it is not meant to be one
+# (cf. "Relax-and-Recover versus backup and restore" in https://en.opensuse.org/SDB:Disaster_Recovery).
+# In particular do not expect too much from ReaR's internal backup methods like 'tar'.
+# For simple tasks ReaR's internal backup methods should be o.k. but
+# ReaR's internal backup methods are not meant as professional backup solutions.
+# In general the backup and restore of the files is "external functionality" for ReaR.
+# ReaR only calls an external tool and that tool does the backup and restore of the files.
+# Use a professional backup solution in particular when you need advanced backup functionality.
 BACKUP_TYPE=
 # Together with BACKUP_TYPE=incremental or BACKUP_TYPE=differential
 # you could define on which weekdays "rear mkbackup" will create a full backup.


### PR DESCRIPTION
Document incremental/differential backup timing granularity
(one day and the differentiating time is at 00:00) and
other shortcomings of BACKUP_TYPE=incremental
or BACKUP_TYPE=differential, see the related issue
https://github.com/rear/rear/issues/1285
