### PR TITLE
Add automatically some important kernel parameters to KERNEL_CMDLINE

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -70,13 +70,13 @@ KERNEL_VERSION="${KERNEL_VERSION:-$( uname -r )}"
 #   e.g. to prevent the rescue/recovery system to use the same IP address as the original system
 #   but for the latter using USE_DHCLIENT="yes" (see below) is probably easier:
 KERNEL_CMDLINE=""
-# The CHECK_KERNEL_PARAMETER array lists kernel parameter that should be part of the KERNEL_CMDLINE (in rescue image)
+# The COPY_KERNEL_PARAMETERS array lists kernel parameter that should be part of the KERNEL_CMDLINE (in rescue image)
 # if present on the current system (/proc/cmdline).
-# CHECK_KERNEL_PARAMETER should only store kernel parameter key, not the value (ex: net.ifnames but not net.ifnames=0)
+# COPY_KERNEL_PARAMETERS should only store kernel parameter key, not the value (ex: net.ifnames but not net.ifnames=0)
 # If the key-value kernel parameter is already set in KERNEL_CMDLINE variable it will always superseed
 # the one detected on the current system (if any).
 # - Check net.ifnames and biosdevname kernel parameter as it may impact the network interface name during recovery/migration.
-CHECK_KERNEL_PARAMETER=( 'net.ifnames' 'biosdevname' )
+COPY_KERNEL_PARAMETERS=( 'net.ifnames' 'biosdevname' )
 
 
 # These variables are used to include arch/os/version specific stuff

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -70,6 +70,14 @@ KERNEL_VERSION="${KERNEL_VERSION:-$( uname -r )}"
 #   e.g. to prevent the rescue/recovery system to use the same IP address as the original system
 #   but for the latter using USE_DHCLIENT="yes" (see below) is probably easier:
 KERNEL_CMDLINE=""
+# The CHECK_KERNEL_PARAMETER array lists kernel parameter that should be part of the KERNEL_CMDLINE (in rescue image)
+# if present on the current system (/proc/cmdline).
+# CHECK_KERNEL_PARAMETER should only store kernel parameter key, not the value (ex: net.ifnames but not net.ifnames=0)
+# If the key-value kernel parameter is already set in KERNEL_CMDLINE variable it will always superseed
+# the one detected on the current system (if any).
+# - Check net.ifnames and biosdevname kernel parameter as it may impact the network interface name during recovery/migration.
+CHECK_KERNEL_PARAMETER=( 'net.ifnames' 'biosdevname' )
+
 
 # These variables are used to include arch/os/version specific stuff
 

--- a/usr/share/rear/rescue/GNU/Linux/290_kernel_cmdline.sh
+++ b/usr/share/rear/rescue/GNU/Linux/290_kernel_cmdline.sh
@@ -1,10 +1,10 @@
 # purpose of the script is to detect some important KERNEL CMDLINE options on the current system
 # we should also use in rescue mode (automatically update KERNEL_CMDLINE array variable).
 
-# Scanning current kernel cmdline to look for important option ($CHECK_KERNEL_PARAMETER) to include in KERNEL_CMDLINE
+# Scanning current kernel cmdline to look for important option ($COPY_KERNEL_PARAMETERS) to include in KERNEL_CMDLINE
 for current_kernel_option in $( cat /proc/cmdline ); do
-    # Get only the option name (part before "=") and add it to new_kernel_options_to_add array if it is part of CHECK_KERNEL_PARAMETER array.
-    if IsInArray "${current_kernel_option%=*}" "${CHECK_KERNEL_PARAMETER[@]}" ; then
+    # Get only the option name (part before "=") and add it to new_kernel_options_to_add array if it is part of COPY_KERNEL_PARAMETERS array.
+    if IsInArray "${current_kernel_option%=*}" "${COPY_KERNEL_PARAMETERS[@]}" ; then
         new_kernel_options_to_add=( "${new_kernel_options_to_add[@]}" "$current_kernel_option" )
     fi
 done

