### PR TITLE
Add support for Bridge Interfaces

### DIFF
--- a/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
+++ b/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
@@ -124,6 +124,10 @@ function bridge_handling {
 
     [ -d "/sys/class/net/$dev/bridge" -o -d "/sys/class/net/$dev/brport" ] || return
 
+    if [ -z "$already_set_up_bridges" ]; then
+        MODULES=( "${MODULES[@]}" 'bridge' )
+    fi
+
     local bridge
 
     if [ -d "/sys/class/net/$dev/bridge" ]; then

--- a/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
+++ b/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
@@ -83,6 +83,9 @@ EOT
 
 # Collect list of all physical network interface cards.
 # Take all interfaces in /sys/class/net and subtract /sys/devices/virtual/net, bonding_masters:
+# Keep Bridges in the list, as if they were physical interfaces: bridges are to
+# be considered as physical interfaces, otherwise building the configuration on
+# the real physical interface may be too complicated.
 physical_network_interfaces=""
 # e.g. on SLES12 with KVM/QEMU 'ls /sys/devices/virtual/net' may result "br0 lo virbr1 virbr1-nic vnet0"
 virtual_network_interfaces=$( ls /sys/devices/virtual/net )
@@ -101,15 +104,55 @@ for network_interface in $network_interfaces ; do
     # virtual_network_interfaces is "lo virt-eth0" and network_interfaces is "eth0 lo virt-eth0"
     # then simple substring search would find "eth0" as substring in "lo virt-eth0"
     # so that to be on the safe side a dumb traditional for-loop approach is used
-    # (unitl someone implements a better solution that works on all bash 3.x versions):
-    for virtual_network_interface in $virtual_network_interfaces ; do
-        test "$network_interface" = "$virtual_network_interface" && network_interface=""
-    done
+    # (until someone implements a better solution that works on all bash 3.x versions):
+    if [ ! -d "/sys/class/net/$network_interface/bridge" ]; then
+        # Skip all virtual interfaces, except bridges
+        for virtual_network_interface in $virtual_network_interfaces ; do
+            test "$network_interface" = "$virtual_network_interface" && network_interface=""
+        done
+    fi
     # bonding_masters is also no physical network interface:
     test "$network_interface" = "bonding_masters" && network_interface=""
-    # Now network_interface is non-epmtry only for physical network interfaces:
+    # Now network_interface is non-empty only for physical network interfaces:
     test "$network_interface" && physical_network_interfaces+=" $network_interface"
 done
+
+# Add-on for bridge devices
+already_set_up_bridges=""
+function bridge_handling {
+    local dev=$1
+
+    [ -d "/sys/class/net/$dev/bridge" -o -d "/sys/class/net/$dev/brport" ] || return
+
+    local bridge
+
+    if [ -z "$already_set_up_bridges" ]; then
+        REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" "brctl" )
+    fi
+    if [ -d "/sys/class/net/$dev/bridge" ]; then
+        # Device is the bridge device
+        bridge=$dev
+    else
+        bridge=$(basename $(readlink "/sys/class/net/$dev/brport/bridge"))
+    fi
+    local found=0
+    for already_set_up_bridge in $already_set_up_bridges ; do
+        test "$bridge" = "$already_set_up_bridge" && found=1 && break
+    done
+    if [ $found -eq 0 ]; then
+        stp=$(brctl show $bridge | awk "\$1 == \"$bridge\" { print \$3 }")
+
+        echo "brctl addbr $bridge" >>$network_devices_setup_script
+        echo "brctl stp $bridge $stp" >>$network_devices_setup_script
+
+        # Remember that we already dealt with this bridge:
+        already_set_up_bridges+=" ${bridge}"
+    fi
+
+    if [ -d "/sys/class/net/$dev/brport" ]; then
+        echo "brctl addif $bridge $dev" >>$network_devices_setup_script
+    fi
+}
 
 # Go over the physical network interfaces and record information.
 # BTW, network interface names luckily do not allow spaces :-)
@@ -150,6 +193,8 @@ for physical_network_interface in $physical_network_interfaces ; do
     fi
     mkdir -p $v $TMP_DIR/mappings >&2
     test -f $CONFIG_DIR/mappings/ip_addresses && read_and_strip_file $CONFIG_DIR/mappings/ip_addresses > $TMP_DIR/mappings/ip_addresses
+
+    bridge_handling $physical_network_interface
 
     if test -s $TMP_DIR/mappings/ip_addresses ; then
         while read network_device ip_address junk ; do
@@ -199,6 +244,7 @@ function vlan_setup () {
         # it is safe to just call bond_setup because that set up an interface only once:
         test "$parent_interface" = "$bonding_interface" &&  bond_setup $parent_interface
     done
+    bridge_handling $network_interface
     # Determine the VLAN ID:
     local vlan_id=$( grep "^${network_interface}" /proc/net/vlan/config | awk '{print $3}' )
     # Set up network device (a.k.a. 'link'):
@@ -228,6 +274,7 @@ function bond_setup () {
     for already_set_up_bonding_interface in $already_set_up_bonding_interfaces ; do
         test "$network_interface" = "$already_set_up_bonding_interface" && return
     done
+    bridge_handling $network_interface
     # Get list of bonding group members:
     local bonding_group_members=$( cat /sys/class/net/${network_interface}/bonding/slaves )
     # If a member of the bonding group is a VLAN, set that up first:
@@ -339,6 +386,9 @@ else
         test -r /proc/net/bonding/$bonding_interface || break
         if ip link show dev $bonding_interface | grep -q UP ; then
             # Link is up:
+
+            bridge_handling $bonding_interface
+
             bonding_enslaved_interfaces=( $( cat /proc/net/bonding/$bonding_interface | grep "Slave Interface:" | cut -d : -f 2 ) )
             for addr in $( ip a show dev $bonding_interface scope global | grep "inet.*\ " | tr -s " " | cut -d " " -f 3 ) ; do
                 # Use bonding_enslaved_interfaces[0] instead of bond$c

--- a/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
+++ b/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
@@ -402,3 +402,8 @@ else
     already_set_up_bonding_interfaces=${bonding_interfaces[@]}
 fi
 
+# Local functions must be 'unset' because bash does not support 'local function ...'
+# cf. https://unix.stackexchange.com/questions/104755/how-can-i-create-a-local-function-in-my-bashrc
+unset -f bridge_handling
+unset -f vlan_setup
+unset -f bond_setup


### PR DESCRIPTION
Bridge interfaces are widely used. This patch enables configurations as
shown below:
1. Bridge over simple Ethernet
2. Bridge over Bond
3. Bridger over Vlan interface

Bridges require the 'brctl' utility. This patch automatically includes
the utility upon need.
Usually, virtual interfaces are skipped, but for Bridges to work, we
consider Bridges as physical interfaces, because the Bridge interface
holds the IP address, not the physical interface attached to the Bridge.

Signed-off-by: Renaud Métrich <rmetrich@redhat.com>