### PR TITLE
Let usr/sbin/rear '-D' automatically also set '-d' and '-v'

### DIFF
--- a/doc/rear.8
+++ b/doc/rear.8
@@ -68,14 +68,14 @@ additional config file; absolute path or relative to config directory
 \-d
 .RS 4
 \fBdebug mode\fR
-(log debug messages to log file)
+(log debug messages to log file \- also sets \-v)
 .RE
 .PP
 \-D
 .RS 4
 \fBdebugscript mode\fR
-(log every function call via
-\fIset \-x\fR)
+(log executed commands via
+\fIset \-x\fR \- also sets \-v and \-d)
 .RE
 .PP
 \-\-debugscripts SET
@@ -94,7 +94,7 @@ kernel version to use (by default use running kernel)
 \-s
 .RS 4
 \fBsimulation mode\fR
-(show what scripts rear would include)
+(show what scripts are run without executing them)
 .RE
 .PP
 \-S
@@ -106,7 +106,7 @@ kernel version to use (by default use running kernel)
 \-v
 .RS 4
 \fBverbose mode\fR
-(show progress output)
+(show more output and run many commands in verbose mode)
 .RE
 .PP
 \-V \-\-version

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -56,7 +56,6 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 -h --help::
     usage information
 
-
 -c DIR::
     alternative config directory; instead of /etc/rear
 
@@ -64,10 +63,10 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
     additional config file; absolute path or relative to config directory
 
 -d::
-    *debug mode* (log debug messages to log file)
+    *debug mode* (log debug messages to log file - also sets -v)
 
 -D::
-    *debugscript mode* (log every function call via 'set -x')
+    *debugscript mode* (log executed commands via 'set -x' - also sets -v and -d)
 
 --debugscripts SET::
     same as -d -v -D but *debugscript mode* with 'set -SET'
@@ -76,13 +75,13 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
     kernel version to use (by default use running kernel)
 
 -s::
-    *simulation mode* (show what scripts rear would include)
+    *simulation mode* (show what scripts are run without executing them)
 
 -S::
     *step-by-step mode* (acknowledge each script individually)
 
 -v::
-    *verbose mode* (show progress output)
+    *verbose mode* (show more output and run many commands in verbose mode)
 
 -V --version::
     version information

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -163,6 +163,8 @@ while true ; do
             VERBOSE=1
             ;;
         (-D)
+            DEBUG=1
+            VERBOSE=1
             DEBUGSCRIPTS=1
             ;;
         (--debugscripts)

--- a/usr/share/rear/lib/help-workflow.sh
+++ b/usr/share/rear/lib/help-workflow.sh
@@ -17,16 +17,16 @@ $PRODUCT comes with ABSOLUTELY NO WARRANTY; for details see
 the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 Available options:
- -h --help           usage information
+ -h --help           usage information (this text)
  -c DIR              alternative config directory; instead of /etc/rear
  -C CONFIG           additional config file; absolute path or relative to config directory
- -d                  debug mode; log debug messages
- -D                  debugscript mode; log every function call (via 'set -x')
+ -d                  debug mode; log debug messages (also sets -v verbose mode)
+ -D                  debugscript mode (implies -v -d); log executed commands (via 'set -x')
  --debugscripts SET  same as -d -v -D but debugscript mode with 'set -SET'
  -r KERNEL           kernel version to use; current: '$KERNEL_VERSION'
- -s                  simulation mode; show what scripts rear would include
+ -s                  simulation mode; show what scripts are run (without executing them)
  -S                  step-by-step mode; acknowledge each script individually
- -v                  verbose mode; show more output
+ -v                  verbose mode; show more output (and run many commands in verbose mode)
  -V --version        version information
 
 List of commands:


### PR DESCRIPTION
Let the 'debugscript mode' ( '-D' ) automatically
also set 'debug mode' ( '-d' ) and 'verbose mode' ( '-v' ).

I never use '-D' alone.
When I need the debugscript mode I always also
need debug messages and verbose command output.

Or is there a reason why '-D' alone without
debug messages and verbose command output
actually makes sense?