--- a/usr/share/rear/rescue/GNU/Linux/290_kernel_cmdline.sh
+++ b/usr/share/rear/rescue/GNU/Linux/290_kernel_cmdline.sh
@@ -1,13 +1,10 @@
 # purpose of the script is to detect some important KERNEL CMDLINE options on the current system
 # we should also use in rescue mode (automatically update KERNEL_CMDLINE array variable).
 
-# Scanning current kernel cmdline option to look for important option to include in KERNEL_CMDLINE
+# Scanning current kernel cmdline to look for important option ($CHECK_KERNEL_PARAMETER) to include in KERNEL_CMDLINE
 for current_kernel_option in $( cat /proc/cmdline ); do
-    # If user use options to force or disable biosdevname (persistant inet naming)
-    # we need to have this option in the rescue image in order to properly configure / migrate
-    # the network configuration.
-
-    if [ "${current_kernel_option%=*}" == "net.ifnames" ] || [ "${current_kernel_option%=*}" == "biosdevname" ] ; then
+    # Get only the option name (part before "=") and add it to new_kernel_options_to_add array if it is part of CHECK_KERNEL_PARAMETER array.
+    if IsInArray "${current_kernel_option%=*}" "${CHECK_KERNEL_PARAMETER[@]}" ; then
         new_kernel_options_to_add=( "${new_kernel_options_to_add[@]}" "$current_kernel_option" )
     fi
 done

--- a/usr/share/rear/rescue/GNU/Linux/290_kernel_cmdline.sh
+++ b/usr/share/rear/rescue/GNU/Linux/290_kernel_cmdline.sh
@@ -1,0 +1,36 @@
+# purpose of the script is to detect some important KERNEL CMDLINE options on the current system
+# we should also use in rescue mode (automatically update KERNEL_CMDLINE array variable).
+
+# Scanning current kernel cmdline option to look for important option to include in KERNEL_CMDLINE
+for current_kernel_option in $( cat /proc/cmdline ); do
+    # If user use options to force or disable biosdevname (persistant inet naming)
+    # we need to have this option in the rescue image in order to properly configure / migrate
+    # the network configuration.
+
+    if [ "${current_kernel_option%=*}" == "net.ifnames" ] || [ "${current_kernel_option%=*}" == "biosdevname" ] ; then
+        new_kernel_options_to_add=( "${new_kernel_options_to_add[@]}" "$current_kernel_option" )
+    fi
+done
+
+# Verify if the kernel option we want to add to KERNEL_CMDLINE are not already set/force by the user in the rear configuration.
+# If yes, the parameter set in the configuration file have the priority and superseed the current kernel option.
+for new_kernel_option in "${new_kernel_options_to_add[@]}" ; do
+
+    kernel_option_superseeded=0
+
+    for rear_kernel_option in $KERNEL_CMDLINE; do
+        # Check if a kernel option key without value parameter (everything before =) is not already present in rear KERNEL_CMDLINE array.
+        if [ "${new_kernel_option%=*}" == "${rear_kernel_option%=*}" ]; then
+            Log "Current kernel option [$new_kernel_option] supperseeded by [$rear_kernel_option] in your rear configuration: (KERNEL_CMDLINE)"
+            kernel_option_superseeded=1
+            break
+        fi
+    done
+
+    if test "$kernel_option_superseeded" -eq 1; then
+        continue
+    else
+        LogPrint "Adding $new_kernel_option to KERNEL_CMDLINE"
+        KERNEL_CMDLINE="$KERNEL_CMDLINE $new_kernel_option"
+    fi
+done


### PR DESCRIPTION
I propose to check the current kernel parameters used (in `/proc/cmdline`) to detect some important parameter we should use when booting in rescue mode (means  add them in KERNEL_CMDLINE variable).

Based on the discussion with @gdha in #1400, I started to detect `net.ifnames` or `biosdevname` parameter in order to preserve interface naming between rescue mode and real system after migration.