### PR TITLE
Only support OpenSSH 3.1 and later for SSH setup

### DIFF
--- a/usr/share/rear/build/default/500_ssh_setup.sh
+++ b/usr/share/rear/build/default/500_ssh_setup.sh
@@ -56,7 +56,8 @@ if test -d "/$sshd_needed_directory" ; then
     mkdir $v -p $ROOTFS_DIR/$sshd_needed_directory
 fi
 
-# Generate new SSH host key in the recovery system when no SSH host key file
+# Generate new SSH protocol version 2 host keys in the recovery system
+# when no SSH host key file of the key types rsa, dsa, ecdsa, and ed25519
 # had been copied into the the recovery system in rescue/default/500_ssh.sh
 # cf. https://github.com/rear/rear/issues/1512#issuecomment-331638066
 # but skip that if SSH_UNPROTECTED_PRIVATE_KEYS is false

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -818,39 +818,56 @@ CLONE_ALL_USERS_GROUPS="no"
 #
 # What SSH files should be copied into the ReaR rescue/recovery system and
 # how SSH access in the ReaR rescue/recovery system should be set up.
+#
+# Only OpenSSH >= 3.1 with its default directories is supported
+# by the automated functionality via those SSH_* variables in ReaR.
+# When a different secure shell software is used, its files and programs
+# that are needed for remote access in the recovery system must be manually specified
+# via COPY_AS_IS and REQUIRED_PROGS (possibly also via COPY_AS_IS_EXCLUDE and LIBS).
+#
 # When SSH_FILES is set to a 'false' value no SSH file is copied into the recovery system
 # and nothing is done to set up SSH (in particular no sshd) in the recovery system.
 # In this case one could still use generic ReaR functionality like COPY_AS_IS and
 # REQUIRED_PROGS to manually copy some plain SSH files into the recovery system
-# but then there is still none of the special SSH setup in the recovery system.
-# When SSH_FILES is set to a 'true' value all the "usual SSH files" in
-# /etc/ssh* /etc/openssh* /etc/centrifydc/ssh* /root/.ssh /root/.shosts
-# (including private SSH keys) get copied into the recovery system
-# to make things "just work" in the recovery system which usually makes
-# the recovery system (in particular its ISO image and any recovery medium)
+# but then there is still none of the special SSH setup for the recovery system.
+#
+# When SSH_FILES is set to a 'true' value the "usual OpenSSH >= 3.1 files" in the
+# /etc/ssh /root/.ssh /root/.shosts directories are copied into the recovery system
+# including private keys provided SSH_UNPROTECTED_PRIVATE_KEYS is 'true' (see below).
+# This makes remote access "just work" in the recovery system but (usually) this also
+# makes the recovery system (in particular its ISO image and any recovery medium)
 # a confidential piece of data that needs to be protected against unwated access
 # cf. https://github.com/rear/rear/issues/1511 and https://github.com/rear/rear/issues/1512
+#
 # When SSH_FILES is an array of files or directories like SSH_FILES=( /etc/ssh /root/.ssh )
 # those files and directories are copied into the recovery system via COPY_AS_IS
 # so that also COPY_AS_IS_EXCLUDE works to exclude some unwanted files from that list
 # like COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" '/etc/ssh/sh_host_*' '/root/.ssh/id_*' )
-# where in particular excluding '/etc/ssh/*key*' results that SSH host key files
-# will be generated anew in the recovery system as described below.
+# where in particular excluding '/etc/ssh/sh_host_*' results that SSH host key files
+# will be generated anew for the recovery system (see below).
+#
 # When SSH_FILES is not set to a 'false' value additionally some SSH programs
 # are copied into the recovery system, in particular ssh, sshd, scp, sftp, ssh-agent,
 # and ssh-keygen plus a sftp-server program (e.g. /usr/lib/ssh/sftp-server).
+#
 # The default setting SSH_FILES='avoid_sensitive_files' should be reasonably secure
 # because it avoids copying sensitive SSH files as follows:
 # From /etc/ssh only moduli, ssh_config, sshd_config, and ssh_known_hosts are copied and
 # from /root/.ssh only authorized_keys and known_hosts are copied into the recovery system.
 # SSH host key files can be generated anew only for the recovery system
 # when SSH_UNPROTECTED_PRIVATE_KEYS is not set to a 'false' value (which is not the default).
