### PR TITLE
Do not recreate BOOTX64.efi, if Secure boot is enabled.

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -268,7 +268,7 @@ RAMDISK_SUFFIX="$HOSTNAME"
 
 # Default "local" ISO directory (usually /var/lib/rear/output). However, to avoid duplicate ISO images when
 # also using the OUTPUT_URL variable with a file syntax, it is then better only to use ISO_DIR.
-# Keep in mind that ISO_DIR works only with an absolute directory path and does not replace OUTPUT_URL 
+# Keep in mind that ISO_DIR works only with an absolute directory path and does not replace OUTPUT_URL
 # which supports the NETFS syntax (to copy the ISO image across the network).
 ISO_DIR=$VAR_DIR/output
 
@@ -1645,7 +1645,8 @@ BOOTLOADER=""
 # instead of '0' also any value that is recognized as 'no' by the is_false function can be used
 # instead of '1' also any value that is recognized as 'yes' by the is_true function can be used
 USING_UEFI_BOOTLOADER=
-#
+
+##
 # UEFI_BOOTLOADER
 #
 # When a filename (with path) is specified in UEFI_BOOTLOADER in /etc/rear/local.conf
@@ -1665,6 +1666,23 @@ USING_UEFI_BOOTLOADER=
 # and then ReaR autodetects from EFI variables in /sys/firmware/efi/vars
 # or /sys/firmware/efi/efivars what to use as UEFI bootloader.
 UEFI_BOOTLOADER=""
+
+##
+# SECURE_BOOT_BOOTLOADER
+#
+# Name of Secure Boot loader (SBL). This lets user to use whatever SBL he likes.
+# If you are using Secure Boot, setup similar to following should work for you:
+#
+# UEFI_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi"
+# SECURE_BOOT_BOOTLOADER="shim.efi"
+#
+# If you are using Secure Boot with your own signed boot loader:
+#
+# UEFI_BOOTLOADER="/boot/efi/EFI/mysignedbootloader"
+# SECURE_BOOT_BOOTLOADER="mysignedbootloader"
+#
+# c.f. https://github.com/rear/rear/pull/1385
+SECURE_BOOT_BOOTLOADER="shim.efi"
 
 ##
 # REAR_INITRD_COMPRESSION

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1670,19 +1670,14 @@ UEFI_BOOTLOADER=""
 ##
 # SECURE_BOOT_BOOTLOADER
 #
-# Name of Secure Boot loader (SBL). This lets user to use whatever SBL he likes.
-# If you are using Secure Boot, setup similar to following should work for you:
+# When using Secure Boot set full path of your signed boot loader here.
+# e. g.
+# SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi"
 #
-# UEFI_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi"
-# SECURE_BOOT_BOOTLOADER="shim.efi"
-#
-# If you are using Secure Boot with your own signed boot loader:
-#
-# UEFI_BOOTLOADER="/boot/efi/EFI/mysignedbootloader"
-# SECURE_BOOT_BOOTLOADER="mysignedbootloader"
+# SECURE_BOOT_BOOTLOADER overrides UEFI_BOOTLOADER
 #
 # c.f. https://github.com/rear/rear/pull/1385
-SECURE_BOOT_BOOTLOADER="shim.efi"
+SECURE_BOOT_BOOTLOADER=""
 
 ##
 # REAR_INITRD_COMPRESSION

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -27,7 +27,7 @@ fi
 if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" ]]; then
     # See https://github.com/rear/rear/issues/758 why 'test' is used here:
     uefi_bootloader_basename=$( basename "$UEFI_BOOTLOADER" )
-    if test "$uefi_bootloader_basename" = $SECURE_BOOT_BOOTLOADER -o "$uefi_bootloader_basename" = "elilo.efi" ; then
+    if test -f "$SECURE_BOOT_BOOTLOADER" -o "$uefi_bootloader_basename" = "elilo.efi" ; then
         # if shim is used, bootloader can be actually anything (also elilo)
         # named as grub*.efi (follow-up loader is shim compile time option)
         # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -14,7 +14,7 @@ StopIfError "Could not create $TMP_DIR/mnt/EFI/BOOT/locale"
 # copy the grub*.efi executable to EFI/BOOT/BOOTX64.efi
 cp  $v "${UEFI_BOOTLOADER}" $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi >&2
 StopIfError "Could not find ${UEFI_BOOTLOADER}"
