### PR TITLE
Improve cryptographic security and user-friendliness for LUKS volumes

### DIFF
--- a/doc/user-guide/06-layout-configuration.adoc
+++ b/doc/user-guide/06-layout-configuration.adoc
@@ -64,7 +64,7 @@ fs /dev/mapper/system-vmxfs /vmware xfs uuid=7457d2ab-8252-4f41-bab6-60731625997
 fs /dev/mapper/system-kvm /kvm ext4 uuid=173ab1f7-8450-4176-8cf7-c09b47f5e3cc label= blocksize=4096 reserved_blocks=256000 max_mounts=21 check_interval=180d options=rw,noatime,commit=0
 fs /dev/sda1 /boot ext3 uuid=f6b08566-ea5e-46f9-8f73-5e8ffdaa7be6 label= blocksize=1024 reserved_blocks=10238 max_mounts=35 check_interval=180d options=rw,commit=0
 swap /dev/mapper/system-swap uuid=9f347fc7-1605-4788-98fd-fca828beedf1 label=
-crypt /dev/mapper/disk /dev/sda2 cipher=aes mode=xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
+crypt /dev/mapper/disk /dev/sda2 cipher=aes-xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
 ----------------------------------
 This document will continue to use this example to explore the various options
 available in Relax-and-Recover. The exact syntax of the layout file is
@@ -118,7 +118,7 @@ fs /dev/mapper/system-kvm /kvm ext4 uuid=173ab1f7-8450-4176-8cf7-c09b47f5e3cc la
 fs /dev/sda1 /boot ext3 uuid=f6b08566-ea5e-46f9-8f73-5e8ffdaa7be6 label= blocksize=1024 reserved_blocks=10238 max_mounts=35 check_interval=180d options=rw,commit=0
 fs /dev/mapper/backup-backup /media/backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
 swap /dev/mapper/system-swap uuid=9f347fc7-1605-4788-98fd-fca828beedf1 label=
-crypt /dev/mapper/disk /dev/sda2 cipher=aes mode=xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
+crypt /dev/mapper/disk /dev/sda2 cipher=aes-xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
 ----------------------------------
 
 This behavior is controlled by the +AUTOEXCLUDE_DISKS=y+ parameter in
@@ -185,7 +185,7 @@ fs /dev/mapper/system-kvm /kvm ext4 uuid=173ab1f7-8450-4176-8cf7-c09b47f5e3cc la
 fs /dev/sda1 /boot ext3 uuid=f6b08566-ea5e-46f9-8f73-5e8ffdaa7be6 label= blocksize=1024 reserved_blocks=10238 max_mounts=35 check_interval=180d options=rw,commit=0
 # fs /dev/mapper/backup-backup /media/backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
 swap /dev/mapper/system-swap uuid=9f347fc7-1605-4788-98fd-fca828beedf1 label=
-crypt /dev/mapper/disk /dev/sda2 cipher=aes mode=xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
+crypt /dev/mapper/disk /dev/sda2 cipher=aes-xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
 ----------------------------------
 
 Another approach would be to exclude the backup volume group. This is achieved by adding this line to the local configuration:
@@ -325,7 +325,7 @@ fs /dev/mapper/system-kvm /kvm ext4 uuid=173ab1f7-8450-4176-8cf7-c09b47f5e3cc la
 fs /dev/sdb1 /boot ext3 uuid=f6b08566-ea5e-46f9-8f73-5e8ffdaa7be6 label= blocksize=1024 reserved_blocks=10238 max_mounts=35 check_interval=180d options=rw,commit=0
 # fs /dev/mapper/backup-backup /media/backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
 swap /dev/mapper/system-swap uuid=9f347fc7-1605-4788-98fd-fca828beedf1 label=
-crypt /dev/mapper/disk /dev/sdb2 cipher=aes mode=xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
+crypt /dev/mapper/disk /dev/sdb2 cipher=aes-xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
 
 1) View disk layout (disklayout.conf)
 2) Edit disk layout (disklayout.conf)
@@ -374,7 +374,7 @@ fs /dev/mapper/system-var /var ext4 uuid=a12bb95f-99f2-42c6-854f-1cb3f144d662 la
 fs /dev/sdb1 /boot ext3 uuid=f6b08566-ea5e-46f9-8f73-5e8ffdaa7be6 label= blocksize=1024 reserved_blocks=10238 max_mounts=35 check_interval=180d options=rw,commit=0
 # fs /dev/mapper/backup-backup /media/backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
 swap /dev/mapper/system-swap uuid=9f347fc7-1605-4788-98fd-fca828beedf1 label=
