### PR TITLE
Some code simplification plus explicit 'return 0' where needed

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -509,9 +509,8 @@ for prog in "${REQUIRED_PROGS[@]}" ; do
     has_binary "$prog" || missing_progs=( "${missing_progs[@]}" "$prog" )
 done
 # Detect when there is any non-empty array member (the first one is always empty, see above)
-# but the test should not succeed when there are only empty or blank array members
-# therefore 'echo -n' is interposed because its output is empty for only empty or blank arrays:
-test "$( echo -n ${missing_progs[*]} )" && Error "Cannot find required programs: ${missing_progs[@]}"
+# but the test should not succeed when there are only empty or blank array members:
+contains_visible_char "${missing_progs[*]}" && Error "Cannot find required programs:${missing_progs[@]}"
 
 readonly VERSION_INFO="
 $PRODUCT $VERSION / $RELEASE_DATE

--- a/usr/share/rear/backup/RSYNC/GNU/Linux/310_stop_selinux.sh
+++ b/usr/share/rear/backup/RSYNC/GNU/Linux/310_stop_selinux.sh
@@ -1,12 +1,15 @@
+#
 # Stop SELinux if present - see prep/RSYNC/GNU/Linux/200_selinux_in_use.sh
-[ -f $TMP_DIR/selinux.mode ] || return
-case "$(basename ${BACKUP_PROG})" in
-	(tar|rsync)
-		#cat /selinux/enforce > $TMP_DIR/selinux.mode
-		echo "0" > $SELINUX_ENFORCE
-		Log "Temporarely stop SELinux enforce mode with BACKUP=${BACKUP} and BACKUP_PROG=${BACKUP_PROG} backup"
-	;;
-	(*) # do nothing
-		:
-	;;
+#
+test -f $TMP_DIR/selinux.mode || return 0
+case "$( basename ${BACKUP_PROG} )" in
+    (tar|rsync)
+        #cat /selinux/enforce > $TMP_DIR/selinux.mode
+        echo "0" > $SELINUX_ENFORCE
+        Log "Temporarily stopping SELinux enforce mode with BACKUP=${BACKUP} and BACKUP_PROG=${BACKUP_PROG} backup"
+        ;;
+    (*) # do nothing
+        :
+        ;;
 esac
+

--- a/usr/share/rear/build/default/500_ssh_setup.sh
+++ b/usr/share/rear/build/default/500_ssh_setup.sh
@@ -2,7 +2,7 @@
 # Adapt some SSH configs and as needed regenerate SSH host key:
 
 # There is nothing to do when there are no SSH binaries on the original system:
-has_binary ssh || has_binary sshd || return
+has_binary ssh || has_binary sshd || return 0
 
 # Do nothing when not any SSH file should be copied into the recovery system:
 is_false "$SSH_FILES" && return

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -305,7 +305,10 @@ ISO_ISOLINUX_BIN=""
 # The ISO_MAX_SIZE value is specified in MiB
 # (is is used in a "split -b ${ISO_MAX_SIZE}m ..." command).
 # It is useful when the backup is included within the ISO image
-# (i.e. together with things like 'BACKUP_URL=iso:///backup'):
+# (i.e. together with things like 'BACKUP_URL=iso:///backup').
+# ISO_MAX_SIZE cannot be less than what the ReaR rescue/recovery system needs
+# because the recovery system must fit onto one (bootable) recovery medium
+# so that the recovery system must be made as a single (bootable) ISO:
 ISO_MAX_SIZE=
 
 # how to find mkisofs

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -293,11 +293,15 @@ RAMDISK_SUFFIX="$HOSTNAME"
 # which supports the NETFS syntax (to copy the ISO image across the network).
 ISO_DIR=$VAR_DIR/output
 
-# default ISO volid
+# Default ISO label:
+# When the backup is split on multiple ISOs (cf. ISO_MAX_SIZE below)
+# the first ISO 'rear-HOSTNAME.iso' has the label $ISO_VOLID
+# and subsequent ISOs 'rear-HOSTNAME_01.iso' 'rear-HOSTNAME_02.iso' ...
+# get the labels ${ISO_VOLID}_01 ${ISO_VOLID}_02 ... respectively.
 ISO_VOLID="RELAXRECOVER"
 
