### PR TITLE
Improved overhauled 900_clone_users_and_groups.sh

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -759,15 +759,24 @@ COPY_AS_IS_EXCLUDE=( dev/shm dev/shm/\* dev/oracleasm dev/mapper dev/.udev $VAR_
 
 # Users and groups to copy into the ReaR recovery system.
 # Users and groups must exist in the original system (i.e. one cannot create new ones).
-# Users must be specified with names as in /etc/passwd (not with numerical user IDs):
+# Users and groups must be specified with names (not with numerical IDs):
 CLONE_USERS=()
-# Groups must be specified with names as in /etc/group (not with numerical group IDs):
 CLONE_GROUPS=( group disk cdrom floppy tape audio video lp tty dialout kmem uucp ssh_keys plugdev )
-# Have users and groups that exist directly in /etc/passwd and /etc/group also in the ReaR recovery system.
-# Users and groups that exist indirectly (e.g. via NIS) are not copied into the ReaR recovery system.
-# This variable overrides CLONE_USERS and CLONE_GROUPS with the users in /etc/passwd and the groups in /etc/group,
-# see the usr/share/rear/rescue/default/900_clone_users_and_groups.sh script:
+# When CLONE_ALL_USERS_GROUPS contains a 'true' value, copy only the users and groups
+# from the /etc/passwd and /etc/group files into the ReaR recovery system.
+# When CLONE_ALL_USERS_GROUPS is 'all', copy all users and groups that are available
+# via 'getent' on the current system into the ReaR recovery system.
+# Using CLONE_ALL_USERS_GROUPS overrides CLONE_USERS and CLONE_GROUPS.
+# For details see the usr/share/rear/rescue/default/900_clone_users_and_groups.sh script.
+# By default CLONE_ALL_USERS_GROUPS="no" to stay backward compatible:
 CLONE_ALL_USERS_GROUPS="no"
+# But CLONE_ALL_USERS_GROUPS="yes" or even CLONE_ALL_USERS_GROUPS="all"
+# could be a more fail-safe setting because otherwise files might get restored
+# with wrong user or group name (e.g. with the fallback 'root:root') or
+# with wrong numerical user ID or group ID when the backup is restored because
+# any backup restore software runs "inside" the ReaR recovery system with the
+# users and groups there and not with the users and groups of the original system
+# except those users and groups that get copied into the ReaR recovery system.
 
 # SSH_ROOT_PASSWORD defines a root password to allow SSH connection whithout a public/private key pair
 # Be aware, the password is saved in hashed MD5 format (do not forget the password after months:)

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -759,14 +759,17 @@ COPY_AS_IS_EXCLUDE=( dev/shm dev/shm/\* dev/oracleasm dev/mapper dev/.udev $VAR_
 
 # Users and groups to copy into the ReaR recovery system.
 # Users and groups must exist in the original system (i.e. one cannot create new ones).
+# Specified users and groups that do not exist in the original system are ignored.
 # Users and groups must be specified with names (not with numerical IDs):
 CLONE_USERS=()
 CLONE_GROUPS=( group disk cdrom floppy tape audio video lp tty dialout kmem uucp ssh_keys plugdev )
-# When CLONE_ALL_USERS_GROUPS contains a 'true' value, copy only the users and groups
+# When CLONE_ALL_USERS_GROUPS is 'true' or 'all' copy users and groups
+# that exist on the current system into the ReaR recovery system
+# in addition to the users and groups in CLONE_USERS and CLONE_GROUPS.
+# When CLONE_ALL_USERS_GROUPS contains a 'true' value, copy also the users and groups
 # from the /etc/passwd and /etc/group files into the ReaR recovery system.
-# When CLONE_ALL_USERS_GROUPS is 'all', copy all users and groups that are available
+# When CLONE_ALL_USERS_GROUPS is 'all', copy also all users and groups that are available
 # via 'getent' on the current system into the ReaR recovery system.
-# Using CLONE_ALL_USERS_GROUPS overrides CLONE_USERS and CLONE_GROUPS.
 # For details see the usr/share/rear/rescue/default/900_clone_users_and_groups.sh script.
 # By default CLONE_ALL_USERS_GROUPS="no" to stay backward compatible:
 CLONE_ALL_USERS_GROUPS="no"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -762,7 +762,7 @@ COPY_AS_IS_EXCLUDE=( dev/shm dev/shm/\* dev/oracleasm dev/mapper dev/.udev $VAR_
 # Specified users and groups that do not exist in the original system are ignored.
 # Users and groups must be specified with names (not with numerical IDs):
 CLONE_USERS=()
-CLONE_GROUPS=( group disk cdrom floppy tape audio video lp tty dialout kmem uucp ssh_keys plugdev )
+CLONE_GROUPS=( disk cdrom floppy tape audio video lp tty dialout kmem uucp ssh_keys plugdev )
 # When CLONE_ALL_USERS_GROUPS is 'true' or 'all' copy users and groups
 # that exist on the current system into the ReaR recovery system
 # in addition to the users and groups in CLONE_USERS and CLONE_GROUPS.

--- a/usr/share/rear/rescue/default/900_clone_users_and_groups.sh
+++ b/usr/share/rear/rescue/default/900_clone_users_and_groups.sh
@@ -26,8 +26,8 @@ for user in "${CLONE_USERS[@]}" ; do
         continue
     fi
     # Prepare to also add the user's group to the CLONE_GROUPS array:
-    # passwd_entry="user:password:UID:GID:description:HOMEdirectory:shell
-    groupID="$( echo "$passwd_entry" | cut -d ':' -f '4' )"
+    # passwd_entry="user:password:UID:GID:description:HOMEdirectory:shell"
+    groupID="$( cut -d ':' -f '4' <<<"$passwd_entry" )"
     if ! group_entry="$( getent group $groupID )" ; then
         Debug "Cannot clone $user because its group $groupID does not exist"
         continue
@@ -36,7 +36,7 @@ for user in "${CLONE_USERS[@]}" ; do
     echo "$passwd_entry" >>$ROOTFS_DIR/etc/passwd
     # Add the user's group to the CLONE_GROUPS array (unless already there):
     # group_entry="group:passwd:GID:userlist"
-    group="$( echo "$group_entry" | cut -d ':' -f '1' )"
+    group="${group_entry%%:*}"
     # Skip if the group is already in the CLONE_GROUPS array:
     IsInArray "$group" "${CLONE_GROUPS[@]}" && continue
     # Add the user's group to the CLONE_GROUPS array:

--- a/usr/share/rear/rescue/default/900_clone_users_and_groups.sh
+++ b/usr/share/rear/rescue/default/900_clone_users_and_groups.sh
@@ -44,7 +44,7 @@ for user in "${CLONE_USERS[@]}" ; do
     grep -q "^$user:" $ROOTFS_DIR/etc/passwd && continue
     # Skip if the user does not exist in the current system:
     if ! passwd_entry="$( getent passwd $user )" ; then
-        Debug "Cannot clone $user because it does not exist"
+        Debug "Cannot clone user $user because it does not exist"
         continue
     fi
     # When CLONE_ALL_USERS_GROUPS was used above, assume
@@ -60,7 +60,7 @@ for user in "${CLONE_USERS[@]}" ; do
     # passwd_entry="user:password:UID:GID:description:HOMEdirectory:shell"
     groupID="$( cut -d ':' -f '4' <<<"$passwd_entry" )"
     if ! group_entry="$( getent group $groupID )" ; then
-        Debug "Cannot clone $user because its group $groupID does not exist"
+        Debug "Cannot clone user $user because its group $groupID does not exist"
         continue
     fi
     # Add the user to /etc/passwd in the ReaR recovery system:
@@ -82,7 +82,7 @@ for group in "${CLONE_GROUPS[@]}" ; do
     grep -q "^$group:" $ROOTFS_DIR/etc/group && continue
     # Skip if the group does not exist in the current system:
     if ! group_entry="$( getent group $group )" ; then
-        Debug "Cannot clone $group because it does not exist"
+        Debug "Cannot clone group $group because it does not exist"
         continue
     fi
     # Add the group to /etc/group in the ReaR recovery system:

--- a/usr/share/rear/rescue/default/900_clone_users_and_groups.sh
+++ b/usr/share/rear/rescue/default/900_clone_users_and_groups.sh
@@ -1,11 +1,29 @@
+#
+# 900_clone_users_and_groups.sh
+#
+# Copy users and groups into the ReaR recovery system.
 
-# Copy users and groups to the ReaR recovery system:
-
+# Copy users and groups on the current system into the ReaR recovery system.
+local cloning_all="no"
+# When CLONE_ALL_USERS_GROUPS contains a 'true' value, copy only
+# the users and groups from the /etc/passwd and /etc/group files:
 if is_true "$CLONE_ALL_USERS_GROUPS" ; then
-    # In particular exclude a possible NIS extension line '+::::::'
+    Log "Copying users and groups from /etc/passwd and /etc/group"
+    cloning_all="yes"
+    # Only keep valid user names (in particular exclude a NIS extension line '+::::::'):
     CLONE_USERS=( $( grep -o '^[[:alnum:]_][^:]*' /etc/passwd ) )
-    # In particular exclude a possible NIS extension line '+:::'
+    # Only keep valid group names (in particular exclude a NIS extension line '+:::'):
     CLONE_GROUPS=( $( grep -o '^[[:alnum:]_][^:]*' /etc/group ) )
+fi
+# When CLONE_ALL_USERS_GROUPS is 'all', copy all users and groups
+# that are available on the current system into the ReaR recovery system:
+if test 'all' = "$CLONE_ALL_USERS_GROUPS" ; then
+    Log "Copying all users and groups that are available via 'getent'"
+    cloning_all="yes"
+    # Only keep valid user names:
+    CLONE_USERS=( $( getent passwd | grep -o '^[[:alnum:]_][^:]*' ) )
+    # Only keep valid group names:
+    CLONE_GROUPS=( $( getent group | grep -o '^[[:alnum:]_][^:]*' ) )
 fi
 
 local user=""
@@ -19,10 +37,19 @@ local group=""
 test "${CLONE_USERS[*]}" && Log "Cloning users: ${CLONE_USERS[@]}"
 for user in "${CLONE_USERS[@]}" ; do
     # Skip if the user exists already in the ReaR recovery system:
-    grep "^$user:" $ROOTFS_DIR/etc/passwd 1>&2 && continue
+    grep -q "^$user:" $ROOTFS_DIR/etc/passwd && continue
     # Skip if the user does not exist in the current system:
     if ! passwd_entry="$( getent passwd $user )" ; then
         Debug "Cannot clone $user because it does not exist"
+        continue
+    fi
+    # When CLONE_ALL_USERS_GROUPS was used above, assume
+    # the users and groups in CLONE_USERS and CLONE_GROUPS
+    # are consistent so that the user's group is in CLONE_GROUPS:
+    if is_true "$cloning_all" ; then
+        # Add the user to /etc/passwd in the ReaR recovery system and
+        # proceed with the next user without further group tests:
+        echo "$passwd_entry" >>$ROOTFS_DIR/etc/passwd
         continue
     fi
     # Prepare to also add the user's group to the CLONE_GROUPS array:
@@ -48,7 +75,7 @@ done
 test "${CLONE_GROUPS[*]}" && Log "Cloning groups: ${CLONE_GROUPS[@]}"
 for group in "${CLONE_GROUPS[@]}" ; do
     # Skip if the group exists already in the ReaR recovery system:
-    grep "^$group:" $ROOTFS_DIR/etc/group 1>&2 && continue
+    grep -q "^$group:" $ROOTFS_DIR/etc/group && continue
     # Skip if the group does not exist in the current system:
     if ! group_entry="$( getent group $group )" ; then
         Debug "Cannot clone $group because it does not exist"

--- a/usr/share/rear/rescue/default/900_clone_users_and_groups.sh
+++ b/usr/share/rear/rescue/default/900_clone_users_and_groups.sh
@@ -3,27 +3,31 @@
 #
 # Copy users and groups into the ReaR recovery system.
 
-# Copy users and groups on the current system into the ReaR recovery system.
 local cloning_all="no"
-# When CLONE_ALL_USERS_GROUPS contains a 'true' value, copy only
+# When CLONE_ALL_USERS_GROUPS is 'true' or 'all' copy users and groups
+# that exist on the current system into the ReaR recovery system
+# in addition to the users and groups in CLONE_USERS and CLONE_GROUPS
+# and regardless of duplicates because when duplicates exists already
+# in the ReaR recovery system they are skipped (see the code below).
+# When CLONE_ALL_USERS_GROUPS contains a 'true' value, copy also
 # the users and groups from the /etc/passwd and /etc/group files:
 if is_true "$CLONE_ALL_USERS_GROUPS" ; then
     Log "Copying users and groups from /etc/passwd and /etc/group"
     cloning_all="yes"
     # Only keep valid user names (in particular exclude a NIS extension line '+::::::'):
-    CLONE_USERS=( $( grep -o '^[[:alnum:]_][^:]*' /etc/passwd ) )
+    CLONE_USERS=( "${CLONE_USERS[@]}" $( grep -o '^[[:alnum:]_][^:]*' /etc/passwd ) )
     # Only keep valid group names (in particular exclude a NIS extension line '+:::'):
-    CLONE_GROUPS=( $( grep -o '^[[:alnum:]_][^:]*' /etc/group ) )
+    CLONE_GROUPS=( "${CLONE_GROUPS[@]}" $( grep -o '^[[:alnum:]_][^:]*' /etc/group ) )
 fi
-# When CLONE_ALL_USERS_GROUPS is 'all', copy all users and groups
+# When CLONE_ALL_USERS_GROUPS is 'all', copy also all users and groups
 # that are available on the current system into the ReaR recovery system:
 if test 'all' = "$CLONE_ALL_USERS_GROUPS" ; then
     Log "Copying all users and groups that are available via 'getent'"
     cloning_all="yes"
     # Only keep valid user names:
-    CLONE_USERS=( $( getent passwd | grep -o '^[[:alnum:]_][^:]*' ) )
+    CLONE_USERS=( "${CLONE_USERS[@]}" $( getent passwd | grep -o '^[[:alnum:]_][^:]*' ) )
     # Only keep valid group names:
-    CLONE_GROUPS=( $( getent group | grep -o '^[[:alnum:]_][^:]*' ) )
+    CLONE_GROUPS=( "${CLONE_GROUPS[@]}" $( getent group | grep -o '^[[:alnum:]_][^:]*' ) )
 fi
 
 local user=""


### PR DESCRIPTION
Some minor improvements of https://github.com/rear/rear/pull/1471
but still kept the behaviour of how it worked before
https://github.com/rear/rear/pull/1471
i.e. CLONE_ALL_USERS_GROUPS
replaces the CLONE_USERS and CLONE_GROUPS

If the behaviour of how it works should be changed
a separated issue or pull request is needed.
Personally I do not intend to change the behaviour
because it seems to work o.k. as is (no user complaints).
