### PR TITLE
#1523 Netbackup agents not automatically started

### DIFF
--- a/usr/share/rear/rescue/NBU/default/450_prepare_netbackup.sh
+++ b/usr/share/rear/rescue/NBU/default/450_prepare_netbackup.sh
@@ -7,6 +7,9 @@
 
 [[ $NBU_version -lt 7 ]] && return	# NBU is using xinetd when version <7.x
 
-cp $v /etc/init.d/netbackup $ROOTFS_DIR/etc/scripts/system-setup.d/90-netbackup.sh
-[ -f $ROOTFS_DIR/etc/scripts/system-setup.d/90-netbackup.sh ] && \
+if [ -e "/etc/init.d/netbackup" ]; then
+	cp $v /etc/init.d/netbackup $ROOTFS_DIR/etc/scripts/system-setup.d/netbackup.real
+	chmod $v +x $ROOTFS_DIR/etc/scripts/system-setup.d/netbackup.real
+	echo "( /etc/scripts/system-setup.d/netbackup.real )" > $ROOTFS_DIR/etc/scripts/system-setup.d/90-netbackup.sh
 	chmod $v +x $ROOTFS_DIR/etc/scripts/system-setup.d/90-netbackup.sh
+fi


### PR DESCRIPTION
When using NetBackup 7 for ReaR backup (BACKUP=NBU in /etc/rear/local.conf), the NetBackup initscript (/etc/init.d/netbackup) is automatically added to the ReaR rescue image as /etc/scripts/system-setup.d/90-netbackup.sh.

Upon recovery, the agent is *not* started automatically.
Also the /etc/scripts/system-setup aborts immediately after sourcing NetBackup initscript, causing auto-recovery to not work.

The root cause is /etc/scripts/system-setup **sourcing** initscripts, instead of executing them.
This is OK for other internal scripts, but not for 3rd-party initscripts ReaR doesn't control.
In particular, netbackup executes "exit XX" at its end, causing /etc/scripts/system-setup to exit.

Suggested fix is to modify /usr/share/rear/rescue/NBU/default/450_prepare_netbackup.sh so that the "/etc/scripts/system-setup.d/netbackup" script runs in a sub-shell, as shown below:

- /etc/init.d/netbackup is copied as /etc/scripts/system-setup.d/netbackup.real
- /etc/scripts/system-setup.d/90-netbackup.sh is created to encapsulate /etc/scripts/system-setup.d/netbackup.real execution in a sub-shell