### PR TITLE
Addded NON_FATAL_BINARIES_WITH_MISSING_LIBRARY

### DIFF
--- a/usr/share/rear/build/default/980_verify_rootfs.sh
+++ b/usr/share/rear/build/default/980_verify_rootfs.sh
@@ -80,10 +80,10 @@ if contains_visible_char "$broken_binaries" ; then
         # Only for programs (i.e. files in a .../bin/... or .../sbin/... directory) treat a missing library as fatal
         # unless specified when a 'not found' reported library is not fatal (when the 'ldd' test was false alarm):
         if grep -q '/[s]*bin/' <<<"$binary" ; then
-            # With an empty NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN egrep -E '' would always match:
-            if test "$NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN" ; then
+            # With an empty NON_FATAL_BINARIES_WITH_MISSING_LIBRARY egrep -E '' would always match:
+            if test "$NON_FATAL_BINARIES_WITH_MISSING_LIBRARY" ; then
                 # A program with missing library is treated as fatal when it does not match the pattern:
-                if grep -E -q "$NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN" <<<"$binary" ; then
+                if grep -E -q "$NON_FATAL_BINARIES_WITH_MISSING_LIBRARY" <<<"$binary" ; then
                     LogPrintError "$binary requires additional libraries (specified as non-fatal)"
                 else
                     LogPrintError "$binary requires additional libraries (fatal error)"

--- a/usr/share/rear/build/default/980_verify_rootfs.sh
+++ b/usr/share/rear/build/default/980_verify_rootfs.sh
@@ -31,12 +31,14 @@ fi
 # Now test each binary (except links) with ldd and look for 'not found' libraries.
 # In case of 'not found' libraries for dynamically linked executables ldd returns zero exit code.
 # When running ldd for a file that is 'not a dynamic executable' ldd returns non-zero exit code.
-local binary=""
-local broken_binaries=""
-# - Catch all binaries and libraries also e.g. those that are copied via COPY_AS_IS into other paths.
 # FIXME: The following code fails if file names contain characters from IFS (e.g. blanks),
 # see https://github.com/rear/rear/pull/1514#discussion_r141031975
 # and for the general issue see https://github.com/rear/rear/issues/1372
+local binary=""
+local broken_binaries=""
+# Third-party backup tools may use LD_LIBRARY_PATH to find their libraries
+# so that for testing such third-party backup tools we must also use
+# their special LD_LIBRARY_PATH here:
 local old_LD_LIBRARY_PATH
 test $LD_LIBRARY_PATH && old_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 if test "$BACKUP" = "TSM" ; then
@@ -44,23 +46,56 @@ if test "$BACKUP" = "TSM" ; then
     # see https://github.com/rear/rear/issues/1533
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TSM_LD_LIBRARY_PATH
 fi
-for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ) ; do
+# Actually test all binaries for 'not found' libraries.
+# Find all binaries and libraries also e.g. those that are copied via COPY_AS_IS into other paths:
+for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ); do
     # In order to handle relative paths, we 'cd' to the directory containing $binary before running ldd.
-    # 'cd' will not work in the chroot without calling bash.
-    # For an example of the problem, see:  https://github.com/rear/rear/pull/1560#issuecomment-343504359
-    chroot $ROOTFS_DIR /bin/bash --login -c "cd $(dirname $binary) && ldd $binary" | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
+    # In particular third-party backup tools may have shared object dependencies with relative paths.
+    # For an example see https://github.com/rear/rear/pull/1560#issuecomment-343504359 that reads (excerpt):
+    #   # ldd /opt/fdrupstream/uscmd1
+    #       ...
+    #       libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f8a7c449000)
+    #       ./bin/ioOptimizer.so => not found
+    #       libc.so.6 => /lib64/libc.so.6 (0x00007f8a7b52d000)
+    #       ...
+    #   # cd /opt/fdrupstream
+    #   # ldd uscmd1
+    #       ...
+    #       libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f6657ac5000)
+    #       ./bin/ioOptimizer.so (0x00007f665747d000)
+    #       libc.so.6 => /lib64/libc.so.6 (0x00007f6656560000)
+    #       ...
+    # The login shell is there so that we can call commands as in a normal working shell,
+    # cf. https://github.com/rear/rear/issues/862#issuecomment-274068914
+    chroot $ROOTFS_DIR /bin/bash --login -c "cd $( dirname $binary ) && ldd $binary" | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
 done
 test $old_LD_LIBRARY_PATH && export LD_LIBRARY_PATH=$old_LD_LIBRARY_PATH || unset LD_LIBRARY_PATH
