### PR TITLE
Update and export LD_LIBRARY_PATH when using TSM

### DIFF
--- a/usr/share/rear/build/default/980_verify_rootfs.sh
+++ b/usr/share/rear/build/default/980_verify_rootfs.sh
@@ -33,10 +33,12 @@ fi
 # When running ldd for a file that is 'not a dynamic executable' ldd returns non-zero exit code.
 local binary=""
 local broken_binaries=""
-# Catch all binaries and libraries also e.g. those that are copied via COPY_AS_IS into other paths.
+# - Catch all binaries and libraries also e.g. those that are copied via COPY_AS_IS into other paths.
 # FIXME: The following code fails if file names contain characters from IFS (e.g. blanks),
 # see https://github.com/rear/rear/pull/1514#discussion_r141031975
 # and for the general issue see https://github.com/rear/rear/issues/1372
+# - You may need to update and export LD_LIBRARY_PATH if third-party software you want to include
+# in the rescue image does not update ldconfig cache. (https://github.com/rear/rear/issues/1533).
 for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ) ; do
     chroot $ROOTFS_DIR /bin/ldd $binary | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
 done
@@ -61,4 +63,3 @@ if contains_visible_char "$broken_binaries" ; then
     is_true "$fatal_missing_library" && Error "ReaR recovery system in '$ROOTFS_DIR' not usable"
     LogPrintError "ReaR recovery system in '$ROOTFS_DIR' needs additional libraries, check $RUNTIME_LOGFILE for details"
 fi
-

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1021,6 +1021,8 @@ GALAXY10_Q_ARGUMENTFILE=
 COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
 COPY_AS_IS_EXCLUDE_TSM=( )
 PROGS_TSM=(dsmc)
+# TSM library PATH that need to be added to LD_LIBRARY_PATH.
+TSM_LD_LIBRARY_PATH="/opt/tivoli/tsm/client/ba/bin:/opt/tivoli/tsm/client/api/bin64:/opt/tivoli/tsm/client/api/bin:/opt/tivoli/tsm/client/api/bin64/cit/bin"
 # where to copy the resulting files to and save them with TSM
 TSM_RESULT_FILE_PATH=/opt/tivoli/tsm/rear
 #

--- a/usr/share/rear/prep/TSM/default/400_prep_tsm.sh
+++ b/usr/share/rear/prep/TSM/default/400_prep_tsm.sh
@@ -10,3 +10,7 @@ COPY_AS_IS=( "${COPY_AS_IS[@]}" "${COPY_AS_IS_TSM[@]}"
 	)
 COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" "${COPY_AS_IS_EXCLUDE_TSM[@]}" )
 PROGS=( "${PROGS[@]}" "${PROGS_TSM[@]}" )
+
+# Need to export LD_LIBRARY_PATH in order for ldd to find TSM libraries during check in build/default/980_verify_rootfs.sh
+# see https://github.com/rear/rear/issues/1533
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/tivoli/tsm/client/ba/bin:/opt/tivoli/tsm/client/api/bin64:/opt/tivoli/tsm/client/api/bin:/opt/tivoli/tsm/client/api/bin64/cit/bin

--- a/usr/share/rear/prep/TSM/default/400_prep_tsm.sh
+++ b/usr/share/rear/prep/TSM/default/400_prep_tsm.sh
@@ -10,7 +10,3 @@ COPY_AS_IS=( "${COPY_AS_IS[@]}" "${COPY_AS_IS_TSM[@]}"
 	)
 COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" "${COPY_AS_IS_EXCLUDE_TSM[@]}" )
 PROGS=( "${PROGS[@]}" "${PROGS_TSM[@]}" )
-
-# Need to export LD_LIBRARY_PATH in order for chrooted ldd to find TSM libraries during check in build/default/980_verify_rootfs.sh
-# see https://github.com/rear/rear/issues/1533
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/tivoli/tsm/client/ba/bin:/opt/tivoli/tsm/client/api/bin64:/opt/tivoli/tsm/client/api/bin:/opt/tivoli/tsm/client/api/bin64/cit/bin

--- a/usr/share/rear/prep/TSM/default/400_prep_tsm.sh
+++ b/usr/share/rear/prep/TSM/default/400_prep_tsm.sh
@@ -11,6 +11,6 @@ COPY_AS_IS=( "${COPY_AS_IS[@]}" "${COPY_AS_IS_TSM[@]}"
 COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" "${COPY_AS_IS_EXCLUDE_TSM[@]}" )
 PROGS=( "${PROGS[@]}" "${PROGS_TSM[@]}" )
 
-# Need to export LD_LIBRARY_PATH in order for ldd to find TSM libraries during check in build/default/980_verify_rootfs.sh
+# Need to export LD_LIBRARY_PATH in order for chrooted ldd to find TSM libraries during check in build/default/980_verify_rootfs.sh
 # see https://github.com/rear/rear/issues/1533
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/tivoli/tsm/client/ba/bin:/opt/tivoli/tsm/client/api/bin64:/opt/tivoli/tsm/client/api/bin:/opt/tivoli/tsm/client/api/bin64/cit/bin


### PR DESCRIPTION
As explain in #1533, `rear mkrescue` failed when using with TSM because of the need of additional libraries.
This error comes from the image rescue check made in `build/default/980_verify_rootfs.sh`.
Two solutions here:  

  1- Update and export LD_LIBRARY_PATH in `prep/TSM/default/400_prep_tsm.sh`. When exported, LD_LIBRARY_PATH will be inherit into the chrooted environment used in  `build/default/980_verify_rootfs.sh`:
```
for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ) ; do
    chroot $ROOTFS_DIR /bin/ldd $binary | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
done
```

  2- We don't need all the stuff provided by the TSM client in the rescue image (~300MB). Only `dsmc` (tsm client) binary, with some libraries and config files.
I usually use the following `COPY_AS_IS_TSM` within my conf file which do not complain about missing libraries during `rear mkrescue` and reduced the size of TSM client to (~30MB).
```
COPY_AS_IS_TSM=( /etc/adsm/TSM.PWD /opt/tivoli/tsm/client/ba/bin/dsmc /opt/tivoli/tsm/client/ba/bin/tsmbench_inclexcl /opt/tivoli/tsm/client/ba/bin/dsm.sys /opt/tivoli/tsm/client/ba/bin/dsm.opt /opt/tivoli/tsm/client/api/bin64/libgpfs.so /opt/tivoli/tsm/client/api/bin64/libdmapi.so /opt/tivoli/tsm/client/ba/bin/EN_US/dsmclientV3.cat /usr/local/ibm/gsk8* )
```

Even if the 2nd option seems to be more optimized (size, time saving during initrd compression) it could be also source of issues because we cannot be sure that this set of file (name, libraries, config files) will remain the same with the next version of TSM. So I prefer to use the First solution (LD_LIBRARY_PATH) and let the users update themselves their local.conf file if they want to optimize initrd size.

@jsmeix, I know you don't have TSM, but I would like to get your feedback about this PR.
Do you think we can use `export LD_LIBRARY_PATH` ?
Could you confirm that `prep/TSM/default/400_prep_tsm.sh`is the best place for that ? 
Thanks for your help and review here.