-# how to find isolinux.bin. Possible values are "" (meaning search for it)
-# or "/path/to/isolinux.bin"
+# How to find isolinux.bin.
+# Possible values are "" (meaning search for it) or "/path/to/isolinux.bin"
 ISO_ISOLINUX_BIN=""
 
 # Maximum size of generated ISO images.
@@ -308,7 +312,18 @@ ISO_ISOLINUX_BIN=""
 # (i.e. together with things like 'BACKUP_URL=iso:///backup').
 # ISO_MAX_SIZE cannot be less than what the ReaR rescue/recovery system needs
 # because the recovery system must fit onto one (bootable) recovery medium
-# so that the recovery system must be made as a single (bootable) ISO:
+# so that the recovery system must be made as a single (bootable) ISO.
+# When the backup is split on multiple ISOs, then "rear mkrescue" would destroy
+# the backup because after "rear mkbackup" the first ISO 'rear-HOSTNAME.iso'
+# contains the recovery system plus the first part of the splitted backup
+# but "rear mkrescue" overwrites that first ISO with one that contains only
+# a new recovery system but no longer the first part of the splitted backup
+# so that then "rear recover" fails with "ERROR: Backup archive ... not found"
+# cf. https://github.com/rear/rear/issues/1545
+# Even with a sufficiently big maximum ISO size so that all is in one ISO
+# "rear mkrescue" would overwrite an ISO that already contains a backup.
+# Accordingly when ISO_MAX_SIZE is set the mkrescue workflow is forbidden
+# to be on the safe side to not possibly destroy an existing backup.
 ISO_MAX_SIZE=
 
 # how to find mkisofs

--- a/usr/share/rear/finalize/Linux-i386/610_install_grub.sh
+++ b/usr/share/rear/finalize/Linux-i386/610_install_grub.sh
@@ -13,7 +13,7 @@
 
 # Skip if another boot loader is already installed
 # (then $NOBOOTLOADER is not a true value cf. finalize/default/010_prepare_checks.sh):
-is_true $NOBOOTLOADER || return
+is_true $NOBOOTLOADER || return 0
 
 # For UEFI systems with grub legacy with should use efibootmgr instead:
 is_true $USING_UEFI_BOOTLOADER && return
@@ -22,7 +22,7 @@ is_true $USING_UEFI_BOOTLOADER && return
 # is not "GRUB" (which means GRUB Legacy) skip this script (which is only for GRUB Legacy)
 # because finalize/Linux-i386/220_install_grub2.sh is for installing GRUB 2
 # and finalize/Linux-i386/220_install_elilo.sh is for installing elilo:
-test "GRUB" = "$BOOTLOADER" || return
+test "GRUB" = "$BOOTLOADER" || return 0
 
 # If the BOOTLOADER variable is "GRUB" (which means GRUB Legacy)
 # do not unconditionally trust that because https://github.com/rear/rear/pull/589

--- a/usr/share/rear/finalize/Linux-i386/620_install_elilo.sh
+++ b/usr/share/rear/finalize/Linux-i386/620_install_elilo.sh
@@ -7,10 +7,10 @@ if [[ -z "$NOBOOTLOADER" ]] ; then
 fi
 
 # for UEFI systems we defined USING_UEFI_BOOTLOADER=1; BIOS based is 0 or ""
-is_true $USING_UEFI_BOOTLOADER || return # when set to 0
+is_true $USING_UEFI_BOOTLOADER || return 0 # when set to 0
 
 # Only for elilo
-[[ "$BOOTLOADER" == "ELILO" ]] || return  # only continue when bootloader is elilo based
+[[ "$BOOTLOADER" == "ELILO" ]] || return 0 # only continue when bootloader is elilo based
 
 [[ $(type -p elilo) ]]
 StopIfError "Could not find elilo executable"

--- a/usr/share/rear/finalize/Linux-i386/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/620_install_grub2.sh
@@ -12,14 +12,14 @@
 
 # skip if another bootloader was installed
 if [[ -z "$NOBOOTLOADER" ]] ; then
