### PR TITLE
Do not 'simply return' when 'set-eu' is set.

### DIFF
--- a/usr/share/rear/restore/ZYPPER/default/980_initial_network_setup.sh
+++ b/usr/share/rear/restore/ZYPPER/default/980_initial_network_setup.sh
@@ -11,15 +11,17 @@
 # should be done manually by the admin after "rear recover".
 #
 
-# Try to care about possible errors
-# see https://github.com/rear/rear/wiki/Coding-Style
-set -e -u -o pipefail
-
 # Do nothing when no initial network setup should be done:
 # Using the '[*]' subscript is required here otherwise test gets more than one argument
 # which fails with bash error 'bash: test: ...: unary operator expected'
 # cf. https://github.com/rear/rear/issues/1068#issuecomment-282741981
+# Do this test before "set -e -u" is set to be able to "simply return" here without an
+# apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS":
 test "${ZYPPER_NETWORK_SETUP_COMMANDS[*]:-}" || return
+
+# Try to care about possible errors
+# see https://github.com/rear/rear/wiki/Coding-Style
+set -e -u -o pipefail
 
 # Initial network setup in the target system.
 # Use a login shell in between so that one has in the chrooted environment


### PR DESCRIPTION
When 'set-e' is set one cannot 'simply return' from a script.
When 'set-e' is set one must always call
<pre>
apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"
</pre>
before returnig into other code where 'set-e' is not set.
Otherwise there happen arbitrary unexpected failures elsewhere
because "the rest of the ReaR code" is not at all ready to
run correctly when 'set -e' is set, see also
https://github.com/rear/rear/issues/700
