### PR TITLE
xfs_info (>= 4.12.0) does not accept device file as valid option, but mountpoint must be used instead.

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -146,7 +146,7 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
                 uuid=$(xfs_admin -u $device | cut -d'=' -f 2 | tr -d " ")
                 label=$(xfs_admin -l $device | cut -d'"' -f 2)
                 echo -n " uuid=$uuid label=$label "
-                xfs_info $device > $LAYOUT_XFS_OPT_DIR/$(basename ${device}.xfs)
+                xfs_info $mountpoint > $LAYOUT_XFS_OPT_DIR/$(basename ${device}.xfs)
                 StopIfError "Failed to save XFS options of $device"
                 ;;
             (reiserfs)

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -146,6 +146,9 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
                 uuid=$(xfs_admin -u $device | cut -d'=' -f 2 | tr -d " ")
                 label=$(xfs_admin -l $device | cut -d'"' -f 2)
                 echo -n " uuid=$uuid label=$label "
+                # Save current XFS file system options.
+                # Saved options will be later used in ReaR recovery system for
+                # file system re-creation.
                 xfs_info $mountpoint > $LAYOUT_XFS_OPT_DIR/$(basename ${device}.xfs)
                 StopIfError "Failed to save XFS options of $device"
                 ;;


### PR DESCRIPTION
For details see my https://github.com/rear/rear/issues/1618#issuecomment-348712258