-if [[ $(basename ${UEFI_BOOTLOADER}) = $SECURE_BOOT_BOOTLOADER ]]; then
+if test -f "$SECURE_BOOT_BOOTLOADER" ; then
     # if shim is used, bootloader can be actually anything
     # named as grub*.efi (follow-up loader is shim compile time option)
     # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim
@@ -71,7 +71,7 @@ fi
 # so we need to reuse existing one.
 # See issue #1374
 # build_bootx86_efi () can be safely used for other scenarios.
-if [[ $(basename ${UEFI_BOOTLOADER}) != $SECURE_BOOT_BOOTLOADER ]]; then
+if ! test -f "$SECURE_BOOT_BOOTLOADER" ; then
     build_bootx86_efi
 fi
 

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -65,8 +65,15 @@ EOF
 # create a grub.cfg
     create_grub2_cfg > $TMP_DIR/mnt/EFI/BOOT/grub.cfg
 fi
-# create BOOTX86.efi
-build_bootx86_efi
+
+# Create BOOTX86.efi but only if we are NOT secure booting.
+# We are not able to create signed boot loader
+# so we need to reuse existing one.
+# See issue #1374
+# build_bootx86_efi () can be safely used for other scenarios.
+if [[ $(basename ${UEFI_BOOTLOADER}) != shim.efi ]]; then
+    build_bootx86_efi
+fi
 
 # we will be using grub-efi or grub2 (with efi capabilities) to boot from ISO
 grubdir=$(ls -d /boot/grub*)

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -14,7 +14,7 @@ StopIfError "Could not create $TMP_DIR/mnt/EFI/BOOT/locale"
 # copy the grub*.efi executable to EFI/BOOT/BOOTX64.efi
 cp  $v "${UEFI_BOOTLOADER}" $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi >&2
 StopIfError "Could not find ${UEFI_BOOTLOADER}"
-if [[ $(basename ${UEFI_BOOTLOADER}) = shim.efi ]]; then
+if [[ $(basename ${UEFI_BOOTLOADER}) = $SECURE_BOOT_BOOTLOADER ]]; then
     # if shim is used, bootloader can be actually anything
     # named as grub*.efi (follow-up loader is shim compile time option)
     # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim
@@ -27,7 +27,7 @@ fi
 if [[ $(basename $ISO_MKISOFS_BIN) = "ebiso" ]]; then
     # See https://github.com/rear/rear/issues/758 why 'test' is used here:
     uefi_bootloader_basename=$( basename "$UEFI_BOOTLOADER" )
-    if test "$uefi_bootloader_basename" = "shim.efi" -o "$uefi_bootloader_basename" = "elilo.efi" ; then
+    if test "$uefi_bootloader_basename" = $SECURE_BOOT_BOOTLOADER -o "$uefi_bootloader_basename" = "elilo.efi" ; then
         # if shim is used, bootloader can be actually anything (also elilo)
         # named as grub*.efi (follow-up loader is shim compile time option)
         # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim
@@ -71,7 +71,7 @@ fi
 # so we need to reuse existing one.
 # See issue #1374
 # build_bootx86_efi () can be safely used for other scenarios.
-if [[ $(basename ${UEFI_BOOTLOADER}) != shim.efi ]]; then
+if [[ $(basename ${UEFI_BOOTLOADER}) != $SECURE_BOOT_BOOTLOADER ]]; then
     build_bootx86_efi
 fi
 

--- a/usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
+++ b/usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
@@ -11,6 +11,9 @@ is_true $USING_UEFI_BOOTLOADER || return
 # (the 'for' loop is run only once so that 'continue' is the same as 'break')
 # which avoids dowdy looking code with deeply nested 'if...else' conditions:
 for dummy in "once" ; do
+    if test -f "$SECURE_BOOT_BOOTLOADER" ; then
+      UEFI_BOOTLOADER="$SECURE_BOOT_BOOTLOADER"
+    fi
 
     # When the user has specified UEFI_BOOTLOADER in /etc/rear/local.conf use it if exists and is a regular file.
     # Double quotes are mandatory here because 'test -f' without any (possibly empty) argument results true:


### PR DESCRIPTION
If server have Secure Boot enabled, ReaR should not try to create boot loader (BL) for recovery system (which is handy in other cases). As we are not able to sign it, it will be refused by Secure Boot.

This patch just skips ReaRs attempt to create BL and uses original shipped with OS.

c.f. https://github.com/rear/rear/issues/1374