### PR TITLE
implemented REBUILD_INITRAMFS variable (issue1321)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1593,6 +1593,26 @@ GRUB_RESCUE_USER=""
 # starting at https://github.com/rear/rear/issues/703#issuecomment-235506494
 
 ##
+# REBUILD_INITRAMFS
+#
+# Whether or not the initramfs/initrd should be rebuild during "rear recover"
+# in the recreated system.
+# The default REBUILD_INITRAMFS="yes" rebuilds the initramfs/initrd in any case
+# to be on the safe side because ReaR cannot check/verify all possible reasons
+# why the initramfs/initrd may have to be rebuild in the recreated system.
+# In special cases the user can explicitly skip rebuilding the initramfs/initrd in any case
+# via REBUILD_INITRAMFS="no" (or any value that is recognized as 'no' by the is_false function)
+# which usually means the initramfs/initrd that was restored form the backup gets used "as is"
+# but that can lead to errors later when booting the recreated system.
+# An empty value REBUILD_INITRAMFS="" (or any value that is neither recognized as 'yes'
+# by the is_true function nor as 'no' by the is_false function) specifies the old behaviour
+# where "rear recover" rebuilds the initrd/initramfs only if some storage drivers changed
+# (cf. 260_storage_drivers.sh and 260_recovery_storage_drivers.sh) but in general
+# that is insufficient (there are other reasons why the initramfs/initrd must be rebuild)
+# see https://github.com/rear/rear/issues/1321
+REBUILD_INITRAMFS="yes"
+
+##
 # BOOTLOADER
 #
 # What kind of bootloader is used on the original system

--- a/usr/share/rear/finalize/Debian/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Debian/i386/550_rebuild_initramfs.sh
@@ -1,16 +1,24 @@
 
-# Rebuild the initramfs if the drivers changed:
+# Rebuild the initramfs:
 
-# Skip if there is nothing to do.
-# During "rear recover" 260_recovery_storage_drivers.sh creates $TMP_DIR/storage_drivers
-if ! test -s $TMP_DIR/storage_drivers ; then
-    Log "Skip recreating initramfs: No needed storage drivers ('$TMP_DIR/storage_drivers' is empty)"
+# Skip if it is explicitly wanted to not rebuild the initramfs:
+if is_false $REBUILD_INITRAMFS ; then
+    Log "Skip recreating initramfs (REBUILD_INITRAMFS is false)"
     return 0
 fi
-# During "rear mkbackup/mkrescue" 260_storage_drivers.sh creates $VAR_DIR/recovery/storage_drivers
-if cmp -s $TMP_DIR/storage_drivers $VAR_DIR/recovery/storage_drivers ; then
-    Log "Skip recreating initramfs: '$TMP_DIR/storage_drivers' and '$VAR_DIR/recovery/storage_drivers' are the same"
-    return 0
+
+# Skip if not needed but only when it is not explicitly wanted to rebuild the initramfs in any case:
+if ! is_true $REBUILD_INITRAMFS ; then
+    # During "rear recover" 260_recovery_storage_drivers.sh creates $TMP_DIR/storage_drivers
+    if ! test -s $TMP_DIR/storage_drivers ; then
+        Log "Skip recreating initramfs: No needed storage drivers ('$TMP_DIR/storage_drivers' is empty)"
+        return 0
+    fi
+    # During "rear mkbackup/mkrescue" 260_storage_drivers.sh creates $VAR_DIR/recovery/storage_drivers
+    if cmp -s $TMP_DIR/storage_drivers $VAR_DIR/recovery/storage_drivers ; then
+        Log "Skip recreating initramfs: '$TMP_DIR/storage_drivers' and '$VAR_DIR/recovery/storage_drivers' are the same"
+        return 0
+    fi
 fi
 
 # A longer time ago udev was optional on some distros.

--- a/usr/share/rear/finalize/Fedora/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Fedora/i386/550_rebuild_initramfs.sh
@@ -1,16 +1,24 @@
 
-# Rebuild the initrd if the drivers changed:
+# Rebuild the initrd:
 
-# Skip if there is nothing to do.
-# During "rear recover" 260_recovery_storage_drivers.sh creates $TMP_DIR/storage_drivers
-if ! test -s $TMP_DIR/storage_drivers ; then
-    Log "Skip recreating initrd: No needed storage drivers ('$TMP_DIR/storage_drivers' is empty)"
+# Skip if it is explicitly wanted to not rebuild the initrd:
+if is_false $REBUILD_INITRAMFS ; then
+    Log "Skip recreating initrd (REBUILD_INITRAMFS is false)"
     return 0
 fi
-# During "rear mkbackup/mkrescue" 260_storage_drivers.sh creates $VAR_DIR/recovery/storage_drivers
-if cmp -s $TMP_DIR/storage_drivers $VAR_DIR/recovery/storage_drivers ; then
-    Log "Skip recreating initrd: '$TMP_DIR/storage_drivers' and '$VAR_DIR/recovery/storage_drivers' are the same"
-    return 0
+
+# Skip if not needed but only when it is not explicitly wanted to rebuild the initrd in any case:
+if ! is_true $REBUILD_INITRAMFS ; then
+    # During "rear recover" 260_recovery_storage_drivers.sh creates $TMP_DIR/storage_drivers
+    if ! test -s $TMP_DIR/storage_drivers ; then
+        Log "Skip recreating initrd: No needed storage drivers ('$TMP_DIR/storage_drivers' is empty)"
+        return 0
+    fi
+    # During "rear mkbackup/mkrescue" 260_storage_drivers.sh creates $VAR_DIR/recovery/storage_drivers
+    if cmp -s $TMP_DIR/storage_drivers $VAR_DIR/recovery/storage_drivers ; then
+        Log "Skip recreating initrd: '$TMP_DIR/storage_drivers' and '$VAR_DIR/recovery/storage_drivers' are the same"
+        return 0
+    fi
 fi
 
 # A longer time ago udev was optional on some distros.

