### PR TITLE
Implement new YUM backup method (based on ZYPPER)

### DIFF
--- a/usr/share/rear/build/YUM/default/600_create_python_symlink.sh
+++ b/usr/share/rear/build/YUM/default/600_create_python_symlink.sh
@@ -1,0 +1,1 @@
+../../DUPLICITY/default/600_create_python_symlink.sh

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1252,6 +1252,17 @@ RBME_BACKUP=
 # Example: RBME_HOSTNAME="$HOSTNAME-bcp"
 RBME_HOSTNAME=$HOSTNAME
 
+##
+# BACKUP=YUM
+##
+YUM_INSTALL_RPMS=""
+COPY_AS_IS_YUM=( '/etc/yum*' '/etc/logrotate.d/yum*' '/usr/bin/python*' '/bin/python*' /usr/lib/python2.7/site-packages/rpmUtils /usr/lib/python2.7/site-packages/yum /usr/lib/yum-plugins '/usr/share/bash-completion/completions/yum*' '/usr/share/doc/yum*' '/usr/share/yum*' '/var/lib/yum*' '/etc/rpm*' /usr/lib/rpm /usr/lib/tmpfiles.d/rpm.conf '/usr/share/bash-completion/completions/rpm*' '/usr/share/doc/rpm*' /lib/modules /usr/bin/urlgrabber /usr/libexec/urlgrabber-ext-down )
+COPY_AS_IS_EXCLUDE_YUM=()
+REQUIRED_PROGS_YUM=( yum rpm rpm2cpio rpmdb rpmkeys rpmquery rpmverify chpasswd )
+PROGS_YUM=()
+YUM_ROOT_PASSWORD="root"
+YUM_NETWORK_SETUP_COMMANDS=()
+YUM_EXCLUDE_PKGS=()
 
 ##
 # BACKUP=ZYPPER

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1262,7 +1262,7 @@ REQUIRED_PROGS_YUM=( yum rpm rpm2cpio rpmdb rpmkeys rpmquery rpmverify chpasswd 
 PROGS_YUM=()
 YUM_ROOT_PASSWORD="root"
 YUM_NETWORK_SETUP_COMMANDS=()
-YUM_EXCLUDE_PKGS=()
+YUM_EXCLUDE_PKGS=("")
 
 ##
 # BACKUP=ZYPPER

--- a/usr/share/rear/prep/YUM/default/050_prep_python.sh
+++ b/usr/share/rear/prep/YUM/default/050_prep_python.sh
@@ -1,0 +1,52 @@
+# This file is part of Relax-and-Recover, licensed under the GNU General
+# Public License. Refer to the included COPYING for full text of license.
+
+# At SLES11 /usr/bin/python is a link to ./python2.6
+# and because copy failed with an error "cp: not writing through dangling symlink"
+# we need to put in the link target ...
+
+PYTHON="$(which python)"
+
+if [ -h "$PYTHON" ]; then
+    PYTHON_BIN=$(basename $(readlink "$PYTHON"))
+else
+    PYTHON_BIN="python"
+fi
+
+REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" "$PYTHON_BIN" )
+
+COPY_AS_IS=(
+"${COPY_AS_IS[@]}"
+/etc/python
+/etc/python2.6
+/etc/python2.7
+/usr/lib/pymodules
+/usr/lib/pyshared
+/usr/lib/python2.6
+/usr/lib64/python2.6
+/usr/lib64/python2.6/lib-dynload
+/usr/lib64/python2.6/site-packages
+/usr/lib/python2.7
+/usr/lib64/python2.7
+/usr/lib/python3
+/usr/lib/python3.1
+/usr/share/pycentral-data
+/usr/share/pyshared
+/usr/share/pyshared-data
+/usr/share/python
+/usr/share/python-apt
+/usr/share/python-support
+/var/lib/pycentral
+/usr/include/python2.6/pyconfig-64.h
+/usr/include/python2.7/pyconfig.h
+)
+
+LIBS=(
+"${LIBS[@]}"
+/usr/lib/librsync.so.1.0.2
+/usr/lib64/librsync.so.1
+/usr/lib64/libexpat.so.1
+/lib/libexpat.so.1
+/lib/x86_64-linux-gnu/libexpat.so.1
+/usr/lib/cruft
+)

--- a/usr/share/rear/prep/YUM/default/070_set_backup_archive.sh
+++ b/usr/share/rear/prep/YUM/default/070_set_backup_archive.sh
@@ -1,0 +1,1 @@
+../../NETFS/default/070_set_backup_archive.sh

--- a/usr/share/rear/prep/YUM/default/400_prep_yum.sh
+++ b/usr/share/rear/prep/YUM/default/400_prep_yum.sh
@@ -1,0 +1,61 @@
+#
+# Prepare for the BACKUP=YUM method.
+#
+
+# Try to care about possible errors
+# see https://github.com/rear/rear/wiki/Coding-Style
+set -e -u -o pipefail
+
+# What files and programs need to be included in the ReaR recovery system.
+# Use "${ARRAY[@]:-}" to avoid unbound variable "${ARRAY[@]}" when ARRAY=():
+COPY_AS_IS=( "${COPY_AS_IS[@]:-}" "${COPY_AS_IS_YUM[@]:-}" )
+COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]:-}" "${COPY_AS_IS_EXCLUDE_YUM[@]:-}" )
+REQUIRED_PROGS=( "${REQUIRED_PROGS[@]:-}" "${REQUIRED_PROGS_YUM[@]:-}" )
+PROGS=( "${PROGS[@]:-}" "${PROGS_YUM[@]:-}" )
+
+# RPM packages data that need to be included in the ReaR recovery system:
+LogPrint "Determining RPM packages data..."
+
+# Create the directory where data for BACKUP=YUM gets stored
+# below $VAR_DIR because the whole $VAR_DIR gets automatically
+# copied into the ReaR recovery system so that this way the data
+# will be automatically available for "rear recover":
+local yum_backup_dir=$( dirname "$backuparchive" )
+test -d $yum_backup_dir || mkdir $verbose -p -m 755 $yum_backup_dir
+
+# Determine all installed RPM packages:
+rpm --query --all --last >$yum_backup_dir/installed_RPMs
+
+cat $yum_backup_dir/installed_RPMs | awk '{print $1}' | xargs repoquery -i | grep ^Repository | sort | uniq | awk -F: '{print $2}' | tr -d '\n' > $yum_backup_dir/rpm_repositories.dat
+
+# Determine which of the installed RPM packages
+# are not required by other installed RPM packages.
+# Those independently installed RPM packages are those that
+# either are intentionally installed by the admin
+# or got unintentionally installed via recommended by other RPMs
+# or are no longer required (orphans) after other RPMs had been removed:
+cat /dev/null >$yum_backup_dir/independent_RPMs
+local rpm_package=""
+for rpm_package in $( cut -d ' ' -f1 $yum_backup_dir/installed_RPMs ) ; do
+    # rpm_package is of the form name-version-release.architecture
+    rpm_package_name_version=${rpm_package%-*}
+    rpm_package_name=${rpm_package_name_version%-*}
+    # The only reliably working way how to find out if an installed RPM package
+    # is needed by another installed RPM package is to test if it can be erased.
+    # In particular regarding "rpm -q --whatrequires" versus "rpm -e --test" see
+    # https://lists.opensuse.org/opensuse-de/2011-11/msg00076.html
+    # that reads (excerpt):
+    # "rpm -q --whatrequires <something>" does not show all package dependencies because
+    # this shows only the dependencies regarding the exact RPM capability <something>.
+    # Only "rpm -e --test <package>" shows you all other packages which depend on package.
+    rpm --erase --test $rpm_package &>/dev/null && echo "$rpm_package" >>$yum_backup_dir/independent_RPMs
+done
+
+# Store releasever since the ReaR restore image won't have this info
+rpm -q --provides $(rpm -q --whatprovides "system-release(releasever)") | grep "system-release(releasever)" | cut -d ' ' -f 3 > $yum_backup_dir/releasever.dat
+
+LogPrint "Wrote RPM packages data to $yum_backup_dir"
+
+# Restore the ReaR default bash flags and options (see usr/sbin/rear):
+apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"
+

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -24,9 +24,12 @@ if has_binary sshd; then
     Log "Adding required libfreeblpriv3.so to LIBS"
 
     # copy ssh user
