### PR TITLE
Add a NSR_CLIENT_MODE to the backup method NSR.

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1118,7 +1118,7 @@ COPY_AS_IS_EXCLUDE_DP=()
 #
 # NSR_ROOT_DIR is relocatable - default location is /nsr
 NSR_ROOT_DIR=/nsr
-COPY_AS_IS_NSR=( $NSR_ROOT_DIR /opt/nsr /usr/lib/nsr /usr/lib64/gconv )
+COPY_AS_IS_NSR=( $NSR_ROOT_DIR /opt/nsr /opt/networker /usr/lib/nsr /usr/lib64/gconv )
 COPY_AS_IS_EXCLUDE_NSR=( "$NSR_ROOT_DIR/logs/*" "$NSR_ROOT_DIR/debug/*" "$NSR_ROOT_DIR/index/*" "$NSR_ROOT_DIR/lockbox/*" "$NSR_ROOT_DIR/mm/*" "$NSR_ROOT_DIR/repository/*" "$NSR_ROOT_DIR/scripts/*" "$NSR_ROOT_DIR/utils/*" )
 PROGS_NSR=( nsrexec nsrexecd mminfo save savefs savepnpc recover nsrfsra nsrinfo nsrretrieve nsrwatch nsrports uasm )
 # NSRSERVER is normally found automatically, but for the rare cases it is not found pls define it in local.conf
@@ -1128,6 +1128,9 @@ NSRSERVER=
 NSR_RETENTION_TIME=
 # The name of the default NSR pool. Default is the upstream default but some sites need to change that to an own default pool name.
 NSR_DEFAULT_POOL_NAME=Default
+# The NSR_CLIENT_MODE defines whether You have direct access to the NSRSERVER's recovery or are just a passive NSR client
+# waiting for the files to be recovered from the NSRSERVER (default is "no")
+NSR_CLIENT_MODE=
 
 ##
 # BACKUP=SESAM  (SEP Sesam: http://www.sep.de)

--- a/usr/share/rear/output/NSR/default/950_nsr_save_result_files.sh
+++ b/usr/share/rear/output/NSR/default/950_nsr_save_result_files.sh
@@ -1,5 +1,10 @@
-#
+# 950_nsr_save_result_files.sh
 # saving result files via NSR
