### PR TITLE
Add SSL cert directories

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -253,8 +253,8 @@ COPY_AS_IS=( ${COPY_AS_IS[@]:-} /dev /etc/inputr[c] /etc/protocols /etc/services
 COPY_AS_IS=( "${COPY_AS_IS[@]}" '/etc/ssl/certs/*' '/etc/pki/*' '/usr/lib/ssl/*' '/usr/share/ca-certificates/*' )
 # exclude /dev/shm/*, due to the way we use tar the leading / should be omitted
 COPY_AS_IS_EXCLUDE=( ${COPY_AS_IS_EXCLUDE[@]:-} dev/shm/\* )
-# Exclude private keys: /etc/pki/tls/private /etc/pki/CA/private and /etc/pki/nssdb/key*.db (cf. above):
-COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" '/etc/pki/tls/private' '/etc/pki/CA/private' '/etc/pki/nssdb/key*.db' )
+# Exclude private keys: /etc/pki/tls/private /etc/pki/CA/private /etc/pki/nssdb/key*.db and /usr/lib/ssl/private (cf. above):
+COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" '/etc/pki/tls/private' '/etc/pki/CA/private' '/etc/pki/nssdb/key*.db' '/usr/lib/ssl/private' )
 
 # some stuff for the Linux command line
 KERNEL_CMDLINE="$KERNEL_CMDLINE selinux=0"

--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -250,7 +250,7 @@ COPY_AS_IS=( ${COPY_AS_IS[@]:-} /dev /etc/inputr[c] /etc/protocols /etc/services
 # Usually the public verified certs, and not private keys.
 # The private keys are stored in /etc/ssl/private (not copied)
 # Private keys in /etc/pki/* are excluded (see below).
-COPY_AS_IS=( "${COPY_AS_IS[@]}" '/etc/ssl/certs/*' '/etc/pki/*' )
+COPY_AS_IS=( "${COPY_AS_IS[@]}" '/etc/ssl/certs/*' '/etc/pki/*' '/usr/lib/ssl/*' '/usr/share/ca-certificates/*' )
 # exclude /dev/shm/*, due to the way we use tar the leading / should be omitted
 COPY_AS_IS_EXCLUDE=( ${COPY_AS_IS_EXCLUDE[@]:-} dev/shm/\* )
 # Exclude private keys: /etc/pki/tls/private /etc/pki/CA/private and /etc/pki/nssdb/key*.db (cf. above):

--- a/usr/share/rear/prep/DUPLICITY/default/050_prep_duplicity.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/050_prep_duplicity.sh
@@ -40,6 +40,8 @@ COPY_AS_IS=(
 /usr/lib64/python2.7
 /usr/lib/python3
 /usr/lib/python3.1
+/usr/lib/ssl
+/usr/share/ca-certificates
 /usr/share/pycentral-data
 /usr/share/pyshared
 /usr/share/pyshared-data

--- a/usr/share/rear/prep/DUPLICITY/default/050_prep_duplicity.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/050_prep_duplicity.sh
@@ -40,8 +40,6 @@ COPY_AS_IS=(
 /usr/lib64/python2.7
 /usr/lib/python3
 /usr/lib/python3.1
-/usr/lib/ssl
-/usr/share/ca-certificates
 /usr/share/pycentral-data
 /usr/share/pyshared
 /usr/share/pyshared-data


### PR DESCRIPTION
Add SSL cert directories so we can interact with Google Cloud Storage

I was using Duply/Duplicity with Google Cloud Storage and the SSL connections to Google where failing because the SSL certificates didn't get copied over into the image.

This fixes that and allows for restores to come straight from Google Cloud Storage.