### PR TITLE
Add dir /etc/adsm dir to COPY_AS_IS_TSM (#1452)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -860,7 +860,7 @@ GALAXY10_Q_ARGUMENTFILE=
 # BACKUP=TSM stuff
 ##
 #
-COPY_AS_IS_TSM=( /etc/adsm/TSM.PWD /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
+COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
 COPY_AS_IS_EXCLUDE_TSM=( )
 PROGS_TSM=(dsmc)
 # where to copy the resulting files to and save them with TSM

--- a/usr/share/rear/layout/save/default/400_check_backup_special_files.sh
+++ b/usr/share/rear/layout/save/default/400_check_backup_special_files.sh
@@ -1,6 +1,6 @@
 # 400_check_backup_special_files.sh
 # tell "rear checklayout" to watch over special backup related files
 case $BACKUP in
-    TSM         ) CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]}  /etc/adsm/TSM.PWD ) ;;
+    TSM         ) CHECK_CONFIG_FILES=( ${CHECK_CONFIG_FILES[@]}  /etc/adsm/* ) ;;
     FDRUPSTREAM ) CHECK_CONFIG_FILES=( "${CHECK_CONFIG_FILES[@]}" "${CHECK_CONFIG_FILES_FDRUPSTREAM[@]}" ) ;;
 esac


### PR DESCRIPTION
New TSM version (since v8.1.2) needs to have additional file copy to Rescue media in order to work.
All those new files are located in /etc/adsm directory.
```
new files in /etc/adsm
-rw-rw-rw- 1 root root 80 Aug 23 09:41 spclicert.rdb
-rw-rw-rw- 1 root root 80 Aug 23 09:41 spclicert.crl
-rw------- 1 root root 193 Aug 23 09:41 spclicert.sth
-rw-rw-rw- 1 root root 5080 Aug 23 09:41 spclicert.kdb
-rw------- 1 root root 193 Aug 23 09:41 TSM.sth
-rw-rw-rw- 1 root root 645 Aug 23 09:41 TSM.IDX
-rw-rw-rw- 1 root root 3260 Aug 23 09:41 TSM.KDB
```

Currently :
<pre>
COPY_AS_IS_TSM=( /etc/adsm/TSM.PWD /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
</pre>
Proposed :
<pre>
COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
</pre>
This change should solve the issue in TSM 8.1.2 and should be compatible with older TSM version
(Thanks to @RolfWeilen for the proposal in #1452)