-crypt /dev/mapper/disk /dev/sdb2 cipher=aes mode=xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
+crypt /dev/mapper/disk /dev/sdb2 cipher=aes-xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
 ----------------------------------
 
 Let's continue recovery.
@@ -615,7 +615,7 @@ lvmvol /dev/<volume group name> <logical volume name> <number of extents> [<size
 
 === LUKS Devices ===
 ----------------------------------
-crypt /dev/mapper/<name> <device> cipher=<cipher> mode=<cipher mode> hash=<hash function> [uuid=<uuid>]
+crypt /dev/mapper/<name> <device> [cipher=<cipher>] [key_size=<key size>] [hash=<hash function>] [uuid=<uuid>] [keyfile=<keyfile>] [password=<password>]
 ----------------------------------
 
 === DRBD ===

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -799,6 +799,13 @@ TIMESYNC_SOURCE=
 # You could redefine it as, e.g. LANG_RECOVER=de_DE@euro
 LANG_RECOVER=C
 
+# LUKS_CRYPTSETUP_OPTIONS contains additional options to cryptsetup which complement auto-detected options.
+# The default setting increases security beyond the level attained by compiled-in cryptsetup defaults.
+# On an embedded system, using the /dev/random random generator may result in (possibly long) delays. In this case, you
+# may set LUKS_CRYPTSETUP_OPTIONS="--iter-time 2000 --use-urandom" instead, but be aware that this produces a
+# low-quality master encryption key. For details, see the cryptsetup(8) manual page.
+LUKS_CRYPTSETUP_OPTIONS="--iter-time 2000 --use-random"
+
 
 ##
 # BACKUP=FDRUPSTREAM stuff

--- a/usr/share/rear/finalize/GNU/Linux/240_reassign_luks_keyfiles.sh
+++ b/usr/share/rear/finalize/GNU/Linux/240_reassign_luks_keyfiles.sh
@@ -6,40 +6,42 @@
 # to its expected location, an error message is displayed and the corresponding temporary keyfile will take
 # over, so that the recovered system remains fully functional.
 
-local device original_keyfile
+local target_name source_device original_keyfile
 
 awk '
     $1 == "crypt" && / keyfile=/ {
-        device = $3;
+        target_name = $2;
+        sub("^/dev/mapper/", "", target_name);
+        source_device = $3;
 
         sub("^.* keyfile=", "");
         sub("[ \t].*$", "");
         original_keyfile = $0;
 
-        print device, original_keyfile;
+        print target_name, source_device, original_keyfile;
     }
 ' "$LAYOUT_FILE" |
-while read device original_keyfile; do
-    Log "Re-assigning keyfile $original_keyfile to LUKS device $device"
+while read target_name source_device original_keyfile; do
+    Log "Re-assigning keyfile $original_keyfile to LUKS device $target_name ($source_device)"
 
     # The scheme for generating a temporary keyfile path must be the same here and in the 'layout/prepare' stage.
-    temp_keyfile="${TMPDIR:-/tmp}/LUKS-keyfile-$(basename $original_keyfile)"
+    temp_keyfile="${TMPDIR:-/tmp}/LUKS-keyfile-$target_name"
     [ -f "$temp_keyfile" ] || BugError "temporary keyfile $temp_keyfile not found"
 
     target_keyfile="$TARGET_FS_ROOT/$original_keyfile"
 
     if [ -f "$target_keyfile" ]; then
         # Assign the original keyfile to the LUKS volume, if successful, remove the temporary keyfile.
-        cryptsetup --key-file "$temp_keyfile" luksAddKey "$device" "$target_keyfile"
-        BugIfError "Could not add the keyfile $original_keyfile to LUKS device $device"
-        cryptsetup luksRemoveKey "$device" "$temp_keyfile"
-        BugIfError "Could not remove the temporary keyfile $temp_keyfile from LUKS device $device"
+        cryptsetup --key-file "$temp_keyfile" luksAddKey "$source_device" "$target_keyfile"
+        BugIfError "Could not add the keyfile $original_keyfile to LUKS device $target_name ($source_device)"
+        cryptsetup luksRemoveKey "$source_device" "$temp_keyfile"
+        BugIfError "Could not remove the temporary keyfile $temp_keyfile from LUKS device $target_name ($source_device)"
     else
         # The original keyfile was not restored from the backup - move the temporary keyfile to
         # the target location so that the LUKS volume can still be decrypted.
         mkdir -p "$(dirname $target_keyfile)"
         cp -p "$temp_keyfile" "$target_keyfile" &&  rm "$temp_keyfile"
-        StopIfError "Could not restore keyfile $original_keyfile for LUKS device $device from temporary keyfile"
-        LogPrintError "$original_keyfile was not restored - LUKS device $device has been assigned a new keyfile"
+        StopIfError "Could not restore keyfile $original_keyfile for LUKS device $target_name ($source_device) from temporary keyfile"
+        LogPrintError "$original_keyfile was not restored from the backup - LUKS device $target_name ($source_device) has been assigned a new keyfile"
     fi
 done

--- a/usr/share/rear/finalize/GNU/Linux/240_reassign_luks_keyfiles.sh
+++ b/usr/share/rear/finalize/GNU/Linux/240_reassign_luks_keyfiles.sh
@@ -1,0 +1,45 @@
+# Re-assign original keyfiles to LUKS volumes
+#
+# In the 'layout/prepare' stage, temporary keyfiles were generated for password-less decryption. By now, the
+# original keyfiles should have been restored from the backup. If so, the original keyfiles are re-assigned
+# to their LUKS volumes and temporary keyfiles are discarded. Where an original keyfile was not restored
+# to its expected location, an error message is displayed and the corresponding temporary keyfile will take
+# over, so that the recovered system remains fully functional.
+
+local device original_keyfile
+
+awk '
+    $1 == "crypt" && / keyfile=/ {
+        device = $3;
+
+        sub("^.* keyfile=", "");
+        sub("[ \t].*$", "");
+        original_keyfile = $0;
+
+        print device, original_keyfile;
+    }
+' "$LAYOUT_FILE" |
+while read device original_keyfile; do
+    Log "Re-assigning keyfile $original_keyfile to LUKS device $device"
+
+    # The scheme for generating a temporary keyfile path must be the same here and in the 'layout/prepare' stage.
+    temp_keyfile="${TMPDIR:-/tmp}/LUKS-keyfile-$(basename $original_keyfile)"
+    [ -f "$temp_keyfile" ] || BugError "temporary keyfile $temp_keyfile not found"
+
+    target_keyfile="$TARGET_FS_ROOT/$original_keyfile"
+
+    if [ -f "$target_keyfile" ]; then
+        # Assign the original keyfile to the LUKS volume, if successful, remove the temporary keyfile.
+        cryptsetup --key-file "$temp_keyfile" luksAddKey "$device" "$target_keyfile"
+        BugIfError "Could not add the keyfile $original_keyfile to LUKS device $device"
+        cryptsetup luksRemoveKey "$device" "$temp_keyfile"
+        BugIfError "Could not remove the temporary keyfile $temp_keyfile from LUKS device $device"
+    else
+        # The original keyfile was not restored from the backup - move the temporary keyfile to
+        # the target location so that the LUKS volume can still be decrypted.
+        mkdir -p "$(dirname $target_keyfile)"
+        cp -p "$temp_keyfile" "$target_keyfile" &&  rm "$temp_keyfile"
+        StopIfError "Could not restore keyfile $original_keyfile for LUKS device $device from temporary keyfile"
+        LogPrintError "$original_keyfile was not restored - LUKS device $device has been assigned a new keyfile"
+    fi
+done

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -9,39 +9,38 @@ Log "Saving Encrypted volumes."
 REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" cryptsetup dmsetup )
 COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/cracklib/\* /etc/security/pwquality.conf )
 