-    if PASSWD_SSH=$(grep ssh /etc/passwd) ; then
+    if PASSWD_SSH=$(egrep "^sshd{0,1}:" /etc/passwd) ; then
     # sshd:x:71:65:SSH daemon:/var/lib/sshd:/bin/false
-        echo "$PASSWD_SSH" >>$ROOTFS_DIR/etc/passwd
+	# skip if this user exists already in the restore system
+	if ! egrep -q "^sshd{0,1}:" $TARGET_FS_ROOT/etc/passwd ; then
+		echo "$PASSWD_SSH" >>$ROOTFS_DIR/etc/passwd
+	fi
         IFS=: read user ex uid gid gecos homedir junk <<<"$PASSWD_SSH"
         # add ssh group to be collected later
         CLONE_GROUPS=( "${CLONE_GROUPS[@]}" "$gid" )

--- a/usr/share/rear/rescue/default/900_clone_users_and_groups.sh
+++ b/usr/share/rear/rescue/default/900_clone_users_and_groups.sh
@@ -12,8 +12,10 @@ for u in "${CLONE_USERS[@]}" ; do
 		# pwd="daemon:x:2:2:Daemon:/sbin:/bin/bash"
 		# if the user exists, add to the passwd in rescue system
 		# skip if this user exists already in the rescue system
-		grep -q "^$pwd:" $ROOTFS_DIR/etc/passwd && continue
-		echo "$pwd" >>$ROOTFS_DIR/etc/passwd
+		user=${pwd%%:*}
+		if ! grep -q "^$user:" $ROOTFS_DIR/etc/passwd ; then
+			echo "$pwd" >>$ROOTFS_DIR/etc/passwd
+		fi
 		# strip gid from passwd line
 		pwd="${pwd#*:*:*:}"
 		gid=${pwd%%:*}
