### PR TITLE
Add 1s sleep time before udevtrigger

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
@@ -235,7 +235,8 @@ fi
 # Reload udev if we have MAC mappings:
 if is_true $reload_udev ; then
     echo -n "Reloading udev ... "
-    sleep 1
+    # Force udev to reload rules (as they were just changed)
+    udevadm control --reload-rules
     my_udevtrigger
     sleep 1
     my_udevsettle

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
@@ -236,7 +236,9 @@ fi
 if is_true $reload_udev ; then
     echo -n "Reloading udev ... "
     # Force udev to reload rules (as they were just changed)
-    udevadm control --reload-rules
+    # Failback to "udevadm control --reload" in case of problem (as specify in udevadm manpage in SLES12)
+    # If nothing work, then wait 1 seconf delay. It should let the time for udev to detect changes in the rules files.
+    udevadm control --reload-rules || udevadm control --reload || sleep 1
     my_udevtrigger
     sleep 1
     my_udevsettle

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
@@ -235,6 +235,7 @@ fi
 # Reload udev if we have MAC mappings:
 if is_true $reload_udev ; then
     echo -n "Reloading udev ... "
+    sleep 1
     my_udevtrigger
     sleep 1
     my_udevsettle


### PR DESCRIPTION
Without the 1s sleep time, I got the following error `Cannot find device "eth0"` during a network migration (sles12sp2).
```
Running 55-migrate-network-devices.sh...
The only original network interface eth0 00:1a:4a:16:01:cc is not available
and no mapping is specified in /etc/rear/mappings/mac
Mapping it to the only available eth1 1a:f4:ea:94:64:0c
Reloading udev ... done.
Running 58-start-dhclient.sh...
Running 60-network-devices.sh...
Cannot find device "eth0"
Cannot find device "eth0"
Cannot find device "eth0"
Running 62-routing.sh...
Cannot find device "eth0"
Running 63-teaming.sh...
Running 65-sysctl.sh...
Running 67-check-by-label-cdrom.sh...
Running 99-makedev.sh...
```

This is solve by adding a 1s delay before triggering udev.