### PR TITLE
Fix UEFI tools integration (should address issues in #1477, #1478)

### DIFF
--- a/usr/share/rear/prep/default/330_include_uefi_tools.sh
+++ b/usr/share/rear/prep/default/330_include_uefi_tools.sh
@@ -1,19 +1,10 @@
 #
-# 310_include_uefi_tools.sh
+# 330_include_uefi_tools.sh
 # Copy UEFI binaries we might need into the ReaR recovery system.
 #
 
-# If 'noefi' is set on the kernel commandline, ignore UEFI altogether:
-grep -qw 'noefi' /proc/cmdline && return
-
-# If no /boot/[eE][fF][iI] directory can be found
-# we might not be able to copy the UEFI binaries:
-if ! test -d /boot/[eE][fF][iI] ; then
-    if is_true $USING_UEFI_BOOTLOADER; then
-        Error "USING_UEFI_BOOTLOADER is set but there is no directory /boot/efi or /boot/EFI"
-    fi
-    return
-fi
+# Include UEFI tools on demand only
+is_true $USING_UEFI_BOOTLOADER || return
 
 # Copy UEFI binaries we might need:
 REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" dosfsck efibootmgr )

--- a/usr/share/rear/prep/default/330_include_uefi_tools.sh
+++ b/usr/share/rear/prep/default/330_include_uefi_tools.sh
@@ -1,5 +1,4 @@
 #
-# 330_include_uefi_tools.sh
 # Copy UEFI binaries we might need into the ReaR recovery system.
 #
 


### PR DESCRIPTION
This change integrates UEFI tools on demand as determined by `320_include_uefi_env.sh`.

It avoids replicating UEFI tests already done in `320_include_uefi_env.sh` and just relies on a correctly set `$USING_UEFI_BOOTLOADER` variable. For such variable to be set correctly, `310_include_uefi_tools.sh` is renamed to `330_include_uefi_tools.sh`.