### PR TITLE
Support for Grub2 + RAID1 on POWER

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
@@ -40,15 +40,24 @@ if [[ -r "$LAYOUT_FILE" ]]; then
     LogIfError "Unable to find /boot/$grub_name/grub.cfg."
 
     # Find PPC PReP Boot partition
-    part=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $LAYOUT_FILE )
+    part_list=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $LAYOUT_FILE )
 
-    if [ -n "$part" ]; then
-        LogPrint "Boot partition found: $part"
-        dd if=/dev/zero of=$part
-        # Run grub-install/grub2-install directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
-        chroot $TARGET_FS_ROOT $grub_name-install $part
-        NOBOOTLOADER=
-    fi
+    # If software RAID1 is used, several boot device will be found
+    # need to install grub2 on each of them
+    for part in $part_list ; do
+        if [ -n "$part" ]; then
+            LogPrint "Boot partition found: $part"
+            dd if=/dev/zero of=$part
+            # Run grub-install/grub2-install directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
+            # When software RAID1 is used, grub2 needs correct PATH to access other tools
+            if chroot $TARGET_FS_ROOT /bin/bash -c "PATH=/sbin:/usr/sbin:/usr/bin:/bin $grub_name-install $part" ; then
+                LogPrint "GRUB2 installed on $part"
+                NOBOOTLOADER=
+            else
+                LogPrint "Failed to install GRUB2 on $part"
+            fi
+        fi
+    done
 fi
 
 if [[ "$NOBOOTLOADER" ]]; then

--- a/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
@@ -50,7 +50,7 @@ if [[ -r "$LAYOUT_FILE" ]]; then
             dd if=/dev/zero of=$part
             # Run grub-install/grub2-install directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
             # When software RAID1 is used, grub2 needs correct PATH to access other tools
-            if chroot $TARGET_FS_ROOT /bin/bash -c "PATH=/sbin:/usr/sbin:/usr/bin:/bin $grub_name-install $part" ; then
+            if chroot $TARGET_FS_ROOT /usr/bin/env PATH=/sbin:/usr/sbin:/usr/bin:/bin $grub_name-install $part ; then
                 LogPrint "GRUB2 installed on $part"
                 NOBOOTLOADER=
             else


### PR DESCRIPTION
Patch to support grub2 installation with software RAID1 on Linux on POWER (ppc64/ppc64le)
 - Need to loop over multiple PReP partition and install grub2 on it.
 - Need to use chroot with set a proper PATH in order for grub2-install
 to call additional  tool when `/boot` is set on md devices.

Tested with CentOS 7 LE pp64le 
```
RESCUE centos7-145:~ # rear -v recover
Relax-and-Recover 2.00-git201705171620 / 2017-05-17
Using log file: /var/log/rear/rear-centos7-145.log
Running workflow recover within the ReaR rescue/recovery system
Starting required daemons for NFS: RPC portmapper (portmap or rpcbind) and rpc.statd if available.
Started RPC portmapper 'rpcbind'.
RPC portmapper 'rpcbind' available.
Started rpc.statd.
RPC status rpc.statd available.
Started rpc.idmapd.
Using backup archive '/tmp/rear.ioiBj1IRYgh5lr2/outputfs/centos7-145/backup.tar.gz'
Calculating backup archive size
Backup archive size is 546M     /tmp/rear.ioiBj1IRYgh5lr2/outputfs/centos7-145/backup.tar.gz (compressed)
Comparing disks.
Disk configuration is identical, proceeding with restore.
Start system layout restoration.
Creating partitions for disk /dev/vda (msdos)
Creating partitions for disk /dev/vdb (msdos)
Creating software RAID /dev/md127
Creating software RAID /dev/md126
Creating LVM PV /dev/md126
  0 logical volume(s) in volume group "rootvg" now active
Restoring LVM VG rootvg
Sleeping 3 seconds to let udev or systemd-udevd create their devices...
Creating filesystem of type xfs with mount point / on /dev/mapper/rootvg-root.
/dev/mapper/rootvg-root: 4 bytes were erased at offset 0x00000000 (xfs): 58 46 53 42
Mounting filesystem /
Creating filesystem of type xfs with mount point /boot on /dev/md127.
/dev/md127: 4 bytes were erased at offset 0x00000000 (xfs): 58 46 53 42
Mounting filesystem /boot
Creating swap on /dev/mapper/rootvg-swap
Disk layout created.
Restoring from '/tmp/rear.ioiBj1IRYgh5lr2/outputfs/centos7-145/backup.tar.gz'...
Restored 1463 MiB [avg. 74932 KiB/sec] OK
Restored 1463 MiB in 21 seconds [avg. 71364 KiB/sec]
Restoring finished.
Restore the Mountpoints (with permissions) from /var/lib/rear/recovery/mountpoint_permissions
Running mkinitrd...
Updated initrd with new drivers for kernel 3.10.0-514.el7.ppc64le.
Installing GRUB2 boot loader
Boot partition found: /dev/vda1
grub installed on /dev/vda1
Boot partition found: /dev/vdb1
grub installed on /dev/vdb1
Finished recovering your system. You can explore it under '/mnt/local'.
```