### PR TITLE
Enhancement what MODULES get included in the reovery system

### DIFF
--- a/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
+++ b/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
@@ -32,8 +32,13 @@ function modinfo_filename () {
     # so that we need to check if we got a non-empty module filename:
     module_filename=$( modinfo -k $KERNEL_VERSION -F filename $module_name 2>/dev/null )
     # If 'modinfo -k ...' stdout is empty we retry without '-k' regardless why stdout is empty
-    # but then we do not discard stderr so that error messages appear in the log file:
-    test $module_filename || module_filename=$( modinfo -F filename $module_name )
+    # but then we do not discard stderr so that error messages appear in the log file.
+    # In this case we must additionally ensure that KERNEL_VERSION matches 'uname -r'
+    # otherwise a module file for a wrong kernel version would be found:
+    if ! test $module_filename ; then
+        test "$KERNEL_VERSION" = "$( uname -r )" || Error "modinfo_filename failed because KERNEL_VERSION does not match 'uname -r'"
+        module_filename=$( modinfo -F filename $module_name )
+    fi
     test $module_filename && echo $module_filename
 }
 

--- a/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
+++ b/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
@@ -1,28 +1,129 @@
 # 400_copy_modules.sh
 #
-# copy kernel modules for Relax-and-Recover
+# Copy kernel modules to the rescue/recovery system.
+
 #
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-Log "Collecting modules for kernel version $KERNEL_VERSION"
-MODFILES=(
-$( ResolveModules "$KERNEL_VERSION" "${MODULES[@]}" "${MODULES_LOAD[@]}"  )
-)
-StopIfError "Could not resolve kernel module dependancies"
+# The special value MODULES=( 'none' ) enforces that
+# no kernel modules get included in the rescue/recovery system
+# regardless of what modules are currently loaded.
+# Test the first MODULES array element because other scripts
+# in particular rescue/GNU/Linux/240_kernel_modules.sh
+# already appended other modules to the MODULES array:
+if test "none" = "$MODULES" ; then
+    LogPrint "Omit copying kernel modules (MODULES contains 'none')"
+    return
+fi
 
-# copy modules & depmod
-LogPrint "Copying kernel modules"
-ModulesCopyTo "$ROOTFS_DIR" "${MODFILES[@]}" >&8
-StopIfError "Could not copy kernel modules"
+# Artificial 'for' clause that is run only once
+# to be able to 'continue' with the code after it
+# when the kernel modules have been copied into the rescue/recovery system
+# (the 'for' loop is run only once so that 'continue' is the same as 'break')
+# which avoids dowdy looking code with deeply nested 'if...else' conditions:
+for dummy in "once" ; do
 
-depmod -avb "$ROOTFS_DIR" "$KERNEL_VERSION" >&8
-StopIfError "Could not configure modules with depmod"
+    # The special user setting MODULES=( 'all' ) enforces that
+    # all files from the /lib/modules/* directories
+    # get included in the rescue/recovery system
+    # regardless of what is set in EXCLUDE_MODULES.
+    # Test all MODULES array members to make the 'all' functionality work for
+    # MODULES array contents like MODULES=( 'moduleX' 'all' 'moduleY' ):
+    if IsInArray "all" "${MODULES[@]}" ; then
+        LogPrint "Copying all kernel modules in /lib/modules/* (MODULES contains 'all')"
+        # The '--parents' is needed to get the '/lib/' directory in the copy:
+        if ! cp $verbose -t $ROOTFS_DIR -a --parents /lib/modules 1>&2 ; then
+            Error "Failed to copy all kernel modules in /lib/modules/*"
+        fi
+        # After successful copying do the the code after the artificial 'for' clause:
+        continue
+    fi
 