-# Only those type of keys are generated where a matching /etc/ssh/ssh_host_TYPE_key file exists
-# on the original system for the SSH protocol version 2 key types rsa, dsa, ecdsa, and ed25519
+#
+# SSH protocol version 2 type host keys are generated anew for the recovery system
+# when no such type of key file was copied into the the recovery system and
+# provided SSH_UNPROTECTED_PRIVATE_KEYS is not set to a 'false' value
+# because private host keys are never protected.
+# When SSH host keys are generated anew for the recovery system, only those types are
+# generated where a matching /etc/ssh/ssh_host_TYPE_key exists on the original system
+# for the SSH protocol version 2 key types rsa, dsa, ecdsa, and ed25519
 # to get the generated SSH host key files on the recovery system in reasonable compliance
 # with what there is on the original system. If a SSH protocol version 1 key is really needed
 # use COPY_AS_IS for example like COPY_AS_IS=( "${COPY_AS_IS[@]}" '/etc/ssh/ssh_host_key*' )
-# When SSH host key files are generated anew for the recovery system, SSH access to the
+# When SSH host keys are generated anew for the recovery system, SSH access to the
 # recovery system from a remote host could fail on the remote host with something like
 # "REMOTE HOST IDENTIFICATION HAS CHANGED - Offending key in /home/user/.ssh/known_hosts"
 # until the offending key is corrected or removed which then could lead on the remote host
@@ -859,6 +876,7 @@ CLONE_ALL_USERS_GROUPS="no"
 # SSH host key files can be generated already during 'rear mkrescue' or 'rear mkbackup'
 # so that the new SSH host key files are available (when KEEP_BUILD_DIR="yes" is used).
 # For details see rescue/default/500_ssh.sh and build/default/500_ssh_setup.sh
+#
 # If there are no SSH host key files in the recovery system but sshd should be started
 # a fallback RSA key is generated when starting sshd during recovery system startup
 # and the RSA key fingerprint is shown on the recovery system login screen.
@@ -897,9 +915,10 @@ SSH_ROOT_PASSWORD=
 # There is no simple way to find and check for unprotected SSH key files
 # so that SSH_UNPROTECTED_PRIVATE_KEYS="no" is not at all any guarantee
 # to not have any kind of unprotected SSH key in the recovery system.
-# To check if there are unwanted files in the recovery system use KEEP_BUILD_DIR="yes"
-# and inspect the recovery system content in $TMPDIR/rear.XXXXXXXXXXXXXXX/rootfs/
-# and use COPY_AS_IS_EXCLUDE to exclude unwanted files from the recovery system.
+# In general to check if there are unwanted files in the recovery system
+# use KEEP_BUILD_DIR="yes" and inspect the recovery system content
+# in $TMPDIR/rear.XXXXXXXXXXXXXXX/rootfs/ and use COPY_AS_IS_EXCLUDE
+# to exclude unwanted files from the recovery system.
 SSH_UNPROTECTED_PRIVATE_KEYS='no'
 
 # time synchronisation, could be NTP, RDATE or empty

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -821,9 +821,12 @@ CLONE_ALL_USERS_GROUPS="no"
 #
 # Only OpenSSH >= 3.1 with its default directories is supported
 # by the automated functionality via those SSH_* variables in ReaR.
