### PR TITLE
BACKUP_PROG_OPTIONS used to be a string variable, turn it into an array

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -76,14 +76,14 @@ case "$(basename ${BACKUP_PROG})" in
 		set_tar_features
 		Log $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
 			--no-wildcards-match-slash --one-file-system \
-			--ignore-failed-read $BACKUP_PROG_OPTIONS \
+			--ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}" \
 			$BACKUP_PROG_CREATE_NEWER_OPTIONS \
 			${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
 			-X $TMP_DIR/backup-exclude.txt -C / -c -f - \
 			$(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
 		$BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
 			--no-wildcards-match-slash --one-file-system \
-			--ignore-failed-read $BACKUP_PROG_OPTIONS \
+			--ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}" \
 			$BACKUP_PROG_CREATE_NEWER_OPTIONS \
 			${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
 			-X $TMP_DIR/backup-exclude.txt -C / -c -f - \
@@ -103,11 +103,11 @@ case "$(basename ${BACKUP_PROG})" in
 		Log "Using unsupported backup program '$BACKUP_PROG'"
 		Log $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
 			$BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
-			$BACKUP_PROG_OPTIONS $backuparchive \
+			"${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
 			$(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
 		$BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
 			$BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
-			$BACKUP_PROG_OPTIONS $backuparchive \
+			"${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
 			$(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
 	;;
 esac 2> "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -503,7 +503,8 @@ BACKUP_PROG_WARN_PARTIAL_TRANSFER=1
 # then you also have to set the CREATE and RESTORE archive options. They are *ignored* if the
 # backup program is supported.
 # default setting for BACKUP_PROG_OPTIONS="" became "--anchored" (GD, 02/DEC/2014 - issue #475)
-BACKUP_PROG_OPTIONS="--anchored"
+# BACKUP_PROG_OPTIONS used to be a string variable, turn it into an array (GD, 06/SEP/2017 - issue #1175)
+BACKUP_PROG_OPTIONS=( "--anchored" )
 # for unsupported backup programs, the last CREATE_ARCHIVE option must be to read excludes from a file
 # (like tar -X filename). Furthermore, you should include an option for verbose output to stdout and
 # an option to stay on the local filesystem (like tar --one-file-system) and maybe options to handle

--- a/usr/share/rear/prep/NETFS/GNU/Linux/205_inspect_tar_capabilities.sh
+++ b/usr/share/rear/prep/NETFS/GNU/Linux/205_inspect_tar_capabilities.sh
@@ -3,35 +3,35 @@
 # add these to the BACKUP_PROG_OPTIONS array
 # See also issue https://github.com/rear/rear/issues/1175
 
-# As we will only inspect 'tar' we make one big if block:
+# As we will only inspect 'tar' we will return if BACKUP_PROG=rsync
+[[ "$(basename $BACKUP_PROG)" != "tar" ]] && return
 
-if [[ "$(basename $BACKUP_PROG)" = "tar" ]] ; then
-    # Verify extended attributes being present:
-    if tar --usage | grep -q -- --xattrs ; then
-        BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--xattrs" )
-        PROGS=( "${PROGS[@]}" getfattr setfattr )
-    fi
-
-    # Verify extended capabilities are present (incl. SElinux security capabilities)
-    # For example : getcap /bin/ping
-    #  /bin/ping = cap_net_admin,cap_net_raw+p
-    # After recovery we should see the same capabilities
-
-    if tar --usage | grep -q -- --xattrs-include ; then
-        BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--xattrs-include=security.capability" "--xattrs-include=security.selinux" )
-        # prep/GNU/Linux/310_include_cap_utils.sh uses NETFS_RESTORE_CAPABILITIES=( 'Yes' ) to kick in next line, and is
-        # meant to save capabilities via rescue/NETFS/default/610_save_capabilities.sh
-        # Here we try to achieve the same via the 'tar' program
-        PROGS=( "${PROGS[@]}" getcap setcap )
-    fi
-    if tar --usage | grep -q -- --acls ; then
-       BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--acls" )
-       PROGS=( "${PROGS[@]}" getfacl setfacl )
-    fi
-
-    # --selinux option was covered by script 200_selinux_in_use.sh
-
-    # save the BACKUP_PROG_OPTIONS array content to the $ROOTFS_DIR/etc/rear/rescue.conf
-    # we need that for the restore part with tar
-    echo "BACKUP_PROG_OPTIONS=( ${BACKUP_PROG_OPTIONS[@]} )" >> $ROOTFS_DIR/etc/rear/rescue.conf
+# BACKUP_PROG=tar - continue:
+# Verify extended attributes being present:
+if tar --usage | grep -q -- --xattrs ; then
+    BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--xattrs" )
+    PROGS=( "${PROGS[@]}" getfattr setfattr )
 fi
+
+# Verify extended capabilities are present (incl. SElinux security capabilities)
+# For example : getcap /bin/ping
+#  /bin/ping = cap_net_admin,cap_net_raw+p
+# After recovery we should see the same capabilities
+
+if tar --usage | grep -q -- --xattrs-include ; then
+    BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--xattrs-include=security.capability" "--xattrs-include=security.selinux" )
+    # prep/GNU/Linux/310_include_cap_utils.sh uses NETFS_RESTORE_CAPABILITIES=( 'Yes' ) to kick in next line, and is
+    # meant to save capabilities via rescue/NETFS/default/610_save_capabilities.sh
+    # Here we try to achieve the same via the 'tar' program
+    PROGS=( "${PROGS[@]}" getcap setcap )
+fi
+if tar --usage | grep -q -- --acls ; then
+   BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--acls" )
+   PROGS=( "${PROGS[@]}" getfacl setfacl )
+fi
+
+# --selinux option was covered by script 200_selinux_in_use.sh
+
+# save the BACKUP_PROG_OPTIONS array content to the $ROOTFS_DIR/etc/rear/rescue.conf
+# we need that for the restore part with tar
+echo "BACKUP_PROG_OPTIONS=( ${BACKUP_PROG_OPTIONS[@]} )" >> $ROOTFS_DIR/etc/rear/rescue.conf

--- a/usr/share/rear/prep/NETFS/GNU/Linux/205_inspect_tar_capabilities.sh
+++ b/usr/share/rear/prep/NETFS/GNU/Linux/205_inspect_tar_capabilities.sh
@@ -1,0 +1,31 @@
+# prep/NETFS/GNU/Linux/205_inspect_tar_capabilities.sh
+# The purpose is to inspect the 'tar --usage' for certain capabilities and if found
+# add these to the BACKUP_PROG_OPTIONS array
+# See also issue https://github.com/rear/rear/issues/1175
+
+# As we will only inspect 'tar' we make one big if block:
+
+if [[ "$(basename $BACKUP_PROG)" = "tar" ]] ; then
+    # Verify extended attributes being present:
+    if tar --usage | grep -q "\-\-xattrs" ; then
+        BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--xattrs" )
+        PROGS=( "${PROGS[@]}" getfattr setfattr )
+    fi
+
+    # Verify extended capabilities are present (incl. SElinux security capabilities)
+    # For example : getcap /bin/ping
+    #  /bin/ping = cap_net_admin,cap_net_raw+p
+    # After recovery we should see the same capabilities
+
+    if tar --usage | grep -q "\-\-xattrs-include" ; then
+        BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--xattrs-include=security.capability" "--xattrs-include=security.selinux" )
+        # prep/GNU/Linux/310_include_cap_utils.sh uses NETFS_RESTORE_CAPABILITIES=( 'Yes' ) to kick in next line, and is
+        # meant to save capabilities via rescue/NETFS/default/610_save_capabilities.sh
+        # Here we try to achieve the same via the 'tar' program
+        PROGS=( "${PROGS[@]}" getcap setcap )
+    fi
+    if tar --usage | grep -q "\-\-acls" ; then
+       BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--acls" )
+       PROGS=( "${PROGS[@]}" getfacl setfacl )
+    fi
+fi

--- a/usr/share/rear/prep/NETFS/GNU/Linux/205_inspect_tar_capabilities.sh
+++ b/usr/share/rear/prep/NETFS/GNU/Linux/205_inspect_tar_capabilities.sh
@@ -7,7 +7,7 @@
 
 if [[ "$(basename $BACKUP_PROG)" = "tar" ]] ; then
     # Verify extended attributes being present:
-    if tar --usage | grep -q "\-\-xattrs" ; then
+    if tar --usage | grep -q -- --xattrs ; then
         BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--xattrs" )
         PROGS=( "${PROGS[@]}" getfattr setfattr )
     fi
@@ -17,15 +17,21 @@ if [[ "$(basename $BACKUP_PROG)" = "tar" ]] ; then
     #  /bin/ping = cap_net_admin,cap_net_raw+p
     # After recovery we should see the same capabilities
 
-    if tar --usage | grep -q "\-\-xattrs-include" ; then
+    if tar --usage | grep -q -- --xattrs-include ; then
         BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--xattrs-include=security.capability" "--xattrs-include=security.selinux" )
         # prep/GNU/Linux/310_include_cap_utils.sh uses NETFS_RESTORE_CAPABILITIES=( 'Yes' ) to kick in next line, and is
         # meant to save capabilities via rescue/NETFS/default/610_save_capabilities.sh
         # Here we try to achieve the same via the 'tar' program
         PROGS=( "${PROGS[@]}" getcap setcap )
     fi
-    if tar --usage | grep -q "\-\-acls" ; then
+    if tar --usage | grep -q -- --acls ; then
        BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--acls" )
        PROGS=( "${PROGS[@]}" getfacl setfacl )
     fi
+
+    # --selinux option was covered by script 200_selinux_in_use.sh
+
+    # save the BACKUP_PROG_OPTIONS array content to the $ROOTFS_DIR/etc/rear/rescue.conf
+    # we need that for the restore part with tar
+    echo "BACKUP_PROG_OPTIONS=( ${BACKUP_PROG_OPTIONS[@]} )" >> $ROOTFS_DIR/etc/rear/rescue.conf
 fi

--- a/usr/share/rear/prep/NETFS/default/040_inspect_configuration_files.sh
+++ b/usr/share/rear/prep/NETFS/default/040_inspect_configuration_files.sh
@@ -1,0 +1,10 @@
+# prep/NETFS/default/040_inspect_configuration_files.sh
+# Purpose of this script is to inspect configuration items which may change over time
+# such as the BACKUP_PROG_OPTIONS variable that becomes an array in rear-2.3
+
+# If the user defines in local.conf for example: BACKUP_PROG_OPTIONS="--option1 --option2" then you will see 
+# the following error message to turn your local setting into an arrary
+[[ ${#BACKUP_PROG_OPTIONS[@]} -eq 1 && "$BACKUP_PROG_OPTIONS" == *\ * ]] && \
+Error "The BACKUP_PROG_OPTIONS variable is now a Bash array and not a string. Please update your configuration to look like this:${IFS}BACKUP_PROG_OPTIONS+=( $BACKUP_PROG_OPTIONS )"
+
+# We can add other checks below (in the future)

--- a/usr/share/rear/prep/RSYNC/GNU/Linux/200_selinux_in_use.sh
+++ b/usr/share/rear/prep/RSYNC/GNU/Linux/200_selinux_in_use.sh
@@ -11,7 +11,7 @@ else
 fi
 
 # check global settings (see default.conf)
-if [[ "$BACKUP_SELINUX_DISABLE" =~ ^[yY1] ]]; then
+if is_true "$BACKUP_SELINUX_DISABLE" ; then
         cat $SELINUX_ENFORCE  > $TMP_DIR/selinux.mode
         RSYNC_SELINUX=
         return
@@ -43,7 +43,7 @@ case $(basename $BACKUP_PROG) in
 	(tar)
 		if tar --usage | grep -q selinux  ; then
 			# during backup we will NOT disable SELinux
-			BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --selinux"
+			BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--selinux" )
 
 			# include SELinux utilities and /etc/selinux directory so rescue/restore ReaR image can run with SELinux enabled
 			PROGS=( "${PROGS[@]}" getenforce setenforce sestatus setfiles chcon restorecon )

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -106,14 +106,14 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                 # Add the --selinux option to be safe with SELinux context restoration
                 if ! is_true "$BACKUP_SELINUX_DISABLE" ; then
                     if tar --usage | grep -q selinux ; then
-                        BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --selinux"
+                        BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--selinux" )
                     fi
                 fi
                 if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
-                    BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --exclude-from=$TMP_DIR/restore-exclude-list.txt "
+                    BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--exclude-from=$TMP_DIR/restore-exclude-list.txt" )
                 fi
-                Log dd if=$restore_input \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
-                dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                Log dd if=$restore_input \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
                 ;;
             (rsync)
                 if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
@@ -124,7 +124,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                 ;;
             (*)
                 Log "Using unsupported backup restore program '$BACKUP_PROG'"
-                $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" $BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE $TARGET_FS_ROOT $BACKUP_PROG_OPTIONS $restore_input
+                $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" $BACKUP_PROG_OPTIONS_RESTORE_ARCHIVE $TARGET_FS_ROOT "${BACKUP_PROG_OPTIONS[@]}" $restore_input
                 ;;
         esac >"${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log"
         # Important trick: The backup prog is the last command in each case entry and the case..esac is the last command

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -104,11 +104,12 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
     (   case "$BACKUP_PROG" in
             (tar)
                 # Add the --selinux option to be safe with SELinux context restoration
-                if ! is_true "$BACKUP_SELINUX_DISABLE" ; then
-                    if tar --usage | grep -q selinux ; then
-                        BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--selinux" )
-                    fi
-                fi
+                # This block can be removed as BACKUP_PROG_OPTIONS was written to rescue.conf
+                #if ! is_true "$BACKUP_SELINUX_DISABLE" ; then
+                    #if tar --usage | grep -q selinux ; then
+                        #BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--selinux" )
+                    #fi
+                #fi
                 if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
                     BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--exclude-from=$TMP_DIR/restore-exclude-list.txt" )
                 fi


### PR DESCRIPTION
BACKUP_PROG_OPTIONS used to be a string variable, turn it into an array (GD, 06/SEP/2017 - issue #1175)

added new script prep/NETFS/GNU/Linux/205_inspect_tar_capabilities.sh which will automatically add capabilities to the BACKUP_PROG_OPTIONS array