### PR TITLE
Use en_US.UTF-8 instead of creating custom rear.UTF-8

### DIFF
--- a/usr/share/rear/prep/BORG/default/200_prep_borg.sh
+++ b/usr/share/rear/prep/BORG/default/200_prep_borg.sh
@@ -14,10 +14,11 @@ if [[ $BORGBACKUP_ARCHIVE_PREFIX =~ [^a-zA-Z0-9] ]] \
     Error "BORGBACKUP_ARCHIVE_PREFIX must be alphanumeric non-empty value only"
 fi
 
-# Create our own locales, used only for Borg restore.
-mkdir -p $ROOTFS_DIR/usr/lib/locale
-localedef -f UTF-8 -i en_US $ROOTFS_DIR/usr/lib/locale/rear.UTF-8
-StopIfError "Could not create locales"
+# Check existence of default locales, to be used for Borg restore.
+BORG_DEFAULT_LOCALE=en_US.utf8
+if ! [[ $(locale -a | fgrep $BORG_DEFAULT_LOCALE) ]]; then
+    Error "Could not find borg default locale $BORG_DEFAULT_LOCALE"
+fi
 
 # Activate $COPY_AS_IS_BORG from default.conf.
 COPY_AS_IS=( "${COPY_AS_IS[@]}" "${COPY_AS_IS_BORG[@]}" )

--- a/usr/share/rear/restore/BORG/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/BORG/default/400_restore_backup.sh
@@ -14,7 +14,7 @@ StopIfError "Could not change directory to /mnt/local"
 # and should not interfere with remaining stages of rear recover.
 # This is still not the ideal solution, but best I can think of so far :-/.
 LogPrint "Recovering from Borg archive $BORGBACKUP_ARCHIVE"
-LC_ALL=rear.UTF-8 \
+LC_ALL=en_US.UTF-8 \
 borg extract --sparse $BORGBACKUP_OPT_REMOTE_PATH \
 $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO::$BORGBACKUP_ARCHIVE
 StopIfError "Could not successfully finish Borg restore"


### PR DESCRIPTION
Since we're using en_US.UTF-8 at the end of the day, better check existence of en_US.UTF-8 rather then creating a single purpose locales, with the risk also of having failing backups if the locales cannot be created. Since trending is to make `glibc-locale-source` optional, better avoid the risk of failure in localedef and to create a barely used locales.