-# When a different secure shell software is used, its files and programs
-# that are needed for remote access in the recovery system must be manually specified
-# via COPY_AS_IS and REQUIRED_PROGS (possibly also via COPY_AS_IS_EXCLUDE and LIBS).
+# When a different secure shell software is used set SSH_FILES='no'
+# to get the SSH setup functionality in ReaR out of the way (see below)
+# and specify the files and programs that are needed for remote access
+# in the recovery system via COPY_AS_IS and REQUIRED_PROGS and
+# possibly also via COPY_AS_IS_EXCLUDE and perhaps also via LIBS
+# (e.g. if the secure shell software loads special libraries via dlopen).
 #
 # When SSH_FILES is set to a 'false' value no SSH file is copied into the recovery system
 # and nothing is done to set up SSH (in particular no sshd) in the recovery system.

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -45,28 +45,15 @@ contains_visible_char "${copy_as_is_ssh_files[*]}" && COPY_AS_IS=( "${COPY_AS_IS
 PROGS=( "${PROGS[@]}" ssh sshd scp sftp ssh-agent ssh-keygen )
 
 # Copy a sftp-server program (e.g. /usr/lib/ssh/sftp-server) into the recovery system (if exists).
-# The funny [] around a letter makes 'shopt -s nullglob' remove this file from the list if it does not exist
-# is no longer funny if none of those files exists because then calling directly a command like
-# grep -h 'sftp' /etc/sshd_co[n]fig /etc/ssh/sshd_co[n]fig /etc/openssh/sshd_co[n]fig 2>/dev/null
-# would become actually (if none of those files exists)
-# grep -h 'sftp' 2>/dev/null
-# which hangs up the whole ReaR because without specified files grep waits endlessly for input on stdin.
-# Accordingly we first test if there are actually files for grep:
-local files_for_grep=( /etc/sshd_co[n]fig /etc/ssh/sshd_co[n]fig /etc/openssh/sshd_co[n]fig )
-if test "${files_for_grep[*]}" ; then
-    # The output of the below command that is something like
-    # grep -h 'sftp' /etc/ssh/sshd_config 2>/dev/null
-    # looks like
-    # Subsystem  sftp    /usr/lib/ssh/sftp-server
-    # The '-h' makes it fail-safe against possible leading spaces that would change the grep_sftp_output array elements
-    # because without a leading space and without '-h' the output of 'grep' would look like
-    # /etc/ssh/sshd_config:Subsystem  sftp    /usr/lib/ssh/sftp-server
-    # but in contrast with a leading space and without '-h' the output of 'grep' would look like
-    # /etc/ssh/sshd_config: Subsystem  sftp    /usr/lib/ssh/sftp-server
-    local grep_sftp_output=( $( grep -h 'sftp' ${files_for_grep[*]} 2>/dev/null ) )
-    local sftp_program="${grep_sftp_output[2]}"
-    test "$sftp_program" && PROGS=( "${PROGS[@]}" "$sftp_program" )
-fi
+# Because only OpenSSH >= 3.1 is supported where /etc/ssh/ is the default directory for configuration files
+# only /etc/ssh/sshd_config is inspected to grep for a sftp-server program therein.
+# The output of the grep command
+# grep 'sftp' /etc/ssh/sshd_config 2>/dev/null
+# looks like
+# Subsystem  sftp    /usr/lib/ssh/sftp-server
+local grep_sftp_output=( $( grep 'sftp' /etc/ssh/sshd_config 2>/dev/null ) )
+local sftp_program="${grep_sftp_output[2]}"
+test "$sftp_program" && PROGS=( "${PROGS[@]}" "$sftp_program" )
 
 # We need to add some specific NSS lib for shadow passwords to work on RHEL 6/7
 # cf. https://github.com/rear/rear/issues/560#issuecomment-124578636 and subsequent comments:

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -46,7 +46,8 @@ PROGS=( "${PROGS[@]}" ssh sshd scp sftp ssh-agent ssh-keygen )
 
 # Copy a sftp-server program (e.g. /usr/lib/ssh/sftp-server) into the recovery system (if exists).
 # Because only OpenSSH >= 3.1 is supported where /etc/ssh/ is the default directory for configuration files
-# only /etc/ssh/sshd_config is inspected to grep for a sftp-server program therein.
+# only /etc/ssh/sshd_config is inspected to grep for a sftp-server program therein
+# cf. https://github.com/rear/rear/pull/1538#issuecomment-337904240
 # The output of the grep command
 # grep 'sftp' /etc/ssh/sshd_config 2>/dev/null
 # looks like


### PR DESCRIPTION
This intends to implement what is described in
https://github.com/rear/rear/pull/1530#issuecomment-337526810
and subsequent comments.

This removes "out-of-the-box" support in ReaR for
other secure shell software like CentrifySSH
cf. https://github.com/rear/rear/issues/836
but it does not make OpenSSH mandatory for ReaR
so that the initial problem in
https://github.com/rear/rear/issues/836
should not re-appear.

In default.conf it is now described how to set up ReaR
with a secure shell software other than OpenSSH >= 3.1
basically via
<pre>
SSH_FILES='no'
COPY_AS_IS=( "${COPY_AS_IS[@]}" my secure shell software files )
REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" my secure shell programs )
</pre>

Currently I have not yet tested it.