-while read dm_name junk ; do
-    # find the device we're mapping
-    if ! [ -e /dev/mapper/$dm_name ] ; then
-        Log "Device Mapper name $dm_name not found in /dev/mapper."
+while read target_name junk ; do
+    # find the target device we're mapping
+    if ! [ -e /dev/mapper/$target_name ] ; then
+        Log "Device Mapper name $target_name not found in /dev/mapper."
         continue
     fi
 
-    dev_name=$(get_sysfs_name /dev/mapper/$dm_name)
-    if [ -z "$dev_name" ] ; then
-        Log "Could not find device $dev_name in sysfs."
+    sysfs_device=$(get_sysfs_name /dev/mapper/$target_name)
+    if [ -z "$sysfs_device" ] ; then
+        Log "Could not find device $target_name in sysfs."
         continue
     fi
 
-    device=""
-    for slave in /sys/block/$dev_name/slaves/* ; do
-        if ! [ -z "$device" ] ; then
-            BugError "Multiple Device Mapper slaves for crypt $dm_name detected."
+    source_device=""
+    for slave in /sys/block/$sysfs_device/slaves/* ; do
+        if ! [ -z "$source_device" ] ; then
+            BugError "Multiple Device Mapper slaves for crypt $target_name detected."
         fi
-        device="$(get_device_name ${slave##*/})"
+        source_device="$(get_device_name ${slave##*/})"
     done
 
