### PR TITLE
Avoid leaking unprotected SSH private key files onto rescue medium

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -805,6 +805,20 @@ CLONE_ALL_USERS_GROUPS="no"
 # into config file /etc/rear/local.conf
 SSH_ROOT_PASSWORD=
 
+# SSH_PRIVATE_KEYS_RECOVER_PASSPHRASE defines a passphrase for SSH private keys during 'rear recover'.
+# If set, ReaR will set the passphrase for each SSH private key which was not passphrase-protected on the original
+# system, before copying the private key to the rescue medium.
+# An empty passphrase (the default) implies that unprotected private keys will not be copied to the rescue medium.
+# CAUTION: Configuration files are copied to the rescue medium. If you define a verbatim passphrase in a configuration
+# file, anyone with physical access to the rescue medium would be allowed unauthenticated access to each account on the
+# network authorizing one of those private keys.
+# Recommendation: Set the passphrase by reading an access-protected file, which will not be copied to the rescue medium.
+# E.g., create
+#   echo "my_recover_passphrase" > /root/.ssh/rear-recover-passphrase && chmod u=rw,go=- /root/.ssh/rear-recover-passphrase
+# then use
+#   SSH_PRIVATE_KEYS_RECOVER_PASSPHRASE="$(cat /root/.ssh/rear-recover-passphrase 2>/dev/null)"
+SSH_PRIVATE_KEYS_RECOVER_PASSPHRASE=
+
 # time synchronisation, could be NTP, RDATE or empty
 TIMESYNC=
 # set a timesync source, mostly needed for RDATE

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -795,7 +795,9 @@ CLONE_ALL_USERS_GROUPS="no"
 # users and groups there and not with the users and groups of the original system
 # except those users and groups that get copied into the ReaR recovery system.
 
-# SSH_ROOT_PASSWORD defines a root password to allow SSH connection whithout a public/private key pair
+# SSH_ROOT_PASSWORD defines a password for remote access to the recovery system as 'root' via SSH whithout requiring a
+# public/private key pair. This password is valid only while the recovery system is running and will not allow access
+# to a restored target system.
 # Be aware, the password is saved in hashed MD5 format (do not forget the password after months:)
 # Generate a hashed password with the following command:
 #   echo "my_rescue_root_password" | openssl passwd -1 -stdin

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -1,26 +1,29 @@
-# 500_ssh.sh
-#
-# take ssh for Relax-and-Recover
+# SSH client (ssh) and server (sshd) configuration for Relax-and-Recover
 #
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-if has_binary sshd; then
+if has_binary ssh || has_binary sshd; then
 
     # assume that we have openssh with configs in /etc/ssh
 
-    COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/ssh* /root/.s[s]h /root/.shos[t]s )
+    # The funny [] around a letter makes shopt -s nullglob remove this file from the list if it does not exist,
+    # files without a [] are mandatory.
+
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/ssh* /root/.ssh/[a]uthorized_keys /root/.shos[t]s )
     PROGS=(
-    ${PROGS[@]}
-    ssh sshd scp sftp
-    $(
-        read subsys sftp file junk < <( grep sftp /etc/sshd_co[n]fig /etc/ssh/sshd_co[n]fig /etc/openssh/sshd_co[n]fig /etc/centrifydc/ssh/sshd_co[n]fig 2>/dev/null )
-        echo $file
-    )
+        "${PROGS[@]}"
+        ssh sshd scp sftp ssh-agent
+        $(
+            read subsys sftp original_file junk < <( grep sftp /etc/sshd_co[n]fig /etc/ssh/sshd_co[n]fig /etc/openssh/sshd_co[n]fig /etc/centrifydc/ssh/sshd_co[n]fig 2>/dev/null )
+            echo $original_file
+        )
     )
 
+    # Part 1: SSH server (sshd) - this is for logging into the recovery system via SSH
+
     # we need to add some specific NSS lib for shadow passwords to work on RHEL 6/7
-    LIBS=( ${LIBS[@]} /usr/lib64/libfreeblpriv3.* /lib/libfreeblpriv3.* )
+    LIBS=( "${LIBS[@]}" /usr/lib64/libfreeblpriv3.* /lib/libfreeblpriv3.* )
     Log "Adding required libfreeblpriv3.so to LIBS"
 
     # copy ssh user
