### PR TITLE
LogPrintError when sourcing unexpected named script (issue 1054)

### DIFF
--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -60,46 +60,48 @@ function Source () {
     fi
 }
 
-# collect scripts given in $1 in the standard subdirectories and
+# Collect scripts given in the stage directory $1
+# therein in the standard subdirectories and
 # sort them by their script file name and
-# source them
+# Source() the scripts one by one:
 function SourceStage () {
-    stage="$1"
-    shift
-    STARTSTAGE=$SECONDS
+    local stage="$1"
+    local start_SourceStage=$SECONDS
     Log "======================"
     Log "Running '$stage' stage"
     Log "======================"
-    scripts=(
-        $(
-        cd $SHARE_DIR/$stage ;
-        # We always source scripts in the same subdirectory structure. The {..,..,..} way of writing
-        # it is just a shell shortcut that expands as intended.
-        ls -d   {default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
-            "$BACKUP"/{default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
-            "$OUTPUT"/{default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
-            "$OUTPUT"/"$BACKUP"/{default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
-        | sed -e 's#/\([0-9][0-9][0-9]\)_#/!\1!_#g' | sort -t \! -k 2 | tr -d \!
-        )
-        # This sed hack is necessary to sort the scripts by their 3-digit number INSIDE independent of the
-        # directory depth of the script. Basically sed inserts a ! before and after the number which makes the
-        # number always field nr. 2 when dividing lines into fields by !. The following tr removes the ! to
-        # restore the original script name. But now the scripts are already in the correct order.
-        )
-    # if no script is found, then $scripts contains only .
-    # remove the . in this case
-    test "$scripts" = . && scripts=()
-
-    if test "${#scripts[@]}" -gt 0 ; then
-        for script in ${scripts[@]} ; do
-            Source $SHARE_DIR/$stage/"$script"
-        done
-        Log "Finished running '$stage' stage in $((SECONDS-STARTSTAGE)) seconds"
-    else
+    # We always source scripts in the same subdirectory structure.
+    # The {...,...,...} way of writing it is a shell shortcut that expands as intended.
+    # The sed pipe is used to sort the scripts by their 3-digit number independent of the directory depth of the script.
+    # Basically sed inserts a ! before and after the number which makes the number field nr. 2
+    # when dividing lines into fields by ! so that the subsequent sort can sort by that field.
+    # The final tr removes the ! to restore the original script name.
+    # That code would break if ! is used in a directory name of the ReaR subdirectory structure
+    # but those directories below ReaR's $SHARE_DIR/$stage directory are not named by the user
+    # so that it even works when a user runs a git clone in his .../ReaRtest!/ directory.
+    local scripts=( $( cd $SHARE_DIR/$stage
+                 ls -d  {default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
+              "$BACKUP"/{default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
+              "$OUTPUT"/{default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
+    "$OUTPUT"/"$BACKUP"/{default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
+                 | sed -e 's#/\([0-9][0-9][0-9]\)_#/!\1!_#g' | sort -t \! -k 2 | tr -d \! ) )
+    # If no script is found, then the scripts array contains only one element '.'
+    if test "$scripts" = '.' ; then
         Log "Finished running empty '$stage' stage"
+        return 0
     fi
+    # Source() the scripts one by one:
+    local script=''
+    for script in "${scripts[@]}" ; do
+        # Tell the user about unexpected named scripts.
+        # All sripts must be named with a leading three-digit number NNN_something.sh
+        # otherwise the above sorting by the 3-digit number may not work as intended
+        # so that sripts without leading 3-digit number are likely run in wrong order:
+        grep -q '^[0-9][0-9][0-9]_' <<< $( basename $script ) || LogPrintError "Script '$script' without leading 3-digit number 'NNN_' is likely run in wrong order"
+        Source $SHARE_DIR/$stage/"$script"
+    done
+    Log "Finished running '$stage' stage in $(( SECONDS - start_SourceStage )) seconds"
 }
-
 
 function cleanup_build_area_and_end_program () {
     # Cleanup build area


### PR DESCRIPTION
Now the SourceStage shows a (non fatal)
LogPrintError message to the user when a script
without leading 3-digit number 'NNN_' is sourced
because sripts without leading 3-digit number are
likely run in wrong order.

This is a further enhancement of
https://github.com/rear/rear/issues/1054
because scripts with the old 2-digit number could exist
as leftover as old/outdated user-specific addon scripts
that had been added during an older ReaR version.

Example how it looks now with two artificially added sripts
without leading 3-digit number 'NNN_':
<pre>
# cp usr/share/rear/init/default/030_update_recovery_system.sh usr/share/rear/init/default/30_update_recovery_system.sh

# cp usr/share/rear/init/default/030_update_recovery_system.sh usr/share/rear/init/default/033update_recovery_system.sh

# usr/sbin/rear -s mkrescue | head
...
Script 'default/033update_recovery_system.sh' without leading 3-digit number 'NNN_' is likely run in wrong order
Source init/default/033update_recovery_system.sh
Script 'default/30_update_recovery_system.sh' without leading 3-digit number 'NNN_' is likely run in wrong order
Source init/default/30_update_recovery_system.sh
Source init/default/010_set_drlm_env.sh
Source init/default/030_update_recovery_system.sh

# usr/sbin/rear mkrescue
Script 'default/033update_recovery_system.sh' without leading 3-digit number 'NNN_' is likely run in wrong order
Script 'default/30_update_recovery_system.sh' without leading 3-digit number 'NNN_' is likely run in wrong order
</pre>
