### PR TITLE
Add /yaboot to ISO_FILE when running SUSE ppc64

### DIFF
--- a/usr/share/rear/output/ISO/Linux-ppc64/300_create_yaboot.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64/300_create_yaboot.sh
@@ -26,6 +26,8 @@ fi
 if [[ "$SUSE_STYLE" ]]; then
   #SUSE type distos
   cp $v $ISO_YABOOT_BIN $TMP_DIR/yaboot >&2
+  # SUSE ppc64 use /yaboot, need to add it to ISO_FILES see #1407
+  ISO_FILES=( ${ISO_FILES[@]} yaboot )
 
 cat >"$TMP_DIR/ppc/bootinfo.txt" <<EOF
 <chrp-boot>


### PR DESCRIPTION
`ISO_FILE` variable must be updated to add `/yaboot` to the ISO image when running SUSE on ppc64.
This could be a side effect of the cleaning made in #1383

This should solve #1407 

@jsmeix @gdha @schlomo, can you review this one please ?