### PR TITLE
cryptsetup hangs on `cryptsetup luksOpen ...`

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -6,7 +6,7 @@ if ! has_binary cryptsetup; then
 fi
 
 Log "Saving Encrypted volumes."
-REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" cryptsetup )
+REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" cryptsetup dmsetup )
 COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/cracklib/\* /etc/security/pwquality.conf )
 
 while read dm_name junk ; do


### PR DESCRIPTION
This patch fixes problem with hanging `cryptsetup luksOpen ...` when `dmestup` binary is missing in ReaR recovery system. (c.f. #1444).
