### PR TITLE
mount noise in 400_save_directories excluded_fs_types?

### DIFF
--- a/usr/share/rear/prep/default/400_save_directories.sh
+++ b/usr/share/rear/prep/default/400_save_directories.sh
@@ -19,6 +19,10 @@ cat /dev/null >"$directories_permissions_owner_group_file"
 # but currently I <jsmeix@suse.de> prefer "bloatware code" that works fail safe
 # over simple code that sometimes fails, cf. "Dirty hacks welcome"
 # at https://github.com/rear/rear/wiki/Coding-Style
+# All elements of the 'pseudofs' array in libmount/src/utils.c
+# cf. https://github.com/karelzak/util-linux/blob/master/libmount/src/utils.c
+# are considered as unwanted "noise" in this context
+# see https://github.com/rear/rear/pull/1648
 local excluded_fs_types="anon_inodefs|autofs|bdev|cgroup|cgroup2|configfs|cpuset|debugfs|devfs|devpts|devtmpfs|dlmfs|efivarfs|fuse.gvfs-fuse-daemon|fusectl|hugetlbfs|mqueue|nfsd|none|nsfs|overlay|pipefs|proc|pstore|ramfs|rootfs|rpc_pipefs|securityfs|sockfs|spufs|sysfs|tmpfs"
 # BUILD_DIR can be used in 'grep -vE "this|$BUILD_DIR|that"' because it is never empty (see usr/sbin/rear)
 # because with any empty part 'grep  -vE "this||that"' would output nothing at all:

--- a/usr/share/rear/prep/default/400_save_directories.sh
+++ b/usr/share/rear/prep/default/400_save_directories.sh
@@ -19,7 +19,7 @@ cat /dev/null >"$directories_permissions_owner_group_file"
 # but currently I <jsmeix@suse.de> prefer "bloatware code" that works fail safe
 # over simple code that sometimes fails, cf. "Dirty hacks welcome"
 # at https://github.com/rear/rear/wiki/Coding-Style
-local excluded_fs_types="cgroup|fuse.*|nfsd"
+local excluded_fs_types="anon_inodefs|autofs|bdev|cgroup|cgroup2|configfs|cpuset|debugfs|devfs|devpts|devtmpfs|dlmfs|efivarfs|fuse.gvfs-fuse-daemon|fusectl|hugetlbfs|mqueue|nfsd|none|nsfs|overlay|pipefs|proc|pstore|ramfs|rootfs|rpc_pipefs|securityfs|sockfs|spufs|sysfs|tmpfs"
 # BUILD_DIR can be used in 'grep -vE "this|$BUILD_DIR|that"' because it is never empty (see usr/sbin/rear)
 # because with any empty part 'grep  -vE "this||that"' would output nothing at all:
 local excluded_other_stuff="/sys/|$BUILD_DIR|$USB_DEVICE_FILESYSTEM_LABEL"


### PR DESCRIPTION
What is the definition of unwanted "noise" from the mount points?

https://github.com/karelzak/util-linux/blob/master/libmount/src/utils.c#L267
till
https://github.com/karelzak/util-linux/blob/master/libmount/src/utils.c#L299
contain more then 3 pseudo file systems "cgroup|fuse.*|nfsd".

Which of libmount/src/utils.c additional pseudo-FS are also "noise" in this context?

I have included them all here, with the goal to easily remove the file systems that are needed are.