--- a/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
@@ -1,16 +1,24 @@
 
-# Rebuild the initrd if the drivers changed:
+# Rebuild the initrd:
 
-# Skip if there is nothing to do.
-# During "rear recover" 260_recovery_storage_drivers.sh creates $TMP_DIR/storage_drivers
-if ! test -s $TMP_DIR/storage_drivers ; then
-    Log "Skip recreating initrd: No needed storage drivers ('$TMP_DIR/storage_drivers' is empty)"
+# Skip if it is explicitly wanted to not rebuild the initrd:
+if is_false $REBUILD_INITRAMFS ; then
+    Log "Skip recreating initrd (REBUILD_INITRAMFS is false)"
     return 0
 fi
-# During "rear mkbackup/mkrescue" 260_storage_drivers.sh creates $VAR_DIR/recovery/storage_drivers
-if cmp -s $TMP_DIR/storage_drivers $VAR_DIR/recovery/storage_drivers ; then
-    Log "Skip recreating initrd: '$TMP_DIR/storage_drivers' and '$VAR_DIR/recovery/storage_drivers' are the same"
-    return 0
+
+# Skip if not needed but only when it is not explicitly wanted to rebuild the initrd in any case:
+if ! is_true $REBUILD_INITRAMFS ; then
+    # During "rear recover" 260_recovery_storage_drivers.sh creates $TMP_DIR/storage_drivers
+    if ! test -s $TMP_DIR/storage_drivers ; then
+        Log "Skip recreating initrd: No needed storage drivers ('$TMP_DIR/storage_drivers' is empty)"
+        return 0
+    fi
+    # During "rear mkbackup/mkrescue" 260_storage_drivers.sh creates $VAR_DIR/recovery/storage_drivers
+    if cmp -s $TMP_DIR/storage_drivers $VAR_DIR/recovery/storage_drivers ; then
+        Log "Skip recreating initrd: '$TMP_DIR/storage_drivers' and '$VAR_DIR/recovery/storage_drivers' are the same"
+        return 0
+    fi
 fi
 
 # A longer time ago udev was optional on some distros.

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -25,12 +25,16 @@ function is_numeric () {
 # because "tertium non datur" (cf. https://en.wikipedia.org/wiki/Law_of_excluded_middle)
 # does not hold for variables because variables could be unset or have empty value
 # and to test if a variable is true or false its value is tested by that functions
-# but the variable may not have a real value (i.e. be unset or have empty value):
+# but the variable may not have a real value (i.e. be unset or have empty value) and
+# because both functions test explicitly '! is_true' is not the same as 'is_false'
+# and '! is_false' is not the same as 'is_true' (see both function comments below):
 
 function is_true () {
     # the argument is usually the value of a variable which needs to be tested
     # only if there is explicitly a 'true' value then is_true returns true
-    # so that an unset variable or an empty value is not true:
+    # so that an unset variable or an empty value is not true
+    # and also for any other value that is not recognized as a 'true' value
+    # by the is_true function the is_true function results false:
     case "$1" in
         ([tT] | [yY] | [yY][eE][sS] | [tT][rR][uU][eE] | 1)
         return 0 ;;
@@ -42,7 +46,9 @@ function is_false () {
     # the argument is usually the value of a variable which needs to be tested
     # only if there is explicitly a 'false' value then is_false returns true
     # so that an unset variable or an empty value is not false
-    # caution: for unset or empty variables is_false is false
+    # (caution: for unset or empty variables is_false is false)
+    # and also for any other value that is not recognized as a 'false' value
+    # by the is_false function the is_false function results false:
     case "$1" in
         ([fF] | [nN] | [nN][oO] | [fF][aA][lL][sS][eE] | 0)
         return 0 ;;

--- a/usr/share/rear/verify/GNU/Linux/260_recovery_storage_drivers.sh
+++ b/usr/share/rear/verify/GNU/Linux/260_recovery_storage_drivers.sh
@@ -22,5 +22,15 @@ if cmp -s $TMP_DIR/storage_drivers $VAR_DIR/recovery/storage_drivers ; then
     return 0
 fi
 
-LogPrint "Will do driver migration (recreating initramfs/initrd)"
+if is_false $REBUILD_INITRAMFS ; then
+    LogPrint "WARNING:
+Changed storage drivers require recreating initramfs/initrd
+but it will not be recreated (REBUILD_INITRAMFS='$REBUILD_INITRAMFS').
+It might work with the initrd 'as is' from the backup restore.
+Before reboot check the recreated system (mounted at $TARGET_FS_ROOT)
+and decide yourself, if your recreated system will boot or not.
+"
+else
+    LogPrint "Will do driver migration (recreating initramfs/initrd)"
+fi
 


### PR DESCRIPTION
This is a minor backward incompatible change:

The new default.conf setting
REBUILD_INITRAMFS="yes"
rebuilds the initramfs/initrd in any case during "rear recover"
in the recreated system to be on the safe side because
ReaR cannot check/verify all possible reasons why the
initramfs/initrd may have to be rebuild,
see https://github.com/rear/rear/issues/1321

With
REBUILD_INITRAMFS=""
the old behaviour where "rear recover" rebuilds the initrd/initramfs
only if some storage drivers changed can be still specified.

With
REBUILD_INITRAMFS="no"
the user can explicitly skip rebuilding the initramfs/initrd.
