### PR TITLE
Borg backup as back end now displays progress, when ReaR is launched in verbose mode

### DIFF
--- a/usr/share/rear/backup/BORG/default/500_make_backup.sh
+++ b/usr/share/rear/backup/BORG/default/500_make_backup.sh
@@ -19,11 +19,16 @@ done
 Log "Creating archive ${BORGBACKUP_ARCHIVE_PREFIX}_$BORGBACKUP_SUFFIX \
 in repository $BORGBACKUP_REPO on host $BORGBACKUP_HOST"
 
+# Only in ReaR verbose mode also show borg progress output and stats
+local borg_progress=''
+test "$verbose" && borg_progress='--progress --stats'
+
 # Start actual Borg backup.
-borg create --one-file-system --verbose --stats $BORGBACKUP_OPT_COMPRESSION \
-$BORGBACKUP_OPT_REMOTE_PATH --exclude-from $TMP_DIR/backup-exclude.txt \
+borg create --one-file-system $borg_progress $verbose \
+$BORGBACKUP_OPT_COMPRESSION $BORGBACKUP_OPT_REMOTE_PATH \
+--exclude-from $TMP_DIR/backup-exclude.txt \
 $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO::\
 ${BORGBACKUP_ARCHIVE_PREFIX}_$BORGBACKUP_SUFFIX \
-${include_list[@]}
+${include_list[@]} 0<&6 1>&7 2>&8
 
 StopIfError "Failed to create backup"

--- a/usr/share/rear/backup/BORG/default/800_prune_old_backups.sh
+++ b/usr/share/rear/backup/BORG/default/800_prune_old_backups.sh
@@ -5,9 +5,9 @@
 
 if [ ! -z $BORGBACKUP_OPT_PRUNE ]; then
     # Purge old archives according user settings.
-    Log "Purging old Borg archives in repository $BORGBACKUP_REPO"
+    LogPrint "Purging old Borg archives in repository $BORGBACKUP_REPO"
 
-    borg prune --verbose --list ${BORGBACKUP_OPT_PRUNE[@]} \
+    borg prune --list ${BORGBACKUP_OPT_PRUNE[@]} \
     $BORGBACKUP_OPT_REMOTE_PATH --prefix ${BORGBACKUP_ARCHIVE_PREFIX}_ \
     $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO
     StopIfError "Failed to purge old backups"

--- a/usr/share/rear/prep/BORG/default/300_init_archive.sh
+++ b/usr/share/rear/prep/BORG/default/300_init_archive.sh
@@ -24,8 +24,8 @@ rc=$?
 # `borg init` has to be triggered in "prep" stage if user decides to include
 # keyfiles to Relax-and-Recover rescue/recovery system using COPY_AS_IS_BORG.
 if [ $rc -ne 0 ]; then
-    Log "Failed to list $BORGBACKUP_REPO on $BORGBACKUP_HOST"
-    Log "Creating new Borg repository $BORGBACKUP_REPO on $BORGBACKUP_HOST"
+    LogPrint "Failed to list $BORGBACKUP_REPO on $BORGBACKUP_HOST"
+    LogPrint "Creating new Borg repository $BORGBACKUP_REPO on $BORGBACKUP_HOST"
     borg init $BORGBACKUP_OPT_ENCRYPTION $BORGBACKUP_OPT_REMOTE_PATH \
     $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO
     rc=$?


### PR DESCRIPTION
This PR fixes #1588.
Borg backup as back end now honors ReaR's verbose option.

V.