### PR TITLE
choose relative link-target for lib-dirs - fixes #1555

### DIFF
--- a/usr/share/rear/build/GNU/Linux/090_create_lib_directories_and_symlinks.sh
+++ b/usr/share/rear/build/GNU/Linux/090_create_lib_directories_and_symlinks.sh
@@ -2,7 +2,7 @@
 Log "Mirroring lib/ structure."
 for libdir in /lib* /usr/lib* ; do
     if [[ -L $libdir ]] ; then
-        target=$(readlink -f $libdir)
+        target=$(readlink $libdir)
 
         if [[ ! -e $ROOTFS_DIR$target ]] ; then
             mkdir $v -p $ROOTFS_DIR$target >&2


### PR DESCRIPTION
Hello @gozora,

as today is really awful weather I looked around the rear-source.
There I found this script which creates the lib-environment.
I'm not sure what else breaks with this - so this PR is more meant like
a question/pointer start of discussion than a real merge-request.

But with this fix my chrooted rootfs looks better (for /usr/lib64 at least)

```
RESCUE osa:/usr # ls -l /usr
total 0
lrwxrwxrwx 1 root root    6 Oct 29 08:36 bin -> ../bin
drwxr-xr-x 2 root root   60 Oct 27 18:13 include
drwxr-xr-x 8 root root 4340 Oct 29 08:36 lib
lrwxrwxrwx 1 root root    3 Oct 29 08:36 lib64 -> lib
lrwxrwxrwx 1 root root    6 Oct 29 08:36 sbin -> ../bin
drwxr-xr-x 8 root root  180 Oct 29 08:36 share
```

and the `ldd` of course also works now. 
Maybe this helps, greetings
Frank
