### PR TITLE
Improve ReaR network migration

### DIFF
--- a/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
+++ b/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
@@ -1,8 +1,9 @@
-# rewrite all the network configuration files for SUSE LINUX according
-# to the mapping files
+# rewrite all the network configuration files (currently Redhat/Suse/Debian/Ubuntu)
+# accoring to the mapping files
 
 # because the bash option nullglob is set in rear (see usr/sbin/rear)
-# PATCH_FILES is empty if nothing matches $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-*
+# PATCH_FILES is empty if nothing matches $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-* $TARGET_FS_ROOT/etc/network/inter[f]aces or $TARGET_FS_ROOT/etc/network/interfaces.d/*
+# $TARGET_FS_ROOT/etc/network/inter[f]aces is a special trick to only add $TARGET_FS_ROOT/etc/network/interfaces if it exists.
 PATCH_FILES=( $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-* $TARGET_FS_ROOT/etc/network/inter[f]aces $TARGET_FS_ROOT/etc/network/interfaces.d/* )
 
 # skip if no network configuration files are found
@@ -24,7 +25,7 @@ if test -s $TMP_DIR/mappings/mac ; then
     SED_SCRIPT=""
     while read old_mac new_mac dev ; do
         SED_SCRIPT="$SED_SCRIPT;s/$old_mac/$new_mac/g"
-        # get device name from mac in case of inet renaming 
+        # get device name from mac in case of inet renaming
         new_dev=$( get_device_by_hwaddr "$new_mac" )
         if test "$new_dev" != "$old_dev" ; then
             SED_SCRIPT="$SED_SCRIPT;s/$dev/$new_dev/g"

--- a/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
+++ b/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
@@ -25,6 +25,11 @@ if test -s $TMP_DIR/mappings/mac ; then
     SED_SCRIPT=""
     while read old_mac new_mac dev ; do
         SED_SCRIPT="$SED_SCRIPT;s/$old_mac/$new_mac/g"
+        # get device name from mac in case of inet renaming 
+        new_dev=$( get_device_by_hwaddr "$new_mac" )
+        if test "$new_dev" != "$old_dev" ; then
+            SED_SCRIPT="$SED_SCRIPT;s/$dev/$new_dev/g"
+        fi
     done < <( read_and_strip_file $CONFIG_DIR/mappings/mac | sed -e 'p;y/abcdef/ABCDEF/' )
     #                                              ^^^^^^^
     #       this is a nasty hack that prints each line as is (lowercase) and once again in uppercase

--- a/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
+++ b/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
@@ -3,11 +3,10 @@
 
 # because the bash option nullglob is set in rear (see usr/sbin/rear)
 # PATCH_FILES is empty if nothing matches $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-*
-PATCH_FILES=( $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-* )
+PATCH_FILES=( $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-* $TARGET_FS_ROOT/etc/network/inter[f]aces $TARGET_FS_ROOT/etc/network/interfaces.d/* )
 
 # skip if no network configuration files are found
 test $PATCH_FILES || return 0
-
 
 # strip all comments and empty lines from the mapping files and copy
 # the results to a temporary directory
@@ -50,11 +49,13 @@ if test -s $TMP_DIR/mappings/mac ; then
     done
 fi
 
-# for the unlikely case where an ip address mapping is supplied but a mac
+# for the unlikely case where an ip address or routes mapping is supplied but a mac
 # mapping is missing, we have to fake a mac mapping file. Otherwise the
-# logic to rewrite the ip addresses wil fail.
+# logic to rewrite the ip addresses or routes will fail.
+# The easiest way is to be sure to always provide a mac mapping files with "old_mac new_mac interface" format
+# with old_mac=new_mac for non-migrated interfaces.
 
-if test -s $TMP_DIR/mappings/ip_addresses && ! test -s $TMP_DIR/mappings/mac ; then
+if ! test -s $TMP_DIR/mappings/mac ; then
     for interface in $(cut -f 1 -d " " $TMP_DIR/mappings/ip_addresses) ; do
         mac=$(cat /sys/class/net/$interface/address)
         echo "$mac $mac $interface" >> $TMP_DIR/mappings/mac
@@ -66,15 +67,18 @@ if test -s $TMP_DIR/mappings/ip_addresses ; then
 
     join -1 3 $TMP_DIR/mappings/mac $TMP_DIR/mappings/ip_addresses |\
     while read dev old_mac new_mac new_ip ; do
+
+        # RHEL 4, 5,... cannot handle IPADDR="x.x.x.x/cidr"
+        nmask=$(prefix2netmask ${new_ip#*/})    # ipaddress/cidr (recalculate the cidr)
+        if [[ "$nmask" = "0.0.0.0" ]]; then
+            nmask=""
+            nip="$new_ip"           # keep ipaddress/cidr
+        else
+            nip="${new_ip%%/*}"     # only keep ipaddress
+        fi
+
+        # Fedora/Suse Family
         for network_file in $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-*${new_mac}* $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-*${dev}*; do
