### PR TITLE
Fix copying kernel modules when module aliases are present

### DIFF
--- a/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
+++ b/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
@@ -26,6 +26,9 @@ fi
 function modinfo_filename () {
     local module_name=$1
     local module_filename=""
+    local alias_module_name=$(modprobe -n -R $module_name 2>/dev/null)
+    # If the installed modprobe command supports resolving module aliases (-R), use that capability.
+    test $alias_module_name && module_name=$alias_module_name
     # Older modinfo (e.g. the one in SLES10) does not support '-k'
     # but that old modinfo returns a zero exit code when called as 'modinfo -k ...'
     # and shows a 'modinfo: invalid option -- k ...' message on stderr and nothing on stdout


### PR DESCRIPTION
ReaR fails to find kernel modules, where aliases are present. For example, the nVidia video driver modules on Ubuntu 16.04 LTS use aliases like this: `nvidia_uvm` -> `nvidia_384_uvm`, making `rear -v mkrescue` produce error messages like this:
```
Copying only currently loaded kernel modules (MODULES contains 'loaded_modules')
ERROR: nvidia_uvm loaded but no module file?
Aborting due to an error[...]
```

This PR fixes the module lookup code. It uses `modprobe` to check for aliased modules. If the modprobe version installed does not support alias resolution via `-R`, the new code will silently fall back to the old behavior (i.e. no alias resolution).