### PR TITLE
Use meaningful variable names for automated UserInput

### DIFF
--- a/usr/share/rear/format/USB/default/200_check_usb_layout.sh
+++ b/usr/share/rear/format/USB/default/200_check_usb_layout.sh
@@ -59,7 +59,9 @@ ID_FS_TYPE=$(
 [[ "$ID_FS_TYPE" == btr* || "$ID_FS_TYPE" == ext* ]]
 if (( $? != 0 )) && [[ -z "$YES" ]]; then
     LogUserOutput "USB device $REAL_USB_DEVICE is not formatted with ext2/3/4 or btrfs filesystem"
-    USB_format_answer="$( UserInput -I type_Yes_to_format_USB_device -p "Type exactly 'Yes' to format $REAL_USB_DEVICE with $USB_DEVICE_FILESYSTEM filesystem" -D 'No' )"
+    # When USER_INPUT_USB_DEVICE_CONFIRM_FORMAT has any 'true' value be liberal in what you accept and assume exactly 'Yes' was actually meant:
+    is_true "$USER_INPUT_USB_DEVICE_CONFIRM_FORMAT" && USER_INPUT_USB_DEVICE_CONFIRM_FORMAT="Yes"
+    USB_format_answer="$( UserInput -I USB_DEVICE_CONFIRM_FORMAT -p "Type exactly 'Yes' to format $REAL_USB_DEVICE with $USB_DEVICE_FILESYSTEM filesystem" -D 'No' )"
     test "Yes" = "$USB_format_answer" || Error "Abort USB format process by user (user input '$USB_format_answer' is not 'Yes')"
 elif [[ "$YES" ]]; then
     USB_format_answer="Yes"

--- a/usr/share/rear/format/USB/default/200_check_usb_layout.sh
+++ b/usr/share/rear/format/USB/default/200_check_usb_layout.sh
@@ -59,7 +59,7 @@ ID_FS_TYPE=$(
 [[ "$ID_FS_TYPE" == btr* || "$ID_FS_TYPE" == ext* ]]
 if (( $? != 0 )) && [[ -z "$YES" ]]; then
     LogUserOutput "USB device $REAL_USB_DEVICE is not formatted with ext2/3/4 or btrfs filesystem"
-    USB_format_answer="$( UserInput -p "Type exactly 'Yes' to format $REAL_USB_DEVICE with $USB_DEVICE_FILESYSTEM filesystem" -D 'No' )"
+    USB_format_answer="$( UserInput -I type_Yes_to_format_USB_device -p "Type exactly 'Yes' to format $REAL_USB_DEVICE with $USB_DEVICE_FILESYSTEM filesystem" -D 'No' )"
     test "Yes" = "$USB_format_answer" || Error "Abort USB format process by user (user input '$USB_format_answer' is not 'Yes')"
 elif [[ "$YES" ]]; then
     USB_format_answer="Yes"

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -27,7 +27,7 @@ if is_true "$EFI" ; then
     while ! [[ "$USB_UEFI_PART_SIZE" =~ ^[0-9]+$ && $USB_UEFI_PART_SIZE > 0 ]] ; do
         # When USB_UEFI_PART_SIZE is empty, do not falsely complain about "Invalid EFI partition size value":
         test "$USB_UEFI_PART_SIZE" && LogPrintError "Invalid EFI system partition size value '$USB_UEFI_PART_SIZE' (must be unsigned integer larger than 0)"
-        USB_UEFI_PART_SIZE="$( UserInput -I EFI_partition_MiBs_on_USB_device -p "Enter size for EFI system partition on '$RAW_USB_DEVICE' in MiB (plain 'Enter' defaults to 200 MiB)" )"
+        USB_UEFI_PART_SIZE="$( UserInput -I USB_DEVICE_EFI_PARTITION_MIBS -p "Enter size for EFI system partition on '$RAW_USB_DEVICE' in MiB (plain 'Enter' defaults to 200 MiB)" )"
         # Plain 'Enter' defaults to 200 MiB (same as the default value in default.conf):
         test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="200"
     done

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -27,7 +27,7 @@ if is_true "$EFI" ; then
     while ! [[ "$USB_UEFI_PART_SIZE" =~ ^[0-9]+$ && $USB_UEFI_PART_SIZE > 0 ]] ; do
         # When USB_UEFI_PART_SIZE is empty, do not falsely complain about "Invalid EFI partition size value":
         test "$USB_UEFI_PART_SIZE" && LogPrintError "Invalid EFI system partition size value '$USB_UEFI_PART_SIZE' (must be unsigned integer larger than 0)"
-        USB_UEFI_PART_SIZE="$( UserInput -p "Enter size for EFI system partition on '$RAW_USB_DEVICE' in MiB (plain 'Enter' defaults to 200 MiB)" )"
+        USB_UEFI_PART_SIZE="$( UserInput -I EFI_partition_MiBs_on_USB_device -p "Enter size for EFI system partition on '$RAW_USB_DEVICE' in MiB (plain 'Enter' defaults to 200 MiB)" )"
         # Plain 'Enter' defaults to 200 MiB (same as the default value in default.conf):
         test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="200"
     done

--- a/usr/share/rear/layout/prepare/GNU/Linux/150_include_drbd_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/150_include_drbd_code.sh
@@ -20,7 +20,7 @@ fi
 EOF
 
     # Ask if we need to become primary.
-    user_input="$( UserInput -p "Type 'yes' if you want DRBD resource $resource to become primary" )"
+    user_input="$( UserInput -I type_yes_for_DRBD_resource_becomes_primary -p "Type 'yes' if you want DRBD resource $resource to become primary" )"
     if [ "$user_input" = "yes" ] ; then
         cat >> "$LAYOUT_CODE" <<-EOF
         if ! drbdadm role $resource &>/dev/null ; then

--- a/usr/share/rear/layout/prepare/GNU/Linux/150_include_drbd_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/150_include_drbd_code.sh
@@ -20,7 +20,9 @@ fi
 EOF
 
     # Ask if we need to become primary.
-    user_input="$( UserInput -I type_yes_for_DRBD_resource_becomes_primary -p "Type 'yes' if you want DRBD resource $resource to become primary" )"
+    # When USER_INPUT_DRBD_RESOURCE_BECOMES_PRIMARY has any 'true' value be liberal in what you accept and assume exactly 'yes' was actually meant:
+    is_true "$USER_INPUT_DRBD_RESOURCE_BECOMES_PRIMARY" && USER_INPUT_DRBD_RESOURCE_BECOMES_PRIMARY="yes"
+    user_input="$( UserInput -I DRBD_RESOURCE_BECOMES_PRIMARY -p "Type 'yes' if you want DRBD resource $resource to become primary" )"
     if [ "$user_input" = "yes" ] ; then
         cat >> "$LAYOUT_CODE" <<-EOF
         if ! drbdadm role $resource &>/dev/null ; then

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -55,7 +55,7 @@ blacklist {
     # Note: On sles11/rhel6, multipath failed if no multipath device is found.
     while ! multipath ; do
         echo
-        choice="$( UserInput -p "$prompt" -D "${choices[0]}" "${choices[@]}")"&& wilful_input="yes" || wilful_input="no"
+        choice="$( UserInput -I multipath_failed_to_list_device -p "$prompt" -D "${choices[0]}" "${choices[@]}")"&& wilful_input="yes" || wilful_input="no"
         case "$choice" in
             (${choices[0]})
                 # continue recovery without multipath

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -55,7 +55,7 @@ blacklist {
     # Note: On sles11/rhel6, multipath failed if no multipath device is found.
     while ! multipath ; do
         echo
-        choice="$( UserInput -I multipath_failed_to_list_device -p "$prompt" -D "${choices[0]}" "${choices[@]}")"&& wilful_input="yes" || wilful_input="no"
+        choice="$( UserInput -I MULTIPATH_FAILED_TO_LIST_DEVICE -p "$prompt" -D "${choices[0]}" "${choices[@]}")"&& wilful_input="yes" || wilful_input="no"
         case "$choice" in
             (${choices[0]})
                 # continue recovery without multipath

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -149,7 +149,7 @@ while read keyword orig_device orig_size junk ; do
     choice=""
     wilful_input=""
     until IsInArray "$choice" "${regular_choices[@]}" ; do
-        choice="$( UserInput -p "$prompt" -D 0 "${regular_choices[@]}" "$rear_shell_choice" )" && wilful_input="yes" || wilful_input="no"
+        choice="$( UserInput -I layout_migration_choose_replacement_disk -p "$prompt" -D 0 "${regular_choices[@]}" "$rear_shell_choice" )" && wilful_input="yes" || wilful_input="no"
         test "$rear_shell_choice" = "$choice" && rear_shell
     done
     # Continue with next original device when the user selected to not map it:
@@ -181,7 +181,7 @@ wilful_input=""
 while true ; do
     LogUserOutput 'Current disk mapping table (source -> target):'
     LogUserOutput "$( sed -e 's|^|    |' "$MAPPING_FILE" )"
-    choice="$( UserInput -p "$prompt" -D "${choices[0]}" "${choices[@]}" )" && wilful_input="yes" || wilful_input="no"
+    choice="$( UserInput -I layout_migration_confirm_mappings -p "$prompt" -D "${choices[0]}" "${choices[@]}" )" && wilful_input="yes" || wilful_input="no"
     case "$choice" in
         (${choices[0]})
             # Continue recovery:

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -183,7 +183,7 @@ choice=""
 wilful_input=""
 # When USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS has any 'true' value be liberal in what you accept
 # and assume choices[0] 'Confirm mapping' was actually meant:
-is_true "$USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS" && USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS="0"
+is_true "$USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS" && USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS="${choices[0]}"
 while true ; do
     LogUserOutput 'Current disk mapping table (source -> target):'
     LogUserOutput "$( sed -e 's|^|    |' "$MAPPING_FILE" )"

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -148,8 +148,11 @@ while read keyword orig_device orig_size junk ; do
     prompt="Choose an appropriate replacement for $preferred_orig_device_name"
     choice=""
     wilful_input=""
+    # TODO: Currently only one single USER_INPUT_LAYOUT_MIGRATION_REPLACEMENT_DISK
+    # can be predefined (which is at least better than nothing) but that dialog can appear
+    # several times for several unmapped original 'disk' devices and 'multipath' devices:
     until IsInArray "$choice" "${regular_choices[@]}" ; do
-        choice="$( UserInput -I layout_migration_choose_replacement_disk -p "$prompt" -D 0 "${regular_choices[@]}" "$rear_shell_choice" )" && wilful_input="yes" || wilful_input="no"
+        choice="$( UserInput -I LAYOUT_MIGRATION_REPLACEMENT_DISK -p "$prompt" -D 0 "${regular_choices[@]}" "$rear_shell_choice" )" && wilful_input="yes" || wilful_input="no"
         test "$rear_shell_choice" = "$choice" && rear_shell
     done
     # Continue with next original device when the user selected to not map it:
@@ -178,10 +181,13 @@ choices[3]="Abort '$rear_workflow'"
 prompt="Confirm or edit the disk mapping"
 choice=""
 wilful_input=""
+# When USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS has any 'true' value be liberal in what you accept
+# and assume choices[0] 'Confirm mapping' was actually meant:
+is_true "$USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS" && USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS="0"
 while true ; do
     LogUserOutput 'Current disk mapping table (source -> target):'
     LogUserOutput "$( sed -e 's|^|    |' "$MAPPING_FILE" )"
-    choice="$( UserInput -I layout_migration_confirm_mappings -p "$prompt" -D "${choices[0]}" "${choices[@]}" )" && wilful_input="yes" || wilful_input="no"
+    choice="$( UserInput -I LAYOUT_MIGRATION_CONFIRM_MAPPINGS -p "$prompt" -D "${choices[0]}" "${choices[@]}" )" && wilful_input="yes" || wilful_input="no"
     case "$choice" in
         (${choices[0]})
             # Continue recovery:

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -181,9 +181,10 @@ choices[3]="Abort '$rear_workflow'"
 prompt="Confirm or edit the disk mapping"
 choice=""
 wilful_input=""
-# When USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS has any 'true' value be liberal in what you accept
-# and assume choices[0] 'Confirm mapping' was actually meant:
-is_true "$USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS" && USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS="${choices[0]}"
+# When USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS has any 'true' value be liberal in what you accept and
+# assume choices[0] 'Confirm mapping' was actually meant which is shown with choice number 1 (not 0) and
+# a predefined user input must match the choice number that is shown to the user (not the choice index):
+is_true "$USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS" && USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS="1"
 while true ; do
     LogUserOutput 'Current disk mapping table (source -> target):'
     LogUserOutput "$( sed -e 's|^|    |' "$MAPPING_FILE" )"

--- a/usr/share/rear/layout/prepare/default/600_show_unprocessed.sh
+++ b/usr/share/rear/layout/prepare/default/600_show_unprocessed.sh
@@ -21,7 +21,7 @@ while read status name type junk ; do
         # so that 'rear recover' proceeds after the timeout regardless that it probably fails
         # when the component is not recreated but perhaps it could succeed in migration mode
         # on different replacement hardware where it might be even right to simply "Continue":
-        case "$( UserInput -p "Manually add code that recreates $missing_component" -D "${choices[3]}" "${choices[@]}" )" in
+        case "$( UserInput -I recreating_missing_components -p "Manually add code that recreates $missing_component" -D "${choices[3]}" "${choices[@]}" )" in
             (${choices[0]})
                 # Run 'less' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
                 less $LAYOUT_CODE 0<&6 1>&7 2>&8

--- a/usr/share/rear/layout/prepare/default/600_show_unprocessed.sh
+++ b/usr/share/rear/layout/prepare/default/600_show_unprocessed.sh
@@ -20,8 +20,11 @@ while read status name type junk ; do
         # The default user input is "Continue" to make it possible to run ReaR unattended
         # so that 'rear recover' proceeds after the timeout regardless that it probably fails
         # when the component is not recreated but perhaps it could succeed in migration mode
-        # on different replacement hardware where it might be even right to simply "Continue":
-        case "$( UserInput -I recreating_missing_components -p "Manually add code that recreates $missing_component" -D "${choices[3]}" "${choices[@]}" )" in
+        # on different replacement hardware where it might be even right to simply "Continue".
+        # TODO: Currently only one single USER_INPUT_ADD_CODE_TO_RECREATE_MISSING_COMPONENT
+        # can be predefined (which is at least better than nothing)
+        # but that dialog can appear several times for several missing components:
+        case "$( UserInput -I ADD_CODE_TO_RECREATE_MISSING_COMPONENT -p "Manually add code that recreates $missing_component" -D "${choices[3]}" "${choices[@]}" )" in
             (${choices[0]})
                 # Run 'less' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
                 less $LAYOUT_CODE 0<&6 1>&7 2>&8

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -336,19 +336,23 @@ function LogPrintIfError () {
 #   input is read from the original STDIN when 'rear' was launched
 #   (which is usually the keyboard of the user who launched 'rear').
 # Synopsis:
-#   UserInput [-t timeout] [-p prompt] [-a output_array] [-n input_max_chars] [-d input_delimiter] [-D default_input] [-I user_input_ID] [choices]
+#   UserInput -I user_input_ID [-t timeout] [-p prompt] [-a output_array] [-n input_max_chars] [-d input_delimiter] [-D default_input] [choices]
 #   The options -t -p -a -n -d  match the ones for the 'read' bash builtin.
 #   The option [choices] are the values that are shown to the user as available choices like if a 'select' bash keyword was used.
 #   The option [-D default_input] specifies what is used as default response when the user does not enter something.
 #       Usuallly this is one of the choices values or an index of one of the choices (the first choice has index 0)
 #       but the default input can be anything else (in particular for free input without predefined choices).
-#   The option [-I user_input_ID] is intended to make UserInput working full automated (e.g. when ReaR runs unattended)
-#       via a user-specified array of user input values like
-#           USER_INPUT_VALUES[123]='input for UserInput -I 123'
-#           USER_INPUT_VALUES[456]='input for UserInput -I 456'
-#           USER_INPUT_VALUES[789]='input for UserInput -I 789'
-#       where each USER_INPUT_VALUES array member index that matches a user_input_ID of a particular 'UserInput -I' call
-#       that will be autoresponded with the matching value of the user input array.
+#   The option '-I user_input_ID' is required so that UserInput can work full automated (e.g. when ReaR runs unattended)
+#       via user-specified variables named UserInput_user_input_ID that contain user input values like
+#           UserInput_some_user_confirmation='input for UserInput -I some_user_confirmation'
+#           UserInput_let_the_user_choose='input for UserInput -I let_the_user_choose'
+#           UserInput_some_user_dialog='input for UserInput -I some_user_dialog'
+#       that will be autoresponded with the value of the matching UserInput_user_input_ID variable.
+#       Accordingly only a valid variable name can be used as user_input_ID value.
+#       Different UserInput calls must use different '-I user_input_ID' option values.
+#       It is recommended to use meaningful and explanatory user_input_ID values
+#       which helps the user to specify automated input via meaningful UserInput_user_input_ID variables
+#       and it avoids that different UserInput calls accidentally use same user_input_ID values.
 # Result:
 #   Any actual user input or an automated user input or the default response is output via STDOUT.
 # Return code:
@@ -363,30 +367,30 @@ function LogPrintIfError () {
 #   so that an attentive user will actively provide user input to proceed even if it is same as the default.
 # Usage examples:
 # * Wait endlessly until the user hits the [Enter] key (without '-t 0' a default timeout is used):
-#       UserInput -t 0 -p 'Press [Enter] to continue'
+#       UserInput -I wait_until_enter -t 0 -p 'Press [Enter] to continue'
 # * Wait up to 30 seconds until the user hits the [Enter] key (i.e. proceed automatically after 30 seconds):
-#       UserInput -t 30 -p 'Press [Enter] to continue'
+#       UserInput -I wait_for_enter_or_timeout -t 30 -p 'Press [Enter] to continue'
 # * Get an input value from the user (proceed automatically with empty input_value after the default timeout).
 #   Leading and trailing spaces are cut from the actual user input:
-#       input_value="$( UserInput -p 'Enter the input value' )"
+#       input_value="$( UserInput -I some_input -p 'Enter the input value' )"
 # * Get an input value from the user (proceed automatically with the 'default input' after 2 minutes).
 #   The timeout interrupts ongoing user input so that 'default input' is used when the user
 #   does not hit the [Enter] key to finish his input before the timeout happens:
-#       input_value="$( UserInput -t 120 -p 'Enter the input value' -D 'default input' )"
+#       input_value="$( UserInput -I some_input -t 120 -p 'Enter the input value' -D 'default input' )"
 # * Get an input value from the user by offering him possible choices (proceed with the default choice after the default timeout).
 #   The choices index starts with 0 so that '-D 1' specifies the second choice as default choice:
-#       input_value="$( UserInput -p 'Select a choice' -D 1 'first choice' 'second choice' 'third choice' )"
+#       input_value="$( UserInput -I some_choice -p 'Select a choice' -D 1 'first choice' 'second choice' 'third choice' )"
 # * When the user enters an arbitrary value like 'foo bar' this actual user input is used as input_value.
 #   The UserInput function provides the actual user input and its caller needs to check the actual user input.
 #   To enforce that the actual user input is one of the choices an endless retrying loop could be used like:
 #       choices=( 'first choice' 'second choice' 'third choice' )
 #       until IsInArray "$input_value" "${choices[@]}" ; do
-#           input_value="$( UserInput -p 'Select a choice' -D 'second choice' "${choices[@]}" )"
+#           input_value="$( UserInput -I some_choice -p 'Select a choice' -D 'second choice' "${choices[@]}" )"
 #       done
 #   Because the default choice is one of the choices the endless loop does not contradict that ReaR can run unattended.
 #   When that code runs unattended (i.e. without actual user input) the default choice is used after the default timeout.
 # * The default choice can be anything as in:
-#       input_value="$( UserInput -p 'Select a choice' -D 'fallback value' -n 1 'first choice' 'second choice' 'third choice' )"
+#       input_value="$( UserInput -I some_choice -p 'Select a choice' -D 'fallback value' -n 1 'first choice' 'second choice' 'third choice' )"
 #   The caller needs to check the actual input_value which could be 'fallback value' when the user hits the [Enter] key
 #   or one of 'first choice' 'second choice' 'third choice' when the user hits the [1] [2] or [3] key respectively
 #   or any other character as actual user input ('-n 1' limits the actual user input to one single character).
@@ -395,18 +399,13 @@ function LogPrintIfError () {
 #   when the actual user input is not one of the choices it is possible to implement valid and convenient user input:
 #       choices=( 'default choice' 'first alternative choice' 'second alternative choice' )
 #       until IsInArray "$choice" "${choices[@]}" ; do
-#           choice="$( UserInput -t 60 -p 'Hit a choice number key' -D 0 -n 1 "${choices[@]}" )"
+#           choice="$( UserInput -I some_other_choice -t 60 -p 'Hit a choice number key' -D 0 -n 1 "${choices[@]}" )"
 #       done
 # * To to let UserInput autorespond full automated a predefined user input value specify the user input value
-#   with a matching index in the USER_INPUT_VALUES array (e.g. specify that it in your local.conf file) like
-#       USER_INPUT_VALUES[123]='third choice'
-#   and call UserInput with that USER_INPUT_VALUES array index as the '-I' option value like
-#       input_value="$( UserInput -p 'Select a choice' -D 1 -I 123 'first choice' 'second choice' 'third choice' )"
-#   which lets UserInput autorespond with 'third choice'.
-#   This means a precondition for an automated response is that a UserInput call has a user_input_ID specified.
-#   No predefined user input value should exist to get real user input for a 'UserInput -I 123' call
-#   or an existing predefined user input value should be unset before 'UserInput -I 123' is called like
-#       unset 'USER_INPUT_VALUES[123]'
+#   with a matching UserInput_user_input_ID variable (e.g. specify that it in your local.conf file) like
+#       UserInput_some_choice='third choice'
+#   which lets a 'UserInput -I some_choice' call autorespond with 'third choice'.
+#   No UserInput_some_choice variable should exist to get real user input for a 'UserInput -I some_choice' call
 #   or the user can interupt any automated response within a relatively short time (minimum is only 1 second).
 function UserInput () {
     # First and foremost log how UserInput was actually called so that subsequent 'Log' messages are comprehensible:
@@ -465,8 +464,7 @@ function UserInput () {
                 default_input="$OPTARG"
                 ;;
             (I)
-                # Avoid stderr if OPTARG is not set or empty or not an integer value:
-                test "$OPTARG" -ge 0 2>/dev/null && user_input_ID="$OPTARG" || Log "UserInput: Invalid -$option argument '$OPTARG' ignored"
+                user_input_ID="$OPTARG"
                 ;;
             (\?)
                 BugError "UserInput: Invalid option: -$OPTARG"
@@ -476,6 +474,8 @@ function UserInput () {
                 ;;
         esac
     done
+    test $user_input_ID || BugError "UserInput: Option '-I user_input_ID' required"
+    declare $user_input_ID="dummy" || BugError "UserInput: Option '-I' argument '$user_input_ID' not a valid variable name"
     # Shift away the options and arguments:
     shift "$(( OPTIND - 1 ))"
     # Everything that is now left in "$@" is neither an option nor an option argument
@@ -537,63 +537,9 @@ function UserInput () {
     # The actual work:
     # Have caller_source as an array so that plain $caller_source is only the filename (with path):
     local caller_source=( $( CallerSource ) )
-    # Avoid stderr if user_input_ID is not set or empty or not an integer value:
-    if test "$user_input_ID" -ge 0 2>/dev/null ; then
-        # In debug mode show the user the script that called UserInput and what user_input_ID was specified
-        # so that the user can prepare an automated response for that UserInput call (without digging in the code):
-        DebugPrint "UserInput -I $user_input_ID needed in ${caller_source[@]}"
-    else
-        # Generate a unique default user_input_ID if it was not specified:
-        # The generated user_input_ID should be different for different scripts
-        # wherefrom the UserInput is called (i.e. different caller_source) and it should be different
-        # for different visual appearence to the user (i.e. different choices, prompt, and default_input)
-        # but it should be independent of the caller script path (ReaR installation path must not matter)
-        # and it should be independent of non-meaningful characters in what is shown to the user like
-        # whitespaces and special characters so that it only depends on letters (case insensitive) and digits.
-        # Intentionally same caller script basename in different ReaR subdirectories
-        # (e.g. the various 400_restore_backup.sh scripts for different backup methods)
-        # does not result different generated user_input_ID so that UserInput calls with same visual appearence
-        # (regarding meaningful characters) in caller scripts with same basename get same generated user_input_ID.
-        # E.g. when several scripts with same basename call the same
-        #   UserInput -p 'Press [Enter] to continue'
-        # then same UserInput calls for same purpose (same basename callers is considered same purpose)
-        # get same generated user_input_ID. If this is not wanted user_input_ID must be explicitly specified.
-        local caller_source_filename="$( basename $caller_source )"
-        local hash_input=$( echo "$caller_source_filename" "${choices[@]}" "$prompt" "$default_input" | tr -c -d '[:alnum:]' | tr '[:upper:]' '[:lower:]' )
-        # Neither 'sum' nor 'cksum' is in PROGS nor REQUIRED_PROGS so that 'md5sum' is used if it is there.
-        # Because 'md5sum' is only in PROGS but not in REQUIRED_PROGS do a simple fallback if 'md5sum' is not there:
-        local hash_hex=""
-        if has_binary md5sum ; then
-            # Have hash_hex as an array so that plain $hash_hex is the actual md5sum
-            # because 'md5sum' outputs the actual md5sum plus the filename (which is '-' here for stdin):
-            hash_hex=( $( echo "$hash_input" | md5sum ) )
-        else
-            Log "No 'md5sum' there, using simple fallback to generate user_input_ID"
-            # The md5sum is a 32 characters hex-number so that we produce that also as fallback.
-            # The main drawback of the simple fallback is that only the first 32 input characters matter:
-            local lower_alnum='0123456789abcdefghijklmnopqrstuvwxyz'
-            # Avoid possibly leading '0' digits to get a hex-number with 32 significant digits:
-            local hex_no_null='123456789abcdef123456789abcdef123456'
-            hash_hex=$( echo "$hash_input" | tr -c -d "$lower_alnum" | tr "$lower_alnum" "$hex_no_null" | head -c 32 )
-        fi
-        # The actual md5sum is a 32 characters hex-number like 'b1946ac92492d2347c6235b4d2611184'
-        # which results a decimal integer up to 340282366920938463463374607431768211455 (it has 39 digits) as result of
-        #   echo "ibase=16; FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" | bc -l
-        # Note that 'bc' requires upper case characters for hex-number input:
-        local hash_uppercase=$( echo $hash_hex | tr '[:lower:]' '[:upper:]' )
-        local hash_decimal=$( echo "ibase=16 ; $hash_uppercase" | bc -l )
-        # In bash 3.x the array index must be a decimal integer number up to 2^63 - 1 = 9223372036854775807 (it has 19 digits)
-        # so that the md5sum output must be converted into a decimal integer number with 18 digits.
-        # Because all substrings of a good hash (and md5 is reasonably good despite being cryptographically unsafe)
-        # are equally random one can take any bits you like from the string, cf.
-        # https://crypto.stackexchange.com/questions/26850/what-is-degree-of-randomness-in-individual-bits-of-md5-hash
-        # https://stackoverflow.com/questions/3819712/is-any-substring-of-a-hash-md5-sha1-more-random-than-another
-        # we take the first 18 digits of the up to 39 digits from the decimal integer md5sum as generated user_input_ID:
-        user_input_ID=$( echo $hash_decimal | head -c 18 )
-        # In debug mode show the user the script that called UserInput and what generated user_input_ID it has
-        # so that the user can prepare an automated response for that UserInput call (without digging in the code):
-        DebugPrint "UserInput (generated ID $user_input_ID) needed in ${caller_source[@]}"
-    fi
+    # In debug mode show the user the script that called UserInput and what user_input_ID was specified
+    # so that the user can prepare an automated response for that UserInput call (without digging in the code):
+    DebugPrint "UserInput -I $user_input_ID needed in ${caller_source[@]}"
     # First of all show the prompt unless an empty prompt was specified (via -p '')
     # so that the prompt can be used as some kind of header line that introduces the user input
     # and separates the following user input from arbitrary other output lines before:
@@ -625,9 +571,10 @@ function UserInput () {
     test "$input_delimiter" && read_options_and_arguments="$read_options_and_arguments -d $input_delimiter"
     # Get the user input:
     local user_input=""
-    # When a (non empty) predefined user input value exists use that as automated user input:
-    if test "${USER_INPUT_VALUES[$user_input_ID]:-}" ; then
-        LogUserOutput "UserInput: Will use predefined input '${USER_INPUT_VALUES[$user_input_ID]}' from USER_INPUT_VALUES[$user_input_ID]"
+    # When a predefined user input value exists use that as automated user input:
+    local predefined_input_variable_name="UserInput_$user_input_ID"
+    if test "${!predefined_input_variable_name:-}" ; then
+        LogUserOutput "UserInput: Will use predefined input in '$predefined_input_variable_name'"
         # Let the user interrupt the automated user input:
         LogUserOutput "Hit any key to interrupt the automated input (timeout $automated_input_interrupt_timeout seconds)"
         # automated_input_interrupt_timeout is at least 1 second (see above) and do not echo the input (it is meaningless here):
@@ -637,7 +584,7 @@ function UserInput () {
             test "$prompt" && LogUserOutput "$prompt" || LogUserOutput "$default_prompt"
             test "$default_and_timeout" && LogUserOutput "($default_and_timeout)"
         else
-            user_input="${USER_INPUT_VALUES[$user_input_ID]}"
+            user_input="${!predefined_input_variable_name}"
             # When a (non empty) output_array was specified it must contain all user input words:
             test "$output_array" && read -a "$output_array" <<<"$user_input"
         fi

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -580,7 +580,7 @@ function UserInput () {
     # When a predefined user input value exists use that as automated user input:
     local predefined_input_variable_name="USER_INPUT_$user_input_ID"
     if test "${!predefined_input_variable_name:-}" ; then
-        LogUserOutput "UserInput: Will use predefined input in '$predefined_input_variable_name'"
+        LogUserOutput "UserInput: Will use predefined input in '$predefined_input_variable_name'='${!predefined_input_variable_name}'"
         # Let the user interrupt the automated user input:
         LogUserOutput "Hit any key to interrupt the automated input (timeout $automated_input_interrupt_timeout seconds)"
         # automated_input_interrupt_timeout is at least 1 second (see above) and do not echo the input (it is meaningless here):

--- a/usr/share/rear/restore/BORG/default/300_load_archives.sh
+++ b/usr/share/rear/restore/BORG/default/300_load_archives.sh
@@ -45,7 +45,7 @@ while true ; do
     UserOutput ""
 
     # Read user input.
-    choice="$( UserInput -p "Choose archive to recover from" )"
+    choice="$( UserInput -I BORGBACKUP_archive_to_recover -p "Choose archive to recover from" )"
 
     # Evaluate user selection and save archive name to restore.
     # Valid pick

--- a/usr/share/rear/restore/BORG/default/300_load_archives.sh
+++ b/usr/share/rear/restore/BORG/default/300_load_archives.sh
@@ -45,7 +45,7 @@ while true ; do
     UserOutput ""
 
     # Read user input.
-    choice="$( UserInput -I BORGBACKUP_archive_to_recover -p "Choose archive to recover from" )"
+    choice="$( UserInput -I BORGBACKUP_ARCHIVE_TO_RECOVER -p "Choose archive to recover from" )"
 
     # Evaluate user selection and save archive name to restore.
     # Valid pick

--- a/usr/share/rear/restore/FDRUPSTREAM/default/270_selinux_considerations.sh
+++ b/usr/share/rear/restore/FDRUPSTREAM/default/270_selinux_considerations.sh
@@ -24,10 +24,12 @@ SELinux is currently set to enforcing mode.
 Relabeling of the root filesystem may be required
 in order to allow login of the restored system."
 
+# When USER_INPUT_SELINUX_RELABEL_ON_NEXT_BOOT has any 'true' value be liberal in what you accept and assume exactly 'y' was actually meant:
+is_true "$USER_INPUT_SELINUX_RELABEL_ON_NEXT_BOOT" && USER_INPUT_SELINUX_RELABEL_ON_NEXT_BOOT="y"
 while true ; do
     # According to what is shown to the user "Relabeling ... required ... to allow login"
     # the default (i.e. the automated respose after the timeout) should be 'y':
-    answer="$( UserInput -I SELinux_relabel_on_next_boot -p "Would you like to relabel on next boot? (y/n)" -D 'y' )"
+    answer="$( UserInput -I SELINUX_RELABEL_ON_NEXT_BOOT -p "Would you like to relabel on next boot? (y/n)" -D 'y' )"
     is_false "$answer" && break
     if is_true "$answer" ; then
         touch $TARGET_FS_ROOT/.autorelabel

--- a/usr/share/rear/restore/FDRUPSTREAM/default/270_selinux_considerations.sh
+++ b/usr/share/rear/restore/FDRUPSTREAM/default/270_selinux_considerations.sh
@@ -27,7 +27,7 @@ in order to allow login of the restored system."
 while true ; do
     # According to what is shown to the user "Relabeling ... required ... to allow login"
     # the default (i.e. the automated respose after the timeout) should be 'y':
-    answer="$( UserInput -p "Would you like to relabel on next boot? (y/n)" -D 'y' )"
+    answer="$( UserInput -I SELinux_relabel_on_next_boot -p "Would you like to relabel on next boot? (y/n)" -D 'y' )"
     is_false "$answer" && break
     if is_true "$answer" ; then
         touch $TARGET_FS_ROOT/.autorelabel

--- a/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
@@ -48,11 +48,15 @@ Verify that the backup has been restored correctly to '$TARGET_FS_ROOT'.
 
 user_input_prompt="
 Have you successfully restored the backup to $TARGET_FS_ROOT ?
-Are you ready ro continue recovery? (y/n)"
+Are you ready to continue recovery? (y/n)"
 
 while true ; do
-    # Restoring the backup may take arbitrary long time so that with explicit '-t 0' it wait endlessly for user input:
-    if is_true "$( UserInput -t 0 -p "$user_input_prompt" )" ; then
+    # Restoring the backup may take arbitrary long time so that with explicit '-t 0' it waits endlessly for user input.
+    # Automated user input via a predefined UserInput_NBKDC_wait_until_restore_succeeded variable does not make sense here
+    # but the UserInput function must be called with a meaningful '-I user_input_ID' option value explicitly specified.
+    # To avoid that a predefined UserInput_NBKDC_wait_until_restore_succeeded variable could cause harm here it is unset:
+    unset UserInput_NBKDC_wait_until_restore_succeeded
+    if is_true "$( UserInput -I NBKDC_wait_until_restore_succeeded -t 0 -p "$user_input_prompt" )" ; then
         LogUserOutput "Done with restore. Continuing recovery."
         break
     fi

--- a/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
@@ -50,12 +50,12 @@ user_input_prompt="
 Have you successfully restored the backup to $TARGET_FS_ROOT ?
 Are you ready to continue recovery? (y/n)"
 
+# Restoring the backup may take arbitrary long time so that with explicit '-t 0' it waits endlessly for user input.
+# Automated user input via a predefined USER_INPUT_NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED variable does not make sense here
+# but the UserInput function must be called with a meaningful '-I user_input_ID' option value explicitly specified.
+# To avoid that a predefined USER_INPUT_NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED variable could cause harm here it is unset:
+unset USER_INPUT_NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED
 while true ; do
-    # Restoring the backup may take arbitrary long time so that with explicit '-t 0' it waits endlessly for user input.
-    # Automated user input via a predefined USER_INPUT_NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED variable does not make sense here
-    # but the UserInput function must be called with a meaningful '-I user_input_ID' option value explicitly specified.
-    # To avoid that a predefined USER_INPUT_NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED variable could cause harm here it is unset:
-    unset USER_INPUT_NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED
     if is_true "$( UserInput -I NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED -t 0 -p "$user_input_prompt" )" ; then
         LogUserOutput "Done with restore. Continuing recovery."
         break

--- a/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
@@ -52,11 +52,11 @@ Are you ready to continue recovery? (y/n)"
 
 while true ; do
     # Restoring the backup may take arbitrary long time so that with explicit '-t 0' it waits endlessly for user input.
-    # Automated user input via a predefined UserInput_NBKDC_wait_until_restore_succeeded variable does not make sense here
+    # Automated user input via a predefined USER_INPUT_NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED variable does not make sense here
     # but the UserInput function must be called with a meaningful '-I user_input_ID' option value explicitly specified.
-    # To avoid that a predefined UserInput_NBKDC_wait_until_restore_succeeded variable could cause harm here it is unset:
-    unset UserInput_NBKDC_wait_until_restore_succeeded
-    if is_true "$( UserInput -I NBKDC_wait_until_restore_succeeded -t 0 -p "$user_input_prompt" )" ; then
+    # To avoid that a predefined USER_INPUT_NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED variable could cause harm here it is unset:
+    unset USER_INPUT_NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED
+    if is_true "$( UserInput -I NBKDC_WAIT_UNTIL_RESTORE_SUCCEEDED -t 0 -p "$user_input_prompt" )" ; then
         LogUserOutput "Done with restore. Continuing recovery."
         break
     fi


### PR DESCRIPTION
Now each UserInput function call requires
a specified '-I user_input_ID' option and
the autogenerated user_input_ID is gone.

Now the user_input_ID option value can and must be
a valid bash variable name e.g. 'choose_replacement_disk'
so that the user can (if he wants) specify a variable named
UserInput_choose_replacement_disk
(i.e. the user_input_ID option value with prefix 'UserInput_')
where its value is used as automated input.

This way meaningful variable names for automated UserInput
are implemented in a generic way using plain bash syntax
without any restriction how the user needs to specify
his particular automated input settings.

The user can do this statically in his local.conf like
UserInput_choose_replacement_disk="/dev/sda"
or via whatever sophisticated scripting magic as he likes
(e.g. also local.conf is sourced and executed as a script).