-
+# Report binaries with 'not found' shared object dependencies:
 if contains_visible_char "$broken_binaries" ; then
     LogPrintError "There are binaries or libraries in the ReaR recovery system that need additional libraries"
     KEEP_BUILD_DIR=1
     local fatal_missing_library=""
     local ldd_output=""
     for binary in $broken_binaries ; do
-        # Only for programs (i.e. files in a .../bin/... or .../sbin/... directory) treat a missing library as fatal:
-        grep -q '/[s]*bin/' <<<"$binary" && fatal_missing_library="yes"
-        LogPrintError "$binary requires additional libraries"
+        # Only for programs (i.e. files in a .../bin/... or .../sbin/... directory) treat a missing library as fatal
+        # unless specified when a 'not found' reported library is not fatal (when the 'ldd' test was false alarm):
+        if grep -q '/[s]*bin/' <<<"$binary" ; then
+            # With an empty NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN egrep -E '' would always match:
+            if test "$NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN" ; then
+                # A program with missing library is treated as fatal when it does not match the pattern:
+                if grep -E -q "$NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN" <<<"$binary" ; then
+                    LogPrintError "$binary requires additional libraries (specified as non-fatal)"
+                else
+                    LogPrintError "$binary requires additional libraries (fatal error)"
+                    fatal_missing_library="yes"
+                fi
+            else
+                LogPrintError "$binary requires additional libraries (fatal error)"
+                fatal_missing_library="yes"
+            fi
+        else
+            LogPrintError "$binary requires additional libraries"
+        fi
         # Run the same ldd call as above but now keep its whole output:
         ldd_output="$( chroot $ROOTFS_DIR /bin/ldd $binary )"
         # Have the whole ldd output only in the log:
@@ -73,3 +108,4 @@ if contains_visible_char "$broken_binaries" ; then
     is_true "$fatal_missing_library" && Error "ReaR recovery system in '$ROOTFS_DIR' not usable"
     LogPrintError "ReaR recovery system in '$ROOTFS_DIR' needs additional libraries, check $RUNTIME_LOGFILE for details"
 fi
+

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -79,9 +79,7 @@ KERNEL_CMDLINE=""
 # - Check net.ifnames and biosdevname kernel parameter as it may impact the network interface name during recovery/migration.
 COPY_KERNEL_PARAMETERS=( 'net.ifnames' 'biosdevname' )
 
-
-# These variables are used to include arch/os/version specific stuff
-
+# These variables are used to include arch/os/version specific stuff:
 # machine architecture, OS independent
 REAL_MACHINE="$( uname -m )"
 case "$REAL_MACHINE" in
@@ -93,7 +91,6 @@ case "$REAL_MACHINE" in
     (*)
         MACHINE=$REAL_MACHINE
 esac
-
 # Architecture, e.g. Linux-i386
 ARCH="$( uname -s )-$MACHINE" 2>>/dev/null
 REAL_ARCH="$( uname -s )-$REAL_MACHINE" 2>>/dev/null
@@ -189,11 +186,11 @@ PROGRESS_MODE="ANSI"
 # on average up to at most the whole amount of PROGRESS_WAIT_SECONDS
 PROGRESS_WAIT_SECONDS="1"
 
-# default backup and output targets
+# Default backup and output targets:
 BACKUP=REQUESTRESTORE
 OUTPUT=ISO
 
-# default cdrom size in MB (probably it is actually MiB?)
+# Default cdrom size in MB (probably it is actually MiB?):
 CDROM_SIZE=20
 
 # The CHECK_CONFIG_FILES array lists files where changes
@@ -251,22 +248,23 @@ RECOVERY_UPDATE_URL=""
 # Alternatively, you can provide your own mount/unmount commands, in that case
 # Relax-and-Recover will append its mountpoint to the command.
 