@@ -31,7 +33,8 @@ for g in "${CLONE_GROUPS[@]}" ; do
 		# grp="daemon:x:2:"
 		# if the group  exists, add to the group in rescue system
 		# skip if this user exists already in the rescue system
-		grep -q "^$grp" $ROOTFS_DIR/etc/group && continue
+		grpname=${grp%%:*}
+		grep -q "^$grpname:" $ROOTFS_DIR/etc/group && continue
 		echo "$grp" >>$ROOTFS_DIR/etc/group
 	else
 		Debug "WARNING: Could not collect group info for '$g'"

--- a/usr/share/rear/restore/YUM/default/100_mount_YUM_path.sh
+++ b/usr/share/rear/restore/YUM/default/100_mount_YUM_path.sh
@@ -1,0 +1,1 @@
+../../NETFS/default/100_mount_NETFS_path.sh

--- a/usr/share/rear/restore/YUM/default/400_restore_packages.sh
+++ b/usr/share/rear/restore/YUM/default/400_restore_packages.sh
@@ -1,0 +1,178 @@
+#
+# restore/YUM/default/400_restore_packages.sh
+# 400_restore_packages.sh is the default script name to exec the restore itself
+# see restore/readme
+#
+
+# Try to care about possible errors
+# see https://github.com/rear/rear/wiki/Coding-Style
+set -e -u -o pipefail
+
+# For BACKUP=YUM the RPM data got stored into the
+# ReaR recovery system via prep/YUM/default/400_prep_rpm.sh
+# in files in the $VAR_DIR/YUM directory.
+local yum_backup_dir=$( dirname "$backuparchive" )
+
+# Add rpm repositories:
+LogPrint "Adding rpm repositories from $yum_backup_dir"
+local repoList=""
+for repo in $(cat $yum_backup_dir/rpm_repositories.dat)
+do
+	repoList="$repoList --enablerepo=$repo"
+done
+
+LogPrint "Running yum makecache"
+yum $verbose --disablerepo=* $repoList --releasever=$(cat $yum_backup_dir/releasever.dat) -y --installroot=$TARGET_FS_ROOT makecache 1>&2
+
+# Provide all /etc/products.d/ stuff in the target system:
+#cp $verbose --archive /etc/products.d $TARGET_FS_ROOT/etc
+
+# First and foremost install the very basic stuff:
+local rpm_package_name="basesystem"
+LogPrint "Installing the very basic stuff ('$rpm_package_name' and what it requires)"
+yum $verbose --disablerepo=* $repoList --installroot=$TARGET_FS_ROOT --releasever=$(cat $yum_backup_dir/releasever.dat) -y install "$rpm_package_name" 1>&2
+# aaa_base requires filesystem so that yum installs filesystem before aaa_base
+# but for a clean filesystem installation YUM needs users and gropus
+# as shown by RPM as warnings like (excerpt):
+#   warning: user news does not exist - using root
+#   warning: group news does not exist - using root
+#   warning: group dialout does not exist - using root
+#   warning: user uucp does not exist - using root
+# Because those users and gropus are created by aaa_base scriptlets and
+# also RPM installation of permissions pam libutempter0 shadow util-linux
+# (that get also installed before aaa_base by yum installation of aaa_base)
+# needs users and gropus that are created by aaa_base scriptlets so that
+# those packages are enforced installed a second time after aaa_base was installed.
+# To be safe against changes in the list of packages that need to be
+# enforced installed a second time after aaa_base was installed
+# simply all packages that are installed up to now are
+# enforced installed a second time:
+local rpms_in_installion_order=""
+rpms_in_installion_order="$( rpm $v --root $TARGET_FS_ROOT --query --all --last | cut -d ' ' -f 1 | tac )"
+local rpm_package=""
+local rpm_package_name_version=""
+for rpm_package in $rpms_in_installion_order ; do
+    # Simple "something is still going on" indicator by printing dots
+    # directly to stdout which is fd7 (see lib/_input-output-functions.sh)
+    # and not using a Print function to always print to the original stdout
+    # i.e. to the terminal wherefrom the user has started "rear recover":
+    echo -n "." >&7
+    # rpm_package is of the form name-version-release.architecture
+    rpm_package_name_version=${rpm_package%-*}
+    rpm_package_name=${rpm_package_name_version%-*}
+    test "gpg-pubkey" = "$rpm_package_name" && rpm_package_name=$rpm_package
+    yum $verbose --disablerepo=* $repoList --installroot=$TARGET_FS_ROOT -y reinstall "$rpm_package_name" 1>&2 || true # ignore errors so 'rear recover' doesn't fail
+done
+# One newline ends the "something is still going on" indicator:
+echo "" >&7
+# Check the differences of what is in the RPM packages
+# compared to the actually installed files in the target system.
+# Differences are only reported here so that the user is informed
+# but differences are not necessarily an error.
+Log "Checking differences of what is in the basic RPM packages compared to what is actually installed"
+# Report all differences except when only the mtime differs but the file content (MD5 sum) is still the same.
+# Do not run "rpm -v" because that lists the results for all files in the RPM package also when nothing differs:
+if rpm --root $TARGET_FS_ROOT --verify --all --nomtime 1>&2 ; then
+    Log "No differences between basic RPM packages and what is actually installed"
+else
+    LogPrint "There are differences between what is in the basic RPM packages and what is actually installed (this is not necessarily an error), check the log file"
+fi
+
+# The actual software installation:
+if test "independent_RPMs" = "$YUM_INSTALL_RPMS" ; then
+    LogPrint "Installing independent RPM packages and what they require and recommend (needs time - be patient)"
+    # Installation must happen in reverse ordering of what is listed in yum_backup_dir/independent_RPMs
+    # because therein the latest installed RPMs are listed topmost:
+    for rpm_package in $( tac $yum_backup_dir/independent_RPMs ) ; do
+        # Simple "something is still going on" indicator by printing dots
+        # directly to stdout which is fd7 (see lib/_input-output-functions.sh)
+        # and not using a Print function to always print to the original stdout
+        # i.e. to the terminal wherefrom the user has started "rear recover":
+        echo -n "." >&7
+        # rpm_package is of the form name-version-release.architecture
+        rpm_package_name_version=${rpm_package%-*}
+        rpm_package_name=${rpm_package_name_version%-*}
+        # Dirty hack for "gpg-pubkey" packages where several of them with different version and release
+        # can be (and actually are) installed at the same time e.g. on my <jsmeix@suse.de> SLES12 system
+        # where "rpm -qa | grep gpg-pubkey" results things like gpg-pubkey-1a2b-3c4d and gpg-pubkey-5e6f-7890
+        # so that the exact "gpg-pubkey" package with version and release must be specified to be installed:
+        test "gpg-pubkey" = "$rpm_package_name" && rpm_package_name=$rpm_package
+        # Report when a non-basic package cannot be installed but do not treat that as an error that aborts "rear recover":
+  	if yum $verbose --disablerepo=* $repoList --installroot=$TARGET_FS_ROOT -y install "$rpm_package_name_version" 1>&2 ; then
+            Log "Installed '$rpm_package_name_version'"
+        else
+            Log "Failed to install '$rpm_package_name_version', falling back to '$rpm_package_name'"
+	    if yum $verbose --disablerepo=* $repoList --installroot=$TARGET_FS_ROOT -y install "$rpm_package_name" 1>&2 ; then
+                Log "Installed '$rpm_package_name'"
+	    else
+            	# One newline to end the current "something is still going on" indicator:
+            	echo "" >&7
+            	# Report also the version because e.g. for gpg-pubkey
+            	LogPrint "Failed to install '$rpm_package_name', check the log file"
+            fi
+        fi
+    done
+else
+    LogPrint "Installing all other RPM packages and what they require (needs time)"
+    # Installation must happen in reverse ordering of what is listed in yum_backup_dir/installed_RPMs
+    # because therein the latest installed RPMs are listed topmost:
+    for rpm_package in $( tac $yum_backup_dir/installed_RPMs | cut -d ' ' -f1 ) ; do
+        # Simple "something is still going on" indicator by printing dots
+        # directly to stdout which is fd7 (see lib/_input-output-functions.sh)
+        # and not using a Print function to always print to the original stdout
+        # i.e. to the terminal wherefrom the user has started "rear recover":
+        echo -n "." >&7
+        # rpm_package is of the form name-version-release.architecture
+        rpm_package_name_version=${rpm_package%-*}
+        rpm_package_name=${rpm_package_name_version%-*}
+	if IsInArray "$rpm_package" "${YUM_EXCLUDE_PKGS[@]}" -o IsInArray "$rpm_package_name_version" "${YUM_EXCLUDE_PKGS[@]}" -o IsInArray "$rpm_package_name" "${YUM_EXCLUDE_PKGS[@]}" ; then
+            	Log "Skipping '$rpm_package'"
+		continue
+	fi
+        # Dirty hack for "gpg-pubkey" packages where several of them with different version and release
+        # can be (and actually are) installed at the same time e.g. on my <jsmeix@suse.de> SLES12 system
+        # where "rpm -qa | grep gpg-pubkey" results things like gpg-pubkey-1a2b-3c4d and gpg-pubkey-5e6f-7890
+        # so that the exact "gpg-pubkey" package with version and release must be specified to be installed:
+        test "gpg-pubkey" = "$rpm_package_name" && rpm_package_name=$rpm_package
+        # Report when a non-basic package cannot be installed but do not treat that as an error that aborts "rear recover":
+  	if yum $verbose --disablerepo=* $repoList --installroot=$TARGET_FS_ROOT -y install "$rpm_package_name_version" 1>&2 ; then
+            Log "Installed '$rpm_package_name'"
+        else
+            Log "Failed to install '$rpm_package_name_version', falling back to '$rpm_package_name'"
+	    if yum $verbose --disablerepo=* $repoList --installroot=$TARGET_FS_ROOT -y install "$rpm_package_name" 1>&2 ; then
+                Log "Installed '$rpm_package_name'"
+	    else
+                # One newline to end the current "something is still going on" indicator:
+                echo "" >&7
+                # Report also the version because e.g. for gpg-pubkey
+                LogPrint "Failed to install '$rpm_package_name', check the log file"
+            fi
+        fi
+    done
+fi
+# One newline ends the "something is still going on" indicator:
+echo "" >&7
+
+# Check the differences of what is in the RPM packages
+# compared to the actually installed files in the target system.
+# Differences are only reported here so that the user is informed
+# but differences are not necessarily an error.
+LogPrint "Checking differences of what is in the RPM packages compared to what is actually installed"
+# Report all differences except when only the mtime differs but the file content (MD5 sum) is still the same.
+# Do not run "rpm -v" because that lists the results for all files in the RPM package also when nothing differs:
+if rpm --root $TARGET_FS_ROOT --verify --all --nomtime 1>&2 ; then
+    LogPrint "No differences between RPM packages and what is actually installed"
+else
+    LogPrint "There are differences between what is in the RPM packages and what is actually installed (this is not necessarily an error), check the log file"
+fi
+
+# Any files which were RPM-provided but were missing on the source system should be removed
+for missing_file in $( cat $yum_backup_dir/rpm_missing_files.dat )
+do
+	LogPrint "Removing $missing_file from restored system (it was missing on the source system)"
+	rm -f $missing_file
+done
+
+# Restore the ReaR default bash flags and options (see usr/sbin/rear):
+apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"
+

