### PR TITLE
Fix btrfsmountedsubvol exclusion and dependency management

### DIFF
--- a/usr/share/rear/layout/save/default/330_remove_exclusions.sh
+++ b/usr/share/rear/layout/save/default/330_remove_exclusions.sh
@@ -16,16 +16,12 @@ remove_second_component() {
 }
 
 # Remove lines in the LAYOUT_FILE.
-while read done name type junk ; do
+while read status name type junk ; do
     case "$type" in
         part)
             ### find the immediate parent
             name=$(grep "^$name " "$LAYOUT_DEPS" | cut -d " " -f 2)
             remove_component "$type" "$name"
-            ;;
-        lvmdev)
-            name=${name#pv:}
-            remove_second_component "$type" "$name"
             ;;
         lvmvol)
             name=${name#/dev/mapper/}
@@ -36,13 +32,9 @@ while read done name type junk ; do
 
             sed -i -r "s|^($type /dev/$vg $lv )|\#\1|" "$LAYOUT_FILE"
             ;;
-        fs)
-            name=${name#fs:}
+        fs|btrfsmountedsubvol|swap|lvmdev)
+            name=${name#$type:}
             remove_second_component "$type" "$name"
-            ;;
-        swap)
-            name=${name#swap:}
-            remove_component "$type" "$name"
             ;;
         *)
             remove_component "$type" "$name"

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -127,26 +127,26 @@ generate_layout_dependencies() {
                 done
                 add_component "$name" "raid"
                 ;;
-            fs)
+            fs|btrfsmountedsubvol)
                 dev=$(echo "$remainder" | cut -d " " -f "1")
                 mp=$(echo "$remainder" | cut -d " " -f "2")
-                add_dependency "fs:$mp" "$dev"
-                add_component "fs:$mp" "fs"
+                add_dependency "$type:$mp" "$dev"
+                add_component "$type:$mp" "$type"
 
                 # find dependencies on other filesystems
-                while read fs bd nmp junk; do
-                    if [ "$nmp" != "/" ] ; then
+                while read dep_type bd dep_mp junk; do
+                    if [ "$dep_mp" != "/" ] ; then
                         # make sure we only match complete paths
                         # e.g. not /data as a parent of /data1
-                        temp_nmp="$nmp/"
+                        temp_dep_mp="$dep_mp/"
                     else
-                        temp_nmp="$nmp"
+                        temp_dep_mp="$dep_mp"
                     fi
 
-                    if [ "${mp#$temp_nmp}" != "${mp}" ] && [ "$mp" != "$nmp" ]; then
-                        add_dependency "fs:$mp" "fs:$nmp"
+                    if [ "${mp#$temp_dep_mp}" != "${mp}" ] && [ "$mp" != "$dep_mp" ]; then
+                        add_dependency "$type:$mp" "$dep_type:$dep_mp"
                     fi
-                done < <(grep "^fs" $LAYOUT_FILE)
+                done < <(awk '$1 ~ /^fs|btrfsmountedsubvol$/ { print; }' $LAYOUT_FILE)
                 ;;
             swap)
                 dev=$(echo "$remainder" | cut -d " " -f "1")


### PR DESCRIPTION
This PR closes the existing gap between 'fs'-type file systems and mounted btrfs subvolumes (type 'btrfsmountedsubvol').

- It allows mounted btrfs subvolumes to be excluded like other components, for example:
```
EXCLUDE_RECREATE=( "${EXCLUDE_RECREATE[@]}" "btrfsmountedsubvol:/mnt/dir" )
```

- It enables dependency management for mounted btrfs subvolumes (making sure that file systems containing btrfs mount points are recreated as well).

Related: #1496

Tested on Ubuntu 16.04.3 LTS