### PR TITLE
Add non blocking userprompt with timeout if no multipath device detected.

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -52,14 +52,16 @@ blacklist {
         choice=""
         wilful_input=""
 
-        while true ; do
+        # looping on this menu while multipath failed to list device.
+        # Note: On sles11/rhel6, multipath failed if no multipath device is found.
+        while ! multipath ; do
             echo
             choice="$( UserInput -t 30 -p "$prompt" -D "${choices[0]}" "${choices[@]}")"&& wilful_input="yes" || wilful_input="no"
             case "$choice" in
                 (${choices[0]})
                     # continue recovery without multipath
                     is_true "$wilful_input" && LogPrint "User confirmed continuing without multipath" || LogPrint "Continuing '$rear_workflow' by default"
-                    LogPrint "If you don't need multipath on this server, you should consider removing BOOT_ON_SAN parameter from your rear configuration file."
+                    LogPrint "WARNING: If you don't need multipath on this server, you should consider removing BOOT_ON_SAN parameter from your rear configuration file."
                     break
                     ;;
                 (${choices[1]})
@@ -77,8 +79,6 @@ blacklist {
                     Error "User chose to abort '$rear_workflow' in ${BASH_SOURCE[0]}"
                     ;;
             esac
-            # if no more error, break the loop and continue recovery.
-            multipath >&2 && break
         done
 
         LogPrint "multipath activated"

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -40,15 +40,14 @@ blacklist {
         # Asking to the User what to do after multipath command return 1.
         # It could be because no multipath device were found (sles11/rhel6)
         # or a real problem in the multipath configuration.
-        LogPrint "Failed to activate multipath, or no multipath device found."
+        prompt="Failed to activate multipath, or no multipath device found."
 
         rear_workflow="rear $WORKFLOW"
         unset choices
-        choices[0]="Multipath is not needed, please continue recovery."
+        choices[0]="Multipath is not needed. Continue recovery."
         choices[1]="Run multipath with debug options."
         choices[2]="Enter into rear-shell to manually debug multipath."
         choices[3]="Abort '$rear_workflow'"
-        prompt="Choice:"
         choice=""
         wilful_input=""
 
@@ -56,7 +55,7 @@ blacklist {
         # Note: On sles11/rhel6, multipath failed if no multipath device is found.
         while ! multipath ; do
             echo
-            choice="$( UserInput -t 30 -p "$prompt" -D "${choices[0]}" "${choices[@]}")"&& wilful_input="yes" || wilful_input="no"
+            choice="$( UserInput -p "$prompt" -D "${choices[0]}" "${choices[@]}")"&& wilful_input="yes" || wilful_input="no"
             case "$choice" in
                 (${choices[0]})
                     # continue recovery without multipath

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -89,11 +89,3 @@ blacklist {
         LogPrint "$(dmsetup ls --target multipath 2>&1)"
     fi
 fi
-
-### Create multipath devices (at least partitions on them).
-create_multipath() {
-    local multipath device
-    read multipath device junk < <(grep "multipath $1 " "$LAYOUT_FILE")
-
-    create_partitions "$device"
-}

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -60,7 +60,7 @@ blacklist {
                 (${choices[0]})
                     # continue recovery without multipath
                     is_true "$wilful_input" && LogPrint "User confirmed continuing without multipath" || LogPrint "Continuing '$rear_workflow' by default"
-                    LogPrint "WARNING: If you don't need multipath on this server, you should consider removing BOOT_ON_SAN parameter from your rear configuration file."
+                    LogPrint "You should consider removing BOOT_ON_SAN parameter from your rear configuration file if you don't need multipath on this server."
                     break
                     ;;
                 (${choices[1]})

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -86,7 +86,7 @@ blacklist {
     # Search and list mpath device.
     if is_true $list_mpath_device ; then
         LogPrint "Listing multipath device found"
-        dmsetup ls --target multipath
+        LogPrint "$(dmsetup ls --target multipath 2>&1)"
     fi
 fi
 

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -38,7 +38,10 @@ blacklist {
     multipath >&2
     if [ $? -ne 0 ] ; then
         LogPrint "Failed to activate multipath, or no multipath device found."
-        rear_shell "Did you activate the multipath devices?"
+        user_input="$(UserInput -t 30 -p "Type 'yes' to enter in rear_shell")"
+        if [ $user_input == "yes" ]; then
+            rear_shell "Did you activate the multipath devices?"
+        fi
     else
         LogPrint "multipath activated"
         dmsetup ls --target multipath

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -89,3 +89,11 @@ blacklist {
         LogPrint "$(dmsetup ls --target multipath 2>&1)"
     fi
 fi
+
+### Create multipath devices (at least partitions on them).
+create_multipath() {
+    local multipath device
+    read multipath device junk < <(grep "multipath $1 " "$LAYOUT_FILE")
+
+    create_partitions "$device"
+}

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -37,8 +37,9 @@ blacklist {
     modprobe dm-multipath >&2
     multipath >&2
     if [ $? -ne 0 ] ; then
-        # Asking to the User what to do next multipath command return 1
+        # Asking to the User what to do after multipath command return 1.
         # It could be because no multipath device were found (sles11/rhel6)
+        # or a real problem in the multipath configuration.
         LogPrint "Failed to activate multipath, or no multipath device found."
 
         rear_workflow="rear $WORKFLOW"

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -91,9 +91,10 @@ blacklist {
 fi
 
 ### Create multipath devices (at least partitions on them).
-create_multipath() {
-    local multipath device
-    read multipath device junk < <(grep "multipath $1 " "$LAYOUT_FILE")
-
-    create_partitions "$device"
+function create_multipath() {
+    local device=$1
+    if grep "^multipath $device " "$LAYOUT_FILE" 1>&2 ; then
+        Log "Found current or former multipath device $device in $LAYOUT_FILE: Creating partitions on it"
+        create_partitions "$device"
+    fi
 }

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -38,7 +38,7 @@ blacklist {
     multipath >&2
     if [ $? -ne 0 ] ; then
         LogPrint "Failed to activate multipath, or no multipath device found."
-        user_input="$(UserInput -t 30 -p "Type 'yes' to enter in rear_shell")"
+        user_input="$(UserInput -t 30 -p "Do you need to enter in rear_shell to manually activate multipath ? [type 'yes']")"
         if [ $user_input == "yes" ]; then
             rear_shell "Did you activate the multipath devices?"
         fi


### PR DESCRIPTION
Some Linux distribution (like sles11) has a version of multipath which return an error when `dm-multipath` kernel module is loaded but no multipath devices are detected.

This produce an exit to `rear_shell` waiting for UserInput. 

I propose to change it to a UserInput with 30s delay in order to avoid to block the recovery process when `BOOT_ON_SAN=yes` but no multipath device are found (in case of migration for example).