--- a/usr/share/rear/restore/YUM/default/405_clone_users_and_groups.sh
+++ b/usr/share/rear/restore/YUM/default/405_clone_users_and_groups.sh
@@ -1,0 +1,72 @@
+# copy required system users and groups to the restore system
+
+if [[ "$CLONE_ALL_USERS_GROUPS" =~ ^[yY1] ]]; then
+    CLONE_USERS=($(cut -d ':' -f '1' /etc/passwd))
+    CLONE_GROUPS=($(cut -d ':' -f '1' /etc/group))
+
+    # If we're populating system users and groups here,
+    # we do not want to restore these files from the backup
+    Log "Excluding group, password and shadow files from restore"
+    for f in etc/passwd etc/group etc/shadow	# no leading slashes
+    do
+	echo "$f" >> $TMP_DIR/restore-exclude-list.txt
+    done
+fi
+
+Log "Cloning users: ${CLONE_USERS[@]}"
+for u in "${CLONE_USERS[@]}" ; do
+	# go over all users
+	if pwd=$(getent passwd "$u") ; then
+		# pwd="daemon:x:2:2:Daemon:/sbin:/bin/bash"
+		# if the user exists, add to the passwd in restore system
+		# skip if this user exists already in the restore system
+		user=${pwd%%:*}
+		if ! grep -q "^$user:" $TARGET_FS_ROOT/etc/passwd ; then
+			echo "$pwd" >>$TARGET_FS_ROOT/etc/passwd
+		fi
+		# strip gid from passwd line
+		pwd="${pwd#*:*:*:}"
+		gid=${pwd%%:*}
+		# add gid to groups to collect
+		CLONE_GROUPS=( "${CLONE_GROUPS[@]}" "$gid" )
+	else
+		Debug "WARNING: Could not collect user info for '$u'"
+	fi
+done
+
+Log "Cloning existing user passwords: ${CLONE_USERS[@]}"
+for u in "${CLONE_USERS[@]}" ; do
+	# go over all users
+	if pwd=$(getent passwd "$u") ; then
+		# pwd="daemon:x:2:2:Daemon:/sbin:/bin/bash"
+		# if the user exists, change the password to match in restore system
+		# skip if this user doesn't exist in the restore system
+		user=${pwd%%:*}
+		grep -q "^$user:" $TARGET_FS_ROOT/etc/passwd || continue
+		# strip passwd from shadow line
+		pass=$(grep "^${pwd%%:*}:" /etc/shadow)
+		pass=${pwd#*:}
+		pass=${pwd%%:*}
+		# set passwd
+		echo "$pwd:$pass" | chpasswd -e --root $TARGET_FS_ROOT
+	else
+		Debug "WARNING: Could not collect user info for '$u'"
+	fi
+done
+
+Log "Cloning groups: ${CLONE_GROUPS[@]}"
+for g in "${CLONE_GROUPS[@]}" ; do
+	# go over all users
+	if grp=$(getent group "$g") ; then
+		# grp="daemon:x:2:"
+		# if the group  exists, add to the group in restore system
+		# skip if this user exists already in the restore system
+                group=${grp%%:*}
+                grep -q "^$group:" $TARGET_FS_ROOT/etc/group && continue
+		echo "$grp" >>$TARGET_FS_ROOT/etc/group
+	else
+		Debug "WARNING: Could not collect group info for '$g'"
+	fi
+done
+
+

--- a/usr/share/rear/restore/YUM/default/940_generate_fstab.sh
+++ b/usr/share/rear/restore/YUM/default/940_generate_fstab.sh
@@ -1,0 +1,79 @@
+#
+# restore/YUM/default/940_generate_fstab.sh
+# 940_generate_fstab.sh is a finalisation script (see restore/readme)
+# that generates etc/fstab in the target system
+# according to what of the target system is currently mounted.
+# Generating etc/fstab in the target system is needed as prerequirement
+# for making a valid initrd via finalize/SUSE_LINUX/i386/170_rebuild_initramfs.sh
+# otherwise when booting the recreated system the kernel panics
+# with 'unable to mount root fs'
+#
+
+# Try to care about possible errors
+# see https://github.com/rear/rear/wiki/Coding-Style
+set -e -u -o pipefail
+
+# Determine system partition and swap partition
+# from what is in LAYOUT_FILE (usually var/lib/rear/layout/disklayout.conf).
+local keyword device_node mountpoint filesystem_type junk
+pushd /dev/disk/by-uuid/ 1>&2
+# Ensure file name generation (globbing) is enabled (needed below in 'for uuid in *'):
+set +f
+# Write swap entries to etc/fstab in the target system:
+# Format of swap partitions or swap files in LAYOUT_FILE:
+# swap <filename> uuid=<uuid> label=<label>
+# e.g.
+# swap /dev/sda1 uuid=28e43119-dac1-4426-a71a-1d70b26d33d7 label=
+while read keyword device_node junk ; do
+    test "$device_node" || Error "No device node in $LAYOUT_FILE for '$keyword [no device node] $junk'"
+    # Do not use a possibly outdated UUID from LAYOUT_FILE but determine the actual one in the current system:
+    uuid=$( for uuid in * ; do readlink -e $uuid | grep -q $device_node && echo $uuid || true ; done  )
+    # If fstab already contains an entry for this swap device, do nothing
+    if $(egrep -q "^UUID=$uuid\s+swap" $TARGET_FS_ROOT/etc/fstab) -o $(egrep -q "^$device_node\s+swap" $TARGET_FS_ROOT/etc/fstab) ; then
+        LogPrint "Skipping addition of swap device $device_node (UUID=$uuid) - already in etc/fstab of the target system"
+	continue
+    fi
+    # One cannot rely on that swap partitions are in use in the recovery system
+    # so that as fallback the device node is set in etc/fstab in the target system:
+    if test "$uuid" ; then
+        echo "UUID=$uuid swap swap defaults 0 0" >>$TARGET_FS_ROOT/etc/fstab
+        LogPrint "Wrote 'UUID=$uuid swap swap defaults 0 0' to etc/fstab in the target system"
+    else
+        LogPrint "Instead of UUID using plain device node '$device_node' for swap in /etc/fstab as fallback, check $TARGET_FS_ROOT/etc/fstab before rebooting"
+        echo "$device_node swap swap defaults 0 0" >>$TARGET_FS_ROOT/etc/fstab
+        LogPrint "Wrote '$device_node swap swap defaults 0 0' to etc/fstab in the target system"
+    fi
+done < <( grep "^swap " "$LAYOUT_FILE" )
+# Write filesystem entries to etc/fstab in the target system:
+# Format of filesystem entries in LAYOUT_FILE:
+# fs <device> <mountpoint> <fstype> [uuid=<uuid>] [label=<label>] [<attributes>]
+# e.g.
+# fs /dev/sda2 / ext4 uuid=46d7e8be-7812-49d1-8d24-e25ed0589e94 label= blocksize=4096 ... default_mount_options=user_xattr,acl options=rw,relatime,data=ordered
+# FIXME: add support for default_mount_options in /etc/fstab (instead of only 'defaults')
+while read keyword device_node mountpoint filesystem_type junk ; do
+    test "$device_node" || Error "No device node in $LAYOUT_FILE for '$keyword [no device node] $mountpoint $filesystem_type $junk'"
+    test "$mountpoint" || Error "No mountpoint in $LAYOUT_FILE for '$keyword $device_node [no mountpoint] $filesystem_type $junk'"
+    test "$filesystem_type" || Error "No filesystem type in $LAYOUT_FILE for '$keyword $device_node $mountpoint [no filesystem type] $junk'"
+    # Do not use a possibly outdated UUID from LAYOUT_FILE but determine the actual one in the current system:
+    uuid=$( for uuid in * ; do readlink -e $uuid | grep -q $device_node && echo $uuid || true ; done  )
+    # If fstab already contains an entry for this filesystem, do nothing
+    if $(egrep -q "^UUID=$uuid\s+$mountpoint" $TARGET_FS_ROOT/etc/fstab) -o $(egrep -q "^$device_node\s+$mountpoint" $TARGET_FS_ROOT/etc/fstab) ; then
+        LogPrint "Skipping addition of swap device $device_node (UUID=$uuid) - already in etc/fstab of the target system"
+	continue
+    fi
+    # Regardless that all active filesystems in LAYOUT_FILE should be in use in the recovery system
+    # do not abort but use as fallback the device node is set in etc/fstab in the target system:
+    if test "$uuid" ; then
+        echo "UUID=$uuid $mountpoint $filesystem_type defaults 0 0" >>$TARGET_FS_ROOT/etc/fstab
+        LogPrint "Wrote 'UUID=$uuid $mountpoint $filesystem_type defaults 0 0' to etc/fstab in the target system"
+    else
+        LogPrint "Instead of UUID using plain device node '$device_node' for '$mountpoint' in /etc/fstab as fallback, check $TARGET_FS_ROOT/etc/fstab before rebooting"
+        echo "$device_node $mountpoint $filesystem_type defaults 0 0" >>$TARGET_FS_ROOT/etc/fstab
+        LogPrint "Wrote '$device_node $mountpoint $filesystem_type defaults 0 0' to etc/fstab in the target system"
+    fi
+done < <( grep "^fs " "$LAYOUT_FILE" )
+popd 1>&2
+
+# Restore the ReaR default bash flags and options (see usr/sbin/rear):
+apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"
+

--- a/usr/share/rear/restore/YUM/default/950_grub2_mkconfig.sh
+++ b/usr/share/rear/restore/YUM/default/950_grub2_mkconfig.sh
@@ -1,0 +1,42 @@
+#
+# restore/YUM/default/950_grub2_mkconfig.sh
+# 950_grub2_mkconfig is a finalisation script (see restore/readme)
+# that runs grub2-mkconfig in the target system
+# after the files have been restored into the target system
+# (i.e. so that GRUB2 is installed in the target system).
+# Running grub2-mkconfig is needed as prerequirement
+# for running grub2-install in finalize/Linux-i386/220_install_grub2.sh
+# otherwise there is no /boot/grub2/grub.cfg in the target system
+# and then finalize/Linux-i386/220_install_grub2.sh still "just works"
+# (i.e. it does not error out when there is no /boot/grub2/grub.cfg)
+# but the recreated system will not boot (stops at "grub>" bootloader prompt).
+#
+
+# Try to care about possible errors
+# see https://github.com/rear/rear/wiki/Coding-Style
+set -e -u -o pipefail
+
+# Ensure /proc /sys /dev from the installation system are available in the target system
+# which are needed to run grub2-mkconfig in the target system.
+# FIXME: If a mount command fails proceed "bona fide" by assuming it is already mounted:
+mount -t proc none $TARGET_FS_ROOT/proc || true
+mount -t sysfs sys $TARGET_FS_ROOT/sys || true
+mount -o bind /dev $TARGET_FS_ROOT/dev || true
+
+# FIXME: This should not be needed here but work via finalize/SUSE_LINUX/i386/170_rebuild_initramfs.sh
+# Make initrd verbosely in the target system:
+#chroot $TARGET_FS_ROOT /sbin/mkinitrd -v
+
+# Run grub2-mkconfig in the target system.
+# A login shell in between is needed when shell scripts are called insinde 'chroot'
+# cf. https://github.com/rear/rear/issues/862#issuecomment-282039428
+# In particular grub2-mkconfig is a shell script that calls other shell scripts:
+chroot $TARGET_FS_ROOT /bin/bash --login -c '/usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg'
+
+# FIXME: This should not be needed here but work via finalize/Linux-i386/220_install_grub2.sh
+# Install bootloader in the target system:
+chroot $TARGET_FS_ROOT /usr/sbin/grub2-install --force /dev/sda
+
+# Restore the ReaR default bash flags and options (see usr/sbin/rear):
+apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"
+

--- a/usr/share/rear/restore/YUM/default/970_set_root_password.sh
+++ b/usr/share/rear/restore/YUM/default/970_set_root_password.sh
@@ -1,0 +1,1 @@
+../../ZYPPER/default/970_set_root_password.sh

--- a/usr/share/rear/restore/YUM/default/980_initial_network_setup.sh
+++ b/usr/share/rear/restore/YUM/default/980_initial_network_setup.sh
@@ -1,0 +1,63 @@
+#
+# restore/YUM/default/980_initial_network_setup.sh
+# 980_initial_network_setup.sh is a finalisation script (see restore/readme)
+# that does some very basic initial network setup in the target system
+# after the files have been restored into the target system
+# so that the ineeded executables can be called inside the target system
+# to avoid to have them also in the ReaR recovery system.
+# This initial network setup is only meant to make the target system
+# accessibel from remote in a very basic way (e.g. for 'ssh').
+# The actually intended network setup for the target system
+# should be done manually by the admin after "rear recover".
+#
+
+# Try to care about possible errors
+# see https://github.com/rear/rear/wiki/Coding-Style
+set -e -u -o pipefail
+
+# Do nothing when no initial network setup should be done:
+# Using the '[*]' subscript is required here otherwise test gets more than one argument
+# which fails with bash error 'bash: test: ...: unary operator expected'
+# cf. https://github.com/rear/rear/issues/1068#issuecomment-282741981
+if test "${YUM_NETWORK_SETUP_COMMANDS[*]:-}"; then
+
+# Initial network setup in the target system.
+# Use a login shell in between so that one has in the chrooted environment
+# all the advantages of a "normal working shell" which means one can write
+# the commands inside 'chroot' as one would type them in a normal working shell.
+# In particular one can call programs (like 'yast2' or 'ip') by their basename without path
+# cf. https://github.com/rear/rear/issues/862#issuecomment-274068914
+local network_setup_command=""
+local networking_preparation_command=""
+for network_setup_command in "${YUM_NETWORK_SETUP_COMMANDS[@]}" ; do
+    case "$network_setup_command" in
+        (YAST)
+            # YaST network card setup in the target system (without having ncurses stuff in the output via TERM=dumb)
+            # plus automated respose to all requested user input via yes '' (i.e. only plain [Enter] as user input)
+            # and ignore non zero exit codes from YaST to avoid that "rear recover" aborts here:
+            LogPrint "Initial network setup in the target system via 'yast2 --ncurses lan add name=eth0 ethdevice=eth0 bootproto=dhcp'"
+            chroot $TARGET_FS_ROOT /bin/bash --login -c "yes '' | TERM=dumb yast2 --ncurses lan add name=eth0 ethdevice=eth0 bootproto=dhcp" || true
+            ;;
+        (NETWORKING_PREPARATION_COMMANDS)
+            LogPrint "Initial network setup in the target system as specified in NETWORKING_PREPARATION_COMMANDS"
+            for networking_preparation_command in "${NETWORKING_PREPARATION_COMMANDS[@]}" ; do
+                if test "$networking_preparation_command" ; then
+                    # Only report errors to avoid that "rear recover" aborts here:
+                    chroot $TARGET_FS_ROOT /bin/bash --login -c "$networking_preparation_command" || LogPrint "Command failed: $networking_preparation_command"
+                fi
+            done
+            ;;
+        (*)
+            if test "$network_setup_command" ; then
+                LogPrint "Initial network setup in the target system via $network_setup_command"
+                # Only report errors to avoid that "rear recover" aborts here:
+                chroot $TARGET_FS_ROOT /bin/bash --login -c "$network_setup_command" || LogPrint "Command failed: $network_setup_command"
+            fi
+            ;;
+    esac
+done
+fi
+
+# Restore the ReaR default bash flags and options (see usr/sbin/rear):
+apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"
+

--- a/usr/share/rear/restore/YUM/default/980_umount_YUM_dir.sh
+++ b/usr/share/rear/restore/YUM/default/980_umount_YUM_dir.sh
@@ -1,0 +1,1 @@
+../../NETFS/default/980_umount_NETFS_dir.sh

--- a/usr/share/rear/verify/YUM/default/050_check_YUM_requirements.sh
+++ b/usr/share/rear/verify/YUM/default/050_check_YUM_requirements.sh
@@ -1,0 +1,1 @@
+../../../prep/NETFS/default/050_check_NETFS_requirements.sh

--- a/usr/share/rear/verify/YUM/default/060_mount_YUM_path.sh
+++ b/usr/share/rear/verify/YUM/default/060_mount_YUM_path.sh
@@ -1,0 +1,1 @@
+../../../backup/NETFS/default/100_mount_NETFS_path.sh

--- a/usr/share/rear/verify/YUM/default/070_set_backup_archive.sh
+++ b/usr/share/rear/verify/YUM/default/070_set_backup_archive.sh
@@ -1,0 +1,1 @@
+../../../prep/NETFS/default/070_set_backup_archive.sh

--- a/usr/share/rear/verify/YUM/default/980_umount_YUM_dir.sh
+++ b/usr/share/rear/verify/YUM/default/980_umount_YUM_dir.sh
@@ -1,0 +1,1 @@
+../../../backup/NETFS/default/980_umount_NETFS_dir.sh


### PR DESCRIPTION
Hi!  

This is my first major commit to this project, so I hope that I'm doing this correctly.

This PR is to add a YUM backup method which will recreate a RPM-based system that uses the yum package manager in the same manner as the ZYPPER backup method.

I symlinked files where possible and copied and updated files when changes were necessary for the YUM method.

I have also updated a couple of existing files to [hopefully] improve them.  The primary changes which could likely be made common to all methods are:

- usr/share/rear/rescue/default/500_ssh.sh
  - improved detection of the ssh user and don't duplicate an existing user

- usr/share/rear/rescue/default/900_clone_users_and_groups.sh
  - improve extraction of users and groups and don't duplicate an existing user

- usr/share/rear/restore/YUM/default/405_clone_users_and_groups.sh
  - clone the users and groups only if the same user or group does not exist.  Previously, the entire line had to match, resulting in duplicate entries if, for instance, the UID differed for the same user.

- usr/share/rear/restore/YUM/default/940_generate_fstab.sh
  - improve detection of existing fstab entries to avoid duplication

If you'd prefer that I submit separate PRs for each, please let me know.

Upon acceptance of the YUM method, I will submit another PR which adds a file backup option to the YUM method.  This will recreate the system from RPM and restore any non-RPM-originated files or RPM-originated files which may have changed (or been removed).

Let me know if there's a better way for me to submit changes of this type or if there's anything I can do to help with the acceptance of this PR.

Thanks!

-Rich Alloway (Rogue Wave)