### PR TITLE
COPY_AS_IS_TSM optimzed example

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1019,6 +1019,11 @@ GALAXY10_Q_ARGUMENTFILE=
 ##
 #
 COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
+# TSM client can be BIG (~300MB). If you need to reduce the size of the rescue image initrd (which can be a good idea for PowerVM based partition),
+# you can use the following COPY_AS_IS_TSM which will only copy what is needed to start a TSM restore.
+# ** Don't forget to add your custom configuration files like Includes and Excludes files. **
+# COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client/ba/bin/dsmc /opt/tivoli/tsm/client/ba/bin/dsm.sys /opt/tivoli/tsm/client/ba/bin/dsm.opt /opt/tivoli/tsm/client/api/bin64/libgpfs.so /opt/tivoli/tsm/client/api/bin64/libdmapi.so /opt/tivoli/tsm/client/ba/bin/EN_US/dsmclientV3.cat /usr/local/ibm/gsk8* )
+
 COPY_AS_IS_EXCLUDE_TSM=( )
 PROGS_TSM=(dsmc)
 # TSM library PATH that need to be added to LD_LIBRARY_PATH.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1019,9 +1019,10 @@ GALAXY10_Q_ARGUMENTFILE=
 ##
 #
 COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
-# TSM client can be BIG (~300MB). If you need to reduce the size of the rescue image initrd (which can be a good idea for PowerVM based partition),
+# TSM client can be BIG (~300MB). If you need to reduce the size of the rescue image initrd (which can be a
+# good idea for PowerVM based partition),
 # you can use the following COPY_AS_IS_TSM which will only copy what is needed to start a TSM restore.
-# ** Don't forget to add your custom configuration files like Includes and Excludes files. **
+# Don't forget to add your custom configuration files like Includes and Excludes files.
 # COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client/ba/bin/dsmc /opt/tivoli/tsm/client/ba/bin/dsm.sys /opt/tivoli/tsm/client/ba/bin/dsm.opt /opt/tivoli/tsm/client/api/bin64/libgpfs.so /opt/tivoli/tsm/client/api/bin64/libdmapi.so /opt/tivoli/tsm/client/ba/bin/EN_US/dsmclientV3.cat /usr/local/ibm/gsk8* )
 
 COPY_AS_IS_EXCLUDE_TSM=( )


### PR DESCRIPTION
Add an example of an optimized COPY_AS_IS_TSM.
This one will only copy `dsmc` binary, needed libraries, passwd and default configuration files.
All the other files generated by the user must be added manually.