@@ -28,23 +31,23 @@ if has_binary sshd; then
     # Only the first line (first returned entry) will be used by 'read' in 'IFS=: read ... <<<"$PASSWD_SSH"', so we ask for sshd first.
     PASSWD_SSH=$(getent passwd sshd ssh)
     if test -n "$PASSWD_SSH" ; then
-    # sshd:x:71:65:SSH daemon:/var/lib/sshd:/bin/false
-        IFS=: read user ex uid gid gecos homedir junk <<<"$PASSWD_SSH"
-	# skip if this user exists already in the restore system
-	if ! egrep -q "^$user:" $TARGET_FS_ROOT/etc/passwd ; then
-		echo "$PASSWD_SSH" >>$ROOTFS_DIR/etc/passwd
-	fi
+        # sshd:x:71:65:SSH daemon:/var/lib/sshd:/bin/false
+            IFS=: read user ex uid gid gecos homedir junk <<<"$PASSWD_SSH"
+        # skip if this user exists already in the restore system
+        if ! egrep -q "^$user:" $ROOTFS_DIR/etc/passwd ; then
+            echo "$PASSWD_SSH" >>$ROOTFS_DIR/etc/passwd
+        fi
         # add ssh group to be collected later
         CLONE_GROUPS=( "${CLONE_GROUPS[@]}" "$gid" )
-        mkdir -p $v -m 0700 "$ROOTFS_DIR$homedir" >&2
-        chown $v root.root "$ROOTFS_DIR$homedir" >&2
+        mkdir -p $v -m 0700 "$ROOTFS_DIR/$homedir" >&2
+        chown $v root:root "$ROOTFS_DIR/$homedir" >&2
     fi
 
     echo "ssh:23:respawn:/bin/sshd -D" >>$ROOTFS_DIR/etc/inittab
 
     # print a warning if there is no authorized_keys file for root and no SSH_ROOT_PASSWORD set
     if ! test -f "/root/.ssh/authorized_keys" -o "$SSH_ROOT_PASSWORD" ; then
-        LogPrint "TIP: To login as root via ssh you need to set up /root/.ssh/authorized_keys or SSH_ROOT_PASSWORD in your configuration file"
+        LogPrint "TIP: To log into the recovery system as root via ssh you need to set up /root/.ssh/authorized_keys or SSH_ROOT_PASSWORD in your configuration file"
     fi
 
     # Set the SSH root password; if pw is hashed just copy it otherwise use openssl (for backward compatibility)
@@ -54,5 +57,110 @@ if has_binary sshd; then
         *     ) echo "root:$(echo $SSH_ROOT_PASSWORD | openssl passwd -1 -stdin):::::::" > $ROOTFS_DIR/etc/shadow ;;
         esac
     fi
-fi
 
