### PR TITLE
Renamed DIRECTORIES_TO_CREATE into DIRECTORY_ENTRIES_TO_RECOVER

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1181,12 +1181,12 @@ DUPLY_PROFILE=""
 # BACKUP_DUPLICITY_OPTIONS="--volsize 100"
 #
 # directories NOT to backup
-# For mountpoints that are not in the backup to restore use DIRECTORIES_TO_CREATE
+# For mountpoints that are not in the backup to restore use DIRECTORY_ENTRIES_TO_RECOVER
 # Mountpoints for proc (e.g. /proc and /var/lib/ntp/proc) and /sys MUST given -
 # if not duplicity will fail!
 # BACKUP_DUPLICITY_EXCLUDE=( '/proc' '/sys' '/run' '/var/lib/ntp/proc' "$HOME/.cache" '/tmp' '/var/tmp' '/app' '/var/app' )
 #
-# Mountpoints and directories to restore via DIRECTORIES_TO_CREATE
+# Mountpoints and directories to restore via DIRECTORY_ENTRIES_TO_RECOVER
 # if defined, used by restore/default/900_create_missing_directories.sh
 #
 #######################################################################
@@ -1496,7 +1496,7 @@ readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/moved_away_after_backup_re
 BACKUP_RESTORE_MOVE_AWAY_FILES=()
 
 ##
-# DIRECTORIES_TO_CREATE
+# DIRECTORY_ENTRIES_TO_RECOVER
 #
 # Create still missing directories and symbolic links
 # after the backup was restored
@@ -1526,9 +1526,9 @@ BACKUP_RESTORE_MOVE_AWAY_FILES=()
 # that actually exist on the system
 # (for details see the 400_save_mountpoint_details.sh script).
 #
-# Via the DIRECTORIES_TO_CREATE array additional directories
+# Via the DIRECTORY_ENTRIES_TO_RECOVER array additional directories
 # and symbolic links that should be created can be specified.
-# For each directory or symbolic link the DIRECTORIES_TO_CREATE array
+# For each directory or symbolic link DIRECTORY_ENTRIES_TO_RECOVER
 # contains an array member which is a string that specifies
 # the directory or symbolic link with the following syntax:
 # A directory is specified as 'directory [ mode [ owner [ group ] ] ]'
@@ -1541,9 +1541,9 @@ BACKUP_RESTORE_MOVE_AWAY_FILES=()
 # so that this way e.g. 'lp lp' can be abbreviated to only 'lp'.
 # A symbolic link is specified as 'symlink_name -> symlink_target'.
 # Example:
-# DIRECTORIES_TO_CREATE=( '/path/to/mytmpdir 1770 myowner mygroup' '/var/mytmpdir -> /path/to/mytmpdir' )
-# By default the DIRECTORIES_TO_CREATE array is empty:
-DIRECTORIES_TO_CREATE=()
+# DIRECTORY_ENTRIES_TO_RECOVER=( '/path/to/mytmpdir 1770 myowner mygroup' '/var/mytmpdir -> /path/to/mytmpdir' )
+# By default the DIRECTORY_ENTRIES_TO_RECOVER array is empty:
+DIRECTORY_ENTRIES_TO_RECOVER=()
 
 ##
 # How to exclude something ----- EXCLUDES -------

--- a/usr/share/rear/restore/default/900_create_missing_directories.sh
+++ b/usr/share/rear/restore/default/900_create_missing_directories.sh
@@ -9,12 +9,12 @@
 # to save permissions, owner, group or symbolic link name and target of basic directories:
 local directories_permissions_owner_group_file="$VAR_DIR/recovery/directories_permissions_owner_group"
 
-# Append other directories or symlinks in the DIRECTORIES_TO_CREATE array
+# Append other directories or symlinks in the DIRECTORY_ENTRIES_TO_RECOVER array
 # to the directories_permissions_owner_group file.
 # For the 'test' one must have all array members as a single word i.e. "${name[*]}"
 # because it should succeed when there is any non-empty array member, not necessarily the first one:
