### PR TITLE
Remove unecessary export variable

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64/540_check_yaboot_path.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/540_check_yaboot_path.sh
@@ -37,5 +37,3 @@ else
     sed -i -e "s|^boot.*|boot = $new_boot_part|" $TARGET_FS_ROOT/etc/yaboot.conf
     PREP_BOOT_PART="$new_boot_part"
 fi
-
-export PREP_BOOT_PART


### PR DESCRIPTION
As requested by @jsmeix in #1446 (https://github.com/rear/rear/pull/1446#issuecomment-324345102), 
I remove the export variable in `540_check_yaboot_path.sh`.