### PR TITLE
Add ntpdate support to rescue/default/430_prepare_timesync.sh…

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1072,9 +1072,9 @@ SSH_UNPROTECTED_PRIVATE_KEYS='no'
 # For details see the build/default/980_verify_rootfs.sh script.
 NON_FATAL_BINARIES_WITH_MISSING_LIBRARY=''
 
-# Time synchronisation, could be NTP, RDATE or empty:
+# Time synchronisation, could be NTP, NTPDATE, RDATE or empty:
 TIMESYNC=
-# Set a timesync source, mostly needed for RDATE:
+# Set a timesync source, mostly needed for NTPDATE and RDATE:
 TIMESYNC_SOURCE=
 
 # Define a default LANG_RECOVER. At least TSM seems to need it to correctly restore foreign language sets.

--- a/usr/share/rear/rescue/default/430_prepare_timesync.sh
+++ b/usr/share/rear/rescue/default/430_prepare_timesync.sh
@@ -31,6 +31,16 @@ case "$TIMESYNC" in
 		EOF
 
 		;;
+	NTPDATE)
+		[ "$TIMESYNC_SOURCE" ]
+		StopIfError "TIMESYNC_SOURCE not set, please set it to your NTPDATE server in $CONFIG_DIR/local.conf"
+		PROGS=( "${PROGS[@]}" ntpdate )
+		cat >$ROOTFS_DIR/etc/scripts/system-setup.d/90-timesync.sh <<-EOF
+			echo "Setting system time via NTPDATE ..."
+			ntpdate -b "$TIMESYNC_SOURCE" # allow for big jumps
+		EOF
+
+		;;
 	"")
 		# no timesync, do nothing
 		;;


### PR DESCRIPTION
… and associated update to conf/default.conf

I have added the support for ntpdate in order to satisfy issue https://github.com/rear/rear/issues/1598#issuecomment-347920758 .

Changes in `/etc/inittab` are not necessary since they appear to do nothing anyway.  I checked the history of `430_prepare_timesync.sh` and the entire file seems to have been added at once (as `43_prepare_timesync.sh`) by @schlomo about 9 years ago ( https://github.com/rear/rear/commit/07c0385e931ffad1a79d7ea841a6d3f978f0bea9#diff-8fcb1c324ed3bff4cc3a656e0c1298d4 ).

ntpd successfully sets the time on both CentOS 6 (SysV) or CentOS 7 (systemd), but ntpd is not running as a daemon on either.

I think we can reasonably delete the following line, but I don't want to do that at this time as I feel it deserves its own PR: https://github.com/rear/rear/blob/d798fdb39bb6d0a111d4655283ad28d91286222e/usr/share/rear/rescue/default/430_prepare_timesync.sh#L7 