### PR TITLE
Remove unecessary /dev prefix

### DIFF
--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -517,7 +517,7 @@ get_device_mapping() {
         if [[ -z "$disk_name" ]]; then
             echo $1
         else
-            echo "/dev/$disk_name"
+            echo "$disk_name"
         fi
     fi
 }


### PR DESCRIPTION
`150_save_diskbyid_mappings.sh` creates `/var/lib/rear/recovery/diskbyid_mappings` which look like this:
```
dm-name-36005076802818058480000000000037b /dev/mapper/36005076802818058480000000000037b
dm-name-36005076802818058480000000000037b_part1 /dev/mapper/36005076802818058480000000000037b_part1
dm-name-36005076802818058480000000000037b_part2 /dev/mapper/36005076802818058480000000000037b_part2
dm-name-system-APPOlv /dev/mapper/system-APPOlv
dm-name-system-root /dev/mapper/system-root
dm-name-system-swap /dev/mapper/system-swap
dm-uuid-LVM-14gcW2jEBtAEVeSWDKsobrD0HkqVM3NGBpdCO7Seomr8qvBfefUUZZ2qGl3c665e /dev/mapper/system-root
dm-uuid-LVM-14gcW2jEBtAEVeSWDKsobrD0HkqVM3NGgL4XzRRtjTHbunSy0oLFtvAhCb50F01z /dev/mapper/system-swap
dm-uuid-LVM-14gcW2jEBtAEVeSWDKsobrD0HkqVM3NGjEZqIdr0yocYNog9hDJO56pgYYtycRjc /dev/mapper/system-APPOlv
dm-uuid-mpath-36005076802818058480000000000037b /dev/mapper/36005076802818058480000000000037b
dm-uuid-part1-mpath-36005076802818058480000000000037b /dev/mapper/36005076802818058480000000000037b_part1
dm-uuid-part2-mpath-36005076802818058480000000000037b /dev/mapper/36005076802818058480000000000037b_part2
lvm2-pvuuid-6SALWb-Tgcz-PY43-RRvC-KcEK-SQu0-sK69EF /dev/mapper/36005076802818058480000000000037b_part2
scsi-36005076802818058480000000000037b /dev/mapper/36005076802818058480000000000037b
scsi-36005076802818058480000000000037b-part1 /dev/mapper/36005076802818058480000000000037b_part1
scsi-36005076802818058480000000000037b-part2 /dev/mapper/36005076802818058480000000000037b_part2
wwn-0x6005076802818058480000000000037b /dev/mapper/36005076802818058480000000000037b
wwn-0x6005076802818058480000000000037b-part1 /dev/mapper/36005076802818058480000000000037b_part1
wwn-0x6005076802818058480000000000037b-part2 /dev/mapper/36005076802818058480000000000037b_part2
```
target device (2nd field) is already prefixes by `/dev`, This mean `get_device_mapping()` function should return `"$disk_name"` and not `"/dev/$disk_name"`.