### PR TITLE
Update 310_include_uefi_tools.sh

### DIFF
--- a/usr/share/rear/prep/default/310_include_uefi_tools.sh
+++ b/usr/share/rear/prep/default/310_include_uefi_tools.sh
@@ -4,14 +4,12 @@ if grep -qw 'noefi' /proc/cmdline; then
 fi
 
 # If no /boot/[eE][fF][iI] directory can be found we might not be able to copy the UEFI binaries.
-if [[ ! -d /boot/[eE][fF][iI] ]]; then
+if [[ ! -d /boot/[eE][fF][iI] || ! mountpoint -q /boot/[eE][fF][iI] ]]; then
     if is_true $USING_UEFI_BOOTLOADER; then
         Error "USING_UEFI_BOOTLOADER = 1 but there is no directory at /boot/efi or /boot/EFI" # abort
     fi
-    if ! grep -q '/boot/efi' /proc/mounts; then
-        return # skip
-    fi
- fi
+    return # skip
+fi
 
 # We copy the UEFI binaries we might need
 REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}"

--- a/usr/share/rear/prep/default/310_include_uefi_tools.sh
+++ b/usr/share/rear/prep/default/310_include_uefi_tools.sh
@@ -8,7 +8,9 @@ if [[ ! -d /boot/[eE][fF][iI] ]]; then
     if is_true $USING_UEFI_BOOTLOADER; then
         Error "USING_UEFI_BOOTLOADER = 1 but there is no directory at /boot/efi or /boot/EFI" # abort
     fi
-    return # skip
+    if ! grep -q '/boot/efi' /proc/mounts; then
+        return # skip
+    fi
  fi
 
 # We copy the UEFI binaries we might need


### PR DESCRIPTION
This change should resolve issue of rear terminating if /boot/efi directory is not mounted