-# specify the location of the backup (see text above)
+# Specify the location of the backup (see text above):
 BACKUP_URL=
 # BACKUP_OPTIONS variable contains the mount options, do not confuse with BACKUP_PROG_OPTIONS
 BACKUP_OPTIONS=
 BACKUP_MOUNTCMD=
 BACKUP_UMOUNTCMD=
 
-# specify the location of the output
-# when OUTPUT_URL is not specified it inherits the BACKUP_URL value
+# Specify the location of the output:
+# When OUTPUT_URL is not specified it inherits the BACKUP_URL value.
 OUTPUT_URL=
 OUTPUT_OPTIONS=
 OUTPUT_MOUNTCMD=
 OUTPUT_UMOUNTCMD=
 OUTPUT_PREFIX="$HOSTNAME"
-# keep an older copy of the output (mv $OUTPUT_PREFIX $OUTPUT_PREFIX.old before we copy the new version)
-# empty means only keep current output
+
+# Keep an older copy of the output (mv $OUTPUT_PREFIX $OUTPUT_PREFIX.old before we copy the new version)
+# empty means only keep current output:
 KEEP_OLD_OUTPUT_COPY=
 
 # The remote file system layout for OUTPUT=PXE can be modified to accommodate different TFTP server layouts
@@ -333,8 +331,8 @@ ISO_ISOLINUX_BIN=""
 # to be on the safe side to not possibly destroy an existing backup.
 ISO_MAX_SIZE=
 
-# how to find mkisofs
-# guess the common names mkisofs or genisoimage
+# How to find mkisofs:
+# Guess the common names mkisofs or genisoimage
 # script in prep stage will verify this and complain if not found
 # ebiso (https://github.com/gozora/ebiso/) can be used as alternative
 # for mkisofs/genisoimage on UEFI bootable systems
@@ -344,7 +342,7 @@ ISO_MAX_SIZE=
 # with mkisofs and genisoimage as second and third option
 ISO_MKISOFS_BIN="$( type -p xorrisofs || type -p mkisofs || type -p genisoimage )"
 
-# which files to include in the ISO image
+# Which files to include in the ISO image:
 ISO_FILES=()
 
 # Prefix name for ISO images without the .iso suffix.
@@ -371,10 +369,10 @@ ISO_RECOVER_MODE=
 # The device must be partitioned and formatted with an ext* file system.
 #
 # NOTE: "USB" means any local block-storage device and includes also eSATA and other external disks
-
+#
 # The device to use, set automatically by BACKUP=NETFS and BACKUP_URL=usb:///dev/sdb1
 USB_DEVICE=
-
+#
 # The partition type that is used when formatting a medium for use with ReaR via the format workflow.
 # It can be 'msdos' to create a MBR partition table or 'gpt' to create a GUID partition table (GPT).
 # When UEFI is used the format workflow will create a GUID partition table in any case.
@@ -383,7 +381,7 @@ USB_DEVICE=
 # set USB_DEVICE_FILESYSTEM_PERCENTAGE appropriately so that what is used for ReaR does not exceed
 # what works with a MBR partition table but then you cannot use the remaining space on the medium:
 USB_DEVICE_PARTED_LABEL=msdos
-
+#
 # The label that is set for the ReaR data partition via the format workflow.
 # That label must be used for settings like
 #   BACKUP_URL=usb:///dev/disk/by-label/$USB_DEVICE_FILESYSTEM_LABEL
@@ -391,7 +389,7 @@ USB_DEVICE_PARTED_LABEL=msdos
 # For OBDR only the default 'REAR-000' works (a label with exactly 8 characters length may also work)
 # cf. prep/OBDR/default/500_check_tape_label.sh and prep/OBDR/default/700_write_OBDR_header.sh
 USB_DEVICE_FILESYSTEM_LABEL='REAR-000'
-
+#
 # Filesystem to use for the USB_DEVICE_FILESYSTEM_LABEL labeled ReaR data partition
 # when formatting a medium for use with ReaR via the format workflow.
 # Only ext3 and ext4 are supported by the format workflow.