+    # Part 2: SSH client (ssh) - this is for accessing other systems (e.g. the backup server) via SSH from the recovery system
+
+    Log "Copying SSH client configuration"
+
+    local target_dir="$ROOTFS_DIR/root/.ssh" original_file target_file passphrase_set="no" passphrase="" repeated_passphrase
+
+    mkdir -p -m u=rwx,go=- "$target_dir"
+
+    for original_file in /root/.ssh/id_* /root/.ssh/known_host[s]; do
+        case "$original_file" in
+            (*/id_*.pub|*/known_hosts)
+                # Public key files or 'knownhosts' contain no secrets and can be copied as-is
+                Log "Copying $original_file"
+                cp -p "$original_file" "$target_dir"
+                ;;
+
+            (*/id_*)
+                # Private key files will be copied, examined and, if desired, passphrase-protected
+
+                target_file="$target_dir/$(basename "$original_file")"
+                cp -p "$original_file" "$target_file"
+
+                # This ssh-keygen invocation checks if a passphrase change succeeds with an empty passphrase for
+                # authentication. If so, the private key file is not currently passphrase-protected.
+                if ssh-keygen -q -p -P '' -N '' -f "$target_file" >/dev/null 2>&1; then
+                    # Handle the unprotected private key file
+
+                    # Obtain a decision on copying and passphrase-protection once
+                    if [ "$passphrase_set" == "no" ]; then
+                        passphrase_set="yes"
+
+                        LogUserOutput ""
+                        LogUserOutput "WARNING: User 'root' on '$HOSTNAME' has potential SSH access to other systems via"
+                        LogUserOutput "unprotected private keys. To copy those keys onto the rescue medium in protected form,"
+                        LogUserOutput "please enter a strong passphrase which will be used when running 'rear recover'."
+                        LogUserOutput "- Entering an empty passphrase will *not* copy unprotected private keys to the rescue medium."
+                        LogUserOutput "- Entering 'UnProtected' (without quotes) will copy unprotected private keys onto the rescue medium."
+                        LogUserOutput ""
+
+                        while true; do
+                            LogUserOutput "SSH client passphrase (or empty, or 'UnProtected'): \c"
+                            read -s passphrase <&6
+                            UserOutput ""
+
+                            case "$passphrase" in
+                                "")
+                                    LogUserOutput "SSH private keys will not be copied"
+                                    break
+                                    ;;
+
+                                UnProtected)
+                                    LogUserOutput ""
+                                    LogUserOutput "WARNING: This will protentially allow anyone in possession of the rescue medium"
+                                    LogUserOutput "unauthenticated access to other systems."
+                                    LogUserOutput ""
+                                    user_input="$( UserInput -I SSH_PRIVATE_KEYS_UNPROTECTED_CONFIRMATION \
+                                        -t 0 -p "Type 'yes' if you want to allow unauthenticated access" )"
+                                    if [ "$user_input" == "yes" ]; then
+                                        LogUserOutput "SSH private keys will be copied in unprotected form"
+                                        break
+                                    fi
+                                    ;;
+
+                                *)
+                                    LogUserOutput "Repeat SSH client passphrase: \c"
+                                    read -s repeated_passphrase <&6
+                                    UserOutput ""
+                                    if [ "$passphrase" != "$repeated_passphrase" ]; then
+                                        LogUserOutput "Passphrases do not match"
+                                        passphrase=""
+                                    else
+                                        LogUserOutput "SSH private keys will be copied and passphrase-protected"
+                                        break
+                                    fi
+                                    ;;
+                            esac
+                        done
+                    fi
+
+                    # Carry out the user's decision
+                    case "$passphrase" in
+                        "")
+                            Log "Ignoring unprotected private key $original_file"
+                            rm "$target_file"
+                            ;;
+
+                        UnProtected)
+                            Log "Copying unprotected private key $original_file"
+                            ;;
+
+                        *)
+                            Log "Copying private key $original_file, adding passphrase-protection"
+                            if ! ssh-keygen -p -P '' -N "$passphrase" -f "$target_file"; then
+                                LogPrintError "Could not assign the passphrase to $target_file"
+                                Error "Stopping to avoid leaking unprotected SSH private keys onto the rescue medium"
+                            fi
+                    esac
+                else
+                    Log "Copying protected private key $original_file retaining its original passphrase"
+                    LogUserOutput "NOTE: private key $original_file was already passphrase-protected and was copied retaining its original passphrase"
+                fi
+                ;;
+        esac
+    done
+
+fi

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -3,164 +3,97 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-if has_binary ssh || has_binary sshd; then
+has_binary ssh || has_binary sshd || return
 
-    # assume that we have openssh with configs in /etc/ssh
+# assume that we have openssh with configs in /etc/ssh
 
-    # The funny [] around a letter makes shopt -s nullglob remove this file from the list if it does not exist,
-    # files without a [] are mandatory.
+# The funny [] around a letter makes shopt -s nullglob remove this file from the list if it does not exist,
+# files without a [] are mandatory.
 