-    return
+    return 0
 fi
 
 # for UEFI systems with grub2 we should use efibootmgr instead
 is_true $USING_UEFI_BOOTLOADER && return # when set to 1
 
 # Only for GRUB2 - GRUB Legacy will be handled by its own script
-[[ $(type -p grub-probe) || $(type -p grub2-probe) ]] || return
+[[ $(type -p grub-probe) || $(type -p grub2-probe) ]] || return 0
 
 LogPrint "Installing GRUB2 boot loader"
 mount -t proc none $TARGET_FS_ROOT/proc

--- a/usr/share/rear/finalize/Linux-i386/630_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/630_run_efibootmgr.sh
@@ -1,5 +1,5 @@
 # only useful for UEFI systems in combination with grub[2]-efi
-is_true $USING_UEFI_BOOTLOADER || return  # empty or 0 means using BIOS
+is_true $USING_UEFI_BOOTLOADER || return 0 # empty or 0 means using BIOS
 
 # check if $TARGET_FS_ROOT/boot/efi is mounted
 [[ -d "$TARGET_FS_ROOT/boot/efi" ]]

--- a/usr/share/rear/finalize/Linux-ppc64/540_check_lilo_path.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/540_check_lilo_path.sh
@@ -8,7 +8,7 @@
 #################################################################
 
 # skip if lilo conf is not found
-test -f $TARGET_FS_ROOT/etc/lilo.conf || return
+test -f $TARGET_FS_ROOT/etc/lilo.conf || return 0
 
 # Find PPC PReP Boot partitions
 part=$( awk -F '=' '/^boot/ {print $2}' $TARGET_FS_ROOT/etc/lilo.conf )

--- a/usr/share/rear/finalize/Linux-ppc64/540_check_yaboot_path.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/540_check_yaboot_path.sh
@@ -8,7 +8,7 @@
 #################################################################
 
 # skip if yaboot conf is not found
-test -f $TARGET_FS_ROOT/etc/yaboot.conf || return
+test -f $TARGET_FS_ROOT/etc/yaboot.conf || return 0
 
 # check if yaboot.conf is managed by lilo, if yes, return
 if test -f $TARGET_FS_ROOT/etc/lilo.conf; then

--- a/usr/share/rear/finalize/Linux-ppc64/600_install_yaboot.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/600_install_yaboot.sh
@@ -2,7 +2,7 @@
 #################################################################
 
 # skip if yaboot conf is not found
-test -f $TARGET_FS_ROOT/etc/yaboot.conf || return
+test -f $TARGET_FS_ROOT/etc/yaboot.conf || return 0
 
 # check if yaboot.conf is managed by lilo, if yes, return
 if test -f $TARGET_FS_ROOT/etc/lilo.conf; then

--- a/usr/share/rear/finalize/Linux-ppc64/610_install_lilo.sh
+++ b/usr/share/rear/finalize/Linux-ppc64/610_install_lilo.sh
@@ -2,7 +2,7 @@
 #################################################################
 
 # skip if lilo conf is not found
-test -f $TARGET_FS_ROOT/etc/lilo.conf || return
+test -f $TARGET_FS_ROOT/etc/lilo.conf || return 0
 
 # Reinstall lilo boot loader
 LogPrint "Installing PPC PReP Boot partition."

--- a/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
@@ -18,7 +18,7 @@ if [[ -z "$NOBOOTLOADER" ]] ; then
 fi
 
 # Only for GRUB2 - GRUB Legacy will be handled by its own script
-[[ $(type -p grub-probe) || $(type -p grub2-probe) ]] || return
+[[ $(type -p grub-probe) || $(type -p grub2-probe) ]] || return 0
 
 LogPrint "Installing GRUB2 boot loader"
 mount -t proc none $TARGET_FS_ROOT/proc

--- a/usr/share/rear/init/default/030_update_recovery_system.sh
+++ b/usr/share/rear/init/default/030_update_recovery_system.sh
@@ -4,7 +4,7 @@
 # See https://github.com/rear/rear/issues/841
 
 # Without a RECOVERY_UPDATE_URL there is nothing to do:
-test "$RECOVERY_UPDATE_URL" || return
+test "$RECOVERY_UPDATE_URL" || return 0
 
 # With a RECOVERY_UPDATE_URL ensure 'curl' is actually there
 # because that 'curl' was added to the default PROGS array