@@ -402,7 +400,7 @@ USB_DEVICE_FILESYSTEM_LABEL='REAR-000'
 # so that what is used for ReaR partitions by the format workflow
 # does not exceed what works for the specified USB_DEVICE_FILESYSTEM:
 USB_DEVICE_FILESYSTEM=ext3
-
+#
 # USB_DEVICE_FILESYSTEM_PARAMS allow to add optimisations to the formatting
 # (mkfs) phase of the USB_DEVICE_FILESYSTEM. This can be handy to optimise
 # flash memory drives. An example for a Sandisk Cruzer Force 16GB USB stick:
@@ -410,7 +408,7 @@ USB_DEVICE_FILESYSTEM=ext3
 # Often the Linux kernel limits increase the block size value above 4096 (4K).
 # To determine optimal values one can use a utility as flashbench.
 USB_DEVICE_FILESYSTEM_PARAMS=
-
+#
 # Percentage of the whole medium that is used for ReaR partitions
 # when formatting a medium via the format workflow.
 # When UEFI is used it specifies what is used by the format workflow for both partitions,
@@ -421,7 +419,7 @@ USB_DEVICE_FILESYSTEM_PARAMS=
 # A setting of less than 100 only leaves unused space on the medium
 # which can be manually used otherwise by the user:
 USB_DEVICE_FILESYSTEM_PERCENTAGE=100
-
+#
 # USB_PARTITION_ALIGN_BLOCK_SIZE specifies partitioning alignment in MiB
 # when formatting a medium via the format workflow.
 # The default alignment of 8 MiB is intended in particular for flash memory devices.
@@ -432,7 +430,7 @@ USB_DEVICE_FILESYSTEM_PERCENTAGE=100
 # A sufficiently big value will improve speed and lifetime of your flash memory device.
 # The default alignment of 8 MiB is intended in particular for flash memory devices:
 USB_PARTITION_ALIGN_BLOCK_SIZE="8"
-
+#
 # When UEFI is used USB_UEFI_PART_SIZE specifies the size of the EFI system partition (ESP)
 # in MiB when formatting a medium by the format workflow.
 # If USB_UEFI_PART_SIZE is empty or invalid (i.e. not an unsigned integer larger than 0)
@@ -442,10 +440,10 @@ USB_PARTITION_ALIGN_BLOCK_SIZE="8"
 # The value of USB_UEFI_PART_SIZE will be rounded to the nearest
 # USB_PARTITION_ALIGN_BLOCK_SIZE chunk:
 USB_UEFI_PART_SIZE="200"
-
+#
 # Resulting files that should be copied onto the USB stick:
 USB_FILES=()
-
+#
 # USB_SUFFIX specifies the last part of the backup directory on the USB medium.
 # When USB_SUFFIX is unset or empty, backup on USB works in its default mode which means
 # multiple timestamp backup directories of the form rear/HOSTNAME/YYYYMMDD.HHMM
@@ -462,7 +460,7 @@ USB_FILES=()
 # so that USB_SUFFIX must be set for incremental or differential backup on USB
 # see https://github.com/rear/rear/issues/1145
 USB_SUFFIX=""
-
+#
 # Number of older rescue environments or backups to retain on USB.
 # What is more than USB_RETAIN_BACKUP_NR gets automatically removed.
 # This setting is ignored when USB_SUFFIX is set (see above).
@@ -470,56 +468,57 @@ USB_RETAIN_BACKUP_NR=2
 
 # Define the default WORKFLOW for the udev handler (empty to disable)
 UDEV_WORKFLOW=mkrescue
-
+#
 # Beep when udev handler has finished
 UDEV_BEEP=y
-
+#
 # Suspend the (USB) device when udev handler has finished ?
 UDEV_SUSPEND=y
-
+#
 # Turn the UID led on during udev workflow
 UDEV_UID_LED=y
 
-# variable will probably be filled automatically if an USB device was manually mounted to avoid recursive backups
+# Variable will probably be filled automatically
+# if an USB device was manually mounted to avoid recursive backups:
 AUTOEXCLUDE_USB_PATH=()
 
 ##
 # PXE stuff
 ##
 # PXE produces files suitable for booting with pxelinux.
