### PR TITLE
Enhance MOUNTPOINTS_TO_RESTORE into DIRECTORIES_TO_CREATE

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1135,14 +1135,14 @@ DUPLY_PROFILE=""
 # BACKUP_DUPLICITY_OPTIONS="--volsize 100"
 #
 # directories NOT to backup
-# NOTE: for mountpoints to restore use MOUNTPOINTS_TO_RESTORE (extra)
+# For mountpoints that are not in the backup to restore use DIRECTORIES_TO_CREATE
 # Mountpoints for proc (e.g. /proc and /var/lib/ntp/proc) and /sys MUST given -
 # if not duplicity will fail!
 # BACKUP_DUPLICITY_EXCLUDE=( '/proc' '/sys' '/run' '/var/lib/ntp/proc' "$HOME/.cache" '/tmp' '/var/tmp' '/app' '/var/app' )
 #
 # Mountpoints to restore
 # if defined, used by restore/default/900_create_missing_directories.sh
-# MOUNTPOINTS_TO_RESTORE="proc sys run tmp dev/pts dev/shm app app/rear var/app"
+# DIRECTORIES_TO_CREATE="proc sys run tmp var/tmp dev/pts dev/shm app app/rear var/app"
 #
 #######################################################################
 

--- a/usr/share/rear/restore/default/900_create_missing_directories.sh
+++ b/usr/share/rear/restore/default/900_create_missing_directories.sh
@@ -1,38 +1,49 @@
 #
-# some backup SW doesn't restore mountpoints properly
+# Create missing directories.
+# For background information and reasoning see
+# https://github.com/rear/rear/issues/1455#issuecomment-324904017
+# that reads:
+#   Typical backup software assumes that the restore always happens
+#   on top of a system that was installed the traditional way,
+#   so that for the backup software it is safe to assume that
+#   those directories are present. From the perspective
+#   of the backup software there is therefore no need
+#   to include such directories in a full backup.
+#   Bottom line is, it is the duty of ReaR to make sure
+#   that these special directories really do exist.
 #
-#
-# create missing directories
-pushd $TARGET_FS_ROOT >/dev/null
-if [[ -f "$VAR_DIR/recovery/mountpoint_permissions" ]] ; then
-    LogPrint "Restore the Mountpoints (with permissions) from $VAR_DIR/recovery/mountpoint_permissions"
-    while read _dir mode userid groupid
-    do
-        ! [[ -d "$_dir" ]] && mkdir -p $_dir
-        chmod $mode $_dir
-        chown $userid:$groupid $_dir
-    done < <(cat "$VAR_DIR/recovery/mountpoint_permissions")
-elif [[ -z "$MOUNTPOINTS_TO_RESTORE" ]] ; then
-    # keep this for backward compatibility
-    mkdir -p mnt proc run sys tmp dev/pts dev/shm
-else
-    # keep this for backward compatibility
-    LogPrint "Restore the Mountpoints $MOUNTPOINTS_TO_RESTORE".
-    mkdir -p $MOUNTPOINTS_TO_RESTORE
-    # ensure some important mountpoints will be restored:
-    for _dir in mnt proc sys tmp dev/pts dev/shm
-    do
-      ! [ -d "$_dir" ] && mkdir -p $_dir
+pushd $TARGET_FS_ROOT 1>/dev/null
+
+local tmp_directories="tmp var/tmp"
+# First of all some generic directories that are created in any case:
+for directory in mnt proc run sys dev/pts dev/shm $tmp_directories ; do
+    test -d "$directory" || mkdir $v -p $directory
+done
+# Set permissions for 'tmp' directories (cf. issue #1455):
+for tmp_dir in $tmp_directories ; do
+    test -d "$tmp_dir" && chmod $v 1777 $tmp_dir
+done
+
+# Recreate mountpoints with permissions from the mountpoint_permissions file:
+local mountpoint_permissions_file="$VAR_DIR/recovery/mountpoint_permissions"
+if test -f "$mountpoint_permissions_file" ; then
+    LogPrint "Creating mountpoints (with permissions) from $mountpoint_permissions_file"
+    while read directory mode userid groupid junk ; do
+        test -d "$directory" || mkdir $v -p $directory
+        chmod $v $mode $directory
+        chown $v $userid:$groupid $directory
+    done < <( grep -v '^#' "$mountpoint_permissions_file" )
+fi
+
+# Finally recreate possibly user-specified DIRECTORIES_TO_CREATE and
+# also add MOUNTPOINTS_TO_RESTORE for backward compatibility (see issue #1455):
+test "$MOUNTPOINTS_TO_RESTORE" && DIRECTORIES_TO_CREATE="$DIRECTORIES_TO_CREATE $MOUNTPOINTS_TO_RESTORE"
+if test "$DIRECTORIES_TO_CREATE" ; then
+    LogPrint "Creating directories from DIRECTORIES_TO_CREATE"
+    for directory in $DIRECTORIES_TO_CREATE ; do
+        test -d "$directory" || mkdir $v -p $directory
     done
 fi
-chmod 1777 tmp
 
-# /var/tmp is used as default by mkinitrd (Dracut) when rebuilding initrd.
-# If user for whatever reason excluded whole /var/tmp directory,
-# initrd recreation might fail. (c.f. issue #1455)
-if [ ! -d var/tmp ]; then
-    mkdir -p var/tmp
-    chmod 1777 var/tmp
-fi
+popd 1>/dev/null
 
