### PR TITLE
Resolve $PXE_TFTP_IP to IP if hostname or FQDN are used

### DIFF
--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -620,7 +620,7 @@ function make_pxelinux_config_grub {
     # else set it based on PXE_TFTP_UR variable.
     if [[ -z $PXE_TFTP_IP ]] ; then
         if [[ -z $PXE_TFTP_URL ]] ; then
-            LogPrint "Can't find TFTP IP information. Variable TFTP_SERVER_IP or PXE_TFTP_URL with clear IP address must be set."
+            LogPrintError "Can't find TFTP IP information. Variable TFTP_SERVER_IP or PXE_TFTP_URL with clear IP address must be set."
             return
         else
             # Get IP address from PXE_TFTP_URL (ex:http://xx.yy.zz.aa:port/foo/bar)
@@ -635,17 +635,20 @@ function make_pxelinux_config_grub {
                 PXE_TFTP_IP=$(get_ip_from_fqdn $PXE_TFTP_IP)
 
                 if ! is_ip $PXE_TFTP_IP ; then
-                    LogPrint "Can't find a valid  boot/tftp server IP. Please update your ReaR configuration file with PXE_TFTP_IP."
+                    LogPrintError "Can't find a valid  boot/tftp server IP. Please update your ReaR configuration file with PXE_TFTP_IP."
+                    return
                 fi
             fi
-            LogPrint "Using $PXE_TFTP_IP as boot/tftp server IP."
         fi
     fi
 
-    if [ ! -z $PXE_TFTP_IP ]; then
+    # If PXE_TFTP_IP is a valid IP, set `net_default_server_opt` grub2 option.
+    if  is_ip $PXE_TFTP_IP ; then
+        LogPrint "Using $PXE_TFTP_IP as boot/tftp server IP."
         net_default_server_opt="set net_default_server=$PXE_TFTP_IP"
     else
-        LogPrint "WARNING: No valid TFTP IP found. GRUB menu will be generated without net_default_server"
+        LogPrintError "No valid TFTP IP found. Please update your ReaR configuration file with PXE_TFTP_IP."
+        return
     fi
 
     # we use this function only when $PXE_CONFIG_URL is set and $PXE_CONFIG_GRUB_STYLE=y

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -629,15 +629,9 @@ function make_pxelinux_config_grub {
             # If PXE_TFTP_IP is not an IP, it could be a FQDM that must be resolved to IP.
             # is_ip() function is defined in network-function.sh
             if ! is_ip $PXE_TFTP_IP ; then
-
                 Log "Trying to resolve [$PXE_TFTP_IP] to a valid IP."
                 # get_ip_from_fqdn() function is defined in network-function.sh
                 PXE_TFTP_IP=$(get_ip_from_fqdn $PXE_TFTP_IP)
-
-                if ! is_ip $PXE_TFTP_IP ; then
-                    LogPrintError "Can't find a valid  boot/tftp server IP. Please update your ReaR configuration file with PXE_TFTP_IP."
-                    return
-                fi
             fi
         fi
     fi

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -625,6 +625,20 @@ function make_pxelinux_config_grub {
         else
             # Get IP address from PXE_TFTP_URL (ex:http://xx.yy.zz.aa:port/foo/bar)
             PXE_TFTP_IP=$(echo "$PXE_TFTP_URL" | awk -F'[/:]' '{ print $4 }')
+
+            # If PXE_TFTP_IP is not an IP, it could be a FQDM that must be resolved to IP.
+            # is_ip() function is defined in network-function.sh
+            if ! is_ip $PXE_TFTP_IP ; then
+
+                Log "Trying to resolve [$PXE_TFTP_IP] to a valid IP."
+                # get_ip_from_fqdn() function is defined in network-function.sh
+                PXE_TFTP_IP=$(get_ip_from_fqdn $PXE_TFTP_IP)
+
+                if ! is_ip $PXE_TFTP_IP ; then
+                    LogPrint "Can't find a valid  boot/tftp server IP. Please update your ReaR configuration file with PXE_TFTP_IP."
+                fi
+            fi
+            LogPrint "Using $PXE_TFTP_IP as boot/tftp server IP."
         fi
     fi
 

--- a/usr/share/rear/lib/network-functions.sh
+++ b/usr/share/rear/lib/network-functions.sh
@@ -743,9 +743,9 @@ function get_ip_from_fqdn()
     [ -z "$fqdn" ] && BugError "function get_ip_from_name() called without argument."
 
     # Get a list of potential IPs that resolve $fqdn
-    ip=( $(getent ahostsv4 $fqdn) ) || Error "Could not resolve $fqdn"
+    ip=( $(getent ahostsv4 $fqdn) ) || Error "Could not resolve $fqdn to IP"
     # Check if $ip is a valide IP
     is_ip "$ip" || Error "Got '$ip' from resolving $fqdn which is not an IP"
-    Log "$fqdn resolved to ${ip[$i]}"
+    Log "$fqdn resolved to $ip"
     echo "$ip"
 }

--- a/usr/share/rear/lib/network-functions.sh
+++ b/usr/share/rear/lib/network-functions.sh
@@ -723,3 +723,28 @@ is_bonding_device ()
    [ -f "/sys/class/net/$1/bonding/slaves" ]
 }
 
+#  ^(([1-9]|[12]?[0-9]{1,2}|2([0-4][0-9]|5[0-5]))\.){3}([1-9]|[12]?[0-9]{1,2}|2([0-4][0-9]|5[0-5]))$
+
+# Retun 0 if args is a valid IPV4 ip_address
+function is_ip() {
+    local test_ip=$1
+    [ -z $test_ip ] && BugError "function is_ip() called without argument."
+
+    # test if $test_ip is a valide IPV4 address: "[1 to 255].[1 to 255].[1 to 255].[1 to 255]"
+    if [[ $test_ip =~ ^(([0-9]{1,2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))\.){3}([0-9]{1,2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))$ ]] ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# function which get the ipv4 address from a fqdn
+function get_ip_from_fqdn()
+{
+    local fqdn=$1
+    [ -z $fqdn ] && BugError "function get_ip_from_name() called without argument."
+
+    # Retuning the 1 Field of the First line of the command `getent ahostsv4 $fqdn`
+    # if the first field is an IPv4 valid address "[1 to 255].[1 to 255].[1 to 255].[1 to 255]"
+    echo $(getent ahostsv4 $fqdn | awk '$1~/^(([0-9]{1,2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))\.){3}([0-9]{1,2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))$/ { print $1 ; exit }' )
+}

--- a/usr/share/rear/lib/network-functions.sh
+++ b/usr/share/rear/lib/network-functions.sh
@@ -723,15 +723,13 @@ is_bonding_device ()
    [ -f "/sys/class/net/$1/bonding/slaves" ]
 }
 
-#  ^(([1-9]|[12]?[0-9]{1,2}|2([0-4][0-9]|5[0-5]))\.){3}([1-9]|[12]?[0-9]{1,2}|2([0-4][0-9]|5[0-5]))$
-
 # Retun 0 if args is a valid IPV4 ip_address
 function is_ip() {
     local test_ip=$1
-    [ -z $test_ip ] && BugError "function is_ip() called without argument."
+    [ -z "$test_ip" ] && BugError "function is_ip() called without argument."
 
-    # test if $test_ip is a valide IPV4 address: "[1 to 255].[1 to 255].[1 to 255].[1 to 255]"
-    if [[ $test_ip =~ ^(([0-9]{1,2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))\.){3}([0-9]{1,2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))$ ]] ; then
+    # test if $test_ip is a valide IPV4 address: "[0 to 255].[0 to 255].[0 to 255].[0 to 255]"
+    if [[ "$test_ip" =~ ^(([0-9]{1,2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))\.){3}([0-9]{1,2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))$ ]] ; then
         return 0
     else
         return 1
@@ -742,9 +740,12 @@ function is_ip() {
 function get_ip_from_fqdn()
 {
     local fqdn=$1
-    [ -z $fqdn ] && BugError "function get_ip_from_name() called without argument."
+    [ -z "$fqdn" ] && BugError "function get_ip_from_name() called without argument."
 
-    # Retuning the 1 Field of the First line of the command `getent ahostsv4 $fqdn`
-    # if the first field is an IPv4 valid address "[1 to 255].[1 to 255].[1 to 255].[1 to 255]"
-    echo $(getent ahostsv4 $fqdn | awk '$1~/^(([0-9]{1,2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))\.){3}([0-9]{1,2}|1[0-9]{2}|2([0-4][0-9]|5[0-5]))$/ { print $1 ; exit }' )
+    # Get a list of potential IPs that resolve $fqdn
+    ip=( $(getent ahostsv4 $fqdn) ) || Error "Could not resolve $fqdn"
+    # Check if $ip is a valide IP
+    is_ip "$ip" || Error "Got '$ip' from resolving $fqdn which is not an IP"
+    Log "$fqdn resolved to ${ip[$i]}"
+    echo "$ip"
 }


### PR DESCRIPTION
Grub2 `net_default_server_opt` variable must be a real IP not a hostname or fqdn.
=> if a user do not specify `PXE_TFTP_IP`, this one will be "guess" from the "PXE_TFTP_URL".
But we need to be sure it is a real numeric IP. if not we need to try to resolve the name to IP.

Creation of two new functions in `network-functions.sh`
 - create is_ip() function
 - create get_ip_from_fqdn() function