-
+#
 # where should I place the PXE configuration ? (legacy way)
 PXE_CONFIG_PATH=/var/lib/rear/output
 # where should I place the PXE configuration ? (URL style)
 PXE_CONFIG_URL=
-
+#
 # put this before the hostname on the PXE server
 PXE_CONFIG_PREFIX=rear-
-
+#
 # TFPT IP server. needed to create grub menu when PXE_CONFIG_GRUB_STYLE=y
 # If not set, we gonna try to get TFTP IP from PXE_TFTP_URL
 PXE_TFTP_IP=
-
+#
 # where should we put the TFTP files ? (legacy way)
 PXE_TFTP_PATH=/var/lib/rear/output
 # where should we put the TFTP files ? (URL style)
 PXE_TFTP_URL=
-
+#
 # prefix for PXE files, e.g. the hostname
 PXE_TFTP_PREFIX=$HOSTNAME.
-
+#
 # Create pxelinux config symlinks for MAC addresses or for IP addresses ? [MAC|IP|'']
 PXE_CREATE_LINKS=MAC
-
+#
 # Should I remove old symlinks for this host ? [BOOL]
 PXE_REMOVE_OLD_LINKS=
-
+#
 # Should I use PXE based on GRUB2 instead of PXE legacy. [BOOL] (default is no)
 # PXE based on GRUB2 can be used by none x86 platform (like POWER ppc64/ppc64le).
 # More information on the GRUB PXE setup can be found here :
 # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-installation-server-setup.html#sect-network-boot-setup-ppc-grub2
 PXE_CONFIG_GRUB_STYLE=
-
+#
 # The way we start up in our PXE mode (keywords known are 'automatic', 'unattended', and empty)
 # 'automatic' is the auto_recover mode which means boot automatic with ReaR and execute a 'rear recover', but
 # when a question has to be answered (e.g. during migration mode) it will wait on an answer...
@@ -539,7 +538,7 @@ REAR_SLEEP_DELAY=1
 REAR_MAX_RETRIES=5
 
 ##
-# internal BACKUP stuff
+# Internal BACKUP stuff
 ##
 # These settings apply to all cases of internal Relax-and-Recover backup
 #
@@ -690,12 +689,12 @@ FULLBACKUPDAY=()
 # when it is older than 7 days ago:
 FULLBACKUP_OUTDATED_DAYS="7"
 
-#
-# program files (find them in the path). These progs are optional,
-# if they are missing, nothing happens
+# Program files (as found in PATH) to include in the rescue/recovery system:
+# These progs are optional, if they are missing, nothing happens
 PROGS=( )
-
-# required programs. Same as above, but if they are missing, we abort.
+#
+# Required programs in the rescue/recovery system:
+# Same as above, but if they are missing, we abort.
 REQUIRED_PROGS=(
 "$SCRIPT_FILE"
 bash
@@ -724,7 +723,7 @@ strings
 bc
 )
 
-# library files
+# Library files to include in the rescue/recovery system:
 LIBS=()
 
 # Kernel modules to include in the rescue/recovery system:
@@ -768,13 +767,12 @@ LIBS=()
 # you have all needed kernel drivers compiled into your kernel.
 MODULES=()
 #
-
 # Enforce to load these modules in the given order in the rescue/recovery system.
 # We also load modules listed in /etc/modules. The order is 1) /etc/modules and
 # 2) MODULES_LOAD and 3) modules loaded by udev or systemd. ReaR also takes the list
 # of modules from your initrd and adds that to MODULES_LOAD.
-
 MODULES_LOAD=()
+#
 # Kernel modules to exclude from the rescue/recovery system.
 # Modules that are specified in EXCLUDE_MODULES are excluded
 # from the rescue/recovery system in any case regardless what is
@@ -936,13 +934,31 @@ SSH_ROOT_PASSWORD=
 # to exclude unwanted files from the recovery system.
 SSH_UNPROTECTED_PRIVATE_KEYS='no'
 
