### PR TITLE
Ignore disk size of multipath slave in 205_compare_disk.sh

### DIFF
--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -75,12 +75,12 @@ if ! is_true "$MIGRATION_MODE" ; then
     local current_disk_name=''
     local current_size=''
     for current_device_path in /sys/block/* ; do
+        # Continue with next block device if the device is a multipath device slave
+        is_multipath_path ${current_device_path#/sys/block/} || continue
         # Continue with next block device if the current one has no queue directory:
         test -d $current_device_path/queue || continue
         # Continue with next block device if no size can be read for the current one:
         test -r $current_device_path/size || continue
-        # Continue with next block device if the device is a multipath device slave
-        test is_multipath_path /dev/$current_device_path || continue
         current_disk_name="${current_device_path#/sys/block/}"
         current_size=$( get_disk_size $current_disk_name )
         test "$current_size" -gt '0' && replacement_hardware_disk_sizes=( "${replacement_hardware_disk_sizes[@]}" "$current_size" )

--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -79,6 +79,8 @@ if ! is_true "$MIGRATION_MODE" ; then
         test -d $current_device_path/queue || continue
         # Continue with next block device if no size can be read for the current one:
         test -r $current_device_path/size || continue
+        # Continue with next block device if the device is a multipath device slave
+        test is_multipath_path /dev/$current_device_path || continue
         current_disk_name="${current_device_path#/sys/block/}"
         current_size=$( get_disk_size $current_disk_name )
         test "$current_size" -gt '0' && replacement_hardware_disk_sizes=( "${replacement_hardware_disk_sizes[@]}" "$current_size" )


### PR DESCRIPTION
@jsmeix, as explain directly in #1596, I got the following small bug ...
```
RESCUE rear-rhel-142:~ # rear -D recover
Relax-and-Recover 2.2 / Git
Using log file: /var/log/rear/rear-rear-rhel-142.log
Running workflow recover within the ReaR rescue/recovery system
Starting required daemons for NFS: RPC portmapper (portmap or rpcbind) and rpc.statd if available.
Started RPC portmapper 'rpcbind'.
RPC portmapper 'rpcbind' available.
Started rpc.statd.
RPC status rpc.statd available.
Started rpc.idmapd.
Using backup archive '/tmp/rear.xAzGbMuWwaH3TfJ/outputfs/rear-rhel-142/backup.tar.gz'
Calculating backup archive size
Backup archive size is 1003M	/tmp/rear.xAzGbMuWwaH3TfJ/outputfs/rear-rhel-142/backup.tar.gz (compressed)
Setting up multipathing
Activating multipath
multipath activated
Listing multipath device found
mpatha	(253, 0)
Comparing disks
Ambiguous possible target disks need manual configuration (more than one with same size found)
Switching to manual disk layout configuration
Using /dev/mapper/mpatha (same name and same size) for recreating /dev/mapper/mpatha
Current disk mapping table (source -> target):
    /dev/mapper/mpatha /dev/mapper/mpatha
UserInput -I LAYOUT_MIGRATION_CONFIRM_MAPPINGS needed in /usr/share/rear/layout/prepare/default/300_map_disks.sh line 211
Confirm or edit the disk mapping
1) Confirm disk mapping and continue 'rear recover'
2) Edit disk mapping (/var/lib/rear/layout/disk_mappings)
3) Use Relax-and-Recover shell and return back to here
4) Abort 'rear recover'
(default '1' timeout 10 seconds)
```

`/dev/mapper/maptha` is the original device (means NO MIGRATION)
but I think the change you introduced in 1e3b0d9 produce this bug:
Ambiguous possible target disks need manual configuration (more than one with same size found)

I think the reason is the fact all disk size are put into the replacement_hardware_disk_sizes array; even the disk which are slaves of a multipathed device.

extract from my disklayout.conf
```
multipath /dev/mapper/mpatha 53687091200 /dev/sda,/dev/sdb,/dev/sdc,/dev/sdd,/dev/sde,/dev/sdf,/dev/sdg,/dev/sdh
```
In the example above, sda, sdb, sdc, sdd, sde, sdf, sdg, sdh are different PATH to the same disk device. mpatha .... So, in the current code, their sized will be stored several times .... Which conduct to the following message: (more than one with same size found) and require a User interaction even if only one multipath device (SAN LUN) is presented to the system.

This PR avoid to add device size into the |replacement_hardware_disk_sizes` array if they are a multipath slave.