### PR TITLE
Systemd automatic serial console detection

### DIFF
--- a/usr/share/rear/conf/Linux-ppc64.conf
+++ b/usr/share/rear/conf/Linux-ppc64.conf
@@ -35,5 +35,3 @@ COPY_AS_IS=(
 # test for "${name[*]}" because FIRMWARE_FILES is an array and the test should succeed
 # when there is any non-empty array member, (not necessarily the first one):
 test "${FIRMWARE_FILES[*]}" || FIRMWARE_FILES=( 'no' )
-
-KERNEL_CMDLINE="LANG=en_US.UTF-8 SYSFONT=latarcyrheb-sun16 KEYTABLE=us console=hvc0"

--- a/usr/share/rear/conf/Linux-ppc64le.conf
+++ b/usr/share/rear/conf/Linux-ppc64le.conf
@@ -26,5 +26,3 @@ if [[ $(awk '/platform/ {print $NF}' < /proc/cpuinfo) != PowerNV ]] ; then
     # No firmware files when ppc64le Linux is not run in BareMetal Mode (PowerNV):
     test "${FIRMWARE_FILES[*]}" || FIRMWARE_FILES=( 'no' )
 fi
-
-KERNEL_CMDLINE="LANG=en_US.UTF-8 SYSFONT=latarcyrheb-sun16 KEYTABLE=us console=hvc0"

--- a/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
+++ b/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
@@ -11,7 +11,8 @@ if ps ax | grep -v grep | grep -q systemd ; then
     # 2- Need to add systemd/network subdir in order to preserve rules about network device naming
     #    (predictable naming or persitant naming / like udev).
     #    more info here: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
-    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* /usr/lib/systemd/network /lib/systemd/network )
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* /usr/lib/systemd/network /lib/systemd/network /usr/lib/systemd/system-generators/systemd-getty-gener
+ator  /lib/systemd/system-generators/systemd-getty-generator )
     CLONE_GROUPS=( "${CLONE_GROUPS[@]}" input )
     Log "Including systemd (init replacement) tool-set to bootstrap Relax-and-Recover"
 fi

--- a/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
+++ b/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
@@ -11,8 +11,7 @@ if ps ax | grep -v grep | grep -q systemd ; then
     # 2- Need to add systemd/network subdir in order to preserve rules about network device naming
     #    (predictable naming or persitant naming / like udev).
     #    more info here: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
-    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* /usr/lib/systemd/network /lib/systemd/network /usr/lib/systemd/system-generators/systemd-getty-gener
-ator  /lib/systemd/system-generators/systemd-getty-generator )
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* /usr/lib/systemd/network /lib/systemd/network /usr/lib/systemd/system-generators/systemd-getty-generator  /lib/systemd/system-generators/systemd-getty-generator )
     CLONE_GROUPS=( "${CLONE_GROUPS[@]}" input )
     Log "Including systemd (init replacement) tool-set to bootstrap Relax-and-Recover"
 fi


### PR DESCRIPTION
I encounter an issue last time when trying to migrate a VM from oVirt on POWER to PowerVM.
After booting the LPAR (PowerVM guest) on the ReaR recue image, I can't log into the console.
To solve that issue I had to connect via SSH and start `agetty` on `hvc0` manually (or run again `/etc/scripts/system-setup`). 

oVirt VM use VNC console (`tty1`) while PowerVM partition need to use `hvc0` serial console.
Because backup was done on oVirt VM, `hvc0` was not present, but this means that hvc0 was not automatically detected by ReaR => `serial console detection` is not working.

(This was working in the past.... may be a possible regression ... #1398) 

Anyway, I dig a bit this and realized that this problem only exist on `systemd` based OS (RHEL7 or SLES12); and discover that `/usr/lib/systemd/system-generators/systemd-getty-generator` was responsible to detect console and serial console to activate them automatically.

I propose then to add this file to `COPY_AS_IS` variable when running on a `systemd` OS.
After doing that, my `hvc0` console was automatically detected and activated with `agetty` when booting in recovery. 

I also propose some cleanup by removing unnecessary KERNEL_CMDLINE option (this could may be satisfy #1420)

**tested successfully with:**
- SLE12-SP2
- RHEL7.3
- SLES11-SP4 (to test possible regression with a non-systemd OS)


**The next question is:**
- There some other systemd-generator scripts in `/usr/lib/systemd/system-generators/`, we may be need to check if there is some other script we should add.
```
cloud-init-generator
ibft-rule-generator
lvm2-activation-generator
nfs-server-generator
systemd-cryptsetup-generator
systemd-dbus1-generator
systemd-debug-generator
systemd-fstab-generator
systemd-getty-generator
systemd-gpt-auto-generator
systemd-hibernate-resume-generator
systemd-insserv-generator
systemd-rc-local-generator
systemd-system-update-generator
systemd-sysv-generator
```