### PR TITLE
Fix lintian error (debian) on rear man-page

### DIFF
--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -367,10 +367,10 @@ device.
 
 BACKUP_URL=*sshfs://*::
 To backup to a remote server via sshfs (SSH protocol), use
-+BACKUP_URL=sshfs://user@remote-system.domain.org/home/user/backup-dir/+
++BACKUP_URL=sshfs://user@remote-system.name.org/home/user/backup-dir/+
 +
 It is advisable to add *ServerAliveInterval 15* in the +/root/.ssh/config+
-file for the remote system (remote-system.domain.org).
+file for the remote system (remote-system.name.org).
 
 BACKUP_URL=*iso://*::
 To include the backup within the ISO image. It is important that the +BACKUP_URL+ and


### PR DESCRIPTION
 The lintian is manpage-has-errors-from-man and the error is
 rear.8.gz 525: warning [p 6, 7.0i]: can't break line
 So I just shorten the original line to prevent this.

Author: Frédéric Bonnard <frediz@linuix.vnet.ibm.com>

This patch header follows DEP-3: http://dep.debian.net/deps/dep3/

=> 3th and last back-port patch for Debian (rear-2.2) - issue #1488 