### PR TITLE
Let /bin/ldd detect *.so with relative paths

### DIFF
--- a/usr/share/rear/build/default/980_verify_rootfs.sh
+++ b/usr/share/rear/build/default/980_verify_rootfs.sh
@@ -38,8 +38,7 @@ local broken_binaries=""
 # see https://github.com/rear/rear/pull/1514#discussion_r141031975
 # and for the general issue see https://github.com/rear/rear/issues/1372
 for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ) ; do
-    # In order to handle relative paths, we 'cd' to the directory containing $binary before running ldd:
-    chroot $ROOTFS_DIR cd $(dirname $binary) && /bin/ldd $binary | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
+    chroot $ROOTFS_DIR /bin/ldd $binary | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
 done
 if contains_visible_char "$broken_binaries" ; then
     LogPrintError "There are binaries or libraries in the ReaR recovery system that need additional libraries"

--- a/usr/share/rear/build/default/980_verify_rootfs.sh
+++ b/usr/share/rear/build/default/980_verify_rootfs.sh
@@ -38,7 +38,10 @@ local broken_binaries=""
 # see https://github.com/rear/rear/pull/1514#discussion_r141031975
 # and for the general issue see https://github.com/rear/rear/issues/1372
 for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ) ; do
-    chroot $ROOTFS_DIR /bin/ldd $binary | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
+    # In order to handle relative paths, we 'cd' to the directory containing $binary before running ldd.
+    # 'cd' will not work in the chroot without calling bash.
+    # For an example of the problem, see:  https://github.com/rear/rear/pull/1560#issuecomment-343504359
+    chroot $ROOTFS_DIR /bin/bash --login -c "cd $(dirname $binary) && ldd $binary" | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
 done
 if contains_visible_char "$broken_binaries" ; then
     LogPrintError "There are binaries or libraries in the ReaR recovery system that need additional libraries"

--- a/usr/share/rear/build/default/980_verify_rootfs.sh
+++ b/usr/share/rear/build/default/980_verify_rootfs.sh
@@ -38,9 +38,7 @@ local broken_binaries=""
 # see https://github.com/rear/rear/pull/1514#discussion_r141031975
 # and for the general issue see https://github.com/rear/rear/issues/1372
 for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ) ; do
-    export binary
-    chroot $ROOTFS_DIR /bin/bash -c 'cd $(dirname $binary) && /bin/ldd $binary' | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
-    unset binary
+    chroot $ROOTFS_DIR /bin/ldd $binary | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
 done
 if contains_visible_char "$broken_binaries" ; then
     LogPrintError "There are binaries or libraries in the ReaR recovery system that need additional libraries"

--- a/usr/share/rear/build/default/980_verify_rootfs.sh
+++ b/usr/share/rear/build/default/980_verify_rootfs.sh
@@ -38,7 +38,9 @@ local broken_binaries=""
 # see https://github.com/rear/rear/pull/1514#discussion_r141031975
 # and for the general issue see https://github.com/rear/rear/issues/1372
 for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ) ; do
-    chroot $ROOTFS_DIR /bin/ldd $binary | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
+    export binary
+    chroot $ROOTFS_DIR /bin/bash -c 'cd $(dirname $binary) && /bin/ldd $binary' | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
+    unset binary
 done
 if contains_visible_char "$broken_binaries" ; then
     LogPrintError "There are binaries or libraries in the ReaR recovery system that need additional libraries"

--- a/usr/share/rear/build/default/980_verify_rootfs.sh
+++ b/usr/share/rear/build/default/980_verify_rootfs.sh
@@ -38,7 +38,8 @@ local broken_binaries=""
 # see https://github.com/rear/rear/pull/1514#discussion_r141031975
 # and for the general issue see https://github.com/rear/rear/issues/1372
 for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ) ; do
-    chroot $ROOTFS_DIR /bin/ldd $binary | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
+    # In order to handle relative paths, we 'cd' to the directory containing $binary before running ldd:
+    chroot $ROOTFS_DIR cd $(dirname $binary) && /bin/ldd $binary | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
 done
 if contains_visible_char "$broken_binaries" ; then
     LogPrintError "There are binaries or libraries in the ReaR recovery system that need additional libraries"


### PR DESCRIPTION
This allows the "broken_binaries" code to properly detect *.so files that have relative paths.  Prior to this change, executables which had relative paths to their *.so files would result in "not found", thus adding those executables to the $broken_binaries array.  This caused problems for one executable in FDR/Upstream version 4.0.

I've tested that this works properly, but I'd appreciate it if somebody could take a look at the code change and let me know if you see any problems.  This is code that gets used by all ReaR users, not just FDR/Upstream customers.