### PR TITLE
Ensure that ROOTFS_DIR variable is set with non-null value.

### DIFF
--- a/usr/share/rear/build/default/500_patch_sshd_config.sh
+++ b/usr/share/rear/build/default/500_patch_sshd_config.sh
@@ -12,7 +12,7 @@
 
 # important for the [n] hack below because we want non-existant patterns to simply disappear
 shopt -s nullglob
-SSH_CONFIG_FILES=( $ROOTFS_DIR/etc/ssh/sshd_co[n]fig $ROOTFS_DIR/etc/sshd_co[n]fig $ROOTFS_DIR/etc/openssh/sshd_co[n]fig )
+SSH_CONFIG_FILES=( ${ROOTFS_DIR:?}/etc/ssh/sshd_co[n]fig ${ROOTFS_DIR:?}/etc/sshd_co[n]fig ${ROOTFS_DIR:?}/etc/openssh/sshd_co[n]fig )
 
 if test "$SSH_CONFIG_FILES" ; then
 sed -i  -e 's/ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/ig' \
@@ -20,8 +20,8 @@ sed -i  -e 's/ChallengeResponseAuthentication.*/ChallengeResponseAuthentication 
     -e 's/ListenAddress.*/ListenAddress 0.0.0.0/ig' \
     -e '1i\PrintMotd no' \
     ${SSH_CONFIG_FILES[@]}
-    
-    if [ -n "$SSH_ROOT_PASSWORD" ] ; then 
+
+    if [ -n "$SSH_ROOT_PASSWORD" ] ; then
         sed -i -e 's/PasswordAuthentication.*/PasswordAuthentication yes/ig' ${SSH_CONFIG_FILES[@]}
         sed -i -e 's/PermitRootLogin.*/PermitRootLogin yes/ig' ${SSH_CONFIG_FILES[@]}
     else


### PR DESCRIPTION
- In case ROOTFS_DIR would, by an accident, was set empty or not to set at all, then system
  level configuration files would be overwritten then.

Actually there are quite a lot more occurrences like this. I guess I could look at it. Let me know if you are ok to change all of those or not.