### PR TITLE
exclude REAR-000 and ESP from df.txt

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/510_current_disk_usage.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/510_current_disk_usage.sh
@@ -2,4 +2,5 @@
 # Public License. Refer to the included COPYING for full text of license.
 
 # Save the current disk usage (POSIX output format) in the rescue image
-df -Plh -x encfs -x tmpfs -x devtmpfs > $VAR_DIR/layout/config/df.txt
+# excluding target (ESP) partition(s)
+df -Plh -x encfs -x tmpfs -x devtmpfs |  egrep  --invert-match "^(`readlink -f "/dev/disk/by-label/$USB_DEVICE_FILESYSTEM_LABEL"`|`readlink -f /dev/disk/by-label/REAR-EFI`)" > $VAR_DIR/layout/config/df.txt


### PR DESCRIPTION
There is no purpose of including the target device in df.txt
Removing that section makes the df.txt better human readable.

TODO#1: only for USB workflow?
TODO#2: make the EFI partition optional (only needed when the target (USB) device contains an EFI partition).
TODO#3: improve line breaking