### PR TITLE
Let the user enforce MIGRATION_MODE

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -27,7 +27,7 @@
 # is not empty so that both VAR=yes and VAR=no evaluate to boolean 'true'.
 # To set a boolean variable to 'false' set it to an empty value.
 #
-# A few variables have ternary semantics:
+# Some variables have ternary semantics:
 # - explicit true value like True T true t Yes Y yes y 1
 # - explicit false value like False F false f No N no n 0
 # - unset or empty or a value that is neither a true value nor a false value
@@ -297,6 +297,49 @@ CHECK_CONFIG_FILES=( '/etc/drbd/' '/etc/drbd.conf' '/etc/lvm/lvm.conf' '/etc/mul
 #   REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" curl )
 #
 RECOVERY_UPDATE_URL=""
+
+##
+# MIGRATION_MODE recovery during "rear recover"
+#
+# There is some basic autodetection during "rear recover" when
+# disks on the replacement hardware seem to not match compared to
+# what there was stored in disklayout.conf on the original system.
+# If a mismatch is autodetected then ReaR goes into its
+# MIGRATION_MODE where manual disk layout configuration happens.
+# In this case ReaR asks the user via several user dialogs what to do.
+# Only the disk size is used to determine whether or not
+# disks on the replacement hardware match the disks on the original system.
+# Problems only appear when more than one disk with same size is used.
+# Examples:
+# When on the original system and on the replacement hardware two disks
+# with same size are used the disk devices may get interchanged
+# so that what there was on /dev/sda on the original system may get
+# recreated on /dev/sdb on the replacement hardware and vice versa.
+# When on the original system one disk is used for the system and
+# another disk with same size for the ReaR recovery system and backup
+# the disk devices may get interchanged on the replacement hardware
+# so that "rear recover" could result an ultimate disaster
+# (instead of a recovery from a disaster) if it recreated the system
+# on the disk where the ReaR recovery system and backup is
+# which would overwrite/destroy the backup via parted and mkfs
+# (cf. https://github.com/rear/rear/issues/1271).
+# Therefore to be on the safe side and to avoid such problems
+# ReaR goes by default automatically into its MIGRATION_MODE
+# when more than one disk with same size is used on the original system
+# or when for one of the used disk sizes on the original system
+# more than one disk with same size is found on the replacement hardware
+# i.e. when there is more than one possible target disk.
+# Accordingly ReaR goes by default not into its MIGRATION_MODE
+# only if for each used disk size on the original system eaxctly one
+# possible target disk with same size is found on the replacement hardware.
+# By setting MIGRATION_MODE='true' one can enfore MIGRATION_MODE.
+# The by-default empty MIGRATION_MODE results that MIGRATION_MODE
+# is set via the above described autodetection during "rear recover".
+# MIGRATION_MODE is set to a default value here only
+# if not already set so that the user can set it also via
+#   export MIGRATION_MODE='true'
+# directly before he calls "rear recover":
+test "$MIGRATION_MODE" || MIGRATION_MODE=''
 
 ##
 # Output/backup locations

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -207,8 +207,12 @@ PROGRESS_WAIT_SECONDS="1"
 # and then some more time to make a decision whether or not
 # the default action ("just proceed") is actually the right one
 # in his particular case and finally even more time to enter
-# his particular input when the default is not the right one:
-USER_INPUT_TIMEOUT=300
+# his particular input when the default is not the right one.
+# USER_INPUT_TIMEOUT is set to a default value here only
+# if not already set so that the user can set it also like
+#   export USER_INPUT_TIMEOUT=30
+# directly before he calls "rear ...":
+test "$USER_INPUT_TIMEOUT" || USER_INPUT_TIMEOUT=300
 #
 # USER_INPUT_INTERRUPT_TIMEOUT specifies the default timeout in seconds
 # for how long UserInput() waits for the user to interrupt an automated input
@@ -216,16 +220,28 @@ USER_INPUT_TIMEOUT=300
 # via a matching USER_INPUT_user_input_ID variable (see below).
 # The minimum waiting time to interrupt an automated input is one second.
 # The default is 5 seconds to give the user a better chance to recognize
-# an automated input and be able to actually hit a key to interrupt:
-USER_INPUT_INTERRUPT_TIMEOUT=5
+# an automated input and be able to actually hit a key to interrupt.
+# USER_INPUT_INTERRUPT_TIMEOUT is set to a default value here only
+# if not already set so that the user can set it also like
+#   export USER_INPUT_INTERRUPT_TIMEOUT=10
+# directly before he calls "rear ...":
+test "$USER_INPUT_INTERRUPT_TIMEOUT" || USER_INPUT_INTERRUPT_TIMEOUT=5
 #
 # USER_INPUT_PROMPT specifies the default prompt text that is shown
-# if no prompt was specified for a particular UserInput() call:
-USER_INPUT_PROMPT='enter your input'
+# if no prompt was specified for a particular UserInput() call.
+# USER_INPUT_PROMPT is set to a default value here only
+# if not already set so that the user can set it also like
+#   export USER_INPUT_PROMPT="$HOSTNAME input"
+# directly before he calls "rear ...":
+test "$USER_INPUT_PROMPT" || USER_INPUT_PROMPT='enter your input'
 #
 # USER_INPUT_MAX_CHARS specifies the default maximum charaters until
-# the UserInput function truncates further input and returns:
-USER_INPUT_MAX_CHARS=1000
+# the UserInput function truncates further input and returns.
+# USER_INPUT_MAX_CHARS is set to a default value here only
+# if not already set so that the user can set it also like
+#   export USER_INPUT_MAX_CHARS=200
+# directly before he calls "rear ...":
+test "$USER_INPUT_MAX_CHARS" || USER_INPUT_MAX_CHARS=1000
 #
 # USER_INPUT_user_input_ID variables can be used to predefine automated
 # input for UserInput() calls with the matching user_input_ID value.

--- a/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
@@ -130,7 +130,7 @@ EOF
             # see https://github.com/rear/rear/issues/544
             if [[ "$label" == "gpt" || "$label" == "gpt_sync_mbr" ]] ; then
                 device_size=$( mathlib_calculate "$device_size - 33*$block_size" )
-                if [[ "$MIGRATION_MODE" ]] ; then
+                if is_true "$MIGRATION_MODE" ; then
                     Log "Size reductions of GPT partitions probably needed."
                 fi
             fi
@@ -146,7 +146,7 @@ EOF
     while read part disk size pstart name flags partition junk; do
 
         ### If not in migration mode and start known, use original start.
-        if [ -z "$MIGRATION_MODE" ] && ! [ "$pstart" = "unknown" ] ; then
+        if ! is_true "$MIGRATION_MODE" && test "$pstart" != "unknown" ; then
             start="$pstart"
         fi
 
@@ -209,7 +209,7 @@ EOF
         # We can't use $end because of extended partitions
         # extended partitions have a small actual size as reported by sysfs
         # in front of a logical partition should be at least 512B empty space
-        if [ -n "$MIGRATION_MODE" ] && [ "$name" = "logical" ] ; then
+        if is_true "$MIGRATION_MODE" && test "$name" = "logical" ; then
             start=$( mathlib_calculate "$start + ${size%B} + $block_size" )
         else
             start=$( mathlib_calculate "$start + ${size%B}" )

--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -34,7 +34,7 @@ create_lvmdev() {
     local uuidopt=""
     local restorefileopt=""
 
-    if [ -z "$MIGRATION_MODE" ] && [ -e "$VAR_DIR/layout/lvm/${vgrp#/dev/}.cfg" ] ; then
+    if ! is_true "$MIGRATION_MODE" && test -e "$VAR_DIR/layout/lvm/${vgrp#/dev/}.cfg" ; then
         # we have a restore file
         restorefileopt=" --restorefile $VAR_DIR/layout/lvm/${vgrp#/dev/}.cfg"
     else
@@ -52,7 +52,7 @@ create_lvmdev() {
 
 # Create a new VG.
 create_lvmgrp() {
-    if [ -z "$MIGRATION_MODE" ] ; then
+    if ! is_true "$MIGRATION_MODE" ; then
         restore_lvmgrp "$1"
         cat >> "$LAYOUT_CODE" <<EOF
 LogPrint "Sleeping 3 seconds to let udev or systemd-udevd create their devices..."
@@ -92,7 +92,7 @@ EOF
 
 # Create a LV.
 create_lvmvol() {
-    if [ -z "$MIGRATION_MODE" ] ; then
+    if ! is_true "$MIGRATION_MODE" ; then
         return
     fi
 

--- a/usr/share/rear/layout/prepare/default/010_prepare_files.sh
+++ b/usr/share/rear/layout/prepare/default/010_prepare_files.sh
@@ -22,13 +22,15 @@ fi
 
 if [ -e $CONFIG_DIR/disklayout.conf ] ; then
     cp $CONFIG_DIR/disklayout.conf $LAYOUT_FILE
-    # Only set MIGRATION_MODE if not already set (could be already enforced via MIGRATION_MODE='TRUE'):
-    is_true "$MIGRATION_MODE" || MIGRATION_MODE='true'
-    LogPrint "Switching to manual disk layout configuration ($CONFIG_DIR/disklayout.conf exists)"
+    # Only set MIGRATION_MODE if not already set (could be already specified by the user):
+    if ! test "$MIGRATION_MODE" ; then
+        MIGRATION_MODE='true'
+        LogPrint "Switching to manual disk layout configuration ($CONFIG_DIR/disklayout.conf exists)"
+    fi
 
     if [ -e $CONFIG_DIR/lun_wwid_mapping.conf ] ; then
         cp $CONFIG_DIR/lun_wwid_mapping.conf $LUN_WWID_MAP
-		LogPrint "$CONFIG_DIR/lun_wwid_mapping.conf exists, creating lun_wwid_mapping"
+        LogPrint "$CONFIG_DIR/lun_wwid_mapping.conf exists, creating lun_wwid_mapping"
     fi
 fi
 

--- a/usr/share/rear/layout/prepare/default/010_prepare_files.sh
+++ b/usr/share/rear/layout/prepare/default/010_prepare_files.sh
@@ -22,8 +22,9 @@ fi
 
 if [ -e $CONFIG_DIR/disklayout.conf ] ; then
     cp $CONFIG_DIR/disklayout.conf $LAYOUT_FILE
-    MIGRATION_MODE="true"
-    LogPrint "$CONFIG_DIR/disklayout.conf exists, entering Migration mode."
+    # Only set MIGRATION_MODE if not already set (could be already enforced via MIGRATION_MODE='TRUE'):
+    is_true "$MIGRATION_MODE" || MIGRATION_MODE='true'
+    LogPrint "Switching to manual disk layout configuration ($CONFIG_DIR/disklayout.conf exists)"
 
     if [ -e $CONFIG_DIR/lun_wwid_mapping.conf ] ; then
         cp $CONFIG_DIR/lun_wwid_mapping.conf $LUN_WWID_MAP

--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -1,56 +1,144 @@
-
+#
 # Compare disks from the original system to this system.
+#
 # This implements some basic autodetection during "rear recover"
 # when disks on the replacement hardware seem to not match compared to
 # what there was stored in disklayout.conf on the original system.
 # If a mismatch is autodetected then ReaR goes into its
 # MIGRATION_MODE where it asks via user dialogs what to do.
+# Only the disk size is used to determine whether or not
+# disks on the replacement hardware match the disks on the original system.
+# Problems only appear when more than one disk with same size is used.
+# Examples:
+# When on the original system and on the replacement hardware two disks
+# with same size are used the disk devices may get interchanged
+# so that what there was on /dev/sda on the original system may get
+# recreated on /dev/sdb on the replacement hardware and vice versa.
+# When on the original system one disk is used for the system and
+# another disk with same size for the ReaR recovery system and backup
+# the disk devices may get interchanged on the replacement hardware
+# so that "rear recover" could result an ultimate disaster
+# (instead of a recovery from a disaster) if it recreated the system
+# on the disk where the ReaR recovery system and backup is
+# which would overwrite/destroy the backup via parted and mkfs
+# (cf. https://github.com/rear/rear/issues/1271).
+# Therefore to be on the safe side and to avoid such problems
+# ReaR goes by default automatically into its MIGRATION_MODE
+# when more than one disk with same size is used on the original system
+# or when for one of the used disk sizes on the original system
+# more than one disk with same size is found on the replacement hardware
+# i.e. when there is more than one possible target disk.
+# Accordingly ReaR goes by default not into its MIGRATION_MODE
+# only if for each used disk size on the original system eaxctly one
+# possible target disk with same size is found on the replacement hardware.
 
+# Nothing to do when MIGRATION_MODE is already set:
 if is_true "$MIGRATION_MODE" ; then
     LogPrint "Enforced manual disk layout configuration (MIGRATION_MODE is 'true')"
     return
 fi
 
+# Nothing to do when MIGRATION_MODE is already set:
 if is_false "$MIGRATION_MODE" ; then
-    LogPrint "Enforced restoring disk layout as specified in '$LAYOUT_FILE' (MIGRATION_MODE is 'false')"
+    LogPrint "Enforced recreating disk layout as specified in '$LAYOUT_FILE' (MIGRATION_MODE is 'false')"
     return
 fi
 
+# Compare disks to determine whether or not MIGRATION_MODE must be used:
 LogPrint "Comparing disks"
 
+# Determine the actually used disk sizes on the original system and
+# remember each one only once in the original_system_used_disk_sizes array:
+local original_system_used_disk_sizes=()
+local more_than_one_same_orig_size=''
+# Cf. the "Compare disks one by one" code below:
 while read disk dev size junk ; do
-    dev=$( get_sysfs_name $dev )
-    Log "Comparing $dev"
-    if test -e "/sys/block/$dev" ; then
-        Log "Device /sys/block/$dev exists"
-        newsize=$( get_disk_size $dev )
-        if test "$newsize" -eq "$size" ; then
-            LogPrint "Device $dev has expected size $size (will be used for restore)"
-        else
-            LogPrint "Device $dev has size $newsize but $size is expected (needs manual configuration)"
-            MIGRATION_MODE='true'
-        fi
+    if IsInArray "$size" "${original_system_used_disk_sizes[@]}" ; then
+        more_than_one_same_orig_size='true'
     else
-        LogPrint "Device $dev does not exist (manual configuration needed)"
-        MIGRATION_MODE='true'
+        original_system_used_disk_sizes=( "${original_system_used_disk_sizes[@]}" "$size" )
     fi
 done < <( grep -E '^disk |^multipath ' "$LAYOUT_FILE" )
+# MIGRATION_MODE is needed when more than one disk with same size is used on the original system:
+if is_true "$more_than_one_same_orig_size"
+    LogPrint "Ambiguous disk layout needs manual configuration (more than one disk with same size used in '$LAYOUT_FILE')"
+    MIGRATION_MODE='true'
+fi
 
+# No further disk comparisons are needed when MIGRATION_MODE is already set true above:
+if ! is_true "$MIGRATION_MODE" ; then
+    # Determine what non-zero block device sizes exists on the replacement hardware:
+    local replacement_hardware_disk_sizes=()
+    # Cf. the "loop over all current block devices" code
+    # in layout/prepare/default/300_map_disks.sh
+    local current_device_path=''
+    local current_disk_name=''
+    local current_size=''
+    for current_device_path in /sys/block/* ; do
+        # Continue with next block device if the current one has no queue directory:
+        test -d $current_device_path/queue || continue
+        # Continue with next block device if no size can be read for the current one:
+        test -r $current_device_path/size || continue
+        current_disk_name="${current_device_path#/sys/block/}"
+        current_size=$( get_disk_size $current_disk_name )
+        test "$current_size" -gt '0' && replacement_hardware_disk_sizes=( "${replacement_hardware_disk_sizes[@]}" "$current_size" )
+    done
+    # For each of the used disk sizes on the original system
+    # determine if that disk size exists more than once on the replacement hardware.
+    # Only the used disk sizes on the original system are tested here
+    # because there could be many same non-zero block device sizes on the replacement hardware
+    # of whatever non-disk block devices that are irrelevant for disk layout recreation.
+    local found_orig_size_on_replacement_hardware=0
+    local orig_size=''
+    for orig_size in "${original_system_used_disk_sizes[@]}" ; do
+        for current_size in "${replacement_hardware_disk_sizes[@]}" ; do
+            test "$current_size" -eq "$orig_size" && (( found_orig_size_on_replacement_hardware += 1 ))
+        done
+    done
+    # MIGRATION_MODE is needed when more than one possible target disk exists for a disk on the original system:
+    if test "$found_orig_size_on_replacement_hardware" -gt 1 ; then
+        LogPrint "Ambiguous possible target disks need manual configuration (more than one with same size found)"
+        MIGRATION_MODE='true'
+    fi
+fi
+
+# No further disk comparisons are needed when MIGRATION_MODE is already set true above:
+if ! is_true "$MIGRATION_MODE" ; then
+    # Compare original disks and their possible target disk one by one:
+    while read disk dev size junk ; do
+        dev=$( get_sysfs_name $dev )
+        Log "Comparing $dev"
+        if test -e "/sys/block/$dev" ; then
+            Log "Device /sys/block/$dev exists"
+            newsize=$( get_disk_size $dev )
+            if test "$newsize" -eq "$size" ; then
+                LogPrint "Device $dev has expected (same) size $size (will be used for recovery)"
+            else
+                LogPrint "Device $dev has size $newsize but $size is expected (needs manual configuration)"
+                MIGRATION_MODE='true'
+            fi
+        else
+            LogPrint "Device $dev does not exist (manual configuration needed)"
+            MIGRATION_MODE='true'
+        fi
+    done < <( grep -E '^disk |^multipath ' "$LAYOUT_FILE" )
+fi
+
+# Show the result to the user:
 if is_true "$MIGRATION_MODE" ; then
     LogPrint "Switching to manual disk layout configuration"
 else
     LogPrint "Disk configuration looks identical"
-    # See https://github.com/rear/rear/issues/1271
-    # why the above autodetection is not safe.
-    # To be more on the safe side a user confirmation dialog is shown here
+    # To be on the safe side a user confirmation dialog is shown here
     # with a relatively short timeout to avoid too much delay by default
-    # so that the user could intervene and enforce MIGRATION_MODE:
-    prompt="Proceed with restore (yes) otherwise manual disk layout configuration is enforced"
+    # but sufficient time for the user to read and understand the message
+    # so that the user could deliberately intervene and enforce MIGRATION_MODE:
+    prompt="Proceed with recovery (yes) otherwise manual disk layout configuration is enforced"
     input_value=""
     wilful_input=""
-    input_value="$( UserInput -I DISK_LAYOUT_PROCEED_RESTORE -t 10 -p "$prompt" -D 'yes' )" && wilful_input="yes" || wilful_input="no"
+    input_value="$( UserInput -I DISK_LAYOUT_PROCEED_RESTORE -t 30 -p "$prompt" -D 'yes' )" && wilful_input="yes" || wilful_input="no"
     if is_true "$input_value" ; then
-        is_true "$wilful_input" && LogPrint "User confirmed to proceed with restore" || LogPrint "Proceeding with restore by default"
+        is_true "$wilful_input" && LogPrint "User confirmed to proceed with recovery" || LogPrint "Proceeding with recovery by default"
     else
         # The user enforced MIGRATION_MODE uses the special 'TRUE' value in upper case letters
         # that is needed to overrule the prepare/default/270_overrule_migration_mode.sh script:

--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -60,7 +60,7 @@ while read disk dev size junk ; do
     fi
 done < <( grep -E '^disk |^multipath ' "$LAYOUT_FILE" )
 # MIGRATION_MODE is needed when more than one disk with same size is used on the original system:
-if is_true "$more_than_one_same_orig_size"
+if is_true "$more_than_one_same_orig_size" ; then
     LogPrint "Ambiguous disk layout needs manual configuration (more than one disk with same size used in '$LAYOUT_FILE')"
     MIGRATION_MODE='true'
 fi

--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -133,10 +133,15 @@ else
     # with a relatively short timeout to avoid too much delay by default
     # but sufficient time for the user to read and understand the message
     # so that the user could deliberately intervene and enforce MIGRATION_MODE:
-    prompt="Proceed with recovery (yes) otherwise manual disk layout configuration is enforced"
-    input_value=""
-    wilful_input=""
-    input_value="$( UserInput -I DISK_LAYOUT_PROCEED_RESTORE -t 30 -p "$prompt" -D 'yes' )" && wilful_input="yes" || wilful_input="no"
+    local timeout=30
+    # Have that timeout not bigger than USER_INPUT_TIMEOUT
+    # e.g. for automated testing a small USER_INPUT_TIMEOUT may be specified and
+    # we do not want to delay it here more than what USER_INPUT_TIMEOUT specifies:
+    test "$timeout" -gt "$USER_INPUT_TIMEOUT" && timeout="$USER_INPUT_TIMEOUT"
+    local prompt="Proceed with recovery (yes) otherwise manual disk layout configuration is enforced"
+    local input_value=""
+    local wilful_input=""
+    local input_value="$( UserInput -I DISK_LAYOUT_PROCEED_RESTORE -t "$timeout" -p "$prompt" -D 'yes' )" && wilful_input="yes" || wilful_input="no"
     if is_true "$input_value" ; then
         is_true "$wilful_input" && LogPrint "User confirmed to proceed with recovery" || LogPrint "Proceeding with recovery by default"
     else

--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -141,7 +141,7 @@ else
     local prompt="Proceed with recovery (yes) otherwise manual disk layout configuration is enforced"
     local input_value=""
     local wilful_input=""
-    local input_value="$( UserInput -I DISK_LAYOUT_PROCEED_RESTORE -t "$timeout" -p "$prompt" -D 'yes' )" && wilful_input="yes" || wilful_input="no"
+    local input_value="$( UserInput -I DISK_LAYOUT_PROCEED_RECOVERY -t "$timeout" -p "$prompt" -D 'yes' )" && wilful_input="yes" || wilful_input="no"
     if is_true "$input_value" ; then
         is_true "$wilful_input" && LogPrint "User confirmed to proceed with recovery" || LogPrint "Proceeding with recovery by default"
     else

--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -1,32 +1,61 @@
+
 # Compare disks from the original system to this system.
+# This implements some basic autodetection during "rear recover"
+# when disks on the replacement hardware seem to not match compared to
+# what there was stored in disklayout.conf on the original system.
+# If a mismatch is autodetected then ReaR goes into its
+# MIGRATION_MODE where it asks via user dialogs what to do.
 
-LogPrint "Comparing disks."
+if is_true "$MIGRATION_MODE" ; then
+    LogPrint "Enforced manual disk layout configuration (MIGRATION_MODE is 'true')"
+    return
+fi
 
-MIGRATION_MODE=${MIGRATION_MODE-""}
+if is_false "$MIGRATION_MODE" ; then
+    LogPrint "Enforced restoring disk layout as specified in '$LAYOUT_FILE' (MIGRATION_MODE is 'false')"
+    return
+fi
+
+LogPrint "Comparing disks"
 
 while read disk dev size junk ; do
     dev=$( get_sysfs_name $dev )
-
-    Log "Looking for $dev..."
-
-    if [ -e "/sys/block/$dev" ] ; then
-        Log "Device $dev exists."
-        newsize=$(get_disk_size $dev)
-
-        if [ "$newsize" -eq "$size" ] ; then
-            Log "Size of device $dev matches."
+    Log "Comparing $dev"
+    if test -e "/sys/block/$dev" ; then
+        Log "Device /sys/block/$dev exists"
+        newsize=$( get_disk_size $dev )
+        if test "$newsize" -eq "$size" ; then
+            LogPrint "Device $dev has expected size $size (will be used for restore)"
         else
-            LogPrint "Device $dev has size $newsize, $size expected"
-            MIGRATION_MODE="true"
+            LogPrint "Device $dev has size $newsize but $size is expected (needs manual configuration)"
+            MIGRATION_MODE='true'
         fi
     else
-        LogPrint "Device $dev does not exist."
-        MIGRATION_MODE="true"
+        LogPrint "Device $dev does not exist (manual configuration needed)"
+        MIGRATION_MODE='true'
     fi
-done < <(grep -E "^disk |^multipath " "$LAYOUT_FILE")
+done < <( grep -E '^disk |^multipath ' "$LAYOUT_FILE" )
 
-if [ -n "$MIGRATION_MODE" ] ; then
-    LogPrint "Switching to manual disk layout configuration."
+if is_true "$MIGRATION_MODE" ; then
+    LogPrint "Switching to manual disk layout configuration"
 else
-    LogPrint "Disk configuration is identical, proceeding with restore."
+    LogPrint "Disk configuration looks identical"
+    # See https://github.com/rear/rear/issues/1271
+    # why the above autodetection is not safe.
+    # To be more on the safe side a user confirmation dialog is shown here
+    # with a relatively short timeout to avoid too much delay by default
+    # so that the user could intervene and enforce MIGRATION_MODE:
+    prompt="Proceed with restore (yes) otherwise manual disk layout configuration is enforced"
+    input_value=""
+    wilful_input=""
+    input_value="$( UserInput -I DISK_LAYOUT_PROCEED_RESTORE -t 10 -p "$prompt" -D 'yes' )" && wilful_input="yes" || wilful_input="no"
+    if is_true "$input_value" ; then
+        is_true "$wilful_input" && LogPrint "User confirmed to proceed with restore" || LogPrint "Proceeding with restore by default"
+    else
+        # The user enforced MIGRATION_MODE uses the special 'TRUE' value in upper case letters
+        # that is needed to overrule the prepare/default/270_overrule_migration_mode.sh script:
+        MIGRATION_MODE='TRUE'
+        LogPrint "User enforced manual disk layout configuration"
+    fi
 fi
+

--- a/usr/share/rear/layout/prepare/default/270_overrule_migration_mode.sh
+++ b/usr/share/rear/layout/prepare/default/270_overrule_migration_mode.sh
@@ -1,13 +1,23 @@
 # 270_overrule_migration_mode.sh
-# Tricky script where we overrule the variable MIGRATION_MODE if it was set to true
-# This means that rear recover could fail because of disk size mismatches, but we give it try
+# Tricky script where we overrule the variable MIGRATION_MODE if it was set to true.
+# This means that rear recover could fail because of disk size mismatches, but we give it try.
 # The 'unattended' parameter must be present on the boot command line - for the moment
-# this feature will only be used by automated PXE booting
+# this feature will only be used by automated PXE booting.
+
+# Nothing to do unless MIGRATION_MODE has a 'true' value:
+is_true "$MIGRATION_MODE" || return 0
 
 for kernel_command_line_parameter in $( cat /proc/cmdline ) ; do
-    if test "unattended" = "$kernel_command_line_parameter" ; then
-        LogPrint "Switching off migration mode due to 'unattended' kernel option"
-        MIGRATION_MODE=
+    if test 'unattended' = "$kernel_command_line_parameter" ; then
+        # In etc/rear/local.conf or via layout/prepare/default/250_compare_disks.sh the user may have
+        # enforced MIGRATION_MODE by setting the special 'TRUE' value in upper case letters
+        # that overrules switching off migration mode due to 'unattended' kernel option:
+        if test 'TRUE' = "$MIGRATION_MODE" ; then
+            LogPrint "User enforced manual disk layout configuration overrules 'unattended' recovery"
+            return
+        fi
+        LogPrint "Switching off manual disk layout configuration (MIGRATION_MODE) due to 'unattended' kernel option"
+        MIGRATION_MODE='false'
         return
     fi
 done

--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -1,7 +1,7 @@
 # Apply the mapping in the layout file.
 
-if [ -z "$MIGRATION_MODE" ] ; then
-    return 0
-fi
+# Skip if not in migration mode:
+is_true "$MIGRATION_MODE" || return 0
 
 apply_layout_mappings "$LAYOUT_FILE"
+

--- a/usr/share/rear/layout/prepare/default/400_autoresize_disks.sh
+++ b/usr/share/rear/layout/prepare/default/400_autoresize_disks.sh
@@ -1,8 +1,7 @@
 # Try to automatically resize disks.
 
-if [[ -z "$MIGRATION_MODE" ]] ; then
-    return 0
-fi
+# Skip if not in migration mode:
+is_true "$MIGRATION_MODE" || return 0
 
 # Resize all partitions, except the boot partition.
 # This does not resize volumes on top of the affected partitions.

--- a/usr/share/rear/layout/prepare/default/500_confirm_layout_file.sh
+++ b/usr/share/rear/layout/prepare/default/500_confirm_layout_file.sh
@@ -3,8 +3,8 @@
 # disk layout file (disklayout.conf) content.
 #
 
-# Skip that unless in migration mode:
-test "$MIGRATION_MODE" || return 0
+# Skip if not in migration mode:
+is_true "$MIGRATION_MODE" || return 0
 
 rear_workflow="rear $WORKFLOW"
 original_disk_space_usage_file="$VAR_DIR/layout/config/df.txt"

--- a/usr/share/rear/layout/recreate/default/100_confirm_layout_code.sh
+++ b/usr/share/rear/layout/recreate/default/100_confirm_layout_code.sh
@@ -3,8 +3,8 @@
 # disk layout recreation code (diskrestore.sh) script.
 #
 
-# Skip that unless in migration mode:
-test "$MIGRATION_MODE" || return 0
+# Skip if not in migration mode:
+is_true "$MIGRATION_MODE" || return 0
 
 rear_workflow="rear $WORKFLOW"
 original_disk_space_usage_file="$VAR_DIR/layout/config/df.txt"


### PR DESCRIPTION
When the user can (if needed) enforce MIGRATION_MODE
he can avoid a disastrous disaster recovery as in
https://github.com/rear/rear/issues/1271

By the way I found a bug in layout/prepare/default/300_map_disks.sh
because for same disk with same size it mapped
e.g. /dev/sda to /sys/block/sda but the latter is no
block device which lets "rear recover" BugError out with
<pre>
BUG in /usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh line 35:
'Disk /sys/block/sda is not a block device.'
</pre>