-    COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/ssh* /root/.ssh/[a]uthorized_keys /root/.shos[t]s )
-    PROGS=(
-        "${PROGS[@]}"
-        ssh sshd scp sftp ssh-agent
-        $(
-            read subsys sftp original_file junk < <( grep sftp /etc/sshd_co[n]fig /etc/ssh/sshd_co[n]fig /etc/openssh/sshd_co[n]fig /etc/centrifydc/ssh/sshd_co[n]fig 2>/dev/null )
-            echo $original_file
-        )
+COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/ssh* /root/.ssh/[a]uthorized_keys /root/.shos[t]s )
+PROGS=(
+    "${PROGS[@]}"
+    ssh sshd scp sftp ssh-agent
+    $(
+        read subsys sftp original_file junk < <( grep sftp /etc/sshd_co[n]fig /etc/ssh/sshd_co[n]fig /etc/openssh/sshd_co[n]fig /etc/centrifydc/ssh/sshd_co[n]fig 2>/dev/null )
+        echo $original_file
     )
+)
 
-    # Part 1: SSH server (sshd) - this is for logging into the recovery system via SSH
+# Part 1: SSH server (sshd) - this is for logging into the recovery system via SSH
 
-    # we need to add some specific NSS lib for shadow passwords to work on RHEL 6/7
-    LIBS=( "${LIBS[@]}" /usr/lib64/libfreeblpriv3.* /lib/libfreeblpriv3.* )
-    Log "Adding required libfreeblpriv3.so to LIBS"
+# we need to add some specific NSS lib for shadow passwords to work on RHEL 6/7
+LIBS=( "${LIBS[@]}" /usr/lib64/libfreeblpriv3.* /lib/libfreeblpriv3.* )
+Log "Adding required libfreeblpriv3.so to LIBS"
 
-    # copy ssh user
-    # getent will return all entries that match the key(s) exactly - most systems use 'sshd', some may use 'ssh', none should use both.
-    # Only the first line (first returned entry) will be used by 'read' in 'IFS=: read ... <<<"$PASSWD_SSH"', so we ask for sshd first.
-    PASSWD_SSH=$(getent passwd sshd ssh)
-    if test -n "$PASSWD_SSH" ; then
-        # sshd:x:71:65:SSH daemon:/var/lib/sshd:/bin/false
-            IFS=: read user ex uid gid gecos homedir junk <<<"$PASSWD_SSH"
-        # skip if this user exists already in the restore system
-        if ! egrep -q "^$user:" $ROOTFS_DIR/etc/passwd ; then
-            echo "$PASSWD_SSH" >>$ROOTFS_DIR/etc/passwd
-        fi
-        # add ssh group to be collected later
-        CLONE_GROUPS=( "${CLONE_GROUPS[@]}" "$gid" )
-        mkdir -p $v -m 0700 "$ROOTFS_DIR/$homedir" >&2
-        chown $v root:root "$ROOTFS_DIR/$homedir" >&2
+# copy ssh user
+# getent will return all entries that match the key(s) exactly - most systems use 'sshd', some may use 'ssh', none should use both.
+# Only the first line (first returned entry) will be used by 'read' in 'IFS=: read ... <<<"$PASSWD_SSH"', so we ask for sshd first.
+PASSWD_SSH=$(getent passwd sshd ssh)
+if test -n "$PASSWD_SSH" ; then
+    # sshd:x:71:65:SSH daemon:/var/lib/sshd:/bin/false
+        IFS=: read user ex uid gid gecos homedir junk <<<"$PASSWD_SSH"
+    # skip if this user exists already in the restore system
+    if ! egrep -q "^$user:" $ROOTFS_DIR/etc/passwd ; then
+        echo "$PASSWD_SSH" >>$ROOTFS_DIR/etc/passwd
     fi