-popd >/dev/null

--- a/usr/share/rear/restore/default/900_create_missing_directories.sh
+++ b/usr/share/rear/restore/default/900_create_missing_directories.sh
@@ -17,11 +17,11 @@ pushd $TARGET_FS_ROOT 1>/dev/null
 local tmp_directories="tmp var/tmp"
 # First of all some generic directories that are created in any case:
 for directory in mnt proc run sys dev/pts dev/shm $tmp_directories ; do
-    test -d "$directory" || mkdir $v -p $directory
+    test -d "$directory" || mkdir $v -p $directory 1>&2
 done
 # Set permissions for 'tmp' directories (cf. issue #1455):
 for tmp_dir in $tmp_directories ; do
-    test -d "$tmp_dir" && chmod $v 1777 $tmp_dir
+    test -d "$tmp_dir" && chmod $v 1777 $tmp_dir 1>&2
 done
 
 # Recreate mountpoints with permissions from the mountpoint_permissions file:
@@ -29,9 +29,9 @@ local mountpoint_permissions_file="$VAR_DIR/recovery/mountpoint_permissions"
 if test -f "$mountpoint_permissions_file" ; then
     LogPrint "Creating mountpoints (with permissions) from $mountpoint_permissions_file"
     while read directory mode userid groupid junk ; do
-        test -d "$directory" || mkdir $v -p $directory
-        chmod $v $mode $directory
-        chown $v $userid:$groupid $directory
+        test -d "$directory" || mkdir $v -p $directory 1>&2
+        chmod $v $mode $directory 1>&2
+        chown $v $userid:$groupid $directory 1>&2
     done < <( grep -v '^#' "$mountpoint_permissions_file" )
 fi
 
@@ -41,7 +41,7 @@ test "$MOUNTPOINTS_TO_RESTORE" && DIRECTORIES_TO_CREATE="$DIRECTORIES_TO_CREATE 
 if test "$DIRECTORIES_TO_CREATE" ; then
     LogPrint "Creating directories from DIRECTORIES_TO_CREATE"
     for directory in $DIRECTORIES_TO_CREATE ; do
-        test -d "$directory" || mkdir $v -p $directory
+        test -d "$directory" || mkdir $v -p $directory 1>&2
     done
 fi
 

--- a/usr/share/rear/restore/default/900_create_missing_directories.sh
+++ b/usr/share/rear/restore/default/900_create_missing_directories.sh
@@ -21,7 +21,7 @@ for directory in mnt proc run sys dev/pts dev/shm $tmp_directories ; do
 done
 # Set permissions for 'tmp' directories (cf. issue #1455):
 for tmp_dir in $tmp_directories ; do
-    test -d "$tmp_dir" && chmod $v 1777 $tmp_dir 1>&2
+    chmod $v 1777 $tmp_dir 1>&2
 done
 
 # Recreate mountpoints with permissions from the mountpoint_permissions file:

--- a/usr/share/rear/verify/TSM/default/400_verify_tsm.sh
+++ b/usr/share/rear/verify/TSM/default/400_verify_tsm.sh
@@ -33,11 +33,12 @@ fi
 included_mountpoints=( $(grep ^fs $VAR_DIR/layout/disklayout.conf  | awk '{print $3}') $(grep ^btrfsmountedsubvol $VAR_DIR/layout/disklayout.conf | awk '{print $3}' | grep -v "/.snapshots") )
 included_mountpoints=($(tr ' ' '\n' <<<"${included_mountpoints[@]}" | awk '!u[$0]++' |  tr '\n' ' '))
 
-# TSM does not restore the mountpoints for filesystems it does not recover. Setting the
-# MOUNTPOINTS_TO_RESTORE variable allows this to be recreated in the restore
-# default 900_create_missing_directories.sh script
-excluded_mountpoints=( $(grep ^#fs $VAR_DIR/layout/disklayout.conf  | awk '{print $3}') )
-MOUNTPOINTS_TO_RESTORE=${excluded_mountpoints[@]#/}
+# TSM does not restore the mountpoints for filesystems it does not recover.
+# Appending excluded mountpoint directories to the DIRECTORIES_TO_CREATE variable
+# (there could be already user specified directories in the DIRECTORIES_TO_CREATE variable)
+# allows them to be recreated in the restore default 900_create_missing_directories.sh script:
+excluded_mountpoints=( $( grep '^#fs' $VAR_DIR/layout/disklayout.conf | awk '{print $3}' ) )
+DIRECTORIES_TO_CREATE="$DIRECTORIES_TO_CREATE ${excluded_mountpoints[@]#/}"
 
 # find out which filespaces (= mountpoints) are available for restore
 LC_ALL=${LANG_RECOVER} dsmc query filespace -date=2 -time=1 -scrollprompt=no | grep -A 10000 'File' >$TMP_DIR/tsm_filespaces


### PR DESCRIPTION
Now restore/default/900_create_missing_directories.sh
recreates by default some generic directories in any case
if they do not exist, namely:
mnt proc run sys dev/pts dev/shm tmp var/tmp
and
MOUNTPOINTS_TO_RESTORE was renamed
into DIRECTORIES_TO_CREATE
but all should be fully backward compatible - in particular
if exists MOUNTPOINTS_TO_RESTORE is still also used.