+
+# In case NSR_CLIENT_MODE is enabled return else continue ...
+if is_true "$NSR_CLIENT_MODE"; then
+    return
+fi
 
 test ${#RESULT_FILES[@]} -gt 0 || Error "No files to copy (RESULT_FILES is empty)"
 

--- a/usr/share/rear/prep/NSR/default/450_check_nsr_client.sh
+++ b/usr/share/rear/prep/NSR/default/450_check_nsr_client.sh
@@ -1,8 +1,13 @@
 # 450_check_nsr_client.sh
-# this script has a simple goal: check if this client system knows the networker server?
+# 
+# This script checks if a EMC Legato client is installed and running
+#
 
 Log "Backup method is NetWorker (NSR): check nsrexecd"
-[ ! -x /usr/sbin/nsrexecd ] && Error "Please install EMC NetWorker (Legato) client software."
+if [ ! -x /usr/sbin/nsrexecd ] \
+&& [ ! -x /opt/networker/sbin/nsrexecd ]; then
+    Error "Please install EMC NetWorker (Legato) client software."
+fi
 
 ps ax | grep nsrexecd | grep -v grep  1>/dev/null
 StopIfError $? "EMC NetWorker (Legato) nsrexecd was not running on this client."

--- a/usr/share/rear/rescue/NSR/default/450_prepare_networker_startup.sh
+++ b/usr/share/rear/rescue/NSR/default/450_prepare_networker_startup.sh
@@ -9,9 +9,16 @@ NSR_ENVEXEC=/opt/nsr/admin/nsr_envexec
 # networkerrc defines environment variables, such as LD_LIBRARY_PATH, required
 # to run NetWorker daemons.
 NETWORKERRC=/opt/nsr/admin/networkerrc
+
 if [ -f /usr/sbin/nsrexecd ]; then
     "\$NSR_ENVEXEC" -u "\$NSRRC" -s "\$NETWORKERRC"  "/usr/sbin/nsrexecd"
+else
+    # In case /usr/sbin/nsrexecd does not exist ... 
+    if [ -f /opt/networker/sbin/nsrexecd ]; then
+    	(/opt/networker/sbin/nsrexecd) 2>&1
+    fi
 fi
 EOF
+
 chmod +x $ROOTFS_DIR/etc/scripts/system-setup.d/90-networker.sh
 Log "Created the EMC NetWorker nsrexecd start-up script (90-networker.sh) for ReaR"

--- a/usr/share/rear/rescue/NSR/default/470_safe_filesystems.sh
+++ b/usr/share/rear/rescue/NSR/default/470_safe_filesystems.sh
@@ -1,4 +1,10 @@
 # 470_safe_filesystems.sh
+#
+# In case NSR_CLIENT_MODE is enabled return else continue ...
+if is_true "$NSR_CLIENT_MODE"; then
+    return
+fi
+
 savefs -p -s $NSRSERVER 2>&1 | awk -F '(=|,)' '/path/ { printf ("%s ", $2) }' > $VAR_DIR/recovery/nsr_paths
 [[ ! -s $VAR_DIR/recovery/nsr_paths ]] && Error "The savefs command could not retrieve the \"save sets\" from this client"
 

--- a/usr/share/rear/restore/NSR/default/400_restore_with_nsr.sh
+++ b/usr/share/rear/restore/NSR/default/400_restore_with_nsr.sh
@@ -1,31 +1,45 @@
 # 400_restore_with_nsr.sh
+#
+# In case NSR_CLIENT_MODE is enabled we need to prompt and wait
+# until the restore rpocess executed at the NSRSERVER has finished.
+#
 
-LogUserOutput "Starting nsrwatch on console 8"
-TERM=linux nsrwatch -p 1 -s $(cat $VAR_DIR/recovery/nsr_server ) </dev/tty8 >/dev/tty8 &
+if is_true "$NSR_CLIENT_MODE"; then
+    LogPrint "Please let the restore process start on Your backup server i.e. $(cat $VAR_DIR/recovery/nsr_server)."
+    LogPrint "Make sure all required data is restored to $TARGET_FS_ROOT ."
+    LogPrint ""
+    LogPrint "When the restore is finished type 'exit' to continue the recovery."
+    LogPrint "Info: You can check the recovery process i.e. with the command 'df'."
+    LogPrint ""
 
-LogUserOutput "Restore filesystem $(cat $VAR_DIR/recovery/nsr_paths) with recover"
+    rear_shell "Has the restore been completed and are You ready to continue the recovery?"
+else
+    LogUserOutput "Starting nsrwatch on console 8"
+    TERM=linux nsrwatch -p 1 -s $(cat $VAR_DIR/recovery/nsr_server ) </dev/tty8 >/dev/tty8 &
 
-blank=" "
-# Use the original STDOUT when 'rear' was launched by the user for the 'while read ... echo' output
-# (which also reads STDERR of the 'recover' command so that 'recover' errors are 'echo'ed to the user)
-# but keep STDERR of the 'while' command going to the log file so that 'rear -D' output goes to the log file:
-recover -s $(cat $VAR_DIR/recovery/nsr_server) -c $(hostname) -d $TARGET_FS_ROOT -a $(cat $VAR_DIR/recovery/nsr_paths) 2>&1 \
-  | while read -r ; do
-        echo -ne "\r${blank:1-COLUMNS}\r"
-        case "$REPLY" in
-            *:*\ *)
-                echo "$REPLY"
-                ;;
-            ./*)
-                if [ "${#REPLY}" -ge $((COLUMNS-5)) ] ; then
-                    echo -n "... ${REPLY:5-COLUMNS}"
-                else
-                    echo -n "$REPLY"
-                fi
-                ;;
-            *)
-                echo "$REPLY"
-                ;;
-        esac
-    done 1>&7
+    LogUserOutput "Restore filesystem $(cat $VAR_DIR/recovery/nsr_paths) with recover"
 
+    blank=" "
+    # Use the original STDOUT when 'rear' was launched by the user for the 'while read ... echo' output
+    # (which also reads STDERR of the 'recover' command so that 'recover' errors are 'echo'ed to the user)
+    # but keep STDERR of the 'while' command going to the log file so that 'rear -D' output goes to the log file:
+    recover -s $(cat $VAR_DIR/recovery/nsr_server) -c $(hostname) -d $TARGET_FS_ROOT -a $(cat $VAR_DIR/recovery/nsr_paths) 2>&1 \
+      | while read -r ; do
+            echo -ne "\r${blank:1-COLUMNS}\r"
+            case "$REPLY" in
+                *:*\ *)
+                    echo "$REPLY"
+                    ;;
+                ./*)
+                    if [ "${#REPLY}" -ge $((COLUMNS-5)) ] ; then
+                        echo -n "... ${REPLY:5-COLUMNS}"
+                    else
+                        echo -n "$REPLY"
+                    fi
+                    ;;
+                *)
+                    echo "$REPLY"
+                    ;;
+            esac
+        done 1>&7
+fi

--- a/usr/share/rear/verify/NSR/default/410_verify_nsr_paths.sh
+++ b/usr/share/rear/verify/NSR/default/410_verify_nsr_paths.sh
@@ -1,4 +1,9 @@
 # 410_verify_nsr_paths.sh
-[[ ! -f $VAR_DIR/recovery/nsr_paths ]] && Error "Missing save sets filesystems to recover from EMC NetWorker"
+#
+# Execute in case NSR_CLIENT_MODE is NOT enabled (default)
+#
+if ! is_true "$NSR_CLIENT_MODE"; then
+    [[ ! -f $VAR_DIR/recovery/nsr_paths ]] && Error "Missing save sets filesystems to recover from EMC NetWorker"
 
-LogPrint "We will recover the following file systems from EMC NetWorker: $( cat $VAR_DIR/recovery/nsr_paths )"
+    LogPrint "We will recover the following file systems from EMC NetWorker: $( cat $VAR_DIR/recovery/nsr_paths )"
+fi


### PR DESCRIPTION
The intention behind this mode/variable is to make it possible to use the EMC Legato networker in a client only mode during recovery. Such a use case is needed if the administrator of the to-be-recovered system is not the administrator of the EMC Legato networker server itself or allowed to access it. This appears for example in an environment in which the backup-and-restore-as-a-service infrastructure is operated elsewhere.
1. NSR_CLIENT_MODE is not set or set to "no": The NSR backup method is executed as before for backwards compatibility in ReaR.
2. NSR_CLIENT_MODE is set to "yes": Several NSR actions will be skipped and during the recovery a user prompt is displayed to trigger the recovery on the remote NSRSERVER.