### PR TITLE
Move the packages isolinux and xorriso from Depends to Recommends lines

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 9)
 Package: rear
 Architecture: i386 ia64 amd64 ppc64el
 Provides: rear
-Depends: syslinux[!ppc64el], syslinux-common[!ppc64el], ethtool, ${shlibs:Depends}, lsb-release, xorriso, iproute, iputils-ping, isolinux, dosfstools, binutils, parted, openssl, gawk, attr, bc, ${misc:Depends}
-Recommends: nfs-client, portmap
+Depends: syslinux[!ppc64el], syslinux-common[!ppc64el], ethtool, ${shlibs:Depends}, lsb-release, iproute, iputils-ping, dosfstools, binutils, parted, openssl, gawk, attr, bc, ${misc:Depends}
+Recommends: nfs-client, portmap, xorriso, isolinux
 Description: Relax-and-Recover is a bare metal disaster recovery and system
  migration framework. See http://relax-and-recover.org/ for all the details.


### PR DESCRIPTION
For Debian and Ubuntu package building and installation we move the packages isolinux and xorriso from Depends to Recommends lines

See issue #1403
A word of warning: xorriso and isolinux will NOT install automatically - when not present if required rear will bail out.

And, also story https://github.com/gdha/rear-automated-testing/issues/26 as background