### PR TITLE
BUG: must continue if device is a multipath slaves

### DIFF
--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -76,7 +76,7 @@ if ! is_true "$MIGRATION_MODE" ; then
     local current_size=''
     for current_device_path in /sys/block/* ; do
         # Continue with next block device if the device is a multipath device slave
-        is_multipath_path ${current_device_path#/sys/block/} || continue
+        is_multipath_path ${current_device_path#/sys/block/} && continue
         # Continue with next block device if the current one has no queue directory:
         test -d $current_device_path/queue || continue
         # Continue with next block device if no size can be read for the current one:


### PR DESCRIPTION
I thought having already corrected this one ... (I may be forgot to push it).