### PR TITLE
Honor $KERNEL_CMDLINE in bootloaders

### DIFF
--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -51,7 +51,7 @@ default=0
 timeout 5
 splashimage=/EFI/BOOT/splash.xpm.gz
 title Relax-and-Recover (no Secure Boot)
-    kernel /isolinux/kernel
+    kernel /isolinux/kernel $KERNEL_CMDLINE
     initrd /isolinux/$REAR_INITRD_FILENAME
 
 EOF

--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -48,14 +48,7 @@ if test "$uefi_bootloader_basename" = "elilo.efi" ; then
     # Create config for elilo
     Log "Creating ${EFI_DST}/elilo.conf"
 
-    cat > ${EFI_DST}/elilo.conf << EOF
-default = rear
-timeout = 5
-
-image = kernel
-    label = rear
-    initrd = $REAR_INITRD_FILENAME
-EOF
+    create_ebiso_elilo_conf > ${EFI_DST}/elilo.conf
 
 # Configure grub for EFI boot or die
 else
@@ -86,7 +79,7 @@ default=0
 timeout=5
 
 title Relax-and-Recover (no Secure Boot)
-    kernel ${EFI_DIR}/kernel
+    kernel ${EFI_DIR}/kernel $KERNEL_CMDLINE
     initrd ${EFI_DIR}/$REAR_INITRD_FILENAME
 EOF
             ;;
@@ -104,7 +97,7 @@ set timeout=5
 set default=0
 
 menuentry "Relax-and-Recover (no Secure Boot)" {
-    linux ${EFI_DIR}/kernel
+    linux ${EFI_DIR}/kernel $KERNEL_CMDLINE
     initrd ${EFI_DIR}/$REAR_INITRD_FILENAME
 }
 EOF


### PR DESCRIPTION
Currently, some bootloader configurations do not honor the $KERNEL_CMDLINE configuration variable. This PR aims to fix the situation.

Background: I am trying to integrate support for TCG Opal-encrypted disks in ReaR. To do so, ReaR has to honor a setting like `KERNEL_CMDLINE="$KERNEL_CMDLINE libata.allow_tpm=1"` on rescue systems.

I've tried to fix all affected spots in ReaR, but did not dare to touch the section beginning at line 175 in `usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh`:
```
# We generate a ReaR syslinux.cfg based on existing ReaR syslinux.cfg files.
Log "Creating /rear/syslinux.cfg"
{
    syslinux_write <<EOF
label rear
    say Relax-and-Recover - Recover $HOSTNAME from $time
    menu hide
    kernel $HOSTNAME-$time

EOF
```

I just did not do sufficient research do discover the motivation behind all the different syslinux configurations in that file.

Also, I am aware that duplicate code for bootloader configuration exists and probably more stuff from `usr/share/rear/lib/bootloader-functions.sh` could be used across ReaR. It is not my intention to re-structure all that code as I do not have the resources to test such extensive changes.