### PR TITLE
systemd-tmpfiles required for rpcbind and comment some unneeded code

### DIFF
--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -31,9 +31,8 @@ done >$copy_as_is_exclude_file
 #  2
 #  -rw-r--r-- root/root         4 2017-10-12 11:31 foo
 #  -rw-r--r-- root/root         4 2017-10-12 11:31 baz
-# We added the extra option "-h" (dereference or follow the symbolic link) to the tar command - see issue #1635
 # Because pipefail is not set it is the second 'tar' in the pipe that determines whether or not the whole operation was successful:
-if ! tar -v -X $copy_as_is_exclude_file -h -P -C / -c "${COPY_AS_IS[@]}" 2>$copy_as_is_filelist_file | tar $v -C $ROOTFS_DIR/ -x 1>/dev/null ; then
+if ! tar -v -X $copy_as_is_exclude_file -P -C / -c "${COPY_AS_IS[@]}" 2>$copy_as_is_filelist_file | tar $v -C $ROOTFS_DIR/ -x 1>/dev/null ; then
     Error "Failed to copy files and directories in COPY_AS_IS minus COPY_AS_IS_EXCLUDE"
 fi
 Log "Finished copying files and directories in COPY_AS_IS minus COPY_AS_IS_EXCLUDE"

--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -31,8 +31,9 @@ done >$copy_as_is_exclude_file
 #  2
 #  -rw-r--r-- root/root         4 2017-10-12 11:31 foo
 #  -rw-r--r-- root/root         4 2017-10-12 11:31 baz
+# We added the extra option "-h" (dereference or follow the symbolic link) to the tar command - see issue #1635
 # Because pipefail is not set it is the second 'tar' in the pipe that determines whether or not the whole operation was successful:
-if ! tar -v -X $copy_as_is_exclude_file -P -C / -c "${COPY_AS_IS[@]}" 2>$copy_as_is_filelist_file | tar $v -C $ROOTFS_DIR/ -x 1>/dev/null ; then
+if ! tar -v -X $copy_as_is_exclude_file -h -P -C / -c "${COPY_AS_IS[@]}" 2>$copy_as_is_filelist_file | tar $v -C $ROOTFS_DIR/ -x 1>/dev/null ; then
     Error "Failed to copy files and directories in COPY_AS_IS minus COPY_AS_IS_EXCLUDE"
 fi
 Log "Finished copying files and directories in COPY_AS_IS minus COPY_AS_IS_EXCLUDE"

--- a/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
+++ b/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
@@ -1,6 +1,6 @@
 # Many Linux distro's are using systemd as init mechanism
 
-# added systemd-tmpfiles and /var/lib/tmpfiles.d for Fedora (and in the future also RHEL) for issue #1575 (rpcbind
+# added systemd-tmpfiles and /{usr|var}/lib/tmpfiles.d for Fedora (and in the future also RHEL) for issue #1575 (rpcbind
 # fails to start within rescue system)
 if ps ax | grep -v grep | grep -q systemd ; then
     PROGS=( "${PROGS[@]}" systemd agetty systemctl systemd-notify systemd-ask-password
@@ -13,7 +13,7 @@ if ps ax | grep -v grep | grep -q systemd ; then
     # 2- Need to add systemd/network subdir in order to preserve rules about network device naming
     #    (predictable naming or persitant naming / like udev).
     #    more info here: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
-    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* /usr/lib/systemd/network /lib/systemd/network /usr/lib/systemd/system-generators/systemd-getty-generator  /lib/systemd/system-generators/systemd-getty-generator /var/lib/tmpfiles.d )
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* /usr/lib/systemd/network /lib/systemd/network /usr/lib/systemd/system-generators/systemd-getty-generator  /lib/systemd/system-generators/systemd-getty-generator /var/lib/tmpfiles.d /usr/lib/tmpfiles.d )
     CLONE_GROUPS=( "${CLONE_GROUPS[@]}" input )
     Log "Including systemd (init replacement) tool-set to bootstrap Relax-and-Recover"
 fi

--- a/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
+++ b/usr/share/rear/prep/GNU/Linux/280_include_systemd.sh
@@ -1,9 +1,11 @@
-# Fedora 15 is using systemd as init mechanism
+# Many Linux distro's are using systemd as init mechanism
 
+# added systemd-tmpfiles and /var/lib/tmpfiles.d for Fedora (and in the future also RHEL) for issue #1575 (rpcbind
+# fails to start within rescue system)
 if ps ax | grep -v grep | grep -q systemd ; then
     PROGS=( "${PROGS[@]}" systemd agetty systemctl systemd-notify systemd-ask-password
         systemd-udevd systemd-journald journalctl dbus-uuidgen dbus-daemon dbus-send
-        upstart-udev-bridge )
+        upstart-udev-bridge systemd-tmpfiles )
     # cgroup stuff - not required for ReaR
     #PROGS=( "${PROGS[@]}" cg_annotate cgclear cgcreate cgget cgrulesengd cgset cgdelete cgclassify cgexec )
 
@@ -11,7 +13,7 @@ if ps ax | grep -v grep | grep -q systemd ; then
     # 2- Need to add systemd/network subdir in order to preserve rules about network device naming
     #    (predictable naming or persitant naming / like udev).
     #    more info here: https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
-    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* /usr/lib/systemd/network /lib/systemd/network /usr/lib/systemd/system-generators/systemd-getty-generator  /lib/systemd/system-generators/systemd-getty-generator )
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/systemd /etc/dbus-1 /usr/lib/systemd/systemd-* /lib/systemd/systemd-* /usr/lib/systemd/network /lib/systemd/network /usr/lib/systemd/system-generators/systemd-getty-generator  /lib/systemd/system-generators/systemd-getty-generator /var/lib/tmpfiles.d )
     CLONE_GROUPS=( "${CLONE_GROUPS[@]}" input )
     Log "Including systemd (init replacement) tool-set to bootstrap Relax-and-Recover"
 fi

--- a/usr/share/rear/skel/default/etc/scripts/dhcp-setup-functions.sh
+++ b/usr/share/rear/skel/default/etc/scripts/dhcp-setup-functions.sh
@@ -519,12 +519,12 @@ dhconfig() {
                 ((hoursWest*=-1))
             fi
 
-            tzfile=/usr/share/zoneinfo/Etc/GMT$(printf '%+d' ${hoursWest})
-            if [ -e ${tzfile} ]; then
+            #tzfile=/usr/share/zoneinfo/Etc/GMT$(printf '%+d' ${hoursWest})
+            #if [ -e ${tzfile} ]; then
                 #save_previous /etc/localtime
-                cp -fp ${tzfile} /etc/localtime
-                touch /etc/localtime
-            fi
+            #    cp -fp ${tzfile} /etc/localtime
+            #    touch /etc/localtime
+            #fi
         fi
     fi
 


### PR DESCRIPTION
1. **Be aware the -`h` PR has been removed!**
2. commented out in `skel/default/etc/scripts/dhcp-setup-functions.sh`
  the _localtime_ copy lines (as the `/usr/share/zoneinfo` is not
  present anyway in the rescue environment)
3. added `systemd-tmpfiles` within the systemd frame-work to fix issue #1575 