-if test "${DIRECTORIES_TO_CREATE[*]}" ; then
-    for directory_permissions_owner_group in "${DIRECTORIES_TO_CREATE[@]}" ; do
+if test "${DIRECTORY_ENTRIES_TO_RECOVER[*]}" ; then
+    for directory_permissions_owner_group in "${DIRECTORY_ENTRIES_TO_RECOVER[@]}" ; do
         test "$directory_permissions_owner_group" || continue
         # Using no double quotes for the variable in the echo command
         # condenses multiple spaces into one and strips leading and trailing spaces:

--- a/usr/share/rear/verify/TSM/default/400_verify_tsm.sh
+++ b/usr/share/rear/verify/TSM/default/400_verify_tsm.sh
@@ -1,64 +1,65 @@
 #
-#
-# NOTE: In this script we use '"${TSM_FILESPACE_NUMS[*]}"' (instead of [@]) and it seems to be intentionally
-# usually this is a cause for trouble but apparently here it was done on purpose.
-# If this code doesn't work then please try with [@] instead
-#
-# 2009-10-12 Schlomo as part of a code review to fix all occurrences of [*]
-#
-#
-# read TSM vars from TSM config files ( look a bit like an init file with KEY=VALUE pairs )
+# Read TSM vars from TSM config files ( look a bit like an init file with KEY=VALUE pairs )
 # The keys are loaded into environment variables called TSM_SYS_$KEY
-# Since TSM has several options that have a dot in their name, the dot is replaced by an underscore
-# read dsm.sys
-while read KEY VALUE ; do echo "$KEY" | grep -q '*' && continue ; test -z "$KEY" && continue ; KEY="$(echo "$KEY" | tr a-z. A-Z_)" ; export TSM_SYS_$KEY="${VALUE//\"}" ; done </opt/tivoli/tsm/client/ba/bin/dsm.sys
-# read dsm.opt
-while read KEY VALUE ; do echo "$KEY" | grep -q '*' && continue ; test -z "$KEY" && continue ; KEY="$(echo "$KEY" | tr a-z. A-Z_)" ; export TSM_OPT_$KEY="${VALUE//\"}" ; done </opt/tivoli/tsm/client/ba/bin/dsm.opt
+# Since TSM has several options that have a dot in their name, the dot is replaced by an underscore.
+# Read dsm.sys:
+while read KEY VALUE ; do
+    echo "$KEY" | grep -q '*' && continue
+    test -z "$KEY" && continue
+    KEY="$(echo "$KEY" | tr a-z. A-Z_)"
+    export TSM_SYS_$KEY="${VALUE//\"}"
+done </opt/tivoli/tsm/client/ba/bin/dsm.sys
+# Read dsm.opt:
+while read KEY VALUE ; do
+    echo "$KEY" | grep -q '*' && continue
+    test -z "$KEY" && continue
+    KEY="$(echo "$KEY" | tr a-z. A-Z_)"
+    export TSM_OPT_$KEY="${VALUE//\"}"
+done </opt/tivoli/tsm/client/ba/bin/dsm.opt
 
-# check that TSM server is actually available (ping)
-[ "${TSM_SYS_TCPSERVERADDRESS}" ]
-StopIfError "TSM Server not set in dsm.sys (TCPSERVERADDRESS) !"
+# Check that TSM server is set in dsm.sys:
+test "$TSM_SYS_TCPSERVERADDRESS" || Error "TSM Server not set in dsm.sys (TCPSERVERADDRESS)"
 
+# Check that TSM server is actually available (ping):
 if test "$PING" ; then
-	ping -c 1 "${TSM_SYS_TCPSERVERADDRESS}" >/dev/null 2>&1
-	StopIfError "Sorry, but cannot reach TSM Server ${TSM_SYS_TCPSERVERADDRESS}"
-
-	Log "TSM Server ${TSM_SYS_TCPSERVERADDRESS} seems to be up and running."
+    ping -c 1 "$TSM_SYS_TCPSERVERADDRESS" >/dev/null 2>&1 || Error "TSM server '$TSM_SYS_TCPSERVERADDRESS' does not respond to a 'ping'"
+    Log "TSM server '$TSM_SYS_TCPSERVERADDRESS' seems to be up and running (responds to a 'ping')"
 else