-            # RHEL 4, 5,... cannot handle IPADDR="x.x.x.x/cidr"
-            nmask=$(prefix2netmask ${new_ip#*/})    # ipaddress/cidr (recalculate the cidr)
-            if [[ "$nmask" = "0.0.0.0" ]]; then
-                nmask=""
-                nip="$new_ip"           # keep ipaddress/cidr
-            else
-                nip="${new_ip%%/*}"     # only keep ipaddress
-            fi
             # TODO: what if NETMASK keyword is not defined? Should be keep new_ip then??
             SED_SCRIPT="s#^IPADDR=.*#IPADDR='${nip}'#g;s#^NETMASK=.*#NETMASK='${nmask}'#g;s#^NETWORK=.*#NETWORK=''#g;s#^BROADCAST=.*#BROADCAST=''#g;s#^BOOTPROTO=.*#BOOTPROTO='static'#g;s#STARTMODE='[mo].*#STARTMODE='auto'#g;/^IPADDR_/d;/^LABEL_/d;/^NETMASK_/d"
             Log "SED_SCRIPT: '$SED_SCRIPT'"
@@ -82,19 +86,53 @@ if test -s $TMP_DIR/mappings/ip_addresses ; then
             sed -i -e "$SED_SCRIPT" "$network_file"
             LogPrintIfError "WARNING! There was an error patching the network configuration files!"
         done
+
+        #Debian / ubuntu Family (with network interfaces configuration files)
+        for network_file in $TARGET_FS_ROOT/etc/network/inter[f]aces $TARGET_FS_ROOT/etc/network/interfaces.d/* ; do
+            new_dev=$( get_device_by_hwaddr "$new_mac" )
+            SED_SCRIPT="\
+                /iface $new_dev/ s/;address [0-9.]*;/;address ${nip};/g ;\
+                /iface $new_dev/ s/;netmask [0-9.]*;/;netmask ${nmask};/g"
+            Log "SED_SCRIPT: '$SED_SCRIPT'"
+
+            tmp_network_file="$TMP_DIR/${network_file##*/}"
+            linearize_interfaces_file "$network_file" > "$tmp_network_file"
+
+            sed -i -e "$SED_SCRIPT" "$tmp_network_file"
+            LogPrintIfError "WARNING! There was an error patching the network configuration files!"
+
+            rebuild_interfaces_file_from_linearized "$tmp_network_file" > "$network_file"
+        done
     done
 fi
 
 # set the new routes if a mapping file is available
 if test -s $TMP_DIR/mappings/routes ; then
-    while read destination gateway device junk ; do
-    #   echo "$destination $gateway - $device" >> $TARGET_FS_ROOT/etc/sysconfig/network/routes
+
+    join -1 3 -2 3  $TMP_DIR/mappings/mac $TMP_DIR/mappings/routes |\
+    while read dev old_mac new_mac destination gateway device junk ; do
+        #   echo "$destination $gateway - $device" >> $TARGET_FS_ROOT/etc/sysconfig/network/routes
         if [[ "$destination" = "default" ]]; then
+            # Fedora/Suse Family
             for network_file in $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-*${device}* $TARGET_FS_ROOT/etc/sysconfig/network ; do
                 SED_SCRIPT="s#^GATEWAY=.*#GATEWAY='$gateway'#g;s#^GATEWAYDEV=.*#GATEWAYDEV='$device'#g"
                 Log "SED_SCRIPT: '$SED_SCRIPT'"
                 sed -i -e "$SED_SCRIPT" "$network_file"
                 LogPrintIfError "WARNING! There was an error patching the network configuration files!"
+            done
+
+            #Debian / ubuntu Family (with network interfaces configuration files)
+            for network_file in $TARGET_FS_ROOT/etc/network/inter[f]aces $TARGET_FS_ROOT/etc/network/interfaces.d/* ; do
+                new_dev=$( get_device_by_hwaddr "$new_mac" )
+                SED_SCRIPT="/iface $new_dev/ s/;gateway [0-9.]*;/;gateway $gateway;/g"
+
+                tmp_network_file="$TMP_DIR/${network_file##*/}"
+                linearize_interfaces_file "$network_file" > "$tmp_network_file"
+
+                sed -i -e "$SED_SCRIPT" "$tmp_network_file"
+                LogPrintIfError "WARNING! There was an error patching the network configuration files!"
+
+                rebuild_interfaces_file_from_linearized "$tmp_network_file" > "$network_file"
             done
         else
             # static-routes or route-<device> settings?
