### PR TITLE
Adapt /etc/motd when 'rear recover' is running (issue 1433)

### DIFF
--- a/usr/share/rear/lib/recover-workflow.sh
+++ b/usr/share/rear/lib/recover-workflow.sh
@@ -7,17 +7,23 @@
 
 WORKFLOW_recover_DESCRIPTION="recover the system"
 WORKFLOWS=( ${WORKFLOWS[@]} recover )
-WORKFLOW_recover () {
+function WORKFLOW_recover () {
+    # Adapt /etc/motd in the ReaR recovery system when 'rear recover' is running
+    # to avoid the additional 'Run "rear recover" to restore your system !' message
+    # that only makes sense as long as 'rear recover' was not ever started, see
+    # https://github.com/rear/rear/issues/1433
+    test -w /etc/motd && echo -e '\nWelcome to Relax-and-Recover.\n' >/etc/motd
 
-	SourceStage "setup"
+    SourceStage "setup"
 
-	SourceStage "verify"
+    SourceStage "verify"
 
-	SourceStage "layout/prepare"
-	SourceStage "layout/recreate"
+    SourceStage "layout/prepare"
+    SourceStage "layout/recreate"
 
-	SourceStage "restore"
+    SourceStage "restore"
 
-	SourceStage "finalize"
-	SourceStage "wrapup"
+    SourceStage "finalize"
+    SourceStage "wrapup"
 }
+


### PR DESCRIPTION
Avoid the additional
<pre>
Run "rear recover" to restore your system !
</pre>
message that only makes sense as long
as 'rear recover' was not ever started, cf.
https://github.com/rear/rear/issues/1433#issuecomment-319084191
