### PR TITLE
Add an ExitTask to show a failure message if it exits unintendedly.

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -70,6 +70,14 @@ readonly CMD_OPTS=( "$@" )
 
 # Allow workflows to set the exit code to a different value (not "readonly"):
 EXIT_CODE=0
+# The separated EXIT_FAIL_MESSAGE variable is used to denote a failure exit.
+# One cannot use EXIT_CODE for that because there are cases where a non-zero exit code
+# is the intended outcome (e.g. in the 'checklayout' workflow, cf. the end of this script).
+# Set EXIT_FAIL_MESSAGE to 1 to have an exit failure message by default which is needed
+# to get a failure message when it exits at an arbitrary place because of 'set -e'
+# cf. https://github.com/rear/rear/issues/700#issuecomment-327755633
+# Before a normal exit EXIT_FAIL_MESSAGE is set to 0 (cf. the end of this script):
+EXIT_FAIL_MESSAGE=1
 
 # Find out if we're running from checkout
 REAR_DIR_PREFIX=""
@@ -553,9 +561,11 @@ if test "$RUNTIME_LOGFILE" != "$LOGFILE" ; then
 fi
 
 # When this point is reached, the workflow is done without a real error because
-# for real errors one of the Error functions should be called that kills rear
-# and then the exit code is usually 143 (i.e. 128 + signal-number)
+# for real errors one of the Error functions should be called that kills rear and
+# then the exit code is usually 143 = 128 + 15 (15 = SIGTERM from the USR1 trap)
 # and the Error function results an "ERROR: ..." syslog message.
+# Set EXIT_FAIL_MESSAGE to 0 to avoid a false exit failure message:
+EXIT_FAIL_MESSAGE=0
 # There should be no syslog message for the help workflow:
 if test "$WORKFLOW" != "help" ; then
     if test $EXIT_CODE -eq 0 ; then


### PR DESCRIPTION
Now a failure message like
<pre>
rear mkrescue failed, check /root/rear.master/var/log/rear/rear-e205.log for details
</pre>
is shown when it exits in any unintended way,
e.g. when it exits because [Ctrl]+[C] was pressed or
when it exits at an arbitrary command because of 'set -e'.
For the latter case cf.
https://github.com/rear/rear/issues/700#issuecomment-327755633


That failure message is not show when it exits/aborts
intentionally via the Error function plus the USR1 trap
because in this case the Error function and the USR1 trap
show already appropriate messages.