-
-    echo "ssh:23:respawn:/bin/sshd -D" >>$ROOTFS_DIR/etc/inittab
-
-    # print a warning if there is no authorized_keys file for root and no SSH_ROOT_PASSWORD set
-    if ! test -f "/root/.ssh/authorized_keys" -o "$SSH_ROOT_PASSWORD" ; then
-        LogPrint "TIP: To log into the recovery system as root via ssh you need to set up /root/.ssh/authorized_keys or SSH_ROOT_PASSWORD in your configuration file"
-    fi
-
-    # Set the SSH root password; if pw is hashed just copy it otherwise use openssl (for backward compatibility)
-    if [[ "$SSH_ROOT_PASSWORD" ]] ; then
-        case "$SSH_ROOT_PASSWORD" in
-        '$1$'*) echo "root:$SSH_ROOT_PASSWORD:::::::" > $ROOTFS_DIR/etc/shadow ;;
-        *     ) echo "root:$(echo $SSH_ROOT_PASSWORD | openssl passwd -1 -stdin):::::::" > $ROOTFS_DIR/etc/shadow ;;
-        esac
-    fi
-
-    # Part 2: SSH client (ssh) - this is for accessing other systems (e.g. the backup server) via SSH from the recovery system
-
-    Log "Copying SSH client configuration"
-
-    local target_dir="$ROOTFS_DIR/root/.ssh" original_file target_file passphrase_set="no" passphrase="" repeated_passphrase
-
-    mkdir -p -m u=rwx,go=- "$target_dir"
-
-    for original_file in /root/.ssh/id_* /root/.ssh/known_host[s]; do
-        case "$original_file" in
-            (*/id_*.pub|*/known_hosts)
-                # Public key files or 'knownhosts' contain no secrets and can be copied as-is
-                Log "Copying $original_file"
-                cp -p "$original_file" "$target_dir"
-                ;;
-
-            (*/id_*)
-                # Private key files will be copied, examined and, if desired, passphrase-protected
-
-                target_file="$target_dir/$(basename "$original_file")"
-                cp -p "$original_file" "$target_file"
-
-                # This ssh-keygen invocation checks if a passphrase change succeeds with an empty passphrase for
-                # authentication. If so, the private key file is not currently passphrase-protected.
-                if ssh-keygen -q -p -P '' -N '' -f "$target_file" >/dev/null 2>&1; then
-                    # Handle the unprotected private key file
-
-                    # Obtain a decision on copying and passphrase-protection once
-                    if [ "$passphrase_set" == "no" ]; then
-                        passphrase_set="yes"
-
-                        LogUserOutput ""
-                        LogUserOutput "WARNING: User 'root' on '$HOSTNAME' has potential SSH access to other systems via"
-                        LogUserOutput "unprotected private keys. To copy those keys onto the rescue medium in protected form,"
-                        LogUserOutput "please enter a strong passphrase which will be used when running 'rear recover'."
-                        LogUserOutput "- Entering an empty passphrase will *not* copy unprotected private keys to the rescue medium."
-                        LogUserOutput "- Entering 'UnProtected' (without quotes) will copy unprotected private keys onto the rescue medium."
-                        LogUserOutput ""
-
-                        while true; do
-                            LogUserOutput "SSH client passphrase (or empty, or 'UnProtected'): \c"
-                            read -s passphrase <&6
-                            UserOutput ""
-
-                            case "$passphrase" in
-                                "")
-                                    LogUserOutput "SSH private keys will not be copied"
-                                    break
-                                    ;;
-
-                                UnProtected)
-                                    LogUserOutput ""
-                                    LogUserOutput "WARNING: This will protentially allow anyone in possession of the rescue medium"
-                                    LogUserOutput "unauthenticated access to other systems."
-                                    LogUserOutput ""
-                                    user_input="$( UserInput -I SSH_PRIVATE_KEYS_UNPROTECTED_CONFIRMATION \
-                                        -t 0 -p "Type 'yes' if you want to allow unauthenticated access" )"
-                                    if [ "$user_input" == "yes" ]; then
-                                        LogUserOutput "SSH private keys will be copied in unprotected form"
-                                        break
-                                    fi
-                                    ;;
-
-                                *)
-                                    LogUserOutput "Repeat SSH client passphrase: \c"
-                                    read -s repeated_passphrase <&6
-                                    UserOutput ""
-                                    if [ "$passphrase" != "$repeated_passphrase" ]; then
-                                        LogUserOutput "Passphrases do not match"
-                                        passphrase=""
-                                    else
-                                        LogUserOutput "SSH private keys will be copied and passphrase-protected"
-                                        break
-                                    fi
-                                    ;;
-                            esac
-                        done
-                    fi
-
-                    # Carry out the user's decision
-                    case "$passphrase" in
-                        "")
-                            Log "Ignoring unprotected private key $original_file"
-                            rm "$target_file"
-                            ;;
-
-                        UnProtected)
-                            Log "Copying unprotected private key $original_file"
-                            ;;
-
-                        *)
-                            Log "Copying private key $original_file, adding passphrase-protection"
-                            if ! ssh-keygen -p -P '' -N "$passphrase" -f "$target_file"; then
-                                LogPrintError "Could not assign the passphrase to $target_file"
-                                Error "Stopping to avoid leaking unprotected SSH private keys onto the rescue medium"
-                            fi
-                    esac
-                else
-                    Log "Copying protected private key $original_file retaining its original passphrase"
-                    LogUserOutput "NOTE: private key $original_file was already passphrase-protected and was copied retaining its original passphrase"
-                fi
-                ;;
-        esac
-    done
-
+    # add ssh group to be collected later
+    CLONE_GROUPS=( "${CLONE_GROUPS[@]}" "$gid" )
+    mkdir -p $v -m 0700 "$ROOTFS_DIR/$homedir" >&2
+    chown $v root:root "$ROOTFS_DIR/$homedir" >&2
 fi