-for m in "${MODULES_LOAD[@]}" ; do
-    echo $m
-done >>$ROOTFS_DIR/etc/modules
+    # The special user setting MODULES=( 'loaded' ) enforces that
+    # exactly those kernel modules get included in the rescue/recovery system
+    # that are currently loaded regardless of what is set in EXCLUDE_MODULES
+    # and regardless of what rescue/GNU/Linux/240_kernel_modules.sh has added.
+    # Test all MODULES array members to make the 'loaded' functionality work for
+    # MODULES array contents like MODULES=( 'moduleX' 'all' 'moduleY' ):
+    if IsInArray "loaded" "${MODULES[@]}" ; then
+        LogPrint "Copying only currently loaded kernel modules (MODULES contains 'loaded')"
+        # The rescue/recovery system cannot work when its kernel modules
+        # do not match the kernel that gets included in the rescue/recovery system
+        # so that "rear mkrescue/mkbackup" errors out to be on the safe side
+        # cf. https://github.com/rear/rear/wiki/Coding-Style
+        # and https://github.com/rear/rear/wiki/Developers-Guide
+        currently_running_kernel_version="$( uname -r )"
+        if ! test "$KERNEL_VERSION" = "$currently_running_kernel_version" ; then
+            Error "KERNEL_VERSION='$KERNEL_VERSION' does not match currently running kernel version ('uname -r' shows '$currently_running_kernel_version')"
+        fi
+        loaded_modules="$( lsmod | tail -n +2 | cut -d ' ' -f 1 )"
+        # Can it really happen that a module is currently loaded but 'modinfo -F filename' cannot show its filename?
+        # To be on the safe side there is a test even for for such a possibly weird error here:
+        loaded_modules_files="$( for loaded_module in $loaded_modules ; do modinfo -F filename $loaded_module || Error "$loaded_module loaded but no module file?" ; done )"
+        for loaded_module_file in $loaded_modules_files ; do
+            if ! cp $verbose -t $ROOTFS_DIR -L --preserve=all --parents $loaded_module_file 1>&2 ; then
+                Error "Failed to copy $loaded_module_file"
+            fi
+        done
+        # After successful copying do the the code after the artificial 'for' clause:
+        continue
+    fi
 
