### PR TITLE
Avoid apply_layout_mappings Error if input file is empty

### DIFF
--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
@@ -24,17 +24,22 @@ for file in     [b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* [b]oot/grub/
 
 	[[ ! -f $file ]] && continue # skip directory or file not found
         # sed -i bails on symlinks, so we follow the symlink and patch the result
-        # on dead links we warn and skip them
-        # TODO: maybe we must put this into a chroot so that absolute symlinks will work correctly
+        # - absolute link are rebased on $TARGET_FS_ROOT (/etc/fstab => $TARGET_FS_ROOT/etc/fstab)
+        # - on dead links we warn and skip them
         if [[ -L "$file" ]] ; then
-                if linkdest="$(readlink -f "$file")" ; then
-                        LogPrint "Patching '$linkdest' instead of '$file'"
-                        file="$linkdest"
+                linkdest="$(readlink -m "$file" | sed -e "s#^/#$TARGET_FS_ROOT/#" )"
+                if test -f $linkdest ; then
+                    LogPrint "Patching '$linkdest' instead of '$file'"
+                    file="$linkdest"
                 else
-                        LogPrint "Not patching dead link '$file'"
-                        continue
+                    LogPrint "Not patching dead link '$file' -> '$linkdest'"
+                    continue
                 fi
         fi
 
-        apply_layout_mappings "$file"
+        if test -s "$file" ; then
+            apply_layout_mappings "$file"
+        else
+            LogPrint "Not Patching empty file ($file)"
+        fi
 done

--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
@@ -28,7 +28,7 @@ for file in     [b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* [b]oot/grub/
         # - on dead links we warn and skip them
         if [[ -L "$file" ]] ; then
                 linkdest="$(readlink -m "$file" | sed -e "s#^/#$TARGET_FS_ROOT/#" )"
-                if test -f $linkdest ; then
+                if test -f "$linkdest" ; then
                     LogPrint "Patching '$linkdest' instead of '$file'"
                     file="$linkdest"
                 else

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -752,10 +752,10 @@ function get_part_device_name_format() {
 function apply_layout_mappings() {
 
     # apply_layout_mappings need one argument (a non-empty file which contains disk device to migrate).
-    if [ -s "$1" ] ; then
-        file_to_migrate="$1"
+    if [ -z $1 ] ; then
+        BugError "apply_layout_mappings function called without argument (file_to_migrate)."
     else
-        BugError "apply_layout_mappings function called without argument (file_to_migrate) or argument is not a non-empty file."
+        file_to_migrate="$1"
     fi
 
     if [ -z "$MIGRATION_MODE" ] ; then

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -759,7 +759,7 @@ function apply_layout_mappings() {
             fi
         }
 
-        # Step-1 replace all source devices with a unique word (the "replacement" )
+        # Step-1 replace all source devices with a unique word (the "replacement")
         let replaced_count=0
         while read source target junk ; do
             if ! has_replacement "$source" ; then

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -687,7 +687,7 @@ function get_replacement() {
 }
 # Guess the part device name from a device, based on the OS distro Level.
 function get_part_device_name_format() {
-    if [ -z $1 ] ; then
+    if [ -z "$1" ] ; then
         BugError "get_part_device_name_format function called without argument (device)"
     else
         device_name="$1"
@@ -754,9 +754,8 @@ function apply_layout_mappings() {
     # apply_layout_mappings need one argument.
     [ "$1" ] || BugError "apply_layout_mappings function called without argument (file_to_migrate)."
 
-    if [ -z "$MIGRATION_MODE" ] ; then
-        return 0
-    fi
+    # Exit if MIGRATION_MODE is not true.
+    is_true "$MIGRATION_MODE" ] || return 0
 
     # Only apply layout mapping on non-empty file.
     if [ -s "$1" ] ; then


### PR DESCRIPTION
- @schlomo, The change made in d89623404c08cf8b4b485e35295fb4caf2a35232 can produce error in some Linux Distro (like Sles11). 
It is not directly link with the Linux version, but how scripts are dealing with `apply_layout_mappings()` function. In `250_migrate_disk_devices_layout.sh` a list of file to migrate is provided to the function. Depending to the configuration, some of them can e empty (or a link which point to an empty file.)

I think we just need to be sure that the function is called with 1 argument... 
But the fact to provide an empty file to the function should not produce an ERROR which kill the recovery process. After all, if the file is empty, no modification will be done.

- I also made some changes in `250_migrate_disk_devices_layout.sh` in order to modify link target when absolute path is used. @schlomo @jsmeix your feedback/review is welcome here. (other scripts in finalize workflow  should be modified in the same way, but lets validate this one before changing the others.)