+
+echo "ssh:23:respawn:/bin/sshd -D" >>$ROOTFS_DIR/etc/inittab
+
+# print a warning if there is no authorized_keys file for root and no SSH_ROOT_PASSWORD set
+if ! test -f "/root/.ssh/authorized_keys" -o "$SSH_ROOT_PASSWORD" ; then
+    LogPrint "TIP: To log into the recovery system as root via ssh you need to set up /root/.ssh/authorized_keys or SSH_ROOT_PASSWORD in your configuration file"
+fi
+
+# Set the SSH root password; if pw is hashed just copy it otherwise use openssl (for backward compatibility)
+if [[ "$SSH_ROOT_PASSWORD" ]] ; then
+    case "$SSH_ROOT_PASSWORD" in
+    '$1$'*) echo "root:$SSH_ROOT_PASSWORD:::::::" > $ROOTFS_DIR/etc/shadow ;;
+    *     ) echo "root:$(echo $SSH_ROOT_PASSWORD | openssl passwd -1 -stdin):::::::" > $ROOTFS_DIR/etc/shadow ;;
+    esac
+fi
+
+# Part 2: SSH client (ssh) - this is for accessing other systems (e.g. the backup server) via SSH from the recovery system
+
+Log "Copying SSH client configuration"
+
+local target_dir="$ROOTFS_DIR/root/.ssh" original_file target_file
+
+mkdir -p -m u=rwx,go=- "$target_dir"  # COPY_AS_IS will take effect later, so create the target .ssh directory first
+
+for original_file in /root/.ssh/id_* /root/.ssh/known_host[s]; do
+    target_file="$target_dir/$(basename "$original_file")"
+    cp -p "$original_file" "$target_file"
+
+    case "$original_file" in
+        (*/id_*.pub|*/known_hosts)
+            # Public key files or 'knownhosts' contain no secrets and can be copied as-is
+            Log "Copying $original_file"
+            ;;
+
+        (*/id_*)
+            # Unprotected private key files will be passphrase-protected, if configured, or discarded
+
+            # This ssh-keygen invocation checks if a passphrase change succeeds with an empty passphrase for
+            # authentication. If so, the private key file is not currently passphrase-protected.
+            if ssh-keygen -q -p -P '' -N '' -f "$target_file" >/dev/null 2>&1; then
+                # Handle the unprotected private key file
+
+                if [ -n "$SSH_PRIVATE_KEYS_RECOVER_PASSPHRASE" ]; then
+                    Log "Copying private key $original_file, adding passphrase-protection"
+                    ssh-keygen -p -P '' -N "$SSH_PRIVATE_KEYS_RECOVER_PASSPHRASE" -f "$target_file" || Error "Could not set SSH passphrase for $target_file"
+                else
+                    LogPrint "TIP: To have the unprotected SSH private key $original_file copied to the rescue system, see SSH_PRIVATE_KEYS_RECOVER_PASSPHRASE in default.conf"
+                    rm "$target_file"
+                fi
+            else
+                Log "Copying protected private key $original_file retaining its original passphrase"
+            fi
+            ;;
+    esac
+done