-	Log "Skipping ping test"
+    Log "Skipping ping test for TSM server '$TSM_SYS_TCPSERVERADDRESS'"
 fi
 
-# Use the included_mountpoints array derived from the disklayout.conf to determine the default
-# TSM filespaces to include in a restore.
-included_mountpoints=( $(grep ^fs $VAR_DIR/layout/disklayout.conf  | awk '{print $3}') $(grep ^btrfsmountedsubvol $VAR_DIR/layout/disklayout.conf | awk '{print $3}' | grep -v "/.snapshots") )
-included_mountpoints=($(tr ' ' '\n' <<<"${included_mountpoints[@]}" | awk '!u[$0]++' |  tr '\n' ' '))
+# Use the included_mountpoints array derived from the disklayout.conf to determine the default TSM filespaces
+# to include in a restore (all filesystems plus all mounted btrfs subvolumes except SUSE snapshot subvolumes):
+included_mountpoints=( $( grep '^fs' $VAR_DIR/layout/disklayout.conf | awk '{print $3}' ) )
+included_mountpoints=( "${included_mountpoints[@]}" $( grep '^btrfsmountedsubvol' $VAR_DIR/layout/disklayout.conf | awk '{print $3}' | grep -v '/.snapshots' ) )
+included_mountpoints=( $( tr ' ' '\n' <<<"${included_mountpoints[@]}" | awk '!u[$0]++' | tr '\n' ' ' ) )
 
 # TSM does not restore the mountpoints for filesystems it does not recover.
-# Appending excluded mountpoint directories to the DIRECTORIES_TO_CREATE variable
-# (there could be already user specified directories in the DIRECTORIES_TO_CREATE variable)
+# Appending excluded mountpoint directories to the DIRECTORY_ENTRIES_TO_RECOVER array
+# (there could be already user specified directories in the DIRECTORY_ENTRIES_TO_RECOVER array)
 # allows them to be recreated in the restore default 900_create_missing_directories.sh script:
 excluded_mountpoints=( $( grep '^#fs' $VAR_DIR/layout/disklayout.conf | awk '{print $3}' ) )
-DIRECTORIES_TO_CREATE="$DIRECTORIES_TO_CREATE ${excluded_mountpoints[@]#/}"
+DIRECTORY_ENTRIES_TO_RECOVER=( "${DIRECTORY_ENTRIES_TO_RECOVER[@]}" "${excluded_mountpoints[@]}" )
 
-# find out which filespaces (= mountpoints) are available for restore
-LC_ALL=${LANG_RECOVER} dsmc query filespace -date=2 -time=1 -scrollprompt=no | grep -A 10000 'File' >$TMP_DIR/tsm_filespaces
+# Find out which filespaces (= mountpoints) are available for restore.
 # Error code 8 can be ignored, see bug report at
 # https://sourceforge.net/tracker/?func=detail&atid=859452&aid=1942895&group_id=171835
-[ $PIPESTATUS -eq 0 -o $PIPESTATUS -eq 8 ]
-StopIfError "'dsmc query filespace' failed !"
-TSM_FILESPACE_TEXT="$(cat $TMP_DIR/tsm_filespaces)"
+LC_ALL=${LANG_RECOVER} dsmc query filespace -date=2 -time=1 -scrollprompt=no | grep -A 10000 'File' >$TMP_DIR/tsm_filespaces
+[ $PIPESTATUS -eq 0 -o $PIPESTATUS -eq 8 ] || Error "'dsmc query filespace' failed"
+
+TSM_FILESPACE_TEXT="$( cat $TMP_DIR/tsm_filespaces )"
 TSM_FILESPACES=()
 TSM_FILESPACE_NUMS=( )
 # TSM_FILESPACE_INCLUDED arrays for use as default value for TSM_RESTORE_FILESPACE_NUMS
 TSM_FILESPACE_INCLUDED=( )
 TSM_FILESPACE_INCLUDED_NUMS=( )
 while read num path ; do
