### PR TITLE
Migrate lilo and yaboot before mkinitrd

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64/540_check_lilo_path.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/540_check_lilo_path.sh
@@ -1,4 +1,10 @@
-# THIS SCRIPT CONTAINS PPC64/PPC64LE SPECIFIC
+# THIS SCRIPT CONTAINS PPC64 SPECIFIC
+#################################################################
+# The purpose of this script is to check if the "part" variable in /etc/lilo.conf
+# is an existing disk partition on the local system. If not replace it with the PReP
+# partition path.
+#
+# This script must be run before 610_intall_lilo.sh and 550_rebuild_initramfs.sh
 #################################################################
 
 # skip if lilo conf is not found

--- a/usr/share/rear/finalize/Linux-ppc64/540_check_lilo_path.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/540_check_lilo_path.sh
@@ -14,7 +14,7 @@ test -f $TARGET_FS_ROOT/etc/lilo.conf || return
 part=$( awk -F '=' '/^boot/ {print $2}' $TARGET_FS_ROOT/etc/lilo.conf )
 
 # test $part is not null and is an existing partition on the current system.
-if ( test -n $part ) && ( fdisk -l | grep -q $part ) ; then
+if ( test -n "$part" ) && ( fdisk -l | grep -q "$part" ) ; then
     LogPrint "Boot partion found in lilo.conf: $part"
     # Run lilo directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
 else

--- a/usr/share/rear/finalize/Linux-ppc64/540_check_lilo_path.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/540_check_lilo_path.sh
@@ -1,0 +1,22 @@
+# THIS SCRIPT CONTAINS PPC64/PPC64LE SPECIFIC
+#################################################################
+
+# skip if lilo conf is not found
+test -f $TARGET_FS_ROOT/etc/lilo.conf || return
+
+# Find PPC PReP Boot partitions
+part=$( awk -F '=' '/^boot/ {print $2}' $TARGET_FS_ROOT/etc/lilo.conf )
+
+# test $part is not null and is an existing partition on the current system.
+if ( test -n $part ) && ( fdisk -l | grep -q $part ) ; then
+    LogPrint "Boot partion found in lilo.conf: $part"
+    # Run lilo directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
+else
+    # If the device found in lilo.conf is not valid, find prep partition in
+    # disklayout file and use it in lilo.conf.
+    LogPrint "Can't find a valid partition from lilo.conf"
+    LogPrint "Looking for PPC PReP partition in $DISKLAYOUT_FILE"
+    newpart=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $DISKLAYOUT_FILE )
+    LogPrint "Updating boot = $newpart in lilo.conf"
+    sed -i -e "s|^boot.*|boot = $newpart|" $TARGET_FS_ROOT/etc/lilo.conf
+fi

--- a/usr/share/rear/finalize/Linux-ppc64/540_check_yaboot_path.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/540_check_yaboot_path.sh
@@ -1,0 +1,39 @@
+# THIS SCRIPT CONTAINS PPC64 SPECIFIC
+#################################################################
+# The purpose of this script is to check if the "part" variable in /etc/yaboot.conf
+# is an existing disk partition on the local system. If not replace it with the PReP
+# partition path.
+#
+# This script must be run before 600_intall_yaboot.sh and 550_rebuild_initramfs.sh
+#################################################################
+
+# skip if yaboot conf is not found
+test -f $TARGET_FS_ROOT/etc/yaboot.conf || return
+
+# check if yaboot.conf is managed by lilo, if yes, return
+if test -f $TARGET_FS_ROOT/etc/lilo.conf; then
+    # if the word "initrd-size" is present in yaboot.conf, this mean it should be
+    # managed by lilo.
+    if grep -qw initrd-size $TARGET_FS_ROOT/etc/yaboot.conf; then
+        LogPrint "yaboot.conf found but seems to be managed by lilo."
+        return
+    fi
+fi
+
+# Find PPC PReP Boot partitions
+part=$( awk -F '=' '/^boot/ {print $2}' $TARGET_FS_ROOT/etc/yaboot.conf )
+
+# test $part is not null and is an existing partition on the current system.
+if ( test -n $part ) && ( fdisk -l 2>/dev/null | grep -q $part ) ; then
+    LogPrint "Boot partion found in yaboot.conf: $part"
+    # Run mkofboot directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
+else
+    # If the device found in yaboot.conf is not valid, find prep partition in
+    # disklayout file and use it in yaboot.conf.
+    LogPrint "Can't find a valid partition in yaboot.conf"
+    LogPrint "Looking for PPC PReP partition in $DISKLAYOUT_FILE"
+    newpart=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $DISKLAYOUT_FILE )
+    LogPrint "Updating boot = $newpart in lilo.conf"
+    sed -i -e "s|^boot.*|boot = $newpart|" $TARGET_FS_ROOT/etc/yaboot.conf
+    part=$newpart
+fi