-    if ! cryptsetup isLuks $device >/dev/null 2>&1; then
+    if ! cryptsetup isLuks $source_device >/dev/null 2>&1; then
         continue
     fi
 
     # gather crypt information
-    cipher=$(cryptsetup luksDump $device | grep "Cipher name" | sed -r 's/^.+:\s*(.+)$/\1/')
-    ##mode=$(cryptsetup luksDump $device | grep "Cipher mode" | sed -r 's/^.+:\s*(.+)$/\1/')
-    mode=$(cryptsetup luksDump $device | grep "Cipher mode" | cut -d: -f2- | awk '{printf("%s",$1)};')
-    key_size=$(cryptsetup luksDump $device | grep "MK bits" | sed -r 's/^.+:\s*(.+)$/\1/')
-    hash=$(cryptsetup luksDump $device | grep "Hash spec" | sed -r 's/^.+:\s*(.+)$/\1/')
-    uuid=$(cryptsetup luksDump $device | grep "UUID" | sed -r 's/^.+:\s*(.+)$/\1/')
-    keyfile=$([ -f /etc/crypttab ] && awk '$1 == "'"$dm_name"'" { print $3; }' /etc/crypttab)
+    cipher=$(cryptsetup luksDump $source_device | grep "Cipher name" | sed -r 's/^.+:\s*(.+)$/\1/')
+    mode=$(cryptsetup luksDump $source_device | grep "Cipher mode" | cut -d: -f2- | awk '{printf("%s",$1)};')
+    key_size=$(cryptsetup luksDump $source_device | grep "MK bits" | sed -r 's/^.+:\s*(.+)$/\1/')
+    hash=$(cryptsetup luksDump $source_device | grep "Hash spec" | sed -r 's/^.+:\s*(.+)$/\1/')
+    uuid=$(cryptsetup luksDump $source_device | grep "UUID" | sed -r 's/^.+:\s*(.+)$/\1/')
+    keyfile_option=$([ -f /etc/crypttab ] && awk '$1 == "'"$target_name"'" && $3 != "none" && $3 != "-" { print "keyfile=" $3; }' /etc/crypttab)
 
-    echo "crypt /dev/mapper/$dm_name $device cipher=$cipher-$mode key_size=$key_size hash=$hash uuid=$uuid keyfile=$keyfile" >> $DISKLAYOUT_FILE
+    echo "crypt /dev/mapper/$target_name $source_device cipher=$cipher-$mode key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE
 done < <( dmsetup ls --target crypt )


### PR DESCRIPTION
#### Problem

ReaR 2.2 with cryptsetup 1.6.6 (as on Ubuntu 16.04.3 LTS) uses compiled-in default values which are not up-to-date in terms of cryptographic security:

Option | cryptsetup 1.6.6 Default | More Secure | Auto-detectable
-------|--------------------------|-------------|----------------
Key size | --key-size 256 | --key-size 512 | Yes
Passphrase processing time (msecs) | --iter-time 1000 | --iter-time 2000 | No
Random number generation device | --use-urandom | --use-random | No

For details, see [Encryption options for LUKS mode](https://wiki.archlinux.org/index.php/Dm-crypt/Device_encryption#Encryption_options_for_LUKS_mode) in the ArchWiki.

In addition, ReaR can neither auto-detect nor use existing keyfiles for the automatic decryption of recreated LUKS volumes. A recovered system will ask the user for a passphrase where the original system would not.


#### Solution

This PR improves LUKS recovery with these characteristics:
* Auto-detect the `--key-size` option from the original volume.
* Auto-detect keyfiles in [crypttab](http://manpages.ubuntu.com/manpages/xenial/en/man5/crypttab.5.html) and add them to recreated LUKS volumes.
* Allow additional cryptsetup options, which cannot be auto-detected, to be configured.

#### Strategy

See comment in commit c9e7e1bdc5a788590e3a378839fbc6e099158a04.

Note: Removing the documented `mode` option is an incompatible change, which simplifies the code by processing each option in the same way. Since `disklayout.conf` is usually re-generated before being edited, introducing this change seems OK to me.

Tested on Ubuntu 16.04.3 LTS.