### PR TITLE
Follow symbolic link with COPY_AS_IS targets

### DIFF
--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -31,8 +31,9 @@ done >$copy_as_is_exclude_file
 #  2
 #  -rw-r--r-- root/root         4 2017-10-12 11:31 foo
 #  -rw-r--r-- root/root         4 2017-10-12 11:31 baz
+# We added the extra option "-h" (dereference or follow the symbolic link) to the tar command - see issue #1635
 # Because pipefail is not set it is the second 'tar' in the pipe that determines whether or not the whole operation was successful:
-if ! tar -v -X $copy_as_is_exclude_file -P -C / -c "${COPY_AS_IS[@]}" 2>$copy_as_is_filelist_file | tar $v -C $ROOTFS_DIR/ -x 1>/dev/null ; then
+if ! tar -v -X $copy_as_is_exclude_file -h -P -C / -c "${COPY_AS_IS[@]}" 2>$copy_as_is_filelist_file | tar $v -C $ROOTFS_DIR/ -x 1>/dev/null ; then
     Error "Failed to copy files and directories in COPY_AS_IS minus COPY_AS_IS_EXCLUDE"
 fi
 Log "Finished copying files and directories in COPY_AS_IS minus COPY_AS_IS_EXCLUDE"

--- a/usr/share/rear/skel/default/etc/scripts/dhcp-setup-functions.sh
+++ b/usr/share/rear/skel/default/etc/scripts/dhcp-setup-functions.sh
@@ -519,12 +519,12 @@ dhconfig() {
                 ((hoursWest*=-1))
             fi
 
-            tzfile=/usr/share/zoneinfo/Etc/GMT$(printf '%+d' ${hoursWest})
-            if [ -e ${tzfile} ]; then
+            #tzfile=/usr/share/zoneinfo/Etc/GMT$(printf '%+d' ${hoursWest})
+            #if [ -e ${tzfile} ]; then
                 #save_previous /etc/localtime
-                cp -fp ${tzfile} /etc/localtime
-                touch /etc/localtime
-            fi
+            #    cp -fp ${tzfile} /etc/localtime
+            #    touch /etc/localtime
+            #fi
         fi
     fi
 


### PR DESCRIPTION
- added the "-h" option to tar to follow the symbolic links  
  instead of adding just the symbolic link to the tar archive
  We run into this issue with /etc/localtime (issue #1635)
- commented out in skel/default/etc/scripts/dhcp-setup-functions.sh
  the localtime copy lines (as the /usr/share/zoneinfo is not
  present anyway in the rescue environment)