### PR TITLE
Issue #1609: keep daemons spawned by sysinit.service alive upon exit

### DIFF
--- a/usr/share/rear/skel/default/usr/lib/systemd/system/sysinit.service
+++ b/usr/share/rear/skel/default/usr/lib/systemd/system/sysinit.service
@@ -6,3 +6,4 @@ After=systemd-udevd.service
 Type=oneshot
 ExecStart=/etc/scripts/system-setup
 StandardInput=tty
+RemainAfterExit=yes


### PR DESCRIPTION
This fixes Issue #1609.

Before patching:
- dhclient is killed after /etc/scripts/system-setup exited

After patching:
- dhclient is still alive after /etc/scripts/system-setup exited

Same applies to NetBackup daemons if applicable.