--- a/usr/share/rear/finalize/Linux-ppc64/540_check_yaboot_path.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/540_check_yaboot_path.sh
@@ -21,19 +21,21 @@ if test -f $TARGET_FS_ROOT/etc/lilo.conf; then
 fi
 
 # Find PPC PReP Boot partitions
-part=$( awk -F '=' '/^boot/ {print $2}' $TARGET_FS_ROOT/etc/yaboot.conf )
+PREP_BOOT_PART=$( awk -F '=' '/^boot/ {print $2}' $TARGET_FS_ROOT/etc/yaboot.conf )
 
-# test $part is not null and is an existing partition on the current system.
-if ( test -n "$part" ) && ( fdisk -l 2>/dev/null | grep -q "$part" ) ; then
-    LogPrint "Boot partion found in yaboot.conf: $part"
+# test $PREP_BOOT_PART is not null and is an existing partition on the current system.
+if ( test -n "$PREP_BOOT_PART" ) && ( fdisk -l 2>/dev/null | grep -q "$PREP_BOOT_PART" ) ; then
+    LogPrint "Boot partion found in yaboot.conf: $PREP_BOOT_PART"
     # Run mkofboot directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
 else
     # If the device found in yaboot.conf is not valid, find prep partition in
     # disklayout file and use it in yaboot.conf.
     LogPrint "Can't find a valid partition in yaboot.conf"
     LogPrint "Looking for PPC PReP partition in $DISKLAYOUT_FILE"
-    newpart=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $DISKLAYOUT_FILE )
-    LogPrint "Updating boot = $newpart in lilo.conf"
-    sed -i -e "s|^boot.*|boot = $newpart|" $TARGET_FS_ROOT/etc/yaboot.conf
-    part=$newpart
+    new_boot_part=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $DISKLAYOUT_FILE )
+    LogPrint "Updating boot = $new_boot_part in lilo.conf"
+    sed -i -e "s|^boot.*|boot = $new_boot_part|" $TARGET_FS_ROOT/etc/yaboot.conf
+    PREP_BOOT_PART="$new_boot_part"
 fi
+
+export PREP_BOOT_PART

--- a/usr/share/rear/finalize/Linux-ppc64/540_check_yaboot_path.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/540_check_yaboot_path.sh
@@ -24,7 +24,7 @@ fi
 part=$( awk -F '=' '/^boot/ {print $2}' $TARGET_FS_ROOT/etc/yaboot.conf )
 
 # test $part is not null and is an existing partition on the current system.
-if ( test -n $part ) && ( fdisk -l 2>/dev/null | grep -q $part ) ; then
+if ( test -n "$part" ) && ( fdisk -l 2>/dev/null | grep -q "$part" ) ; then
     LogPrint "Boot partion found in yaboot.conf: $part"
     # Run mkofboot directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
 else

--- a/usr/share/rear/finalize/Linux-ppc64/600_install_yaboot.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/600_install_yaboot.sh
@@ -17,8 +17,10 @@ fi
 # Reinstall yaboot boot loader
 LogPrint "Installing PPC PReP Boot partition."
 
+test -z "$PREP_BOOT_PART" && LogPrint "PReP boot partition not found."
+
 LogPrint "Running mkofboot ..."
-chroot $TARGET_FS_ROOT /sbin/mkofboot -b $part --filesystem raw -f
+chroot $TARGET_FS_ROOT /sbin/mkofboot -b "$PREP_BOOT_PART" --filesystem raw -f
 [ $? -eq 0 ] && NOBOOTLOADER=
 
 test $NOBOOTLOADER && LogPrint "No bootloader configuration found. Install boot partition manually."

--- a/usr/share/rear/finalize/Linux-ppc64/600_install_yaboot.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/600_install_yaboot.sh
@@ -17,24 +17,6 @@ fi
 # Reinstall yaboot boot loader
 LogPrint "Installing PPC PReP Boot partition."
 