@@ -102,5 +140,5 @@ if test -s $TMP_DIR/mappings/routes ; then
                 LogPrint "WARNING! Change entries in $network_file manually please!"
             done
         fi
-    done < $TMP_DIR/mappings/routes
+    done
 fi

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/00-functions.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/00-functions.sh
@@ -2,7 +2,7 @@
 # call udevtrigger
 my_udevtrigger() {
     type -p udevadm >/dev/null && udevadm trigger $@ || udevtrigger $@
-    
+
     # If systemd is running, this should help to rename devices
     if [[ $(ps --no-headers -C systemd) ]]; then
         sleep 1
@@ -28,3 +28,6 @@ Error() {
 
 # source the global functions
 . /usr/share/rear/lib/global-functions.sh
+
+# source the network functions
+. /usr/share/rear/lib/network-functions.sh

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
@@ -1,9 +1,12 @@
 #
-# update 60-network-devices.sh and 62-routing.sh system-setup script if needed (inet renamed, migration)
+# Propose new network insterface if original interface MAC is not found on the current system.
 #
 # migrate network device configuration found in /etc/udev/rules.d/*persistent*{net|names}*.rules to match
 # different hardware from the source system. We assume that udev or static module loading was used to load the
 # appropriate drivers and do not do anything about driver loading
+#
+# if network interface name is not managed by udev ( > rhel7 and > ubuntu 16.04 ), update 60-network-devices.sh
+# and 62-routing.sh system-setup script (inet renamed, migration)
 #
 # adjusts the udev rule and triggers udev
 #
@@ -25,7 +28,6 @@ while read orig_dev orig_mac ; do
 	if ip link show | grep -q "$orig_mac" ; then
 		: noop
 	else
-		#TODO: Check if we really need to store DEVNAMES here.
 		MIGRATE_MACS=( "${MIGRATE_MACS[@]}" "$orig_mac" )
 		MIGRATE_DEVNAMES=( "${MIGRATE_DEVNAMES[@]}" "$orig_dev" )
 	fi

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
@@ -54,8 +54,6 @@ for dev_dir in /sys/class/net/* ; do
 	NEW_DEVICES=( "${NEW_DEVICES[@]}" "$dev $mac $driver" )
 done
 
-TOTAL_MACS=${#MIGRATE_MACS[@]}
-
 # check the existence of a valid mapping file. The file is valid, if at least one "old" mac is mapped
 # to an existing new one.
 read_and_strip_file $MAC_MAPPING_FILE && while read orig_dev orig_mac ; do


### PR DESCRIPTION
The objective of this PR is to update the network migration process in ReaR.

Before this PR, network migration was based on udev rules files to detect and update mac or interface name.

A) The problem is that newer Linux distro (rhel7, ubuntu) does not automatically update anymore the udev network rule files.

This prevent ReaR :
  - to propose new interface in case of migration
  - to rename interface and properly activate network in recovery mode
  - to perform Network Migration on the restored image.

=> Migration is also currently impossible with `biosdevname` network interface name format (which is the new default for ubuntu/redhat.)

B) Network parameter migration (ip/routes via `/etc/rear/mapping/ip_addresses` or  `/etc/rear/mapping/routes`) are only compatible with RedHat/Suse sysconfig file format. (not debian/ubuntu)

This PR propose a migration compatible with latest RH / ubuntu (not based in udev rules but biosdevname) while keeping compatibility with udev rules for older distro.

 1) always propose new interface (even when udev rules is not used or empty)
 2) keep udev rules renaming as default (for compatibility)
 3) perform a direct migration of network system-setup scripts (only if udev migration cannot be done.) => to activate network in rescue mode
 4) Allow a migration of debian/ubuntu network configuration files (currently only redhat/suse)

Tested in migration on POWER with rhel 7.3 / suse 11 / suse 12 / ubuntu 16.04 (with and without `net.ifnames=0`)