### PR TITLE
Add function to test for 'real value'

### DIFF
--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -638,13 +638,7 @@ function UserInput () {
     fi
     # When there is no (non empty) automated user input read the user input:
     local return_code=0
-    # To test a single word for non-empty and no-spaces there must be no double quotes because test " " results true.
-    # But input_string can be a string of several words and 'test' must have all the words as one argument
-    # because 'test' for a string of several (non empty) words fails with 'bash: test: unary operator expected'.
-    # On the other hand this 'test' should not succeed when input_string is only spaces.
-    # Therefore 'echo -n' is interposed because the output of foo=' ' ; echo -n $foo
-    # is empty:
-    if ! test "$( echo -n $input_string )" ; then
+    if ! contains_visible_char "$input_string" ; then
         # Read the user input from the original STDIN that is saved as fd6 (see above).
         # STDOUT is meaningless because 'read' echoes input from a terminal directly onto the terminal (not via STDOUT) and
         # STDERR can still go into the log because no 'read' prompt is used (the prompt is already shown via LogUserOutput):
@@ -672,11 +666,9 @@ function UserInput () {
         input_string="${!input_words_array_name_dereferenced}"
     fi
     # When there is no user input or when the user input is only spaces use the "best" fallback or default that exists.
-    # The 'echo -n' is interposed because the output of foo=' ' ; echo -n $foo
-    # is empty (see the same test above):
-    if ! test "$( echo -n $input_string )" ; then
+    if ! contains_visible_char "$input_string" ; then
         # There is no real user input (user input is empty or only spaces):
-        if ! test "$( echo -n $default_input )" ; then
+        if ! contains_visible_char "$default_input" ; then
             # There is neither real user input nor a real default input:
             DebugPrint "UserInput: Neither real user input nor real default input (both empty or only spaces) results ''"
             echo ""

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -21,7 +21,26 @@ function is_numeric () {
     fi
 }
 
-# two explicit functions to be able to test explicitly for true and false (see issue #625)
+# A function to test whether or not its arguments contain at least one 'real value'
+# where 'real value' means to be neither empty nor only blank or control characters.
+# The [:graph:] character class are the visible (a.k.a. printable) characters
+# which is anything except spaces and control characters - i.e. the
+# 7-bit ASCII codes from 0x21 up to 0x7E which are the following
+# alphanumeric characters plus punctuation and symbol characters:
+#  ! " # $ % & ' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @
+#  A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ `
+#  a b c d e f g h i j k l m n o p q r s t u v w x y z { | } ~
+# cf. http://www.regular-expressions.info/posixbrackets.html
+function contains_visible_char () {
+    # The outermost quotation "..." is dispensable in this particular case because
+    # plain 'test' without an argument (i.e. with an empty argument) returns '1'
+    # and here 'test' cannot get more than one argument ('test' for a string of
+    # several non empty words returns '2' with 'bash: test: unary operator expected')
+    # because 'tr' had removed all IFS characters so that 'test' gets at most one word:
+    test "$( tr -d -c '[:graph:]' <<<"$*" )"
+}
+
+# Two explicit functions to be able to test explicitly for true and false (see issue #625)
 # because "tertium non datur" (cf. https://en.wikipedia.org/wiki/Law_of_excluded_middle)
 # does not hold for variables because variables could be unset or have empty value
 # and to test if a variable is true or false its value is tested by that functions
@@ -30,7 +49,7 @@ function is_numeric () {
 # and '! is_false' is not the same as 'is_true' (see both function comments below):
 
 function is_true () {
-    # the argument is usually the value of a variable which needs to be tested
+    # The argument is usually the value of a variable which needs to be tested
     # only if there is explicitly a 'true' value then is_true returns true
     # so that an unset variable or an empty value is not true
     # and also for any other value that is not recognized as a 'true' value
@@ -43,7 +62,7 @@ function is_true () {
 }
 
 function is_false () {
-    # the argument is usually the value of a variable which needs to be tested
+    # The argument is usually the value of a variable which needs to be tested
     # only if there is explicitly a 'false' value then is_false returns true
     # so that an unset variable or an empty value is not false
     # (caution: for unset or empty variables is_false is false)

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -456,8 +456,7 @@ get_device_name() {
     local name=${1#/dev/}
     name=${name#/sys/block/}
 
-    [[ "$name" ]]
-    BugIfError "Empty string passed to get_device_name"
+    contains_visible_char "$name" || BugError "Empty string passed to get_device_name"
 
     ### Translate dm-8 -> mapper/test
     local device dev_number mapper_number
@@ -621,7 +620,7 @@ function UdevSymlinkName() {
     device="$1"
 
     # Exit with Error if no argument is provided to UdevSymlinkName
-    test $device || Error "Empty string passed to UdevSymlinkName()"
+    contains_visible_char "$device" || Error "Empty string passed to UdevSymlinkName()"
 
     # udevinfo is deprecated by udevadm (SLES 10 still uses udevinfo)
     type -p udevinfo >/dev/null && UdevSymlinkName="udevinfo -r / -q symlink -n"
@@ -645,7 +644,7 @@ function UdevQueryName() {
     device_link="$1"
 
     # Exit with Error if no argument is provided to UdevSymlinkName
-    test $device_link || Error "Empty string passed to UdevQueryName()"
+    contains_visible_char "$device_link" || Error "Empty string passed to UdevQueryName()"
 
     # be careful udevinfo is old, now we have udevadm
     # udevinfo -r -q name -n /dev/disk/by-id/scsi-360060e8015268c000001268c000065c0-part4

--- a/usr/share/rear/prep/default/950_check_missing_programs.sh
+++ b/usr/share/rear/prep/default/950_check_missing_programs.sh
@@ -11,15 +11,8 @@ for prog in "${REQUIRED_PROGS[@]}" ; do
     has_binary "$prog" || missing_progs=( "${missing_progs[@]}" "$prog" )
 done
 
-# For the 'test' one must have all array members as a single word like "${arr[*]}" with double-quotes
-# because it should detect when there is any non-empty array member (not necessarily the first one)
-# but here the first array member is always the empty string because of missing_progs=( '' ) above
-# and test must have all as one argument (otherwise on gets 'bash: test: unary operator expected').
-# But on the other hand the test should not succeed when there are only empty or blank members
-# which would falsely succeed when the array is e.g. something like arr=( '' ' ' ) because then
-# "${arr[*]}" evaluates to "  " (the empty and blank members separated by the first character of IFS).
-# and test "${arr[*]}" results true for any non-empty argument (e.g. test " " results true).
-# Therefore 'echo -n' is interposed because the output of arr=( '' ' ' ) ; echo -n ${arr[*]}
-# is empty when the array has only empty or blank array members:
-test "$( echo -n ${missing_progs[*]} )" && Error "Cannot find required programs: ${missing_progs[@]}"
+# Have all array members as a single word like "${arr[*]}" because it should detect
+# when there is any non-empty array member (not necessarily the first one) and here
+# the first array member is always the empty string because of missing_progs=( '' ) above:
+contains_visible_char "${missing_progs[*]}" && Error "Cannot find required programs: ${missing_progs[@]}"
 


### PR DESCRIPTION
The new contains_visible_char function tests
whether or not its arguments contain at least one 'real value'
where 'real value' means to be neither empty nor only blank
or control characters.

Currently it is already used in the UserInput function and in the
get_device_name UdevSymlinkName UdevQueryName
functions in lib/layout-functions.sh and
in 950_check_missing_programs.sh

@schabrolles 
the contains_visible_char function should be in particular
useful for you when you like to ensure a value is
neither empty nor blank.

Note that using plain
<pre>
test $var && echo "var is neither empty nor blank"
</pre>
without quoting $var only works when var contains
at most one single word because it fails for strings:
<pre>
# var='foo bar'

# test $var && echo "var is neither empty nor blank"
-bash: test: foo: unary operator expected
</pre>
In contrast the contains_visible_char function works
basically for any arguments, e.g. even for things like
<pre>
# arr=( '  ' '' '   ' )

# contains_visible_char "${arr[@]}" && echo y || echo n
n

# arr=( '  ' '' '   ' x )

# contains_visible_char "${arr[@]}" && echo y || echo n
y
</pre>