--- a/usr/share/rear/init/default/050_check_rear_recover_mode.sh
+++ b/usr/share/rear/init/default/050_check_rear_recover_mode.sh
@@ -3,14 +3,13 @@
 # cf. https://github.com/rear/rear/issues/987
 # and https://github.com/rear/rear/issues/1088
 # In the ReaR rescue/recovery system /etc/rear-release is unique (it does not exist otherwise):
-if test -f /etc/rear-release ; then
-    case "$WORKFLOW" in
-        (recover|layoutonly|restoreonly|finalizeonly)
-            LogPrint "Running workflow $WORKFLOW within the ReaR rescue/recovery system"
-            ;;
-        (*)
-            Error "The workflow $WORKFLOW is not supported in the ReaR rescue/recovery system"
-            ;;
-    esac
-fi
+test -f /etc/rear-release || return 0
+case "$WORKFLOW" in
+    (recover|layoutonly|restoreonly|finalizeonly)
+        LogPrint "Running workflow $WORKFLOW within the ReaR rescue/recovery system"
+        ;;
+    (*)
+        Error "The workflow $WORKFLOW is not supported in the ReaR rescue/recovery system"
+        ;;
+esac
 

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -406,6 +406,9 @@ function make_syslinux_config {
 		echo ""
 	fi
 
+	# Because usr/sbin/rear sets 'shopt -s nullglob' the 'ls' command will list all files
+	# in the current working directory if nothing matches the globbing pattern '/boot/memtest86+-*'
+	# which results '.' in MEMTEST_BIN (the plain 'ls -d' output in the current working directory).
 	# You need the memtest86+ package installed for this to work
 	MEMTEST_BIN=$(ls -d /boot/memtest86+-* 2>/dev/null | tail -1)
 	if [[ "$MEMTEST_BIN" != "." && -r "$MEMTEST_BIN" ]]; then

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -75,9 +75,12 @@ if ! test -f "$SECURE_BOOT_BOOTLOADER" ; then
     build_bootx86_efi
 fi
 
-# we will be using grub-efi or grub2 (with efi capabilities) to boot from ISO
-grubdir=$(ls -d /boot/grub*)
-[[ ! -d $grubdir ]] && grubdir=/boot/grub
+# We will be using grub-efi or grub2 (with efi capabilities) to boot from ISO.
+# Because usr/sbin/rear sets 'shopt -s nullglob' the 'echo -n' command
+# outputs nothing if nothing matches the bash globbing pattern '/boot/grub*'
+local grubdir="$( echo -n /boot/grub* )"
+# Use '/boot/grub' as fallback if nothing matches '/boot/grub*'
+test -d "$grubdir" || grubdir='/boot/grub'
 
 if [ -d $(dirname ${UEFI_BOOTLOADER})/fonts ]; then
     cp $v $(dirname ${UEFI_BOOTLOADER})/fonts/* $TMP_DIR/mnt/EFI/BOOT/fonts/ >&2

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -1,6 +1,6 @@
 # 250_populate_efibootimg.sh
 
-is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
+is_true $USING_UEFI_BOOTLOADER || return 0 # empty or 0 means NO UEFI
 
 mkdir $v -p $TMP_DIR/mnt/EFI/BOOT >&2
 StopIfError "Could not create $TMP_DIR/mnt/EFI/BOOT"

--- a/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
@@ -1,5 +1,5 @@
 # 700_create_efibootimg.sh
-is_true $USING_UEFI_BOOTLOADER || return    # empty or 0 means NO UEFI
+is_true $USING_UEFI_BOOTLOADER || return 0 # empty or 0 means NO UEFI
 
 # Calculate exact size of EFI virtual image (efiboot.img):
 # Get size of directory holding EFI virtual image content.

--- a/usr/share/rear/output/ISO/Linux-i386/810_prepare_multiple_iso.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/810_prepare_multiple_iso.sh
@@ -10,7 +10,7 @@
 test "mkrescue" = "$WORKFLOW" && return
 
 # Without a maximum ISO size all is in one single ISO:
-test "$ISO_MAX_SIZE" || return
+test "$ISO_MAX_SIZE" || return 0
 
 local backup_path=$( url_path $BACKUP_URL )
 local isofs_path=$( dirname $backuparchive )

--- a/usr/share/rear/output/PXE/default/820_copy_to_net.sh
+++ b/usr/share/rear/output/PXE/default/820_copy_to_net.sh
@@ -2,7 +2,7 @@
 # 820_copy_to_net.sh
 
 # Check if we have a target location OUTPUT_URL
-test "$OUTPUT_URL" || return
+test "$OUTPUT_URL" || return 0
 
 local scheme=$( url_scheme $OUTPUT_URL )
 local result_file=""

--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -1,7 +1,7 @@
 # 100_create_efiboot.sh
 # USB device needs to be formatted with command `rear format -- --efi /dev/<device_name>'
 
-is_true $USING_UEFI_BOOTLOADER || return
+is_true $USING_UEFI_BOOTLOADER || return 0
 
 Log "Configuring device for EFI boot"
 

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -410,6 +410,9 @@ Information about your current hardware configuration
 EOF
     fi
 
+    # Because usr/sbin/rear sets 'shopt -s nullglob' the 'ls' command will list all files
+    # in the current working directory if nothing matches the globbing pattern '/boot/memtest86+-*'
+    # which results '.' in MEMTEST_BIN (the plain 'ls -d' output in the current working directory).
     # You need the memtest86+ package installed for this to work
     MEMTEST_BIN=$(ls -d /boot/memtest86+-* 2>/dev/null | tail -1)
     if [[ "$MEMTEST_BIN" != "." && -r "$MEMTEST_BIN" ]]; then

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -5,7 +5,7 @@
 # Add the rescue kernel and initrd to the local GRUB 2 bootloader.
 
 # Only do it when explicitly enabled:
-is_true "$GRUB_RESCUE" || return
+is_true "$GRUB_RESCUE" || return 0
 
 # Only run this script when GRUB 2 is there
 # (grub-probe or grub2-probe only exist in GRUB 2)

--- a/usr/share/rear/prep/GNU/Linux/220_include_lvm_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/220_include_lvm_tools.sh
@@ -1,6 +1,6 @@
 # Include LVM tools if LVM exists
 
-test -c /dev/mapper/control -a -x "$(get_path lvm)" || return    # silently skip
+test -c /dev/mapper/control -a -x "$(get_path lvm)" || return 0 # silently skip
 
 Log "Device mapper found enabled. Including LVM tools."
 

--- a/usr/share/rear/prep/GNU/Linux/230_include_md_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/230_include_md_tools.sh
@@ -1,6 +1,6 @@
 # Include software raid tools
 
-grep -q blocks /proc/mdstat 2>/dev/null || return
+grep -q blocks /proc/mdstat 2>/dev/null || return 0
 
 Log "Software RAID detected. Including mdadm tools."
 

--- a/usr/share/rear/prep/GNU/Linux/240_include_multipath_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/240_include_multipath_tools.sh
@@ -2,7 +2,7 @@
 # Boot Over SAN executables and other goodies
 
 # Run the following only if BOOT_OVER_SAN is true
-is_true "$BOOT_OVER_SAN" || return
+is_true "$BOOT_OVER_SAN" || return 0
 
 PROGS=( "${PROGS[@]}" multipath mpathconf dmsetup kpartx multipathd scsi_id  )
 COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/multipath.conf /etc/multipath/* /lib*/multipath )