--- a/usr/share/rear/setup/default/005_ssh_agent_start.sh
+++ b/usr/share/rear/setup/default/005_ssh_agent_start.sh
@@ -1,0 +1,11 @@
+# If available, start ssh-agent so that SSH passphrases must be entered only once during 'rear recover' even with
+# multiple ssh invocations (as may be the case when restoring from a network backup server).
+#
+# This file is part of Relax-and-Recover, licensed under the GNU General
+# Public License. Refer to the included COPYING for full text of license.
+
+if has_binary ssh-agent; then
+    Log "Starting up ssh-agent"
+    eval "$(ssh-agent -s)"
+    echo -e "\nHost *\nAddKeysToAgent yes\n" >> /root/.ssh/config
+fi

--- a/usr/share/rear/setup/default/005_ssh_agent_start.sh
+++ b/usr/share/rear/setup/default/005_ssh_agent_start.sh
@@ -4,8 +4,14 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-if has_binary ssh-agent; then
+if has_binary ssh-agent && has_binary ssh && strings "$(which ssh)" | grep -iq AddKeysToAgent ; then
+    # Use ssh-agent only if ssh supports the AddKeysToAgent option. Otherwise, we'd have to use ssh-add to
+    # register keys for repeated use but we don't know which keys might be required during 'read recover'.
+
     Log "Starting up ssh-agent"
+
+    AddExitTask "ssh-agent -k >/dev/null"
     eval "$(ssh-agent -s)"
+
     echo -e "\nHost *\nAddKeysToAgent yes\n" >> /root/.ssh/config
 fi

--- a/usr/share/rear/wrapup/default/970_ssh_agent_stop.sh
+++ b/usr/share/rear/wrapup/default/970_ssh_agent_stop.sh
@@ -1,9 +1,0 @@
-# ssh-agent shutdown during 'rear recover'
-#
-# This file is part of Relax-and-Recover, licensed under the GNU General
-# Public License. Refer to the included COPYING for full text of license.
-
-if [ -n "$SSH_AGENT_PID" ]; then
-    Log "Shutting down ssh-agent"
-    eval "$(ssh-agent -k)"
-fi

--- a/usr/share/rear/wrapup/default/970_ssh_agent_stop.sh
+++ b/usr/share/rear/wrapup/default/970_ssh_agent_stop.sh
@@ -1,0 +1,9 @@
+# ssh-agent shutdown during 'rear recover'
+#
+# This file is part of Relax-and-Recover, licensed under the GNU General
+# Public License. Refer to the included COPYING for full text of license.
+
+if [ -n "$SSH_AGENT_PID" ]; then
+    Log "Shutting down ssh-agent"
+    eval "$(ssh-agent -k)"
+fi


### PR DESCRIPTION
**Note:** This is not about logging into the rescue system via SSH (incoming access). It is about accessing _other systems_ from a running rescue system via SSH private keys stored on the rescue medium (outgoing access).

#### Problem

The 'root' account on the original system may contain SSH private key files without passphrase protection. Such unprotected private key files are typically used to access other systems during unattended operations (e.g. automatic backup to a network server). This kind of access can be useful during restore, too.

Security then depends entirely on keeping such private keys secret, which might be compromised if unprotected private key files leak onto an unencrypted rescue medium. Anyone with physical access to the rescue medium would be allowed unauthenticated access to each account on the network authorizing one of those private keys.

#### Solution

Avoid leaking SSH private key files onto the rescue medium in unprotected form:

This PR enables ReaR to copy the SSH client configuration for 'root' with the option of passphrase-protecting otherwise unprotected private keys. The user can choose between
- copying previously unprotected private keys with added passphrase-protection,
- copying previously unprotected private keys as-is (with a proper warning),
- not copying unprotected private keys at all.

Private key files which already contain a passphrase are assumed to be sufficiently secure and are copied as-is.

The PR also aims to optimize usability during 'rear recover' by asking the user just once for any required SSH passphrase (using ssh-agent).

Tested on Ubuntu 16.04.3 LTS.