-# time synchronisation, could be NTP, RDATE or empty
+##
+# NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN
+#
+# What programs/binaries (i.e. files in a /bin/ or /sbin/ directory)
+# are o.k. in the ReaR rescue/recovery system regardless
+# that 'ldd' reports a 'not found' library for them.
+# NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN is a 'egrep' pattern
+# like NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN='myprog|/mydir/'
+# where it is known that things work regardless of what 'ldd' reports.
+# By default it is fatal when 'ldd' reports a 'not found' library for
+# any file in a /bin/ or /sbin/ directory in the recovery system and
+# "rear mkrescue/mkbackup" aborts with "recovery system not usable".
+# For details see the build/default/980_verify_rootfs.sh script.
+NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN=''
+
+# Time synchronisation, could be NTP, RDATE or empty:
 TIMESYNC=
-# set a timesync source, mostly needed for RDATE
+# Set a timesync source, mostly needed for RDATE:
 TIMESYNC_SOURCE=
 
-# define a default RECOVER_LANG - at least TSM seems to need it to correctly restore foreign language sets
-# You could redefine it as, e.g. LANG_RECOVER=de_DE@euro
+# Define a default LANG_RECOVER. At least TSM seems to need it to correctly restore foreign language sets.
+# You may redefine it e.g. like LANG_RECOVER=de_DE@euro but be careful because there could be weird failures
+# because the plain UTF-8 encoding is compatible with ASCII but setting LANG e.g. to en_US.UTF-8 is no longer
+# ASCII compatible, see "Character encoding" in https://github.com/rear/rear/wiki/Coding-Style
+# and https://github.com/rear/rear/issues/1035 and https://github.com/rear/rear/pull/1469
 LANG_RECOVER=C
 
 # LUKS_CRYPTSETUP_OPTIONS contains additional options to cryptsetup which complement auto-detected options.
@@ -952,20 +968,18 @@ LANG_RECOVER=C
 # low-quality master encryption key. For details, see the cryptsetup(8) manual page.
 LUKS_CRYPTSETUP_OPTIONS="--iter-time 2000 --use-random"
 
-
 ##
 # BACKUP=FDRUPSTREAM stuff
 ##
 # ReaR support for FDR/Upstream is limited to disaster recovery only.
 # ReaR will not perform an FDR/Upstream backup.
 # ReaR will install a working FDR/Upstream client when you issue the 'rear recover' command
-
 FDRUPSTREAM_INSTALL_PATH="/opt/fdrupstream"
 FDRUPSTREAM_CONFIG_PATH="/etc/opt/fdrupstream"
 FDRUPSTREAM_DATA_PATH="/var/opt/fdrupstream"
 COPY_AS_IS_FDRUPSTREAM=( "$FDRUPSTREAM_INSTALL_PATH" "$FDRUPSTREAM_CONFIG_PATH" "$FDRUPSTREAM_DATA_PATH" )
 COPY_AS_IS_EXCLUDE_FDRUPSTREAM=( "$FDRUPSTREAM_INSTALL_PATH/usserver" )