--- a/usr/share/rear/prep/GNU/Linux/300_include_grub_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/300_include_grub_tools.sh
@@ -2,13 +2,16 @@
 # check if we're using grub2 before doing something...
 [[ ! -d $VAR_DIR/recovery ]] && mkdir -p $VAR_DIR/recovery
 
-grubdir=$(ls -d /boot/grub*)
-[[ ! -d $grubdir ]] && grubdir=/boot/grub	# a safe choice
+# FIXME: Because usr/sbin/rear sets 'shopt -s nullglob' the 'ls' command will list all files
+# in the current working directory if nothing matches the bash globbing pattern '/boot/grub*'
+# which results '.' in 'grubdir' (the plain 'ls -d' output in the current working directory):
+grubdir=$( ls -d /boot/grub* )
+[[ ! -d $grubdir ]] && grubdir=/boot/grub # a safe choice
 
-if has_binary grub-probe; then
-	grub-probe -t device $grubdir > $VAR_DIR/recovery/bootdisk 2>/dev/null || return
-elif has_binary grub2-probe; then
-	grub2-probe -t device $grubdir >$VAR_DIR/recovery/bootdisk 2>/dev/null || return
+if has_binary grub-probe ; then
+    grub-probe -t device $grubdir >$VAR_DIR/recovery/bootdisk 2>/dev/null || return 0
+elif has_binary grub2-probe ; then
+    grub2-probe -t device $grubdir >$VAR_DIR/recovery/bootdisk 2>/dev/null || return 0
 fi
 
 PROGS=( "${PROGS[@]}"

--- a/usr/share/rear/prep/GNU/Linux/300_include_grub_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/300_include_grub_tools.sh
@@ -1,12 +1,17 @@
-# GRUB2 has much more commands then the legacy grub command, including modules
-# check if we're using grub2 before doing something...
-[[ ! -d $VAR_DIR/recovery ]] && mkdir -p $VAR_DIR/recovery
+#
+# FIXME: I <jsmeix@suse.de> do not understand what the next comment means.
+# Where is the "check if we're using grub2 before doing something"?
+#
+# GRUB2 has much more commands than the legacy grub command, including modules
+# check if we're using grub2 before doing something.
 
-# FIXME: Because usr/sbin/rear sets 'shopt -s nullglob' the 'ls' command will list all files
-# in the current working directory if nothing matches the bash globbing pattern '/boot/grub*'
-# which results '.' in 'grubdir' (the plain 'ls -d' output in the current working directory):
-grubdir=$( ls -d /boot/grub* )
-[[ ! -d $grubdir ]] && grubdir=/boot/grub # a safe choice
+test -d $VAR_DIR/recovery || mkdir -p $VAR_DIR/recovery
+
+# Because usr/sbin/rear sets 'shopt -s nullglob' the 'echo -n' command
+# outputs nothing if nothing matches the bash globbing pattern '/boot/grub*'
+local grubdir="$( echo -n /boot/grub* )"
+# Use '/boot/grub' as fallback if nothing matches '/boot/grub*'
+test -d "$grubdir" || grubdir='/boot/grub'
 
 if has_binary grub-probe ; then
     grub-probe -t device $grubdir >$VAR_DIR/recovery/bootdisk 2>/dev/null || return 0
@@ -14,10 +19,19 @@ elif has_binary grub2-probe ; then
     grub2-probe -t device $grubdir >$VAR_DIR/recovery/bootdisk 2>/dev/null || return 0
 fi
 
+# Missing programs in the PROGS array are ignored:
 PROGS=( "${PROGS[@]}"
-grub-install grub-mkdevicemap grub-probe grub-set-default grub-mkconfig grub-reboot grub-setup grub-mkimage grub-mkrelpath grub-mkpasswd-pbkdf2
-grub2-install grub2-mkdevicemap grub2-probe grub2-set-default grub2-mkconfig grub2-reboot grub2-setup grub2-mkimage grub2-mkrelpath grub2-mkpasswd-pbkdf2
-grub-bios-setup grub2-bios-setup
-)
+        grub-bios-setup      grub2-bios-setup
+        grub-install         grub2-install
+        grub-mkconfig        grub2-mkconfig
+        grub-mkdevicemap     grub2-mkdevicemap
+        grub-mkimage         grub2-mkimage
+        grub-mkpasswd-pbkdf2 grub2-mkpasswd-pbkdf2
+        grub-mkrelpath       grub2-mkrelpath
+        grub-probe           grub2-probe
+        grub-reboot          grub2-reboot
+        grub-set-default     grub2-set-default
+        grub-setup           grub2-setup )
 
 COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/default/grub /etc/grub.d/* /etc/grub*.cfg /boot/grub* /usr/lib/grub* /usr/share/grub* )
+

--- a/usr/share/rear/prep/RSYNC/GNU/Linux/200_selinux_in_use.sh
+++ b/usr/share/rear/prep/RSYNC/GNU/Linux/200_selinux_in_use.sh
@@ -1,5 +1,5 @@
 # check if SELinux is in use, if not, just silently return
-[[ -f /selinux/enforce || -f /sys/fs/selinux/enforce ]] || return
+[[ -f /selinux/enforce || -f /sys/fs/selinux/enforce ]] || return 0
 
 if [ -f /selinux/enforce ]; then
         SELINUX_ENFORCE=/selinux/enforce

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -34,12 +34,12 @@ modprobe -q efivars
 # next step, is checking the presence of UEFI variables directory
 # However, we should first check kernel command line to see whether we hide on purpose the UEFI vars with 'noefi'
 SYSFS_DIR_EFI_VARS=
-if [[ -d /sys/firmware/efi/vars ]]; then
+if [[ -d /sys/firmware/efi/vars ]] ; then
     SYSFS_DIR_EFI_VARS=/sys/firmware/efi/vars
-elif [[ -d /sys/firmware/efi/efivars ]]; then
+elif [[ -d /sys/firmware/efi/efivars ]] ; then
     SYSFS_DIR_EFI_VARS=/sys/firmware/efi/efivars
 else
-    return    # when UEFI is enabled the dir is there
+    return 0 # when UEFI is enabled the dir is there
 fi
 
 # mount-point: efivarfs on /sys/firmware/efi/efivars type efivarfs (rw,nosuid,nodev,noexec,relatime)
@@ -48,7 +48,7 @@ if grep -qw efivars /proc/mounts; then
 fi
 
 # next step, is case-sensitive checking /boot for case-insensitive /efi directory (we need it)
-test "$( find /boot -maxdepth 1 -iname efi -type d )" || return
+test "$( find /boot -maxdepth 1 -iname efi -type d )" || return 0
 
 local esp_mount_point=""
 

--- a/usr/share/rear/prep/default/330_include_uefi_tools.sh
+++ b/usr/share/rear/prep/default/330_include_uefi_tools.sh
@@ -3,7 +3,7 @@
 #
 
 # Include UEFI tools on demand only
-is_true $USING_UEFI_BOOTLOADER || return
+is_true $USING_UEFI_BOOTLOADER || return 0
 
 # Copy UEFI binaries we might need:
 REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" dosfsck efibootmgr )

--- a/usr/share/rear/rescue/GNU/Linux/960_collect_MC_serviceguard_infos.sh
+++ b/usr/share/rear/rescue/GNU/Linux/960_collect_MC_serviceguard_infos.sh
@@ -23,7 +23,7 @@ SGLX_FILES="/etc/hostname
 
 # Phase 1 : does sglx soft is installed?
 # on RH path is /usr/local/cmcluster; on SUSE path is /opt/cmcluster
-[ -d /usr/local/cmcluster/conf -o -d /opt/cmcluster/conf ] || return
+[ -d /usr/local/cmcluster/conf -o -d /opt/cmcluster/conf ] || return 0
 
 # Phase 2: create a /etc/rear/recovery/sglx directory
 mkdir -p $v -m755 "$VAR_DIR/recovery/sglx" >&2

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -4,13 +4,13 @@
 # Public License. Refer to the included COPYING for full text of license.
 
 # There is nothing to do when there are no SSH binaries on the original system:
-has_binary ssh || has_binary sshd || return
+has_binary ssh || has_binary sshd || return 0
 
 # Do nothing when not any SSH file should be copied into the recovery system:
 if is_false "$SSH_FILES" ; then
     # Print an info if SSH_ROOT_PASSWORD is set but that cannot work when SSH_FILES is set to a 'false' value:
     test "$SSH_ROOT_PASSWORD" && LogPrintError "SSH_ROOT_PASSWORD cannot work when SSH_FILES is set to a 'false' value"
-    return
+    return 0
 fi
 
 # Only support OpenSSH >= 3.1 where /etc/ssh/ is the default directory for keys and configuration files

--- a/usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
+++ b/usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
@@ -3,7 +3,7 @@
 # A simplified uefivars replacement.
 
 # USING_UEFI_BOOTLOADER empty or no explicit 'true' value means NO UEFI:
-is_true $USING_UEFI_BOOTLOADER || return
+is_true $USING_UEFI_BOOTLOADER || return 0
 
 # Artificial 'for' clause that is run only once
 # to be able to 'continue' with the code after it

--- a/usr/share/rear/restore/NETFS/Linux-i386/510_selinux_fixfiles_exclude_dirs.sh
+++ b/usr/share/rear/restore/NETFS/Linux-i386/510_selinux_fixfiles_exclude_dirs.sh
@@ -2,7 +2,7 @@
 # for UEFI only we should avoid SElinux relabeling vfat filesystem: /boot/efi
 
 # empty or 0 means using BIOS method
-is_true $USING_UEFI_BOOTLOADER || return
+is_true $USING_UEFI_BOOTLOADER || return 0
 
 # check if $TARGET_FS_ROOT/boot/efi is mounted
 if ! test -d "$TARGET_FS_ROOT/boot/efi" ; then

--- a/usr/share/rear/restore/NETFS/default/380_prepare_multiple_isos.sh
+++ b/usr/share/rear/restore/NETFS/default/380_prepare_multiple_isos.sh
@@ -5,7 +5,7 @@ local scheme=$(url_scheme $BACKUP_URL)
 local path=$(url_path $BACKUP_URL)
 local opath=$(backup_path $scheme $path)
 
-[[ -f "${opath}/backup.splitted" ]] || return
+[[ -f "${opath}/backup.splitted" ]] || return 0
 
 FIFO="$TMP_DIR/tar_fifo"
 mkfifo $FIFO
@@ -14,4 +14,4 @@ mkfifo $FIFO
 cp "${opath}/backup.splitted" ${TMP_DIR}
 cp "${backuparchive}.md5" ${TMP_DIR}/backup.md5
 
-Log "fifo creation successful !" 
+Log "fifo creation successful"

--- a/usr/share/rear/restore/ZYPPER/default/980_initial_network_setup.sh
+++ b/usr/share/rear/restore/ZYPPER/default/980_initial_network_setup.sh
@@ -17,7 +17,7 @@
 # cf. https://github.com/rear/rear/issues/1068#issuecomment-282741981
 # Do this test before "set -e -u" is set to be able to "simply return" here without an
 # apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS":
-test "${ZYPPER_NETWORK_SETUP_COMMANDS[*]:-}" || return
+test "${ZYPPER_NETWORK_SETUP_COMMANDS[*]:-}" || return 0
 
 # Try to care about possible errors
 # see https://github.com/rear/rear/wiki/Coding-Style

--- a/usr/share/rear/verify/NETFS/default/050_start_required_nfs_daemons.sh
+++ b/usr/share/rear/verify/NETFS/default/050_start_required_nfs_daemons.sh
@@ -25,7 +25,7 @@
 #
 local backup_url_scheme=$( url_scheme "$BACKUP_URL" )
 # nothing to do when backup_url_scheme is not "nfs"
-test "nfs" = "$backup_url_scheme" || return
+test "nfs" = "$backup_url_scheme" || return 0
 # predefine all used variables
 local attempt=""
 local portmapper_program=""

--- a/usr/share/rear/verify/USB/NETFS/default/540_choose_backup_archive.sh
+++ b/usr/share/rear/verify/USB/NETFS/default/540_choose_backup_archive.sh
@@ -5,7 +5,7 @@
 
 scheme=$( url_scheme "$BACKUP_URL" )
 # Skip if not backup on USB:
-test "usb" = "$scheme" || return
+test "usb" = "$scheme" || return 0
 
 # When USB_SUFFIX is set the compliance mode is used where
 # backup on USB works in compliance with backup on NFS which means


### PR DESCRIPTION
Some simplification in code that is related to issue 1541
plus explicit 'return 0' when return is intended after
a failed command i.e. when return is actually 'success'
because otherwise return results the exit code of the
failed command e.g. as in
<pre>
# function testfunc1 () { test -f qqq || return ; }
# testfunc1
# echo $?
1

# function testfunc2 () { grep -Q foo bar && echo found ; return ; }
# testfunc2
grep: invalid option -- 'Q'
Usage: grep [OPTION]... PATTERN [FILE]...
Try `grep --help' for more information.
# echo $?
2
</pre>
