### PR TITLE
removing duplicate hvc0 console creation.

### DIFF
--- a/usr/share/rear/rescue/Linux-ppc64/410_use_hvc_console.sh
+++ b/usr/share/rear/rescue/Linux-ppc64/410_use_hvc_console.sh
@@ -1,8 +1,0 @@
-# if this system has a hvc console then start a getty on it
-
-if [ -d $ROOTFS_DIR/usr/lib/systemd/system ] && [ -c /dev/hvc0 ] ; then
-	pushd $ROOTFS_DIR/usr/lib/systemd/system/getty.target.wants >/dev/null
-	ln -s ../getty\@.service getty\@hvc0.service
-	popd >/dev/null
-	Log "hvc console support enabled"
-fi

--- a/usr/share/rear/rescue/Linux-ppc64le/410_use_hvc_console.sh
+++ b/usr/share/rear/rescue/Linux-ppc64le/410_use_hvc_console.sh
@@ -1,8 +1,0 @@
-# if this system has a hvc console then start a getty on it
-
-if [ -c /dev/hvc0 ] ; then
-	pushd $ROOTFS_DIR/usr/lib/systemd/system/getty.target.wants >/dev/null
-	ln -s ../getty\@.service getty\@hvc0.service
-	popd >/dev/null
-	Log "hvc console support enabled"
-fi


### PR DESCRIPTION
removing 2 "POWER only" scripts that create hvc0 link to systemd.

 - as `hvc0 tty` are now automatically detected and created by `systemd-generator` (#1442) we don't
need to create them manually.

 - Having `agetty hvc0` started twice produce strange console behaviour (double character typing, echo, character missing.... )