### PR TITLE
Improve encrypted password detection in 500_ssh.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ validate:
 	@echo -e "\033[1m== Validating scripts and configuration ==\033[0;0m"
 	find etc/ usr/share/rear/conf/ -name '*.conf' | xargs -n 1 bash -n
 	bash -n $(rearbin)
-	find . -name '*.sh' | xargs -n 1 bash -n
+	find . -name '*.sh' | xargs -n 1 bash -O extglob -O nullglob -n
 	find usr/share/rear -name '*.sh' | grep -v -E '(lib|skel|conf)' | while read FILE ; do \
 		num=$$(echo $${FILE##*/} | cut -c1-3); \
 		if [[ "$$num" = "000" || "$$num" = "999" ]] ; then \

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -48,12 +48,17 @@ if has_binary sshd; then
     fi
 
     # Set the SSH root password; if pw is encrypted just copy it otherwise use openssl (for backward compatibility)
-    #  Encryption syntax is detected as a '$D$' or '$Dx$' prefix in the password, where D is a single digit and x is one lowercase character.
-    #  For more information on encryption IDs, check out the NOTES section of the man page for crypt(3).  The extglob shell option is required for this to work.
-    if [[ "$SSH_ROOT_PASSWORD" ]] ; then
+    # Encryption syntax is detected as a '$D$' or '$Dx$' prefix in the password, where D is a single digit and x is one lowercase character.
+    # For more information on encryption IDs, check out the NOTES section of the man page for crypt(3).
+    # The extglob shell option is required for this to work.
+    if test "$SSH_ROOT_PASSWORD" ; then
         case "$SSH_ROOT_PASSWORD" in
-        \$[0-9]?([a-z])\$*) echo "root:$SSH_ROOT_PASSWORD:::::::" > $ROOTFS_DIR/etc/shadow ;;
-        *     ) echo "root:$(echo $SSH_ROOT_PASSWORD | openssl passwd -1 -stdin):::::::" > $ROOTFS_DIR/etc/shadow ;;
+            (\$[0-9]?([a-z])\$*)
+                echo "root:$SSH_ROOT_PASSWORD:::::::" > $ROOTFS_DIR/etc/shadow
+                ;;
+            (*)
+                echo "root:$(echo $SSH_ROOT_PASSWORD | openssl passwd -1 -stdin):::::::" > $ROOTFS_DIR/etc/shadow
+                ;;
         esac
     fi
 fi

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -47,10 +47,12 @@ if has_binary sshd; then
         LogPrint "TIP: To login as root via ssh you need to set up /root/.ssh/authorized_keys or SSH_ROOT_PASSWORD in your configuration file"
     fi
 
-    # Set the SSH root password; if pw is hashed just copy it otherwise use openssl (for backward compatibility)
+    # Set the SSH root password; if pw is encrypted just copy it otherwise use openssl (for backward compatibility)
+    #  Encryption syntax is detected as a '$D$' or '$Dx$' prefix in the password, where D is a single digit and x is one lowercase character.
+    #  For more information on encryption IDs, check out the NOTES section of the man page for crypt(3).  The extglob shell option is required for this to work.
     if [[ "$SSH_ROOT_PASSWORD" ]] ; then
         case "$SSH_ROOT_PASSWORD" in
-        '$1$'*) echo "root:$SSH_ROOT_PASSWORD:::::::" > $ROOTFS_DIR/etc/shadow ;;
+        \$[0-9]?([a-z])\$*) echo "root:$SSH_ROOT_PASSWORD:::::::" > $ROOTFS_DIR/etc/shadow ;;
         *     ) echo "root:$(echo $SSH_ROOT_PASSWORD | openssl passwd -1 -stdin):::::::" > $ROOTFS_DIR/etc/shadow ;;
         esac
     fi


### PR DESCRIPTION
Currently, usr/share/rear/rescue/default/500_ssh.sh can only detect if SSH_ROOT_PASSWORD is MD5 encrypted.  Any string other than those with a '$1$' prefix will be encrypted using MD5.  For instance, SHA-512 encrypted passwords are common and are identified with a '$6$' prefix... but would not be detected as an encrypted password and rear would re-encrypt the already encrypted string using MD5, breaking the ability to use intended password.

Per the discussion with @schlomo and @jsmeix in https://github.com/rear/rear/pull/1489#issuecomment-329745987 , this PR improves encrypted password detection.