-CHECK_CONFIG_FILES_FDRUPSTREAM=( 
+CHECK_CONFIG_FILES_FDRUPSTREAM=(
 "$FDRUPSTREAM_INSTALL_PATH/fdrupstream"
 "$FDRUPSTREAM_INSTALL_PATH/upstream.msg"
 "$FDRUPSTREAM_INSTALL_PATH/uscmd*"
@@ -981,7 +995,7 @@ CHECK_CONFIG_FILES_FDRUPSTREAM=(
 "$FDRUPSTREAM_CONFIG_PATH/*"
 "$FDRUPSTREAM_DATA_PATH/*/parms/*"
 )
-PROGS_FDRUPSTREAM=( )
+PROGS_FDRUPSTREAM=()
 
 ##
 # BACKUP=NBKDC stuff
@@ -991,7 +1005,6 @@ PROGS_FDRUPSTREAM=( )
 #  prep/NBKDC/default/400_prep_nbkdc.sh
 # ReaR will not perform the backup, this will be triggered by NBK DataCenter
 ##
-
 NBKDC_DIR=/opt/NovaStor/DataCenter
 COPY_AS_IS_NBKDC=()
 COPY_AS_IS_EXCLUDE_NBKDC=()
@@ -1040,7 +1053,6 @@ GALAXY10_BACKUPSET=
 # automatically included in COPY_AS_IS
 GALAXY10_Q_ARGUMENTFILE=
 
-
 ##
 # BACKUP=TSM stuff
 ##
@@ -1051,7 +1063,6 @@ COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
 # you can use the following COPY_AS_IS_TSM which will only copy what is needed to start a TSM restore.
 # Don't forget to add your custom configuration files like Includes and Excludes files.
 # COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client/ba/bin/dsmc /opt/tivoli/tsm/client/ba/bin/dsm.sys /opt/tivoli/tsm/client/ba/bin/dsm.opt /opt/tivoli/tsm/client/api/bin64/libgpfs.so /opt/tivoli/tsm/client/api/bin64/libdmapi.so /opt/tivoli/tsm/client/ba/bin/EN_US/dsmclientV3.cat /usr/local/ibm/gsk8* )
-
 COPY_AS_IS_EXCLUDE_TSM=( )
 PROGS_TSM=(dsmc)
 # TSM library PATH that need to be added to LD_LIBRARY_PATH.
@@ -1078,10 +1089,10 @@ TSM_RESTORE_PIT_TIME=
 # You can disable these saving when the result is saved on an different way (ISO_URL, PXE_TFTP_URL....)
 # (y/n) default to y
 TSM_RESULT_SAVE=y
-
+#
 # TSM archive management class definition
 TSM_ARCHIVE_MGMT_CLASS=
-
+#
 # Say "y", "Yes" or "1" to remove the ISO file from local system (in the ISO_DIR location)
 # if TSM server confirms the backup was successful (to preserve space on the local system)
 TSM_RM_ISOFILE=
@@ -1093,7 +1104,6 @@ TSM_RM_ISOFILE=
 COPY_AS_IS_OBDR=( )
 COPY_AS_IS_EXCLUDE_OBDR=( )
 REQUIRED_PROGS_OBDR=( lsscsi sg_wr_mode )
-
 # OBDR block size, known to work with 2048
 OBDR_BLOCKSIZE=2048
 
@@ -1136,7 +1146,6 @@ NSR_DEFAULT_POOL_NAME=Default
 ##
 COPY_AS_IS_SESAM=()
 COPY_AS_IS_EXCLUDE_SESAM=()
-
 
 ##
 # BACKUP=BACULA stuff (www.bacula.org stuff)
@@ -1195,7 +1204,7 @@ BORGBACKUP_PRUNE_DAILY=
 BORGBACKUP_PRUNE_WEEKLY=
 BORGBACKUP_PRUNE_MONTHLY=
 BORGBACKUP_PRUNE_YEARLY=
-
+#
 # Environment variables
 # Borg is using couple of environment variables which can influence its behavior.
 # You can make use of them by putting 'export BORG_var_name="var_value"'
@@ -1278,7 +1287,7 @@ BEXTRACT_DEVICE=
 #
 # BACKUP_PROG="duply"
 DUPLY_PROFILE=""
-
+#
 #######################################################################
 # Extension for DUPLICITY
 #
@@ -1401,14 +1410,14 @@ RSYNC_PROTOCOL_VERSION=
 BACKUP_RSYNC_OPTIONS=(--sparse --archive --hard-links --numeric-ids --stats)
 ############
 
-# Tape block size, default is to leave it up to the tape-device
+# Tape block size, default is to leave it up to the tape-device:
 TAPE_BLOCKSIZE=
 
-# disable ping
-# some environments don't allow to ping the backup host, even though the backup
-# software is reachable
-# e.g. in a DMZ. since most backup methods check the host availability, you can disable ping by
-# unsetting the PING variable [BOOL]
+# Disable ping:
+# Some environments don't allow to ping the backup host,
+# even though the backup software is reachable
+# e.g. in a DMZ. since most backup methods check the host availability,
+# you can disable ping by unsetting the PING variable [BOOL]
 PING=
 
 ##
@@ -1420,14 +1429,13 @@ PING=
 # the magical restore is just me pushing the files back via rsync/ssh. That is the reason why
 # Relax-and-Recover includes an SSH server for your convenience.
 #
-
 # The text to display in order to prompt the user to restore the data
 REQUESTRESTORE_TEXT="Please start the restore process on your backup host.
 
 Make sure that you restore the data into $TARGET_FS_ROOT (by default '/mnt/local')
 instead of '/' because the hard disks of the recovered system are mounted there.
 "
-
+#
 # The example command added to the history to make it easier for the user.
 REQUESTRESTORE_COMMAND=
 
@@ -1438,12 +1446,12 @@ REQUESTRESTORE_COMMAND=
 # As NFSv4 is not fully supported with ReaR (yet) it is safer to
 # use BACKUP_OPTIONS="nfsvers=3,nolock" in the local.conf file.
 # Also, do not forget to open the TCP/UDP ports on the NFS server (iptables)!
-
+#
 # Configure the RBME backup ahead of time.
 # RBME will present you a list of all backups that are available.
 # A magic value of 'latest' will automatically use the latest backup
 RBME_BACKUP=
-
+#
 # If the RBME hostname is different from the system hostname, configure it here
 # Example: RBME_HOSTNAME="$HOSTNAME-bcp"
 RBME_HOSTNAME=$HOSTNAME
@@ -1563,13 +1571,12 @@ ZYPPER_ROOT_PASSWORD="root"
 ZYPPER_NETWORK_SETUP_COMMANDS=()
 # End of BACKUP=ZYPPER default setings.
 
-
 ##
 # BACKUP=EXTERNAL
 ##
-# Custom command backup stuff
-
-# examples for external backup. In this mode your external program must do EVERYTHING
+# Custom command backup stuff.
+#
+# Examples for external backup. In this mode your external program must do EVERYTHING
 # In the example below we backup / to the vms host via tar and netcat
 # NOTE: The EXTERNAL_* commands can be also defined as an array () to better protect
 # arguments with blanks

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -935,19 +935,19 @@ SSH_ROOT_PASSWORD=
 SSH_UNPROTECTED_PRIVATE_KEYS='no'
 
 ##
-# NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN
+# NON_FATAL_BINARIES_WITH_MISSING_LIBRARY
 #
 # What programs/binaries (i.e. files in a /bin/ or /sbin/ directory)
 # are o.k. in the ReaR rescue/recovery system regardless
 # that 'ldd' reports a 'not found' library for them.
-# NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN is a 'egrep' pattern
-# like NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN='myprog|/mydir/'
+# NON_FATAL_BINARIES_WITH_MISSING_LIBRARY is a 'egrep' pattern
+# like NON_FATAL_BINARIES_WITH_MISSING_LIBRARY='myprog|/mydir/'
 # where it is known that things work regardless of what 'ldd' reports.
 # By default it is fatal when 'ldd' reports a 'not found' library for
 # any file in a /bin/ or /sbin/ directory in the recovery system and
 # "rear mkrescue/mkbackup" aborts with "recovery system not usable".
 # For details see the build/default/980_verify_rootfs.sh script.
-NON_FATAL_BINARIES_WITH_MISSING_LIBRARY_PATTERN=''
+NON_FATAL_BINARIES_WITH_MISSING_LIBRARY=''
 
 # Time synchronisation, could be NTP, RDATE or empty:
 TIMESYNC=


### PR DESCRIPTION
With the new config variable
NON_FATAL_BINARIES_WITH_MISSING_LIBRARY
the user can specify an 'egrep' pattern what programs
(i.e. files in a /bin/ or /sbin/ directory) where the 'ldd' test in
build/default/980_verify_rootfs.sh reports 'not found' libraries
are non-fatal so that those programs in the recovery system
do not lead to an Error abort of "rear mkrescue/mkbackup".

This is a generic method so that the user can avoid issues
in particular with third-party backup tools that soemtimes
have unexpected ways to use their specific libraries like
https://github.com/rear/rear/issues/1533 (for TSM) and
https://github.com/rear/rear/pull/1560 (for FDR/Upstream).

I consider it as a "minor bug" when there is no generic method
in ReaR where the user can overrule an automatism in ReaR
and as an "enhancement" when such a method is added.