-# avoid duplicates in etc/modules
-cat $ROOTFS_DIR/etc/modules | sort -u > $ROOTFS_DIR/etc/modules.new
-mv -f $ROOTFS_DIR/etc/modules.new  $ROOTFS_DIR/etc/modules
+    # Finally the default case:
+    LogPrint "Copying kernel modules"
+    for module in "${MODULES[@]}" ; do
+        # Strip trailing ".o" if there:
+        module=${module#.o}
+        # Strip trailing ".ko" if there:
+        module=${module#.ko}
+        # Check if the module is not in the exclude list:
+        for exclude_module in "${EXCLUDE_MODULES[@]}" ; do
+            # Continue with the next module if the current one is in EXCLUDE_MODULES:
+            test "$module" = "$exclude_module" && continue 2
+        done
+        # Continue with the next module if the current one does not exist:
+        modinfo $module &>/dev/null || continue
+        # Use /etc/modprobe.conf if exists:
+        with_modprobe_conf=""
+        test -e /etc/modprobe.conf && with_modprobe_conf="-C /etc/modprobe.conf"
+        # Resolve module dependencies:
+        # I.e. get the module file plus the module files of other needed modules.
+        # This is currently only a "best effort" attempt because
+        # in general 'modprobe --show-depends' insufficient to get all needed modules
+        # see https://github.com/rear/rear/issues/1355
+        # The --ignore-install is helpful because that converts currently unsupported '^install' output lines
+        # into supported '^insmod' output lines for the particular module but that is also insufficient
+        # see also https://github.com/rear/rear/issues/1355
+        module_files=$( /sbin/modprobe $with_modprobe_conf --ignore-install --set-version $KERNEL_VERSION --show-depends $module 2>/dev/null | awk '/^insmod / { print $2 }' )
+        if ! test "$module_files" ; then
+            # Fallback is the plain module file without other needed modules (cf. the MODULES=( 'loaded' ) case above):
+            # Can it really happen that a module exists (which is tested above) but 'modinfo -F filename' cannot show its filename?
+            # To be on the safe side there is a test even for for such a possibly weird error here:
+            module_files="$( modinfo -F filename $module || Error "$module exists but no module file?" )"
+        fi
+        for module_file in $module_files ; do
+            if ! cp $verbose -t $ROOTFS_DIR -L --preserve=all --parents $module_file 1>&2 ; then
+                Error "Failed to copy $module_file"
+            fi
+        done
+    done
+
+done
+
+# Generate modules.dep and map files in all existing $ROOTFS_DIR/lib/modules/* directories
+# (because of the MODULES=( 'all' ) case several such directories could exist):
+for kernel_version in $( ls $ROOTFS_DIR/lib/modules/ ) ; do
+    if test -d $ROOTFS_DIR/lib/modules/$kernel_version ; then
+        depmod -b "$ROOTFS_DIR" -v "$kernel_version" >/dev/null || Error "depmod failed to configure modules for the rescue/recovery system"
+    fi
+done
+
+recovery_system_etc_modules="$ROOTFS_DIR/etc/modules"
+for module_to_be_loaded in "${MODULES_LOAD[@]}" ; do
+    echo $module_to_be_loaded
+done >>$recovery_system_etc_modules
+# remove duplicates:
+cat $recovery_system_etc_modules | sort -u > $recovery_system_etc_modules.new
+mv -f $recovery_system_etc_modules.new $recovery_system_etc_modules
+

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -654,12 +654,52 @@ bc
 # library files
 LIBS=()
 
-# Kernel modules to include in the rescue/recovery system
-# in addition to the default ones at mkrescue/mkbackup time:
+# Kernel modules to include in the rescue/recovery system:
+# The by default empty MODULES=() means that the currently loaded
+# kernel modules get included in the rescue/recovery system
+# (so that recovery should work on same replacement hardware)
+# plus kernel modules for certain kernel drivers like
+# storage drivers, network drivers, crypto drivers,
+# virtualization drivers, and some extra drivers
+# (see rescue/GNU/Linux/230_storage_and_network_modules.sh
+# and rescue/GNU/Linux/240_kernel_modules.sh). Usually this
+# works reasonably well but no automatism works in any case
+# so that more explicit user settings are possible:
+# Via MODULES=( "${MODULES[@]}" 'moduleX' 'moduleY' )
+# additional kernel modules can be specified to be included
+# in the rescue/recovery system in addition to the default ones.
+# In this case other required kernel modules are usually also
+# automatically included but this may not work in any case
+# (see https://github.com/rear/rear/issues/1355).
+# The special user setting MODULES=( 'all_modules' ) enforces that
+# all files in the /lib/modules/$KERNEL_VERSION directory
+# get included in the rescue/recovery system. Usually this is
+# required when migrating to different hardware to ensure
+# that all possibly needed kernel drivers for the new hardware
+# are available in the rescue/recovery system. It is also required
+# to have the rescue/recovery system better prepared for somewhat
+# "unusual use cases" where this or that additional kernel module
+# might be needed (see https://github.com/rear/rear/issues/1202).
+# Furthermore this is helpful to be on the safe side against possibly
+# missing other (dependant) kernel modules that are not automatically
+# found (cf. above https://github.com/rear/rear/issues/1355).
+# The special user setting MODULES=( 'loaded_modules' ) enforces that
+# only those kernel modules that are currently loaded
+# get included in the rescue/recovery system. This results a smaller
+# rescue/recovery system but on the other hand it means that recovery
+# will only work on same replacement hardware.
+# The special user setting MODULES=( 'no_modules' ) enforces that
+# no kernel modules get included in the rescue/recovery system
+# regardless of what modules are currently loaded. Usually this
+# means that the rescue/recovery system will not work - unless
+# you have all needed kernel drivers compiled into your kernel.
 MODULES=()
-# Load these modules in the given order in the rescue/recovery system:
+# Enforce to load these modules in the given order in the rescue/recovery system:
 MODULES_LOAD=()
-# Modules to exclude from the rescue/recovery system.
+# Kernel modules to exclude from the rescue/recovery system.
+# Modules that are specified in EXCLUDE_MODULES are excluded
+# from the rescue/recovery system in any case regardless what is
+# specified for MODULES e.g. also for MODULES=( 'all_modules' ).
 # By default we exclude scsi_debug - see issue #626:
 EXCLUDE_MODULES=( scsi_debug )
 

--- a/usr/share/rear/rescue/GNU/Linux/240_kernel_modules.sh
+++ b/usr/share/rear/rescue/GNU/Linux/240_kernel_modules.sh
@@ -5,6 +5,14 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
+# The special user setting MODULES=( 'no_modules' ) enforces that
+# no kernel modules get included in the rescue/recovery system
+# regardless of what modules are currently loaded.
+# Test the first MODULES array element because other scripts
+# in particular rescue/GNU/Linux/240_kernel_modules.sh
+# already appended other modules to the MODULES array:
+test "no_modules" = "$MODULES" && return
+
 # Note: The various DRIVERS list variables are set in the previous script.
 
 # 1. take all kernel modules for network and storage devices


### PR DESCRIPTION
Implemented support for additional meta values like
MODULES=( 'none' )
MODULES=( 'all' )
MODULES=( 'loaded' )
in build/GNU/Linux/400_copy_modules.sh
what MODULES get included in the recovery system
see https://github.com/rear/rear/issues/1202
and https://github.com/rear/rear/issues/1355
