### PR TITLE
Add finalize/550_rebuild_initramfs.sh to ppc64le arch for Debian/Ubuntu

### DIFF
--- a/usr/share/rear/finalize/Debian/ppc64le/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Debian/ppc64le/550_rebuild_initramfs.sh
@@ -1,0 +1,1 @@
+../i386/550_rebuild_initramfs.sh


### PR DESCRIPTION
rebuild_mkinitrd is missing for Debian/Ubuntu on ppc64le arch.

Add a link to `finalize/i386/550_rebuild_initramfs.sh`

