### PR TITLE
anti-bloatware suggestion

### DIFF
--- a/usr/share/rear/prep/default/400_save_directories.sh
+++ b/usr/share/rear/prep/default/400_save_directories.sh
@@ -17,11 +17,11 @@ local mountpoints="$( findmnt -runit $excluded_fs_types -o TARGET )"
 local directory
 for directory in $mountpoints ; do
     case $directory in
-        /|/sys/*|/tmp|/tmp/*|/mnt/*|/media/*)
+        (/|/sys/*|/tmp|/tmp/*|/mnt/*|/media/*)
             # Skip these directories
             continue 
             ;;
-        *)
+        (*)
             # Output directory name, access rights in octal, user name of owner, group name of owner
             $STAT -c '%n %a %U %G' "$directory" >>"$directories_permissions_owner_group_file"
             ;;

--- a/usr/share/rear/prep/default/400_save_directories.sh
+++ b/usr/share/rear/prep/default/400_save_directories.sh
@@ -29,7 +29,6 @@ for directory in $mountpoints ; do
 done
 
 # Output is lines that look like (e.g. on a SLES12 system):
-# /sys 555 root root
 # /proc 555 root root
 # /dev 755 root root
 # /dev/shm 1777 root root

--- a/usr/share/rear/prep/default/400_save_directories.sh
+++ b/usr/share/rear/prep/default/400_save_directories.sh
@@ -23,7 +23,7 @@ for directory in $mountpoints ; do
             ;;
         (*)
             # Output directory name, access rights in octal, user name of owner, group name of owner
-            $STAT -c '%n %a %U %G' "$directory" >>"$directories_permissions_owner_group_file"
+            /usr/bin/stat -c '%n %a %U %G' "$directory" >>"$directories_permissions_owner_group_file"
             ;;
     esac
 done


### PR DESCRIPTION
for mount point saving, "look ma: without grep and awk".

Especially the excluded_fs_types list might need some additional tuning.