### PR TITLE
In 300_map_disks.sh use runtime generated UserInput-IDs

### DIFF
--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -148,11 +148,17 @@ while read keyword orig_device orig_size junk ; do
     prompt="Choose an appropriate replacement for $preferred_orig_device_name"
     choice=""
     wilful_input=""
-    # TODO: Currently only one single USER_INPUT_LAYOUT_MIGRATION_REPLACEMENT_DISK
-    # can be predefined (which is at least better than nothing) but that dialog can appear
-    # several times for several unmapped original 'disk' devices and 'multipath' devices:
+    # Generate a runtime-specific user_input_ID so that for each unmapped original device
+    # a different user_input_ID is used for the UserInput call so that the user can specify
+    # for each unmapped original device a different predefined user input.
+    # Only uppercase letters and digits are used to ensure the user_input_ID is a valid bash variable name
+    # (otherwise the UserInput call could become invalid which aborts 'rear recover' with a BugError) and
+    # hopefully only uppercase letters and digits are sufficient to distinguish different devices:
+    current_orig_device_basename_alnum_uppercase="$( basename "$preferred_orig_device_name" | tr -d -c '[:alnum:]' | tr '[:lower:]' '[:upper:]' )"
+    test "$current_orig_device_basename_alnum_uppercase" || current_orig_device_basename_alnum_uppercase="DISK"
+    user_input_ID="LAYOUT_MIGRATION_REPLACEMENT_$current_orig_device_basename_alnum_uppercase"
     until IsInArray "$choice" "${regular_choices[@]}" ; do
-        choice="$( UserInput -I LAYOUT_MIGRATION_REPLACEMENT_DISK -p "$prompt" -D 0 "${regular_choices[@]}" "$rear_shell_choice" )" && wilful_input="yes" || wilful_input="no"
+        choice="$( UserInput -I $user_input_ID -p "$prompt" -D 0 "${regular_choices[@]}" "$rear_shell_choice" )" && wilful_input="yes" || wilful_input="no"
         test "$rear_shell_choice" = "$choice" && rear_shell
     done
     # Continue with next original device when the user selected to not map it:

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -188,9 +188,8 @@ prompt="Confirm or edit the disk mapping"
 choice=""
 wilful_input=""
 # When USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS has any 'true' value be liberal in what you accept and
-# assume choices[0] 'Confirm mapping' was actually meant which is shown with choice number 1 (not 0) and
-# a predefined user input must match the choice number that is shown to the user (not the choice index):
-is_true "$USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS" && USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS="1"
+# assume choices[0] 'Confirm mapping' was actually meant:
+is_true "$USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS" && USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS="${choices[0]}"
 while true ; do
     LogUserOutput 'Current disk mapping table (source -> target):'
     LogUserOutput "$( sed -e 's|^|    |' "$MAPPING_FILE" )"

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -640,6 +640,13 @@ function UserInput () {
         # When there is a real default input but no real user input use the default input as user input:
         DebugPrint "UserInput: No real user input (empty or only spaces) - using default input"
         input_string="$default_input"
+        # Avoid stderr if default_input is not set or empty or not an integer value:
+        if test "$default_input" -ge 0 2>/dev/null ; then
+            # When there are choices and the default input is a valid choice index
+            # the number that is used as input must be one more because the choices are shown
+            # with choice numbers 1 2 3 ... as in 'select' (i.e. starting at 1):
+            test "$choices" && test "${choices[$default_input]:=}" && input_string=$(( default_input + 1 ))
+        fi
     fi
     # Now there is real input in input_string (neither empty nor only spaces):
     # When there are no choices result the input as is:


### PR DESCRIPTION
In 300_map_disks.sh use runtime generated UserInput-IDs
to support multiple same UserInput calls for different devices
that need to be mapped.

This one implements the missing part in
https://github.com/rear/rear/pull/1473#issuecomment-328832250

How it looks now compared to
https://github.com/rear/rear/pull/1473#issuecomment-328811035
<pre>
RESCUE e205:~ # export USER_INPUT_LAYOUT_MIGRATION_REPLACEMENT_SDA="1"

RESCUE e205:~ # export USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS="yEs"

RESCUE e205:~ # rear recover
...
Comparing disks.
Device sda has size 22548578304, 21474836480 expected
Switching to manual disk layout configuration.
Original disk /dev/sda does not exist (with same size) in the target system
Choose an appropriate replacement for /dev/sda
1) /dev/sda
2) /dev/sdb
3) Do not map /dev/sda
4) Use Relax-and-Recover shell and return back to here
(default 1 timeout 300 seconds)
UserInput: Will use predefined input in 'USER_INPUT_LAYOUT_MIGRATION_REPLACEMENT_SDA'='1'
Hit any key to interrupt the automated input (timeout 5 seconds)
Using /dev/sda (chosen by user) for recreating /dev/sda
Current disk mapping table (source -> target):
    /dev/sda /dev/sda
Confirm or edit the disk mapping
1) Confirm disk mapping and continue 'rear recover'
2) Edit disk mapping (/var/lib/rear/layout/disk_mappings)
3) Use Relax-and-Recover shell and return back to here
4) Abort 'rear recover'
(default 1 timeout 300 seconds)
UserInput: Will use predefined input in 'USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS'='1'
Hit any key to interrupt the automated input (timeout 5 seconds)
User confirmed disk mapping
...
</pre>
