### PR TITLE
Allow TSM_DSMC_RESTORE_OPTIONS to be also set via export

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1193,9 +1193,16 @@ TSM_LD_LIBRARY_PATH="/opt/tivoli/tsm/client/ba/bin:/opt/tivoli/tsm/client/api/bi
 # where to copy the resulting files to and save them with TSM
 TSM_RESULT_FILE_PATH=/opt/tivoli/tsm/rear
 #
-# Additional dsmc options for restore. Point-in-time read from user
-# input is also added to this array.
-TSM_DSMC_RESTORE_OPTIONS=( )
+# Additional dsmc options for restore.
+# Point-in-time read from user input is also added to this array.
+# TSM_DSMC_RESTORE_OPTIONS is set to a default value here only
+# if not already set so that the user can set it also like
+#   export TSM_DSMC_RESTORE_OPTIONS=( ... )
+# directly before he calls "rear recover", cf.
+# https://github.com/rear/rear/issues/1534#issuecomment-351368461
+# test for "${name[*]}" because it is an array and the test should succeed
+# when there is any non-empty array member, (not necessarily the first one):
+test "${TSM_DSMC_RESTORE_OPTIONS[*]}" || TSM_DSMC_RESTORE_OPTIONS=()
 #
 # Point-in-time date to use, calculated from user input during recovery.
 # User input is read as YYYY-MM-DD, but internally MM/DD/YYYY is used.


### PR DESCRIPTION
Now TSM_DSMC_RESTORE_OPTIONS is only set
to an empty array in default.conf when it is not already set
so that the user can set it on command line via
<pre>
export TSM_DSMC_RESTORE_OPTIONS=( ... )
</pre>
directly before he calls "rear recover", cf.
https://github.com/rear/rear/issues/1534#issuecomment-351368461