-	TSM_FILESPACES[$num]="$path"
-	TSM_FILESPACE_NUMS[$num]="$num"
-        if IsInArray $path "${included_mountpoints[@]}" ; then
-              TSM_FILESPACE_INCLUDED[$num]="$path"
-              TSM_FILESPACE_INCLUDED_NUMS[$num]="$num"
-        fi
+    TSM_FILESPACES[$num]="$path"
+    TSM_FILESPACE_NUMS[$num]="$num"
+    if IsInArray $path "${included_mountpoints[@]}" ; then
+        TSM_FILESPACE_INCLUDED[$num]="$path"
+        TSM_FILESPACE_INCLUDED_NUMS[$num]="$num"
+    fi
 done < <((grep -A 10000 '^  1' | awk '{print $1 " " $NF}') <<<"$TSM_FILESPACE_TEXT")
 
 Log "Available filespaces:
@@ -66,32 +67,36 @@ $TSM_FILESPACE_TEXT"
 
 LogUserOutput "
 The TSM Server reports the following for this node:
-$(echo "$TSM_FILESPACE_TEXT" | sed -e 's/^/\t\t/')
+$( echo "$TSM_FILESPACE_TEXT" | sed -e 's/^/\t\t/' )
 Please enter the numbers of the filespaces we should restore.
 Pay attention to enter the filesystems in the correct order
-(like restore / before /var/log) ! "
+(like restore / before /var/log)"
 # Use the original STDIN STDOUT and STDERR when rear was launched by the user
 # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
 read -t $WAIT_SECS -p "(default: ${TSM_FILESPACE_INCLUDED_NUMS[*]}): [$WAIT_SECS secs] " -r TSM_RESTORE_FILESPACE_NUMS 0<&6 1>&7 2>&8
 if test -z "$TSM_RESTORE_FILESPACE_NUMS" ; then
-	TSM_RESTORE_FILESPACE_NUMS="${TSM_FILESPACE_INCLUDED_NUMS[*]}" # set default on ENTER
-	Log "User pressed ENTER, setting default of ${TSM_FILESPACE_INCLUDED_NUMS[*]}"
+    # Set default on ENTER:
+    TSM_RESTORE_FILESPACE_NUMS="${TSM_FILESPACE_INCLUDED_NUMS[*]}"
+    Log "User pressed ENTER, setting default of ${TSM_FILESPACE_INCLUDED_NUMS[*]}"
 fi
-# remove extra spaces
-TSM_RESTORE_FILESPACE_NUMS="$(echo "$TSM_RESTORE_FILESPACE_NUMS" |tr -s " ")"
+# Remove extra spaces:
+TSM_RESTORE_FILESPACE_NUMS="$( echo "$TSM_RESTORE_FILESPACE_NUMS" | tr -s ' ' )"
 
-[ "${#TSM_RESTORE_FILESPACE_NUMS}" -gt 0 ]
-StopIfError "No filespaces selected !"
+test "${#TSM_RESTORE_FILESPACE_NUMS}" -gt 0 || Error "No filespaces selected"
 
-LogPrint "We will now restore the following filesystems:"
+LogPrint "The following filesystems will be restored:"
 for num in $TSM_RESTORE_FILESPACE_NUMS ; do
-        LogPrint "${TSM_FILESPACES[$num]}"
+    LogPrint "${TSM_FILESPACES[$num]}"
 done
 # Use the original STDIN STDOUT and STDERR when rear was launched by the user
 # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
 read -t $WAIT_SECS -r -p "Is this selection correct ? (Y|n) [$WAIT_SECS secs] " 0<&6 1>&7 2>&8
 case "$REPLY" in
-	""|y|Y)	Log "User confirmed filespace selection" ;;
-	*)	Error "User aborted filespace confirmation." ;;
+    (""|y|Y)
+        Log "User confirmed filespace selection"
+        ;;
+    (*)
+        Error "User aborted filespace confirmation"
+        ;;
 esac
 


### PR DESCRIPTION
Renamed DIRECTORIES_TO_CREATE into
DIRECTORY_ENTRIES_TO_RECOVER according to
https://github.com/rear/rear/pull/1513#discussion_r141318652

Plus a fix for that in  400_verify_tsm.sh
and - by the way - some code cleanup therein.
