### PR TITLE
FIXME comments for *rpmb block devices

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -257,7 +257,7 @@ Log "Saving disk partitions."
             #Check if blockd is a path of a multipath device.
             if is_multipath_path ${blockd} ; then
                 Log "Ignoring $blockd: it is a path of a multipath device"
-            else    
+            elif [[ ! ($blockd = *rpmb || *[0-9]boot[0-9]) ]]; then # Silently skip Replay Protected Memory Blocks and others  
                 devname=$(get_device_name $disk)
                 devsize=$(get_disk_size ${disk#/sys/block/})
                 disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -247,7 +247,12 @@ Log "Saving disk partitions."
     # format: disk <disk> <sectors> <partition label type>
     for disk in /sys/block/* ; do
         blockd=${disk#/sys/block/}
+        FIXME: include mmcblk* devices
         if [[ $blockd = hd* || $blockd = sd* || $blockd = cciss* || $blockd = vd* || $blockd = xvd* || $blockd = dasd* || $blockd = nvme* ]] ; then
+
+            #FIXME: exclude *rpmb (Replay Protected Memory Block) for nvme*, mmcblk* and uas
+            # *rpmb = no read access && no write access
+            # GNU Parted <= 3.2 -> Input/output error
 
             #Check if blockd is a path of a multipath device.
             if is_multipath_path ${blockd} ; then


### PR DESCRIPTION
Don't even read *.rpmb $blockd.

Error: Partition mmcblk0rpmb is numbered ''. More than 128 partitions is not supported.