### PR TITLE
Document USER_INPUT variables in default.conf

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -186,6 +186,70 @@ PROGRESS_MODE="ANSI"
 # on average up to at most the whole amount of PROGRESS_WAIT_SECONDS
 PROGRESS_WAIT_SECONDS="1"
 
+##
+# Relax-and-Recover UserInput function default behaviour
+#
+# see the UserInput function decription in
+# usr/share/rear/lib/_input-output-functions.sh
+#
+# USER_INPUT_TIMEOUT
+# USER_INPUT_INTERRUPT_TIMEOUT
+# USER_INPUT_PROMPT
+# USER_INPUT_MAX_CHARS
+# USER_INPUT_user_input_ID
+#
+# USER_INPUT_TIMEOUT specifies the default timeout in seconds
+# after that UserInput() automatically proceeds with a default value.
+# That timeout interrupts a possibly ongoing user input
+# (same as the timeout of the 'read' bash builtin).
+# The UserInput timeout must be sufficiently long for the user
+# to read and understand the possibly unexpected UserInput() message
+# and then some more time to make a decision whether or not
+# the default action ("just proceed") is actually the right one
+# in his particular case and finally even more time to enter
+# his particular input when the default is not the right one:
+USER_INPUT_TIMEOUT=300
+#
+# USER_INPUT_INTERRUPT_TIMEOUT specifies the default timeout in seconds
+# for how long UserInput() waits for the user to interrupt an automated input
+# when a predefined input value is specified for a particular UserInput() call
+# via a matching USER_INPUT_user_input_ID variable (see below).
+# The minimum waiting time to interrupt an automated input is one second.
+# The default is 5 seconds to give the user a better chance to recognize
+# an automated input and be able to actually hit a key to interrupt:
+USER_INPUT_INTERRUPT_TIMEOUT=5
+#
+# USER_INPUT_PROMPT specifies the default prompt text that is shown
+# if no prompt was specified for a particular UserInput() call:
+USER_INPUT_PROMPT='enter your input'
+#
+# USER_INPUT_MAX_CHARS specifies the default maximum charaters until
+# the UserInput function truncates further input and returns:
+USER_INPUT_MAX_CHARS=1000
+#
+# USER_INPUT_user_input_ID variables can be used to predefine automated
+# input for UserInput() calls with the matching user_input_ID value.
+# Each UserInput() call has a specific user_input_ID that is shown
+# when ReaR is run in debug mode (via the '-d' command line option).
+# For example "rear -d recover" may show something like:
+#   UserInput -I LAYOUT_MIGRATION_CONFIRM_MAPPINGS needed ...
+#   Confirm or edit the disk mapping
+#   1) Confirm disk mapping and continue 'rear recover'
+#   2) Edit disk mapping (/var/lib/rear/layout/disk_mappings)
+#   3) Use Relax-and-Recover shell and return back to here
+#   4) Abort 'rear recover'
+#   (default '1' timeout 300 seconds)
+# In this case one can specify a predefined input in local.conf like
+#   USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS=2
+# or directly on command line before running "rear recover" like
+#   export USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS=2
+# The user_input_ID that is shown 'LAYOUT_MIGRATION_CONFIRM_MAPPINGS'
+# must be appended to a USER_INPUT_ variable prefix to get the right
+# USER_INPUT_LAYOUT_MIGRATION_CONFIRM_MAPPINGS variable name.
+# Then the "Edit disk mapping" choice will be selected automatically.
+# In this case the USER_INPUT_INTERRUPT_TIMEOUT is crucial because
+# otherwise one would be caught in an endless "Edit disk mapping" loop.
+
 # Default backup and output targets:
 BACKUP=REQUESTRESTORE
 OUTPUT=ISO


### PR DESCRIPTION
Now the USER_INPUT variables are officially
documented in default.conf which means
now those variables and how they work
can no longer be easily changed.
The default values are the fallback values
in the UserInput() function.
This should be one of the final steps related to
https://github.com/rear/rear/issues/1399
before the ReaR 2.3 release.