-# Find PPC PReP Boot partitions
-part=$( awk -F '=' '/^boot/ {print $2}' $TARGET_FS_ROOT/etc/yaboot.conf )
-
-# test $part is not null and is an existing partition on the current system.
-if ( test -n $part ) && ( fdisk -l 2>/dev/null | grep -q $part ) ; then
-    LogPrint "Boot partion found in yaboot.conf: $part"
-    # Run mkofboot directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
-else
-    # If the device found in yaboot.conf is not valid, find prep partition in
-    # disklayout file and use it in yaboot.conf.
-    LogPrint "Can't find a valid partition in yaboot.conf"
-    LogPrint "Looking for PPC PReP partition in $DISKLAYOUT_FILE"
-    newpart=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $DISKLAYOUT_FILE )
-    LogPrint "Updating boot = $newpart in lilo.conf"
-    sed -i -e "s|^boot.*|boot = $newpart|" $TARGET_FS_ROOT/etc/yaboot.conf
-    part=$newpart
-fi
-
 LogPrint "Running mkofboot ..."
 chroot $TARGET_FS_ROOT /sbin/mkofboot -b $part --filesystem raw -f
 [ $? -eq 0 ] && NOBOOTLOADER=

--- a/usr/share/rear/finalize/Linux-ppc64/610_install_lilo.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/610_install_lilo.sh
@@ -7,23 +7,6 @@ test -f $TARGET_FS_ROOT/etc/lilo.conf || return
 # Reinstall lilo boot loader
 LogPrint "Installing PPC PReP Boot partition."
 
-# Find PPC PReP Boot partitions
-part=$( awk -F '=' '/^boot/ {print $2}' $TARGET_FS_ROOT/etc/lilo.conf )
-
-# test $part is not null and is an existing partition on the current system.
-if ( test -n $part ) && ( fdisk -l | grep -q $part ) ; then
-    LogPrint "Boot partion found in lilo.conf: $part"
-    # Run lilo directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
-else
-    # If the device found in lilo.conf is not valid, find prep partition in
-    # disklayout file and use it in lilo.conf.
-    LogPrint "Can't find a valid partition from lilo.conf"
-    LogPrint "Looking for PPC PReP partition in $DISKLAYOUT_FILE"
-    newpart=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $DISKLAYOUT_FILE )
-    LogPrint "Updating boot = $newpart in lilo.conf"
-    sed -i -e "s|^boot.*|boot = $newpart|" $TARGET_FS_ROOT/etc/lilo.conf
-fi
-
 LogPrint "Running LILO ..."
 chroot $TARGET_FS_ROOT /sbin/lilo
 [ $? -eq 0 ] && NOBOOTLOADER=


### PR DESCRIPTION
I currently facing a BUG with mkinitrd re-creation when : 
 - restoration is made to a different system (migration)
 - running with ppc64 with lilo or yaboot boot loader
 - boot device is multipathed.
 - and boot partition is defined with `/dev/disk/by-id` in `lilo.conf` or `yaboot.conf`

mkinitrd gets the boot device from `/etc/lilo.conf` or ` /etc/yaboot.conf` when they exists. 
This means those one need to be migrated BEFORE running mkinitrd.

`/etc/lilo.conf` and `/etc/yaboot.conf` are with migrated with (`250_migrate_disk_devices_layout.sh`) for non-diskbyid device (/dev/vda, /dev/sda, /dev/mapper/vg-lv) which is before `550_rebuild_initramfs.sh`.

But diskbyid devices which are multipathed are not migrated (`260_rename_diskbyid.sh`).
```
while read ID DEV_NAME; do
  ID_NEW=""
  if [[ $DEV_NAME =~ ^dm- ]]; then
    # probably a multipath device
    # we cannot migrate device mapper targets
    # we delete DEV_NAME to make sure it won't get used
    DEV_NAME=""
  else
...
```

The script `610_install_yaboot.sh` or `610_install_lilo.sh` contain a verification and replace `part=` with the good Power PReP partition. (but it runs after `550_rebuild_initramfs.sh`)
(@jsmeix, this explain why mkinitrd part was running originally after bootloader for ppc64. cf #1323)

====
Solutions:

1) The best would be to update `260_rename_diskbyid.sh` in order to also migrate multipathed...
but it looks complex

2) Another way would be to move the `part=` renaming of `lilo.conf` and `yaboot.conf` from bootloader installation script to run it before mkinitrd. This solution is quick & easy and reduce the potential side-effect because we can apply this change to only ppc64 arch.

This pull-request implements the solution 2), but I ask advice/feedback from the team (@gdha @jsmeix  @schlomo @gozora).

tested on ppc64 with SLES11 SP4  
