### PR TITLE
Make duply wrapper work again

### DIFF
--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -440,3 +440,32 @@ function mathlib_calculate()
 {
     bc -ql <<<"result=$@ ; scale=0 ; result / 1 "
 }
+
+# Purpose is to find a working DUPLY profile configuration
+# Duply is a wrapper script around duplicity - this function is
+# used in the prep phase (for mkbackup) and in the verify phase
+# (to check the TEMP_DIR directory - it must be defined and cannot
+# be /tmp as this is usally a tmpfs file system which is too small) 
+function find_duply_profile ()
+{
+    # there could be more then one profile present - select where SOURCE='/'
+    for CONF in $(echo "$1")
+    do
+        [[ ! -f $CONF ]] && continue
+        source $CONF    # is a normal shell configuration file
+        LogIfError "Could not source $CONF [duply profile]"
+        [[ -z "$SOURCE" ]] && continue
+        [[ -z "$TARGET" ]] && continue
+        # still here?
+        if [[ "$SOURCE" = "/" ]]; then
+            DUPLY_PROFILE_FILE=$CONF
+            DUPLY_PROFILE=$( dirname $CONF  )   # /root/.duply/mycloud/conf -> /root/.duply/mycloud
+            DUPLY_PROFILE=${DUPLY_PROFILE##*/}  # /root/.duply/mycloud      -> mycloud
+            break # the loop
+        else
+            DUPLY_PROFILE=""
+            continue
+        fi
+    done
+}
+

--- a/usr/share/rear/restore/DUPLICITY/default/110_check_temp_dir_with_duply.sh
+++ b/usr/share/rear/restore/DUPLICITY/default/110_check_temp_dir_with_duply.sh
@@ -1,0 +1,31 @@
+# 210_check_temp_dir_with_duply.sh
+
+# This file is part of Relax-and-Recover, licensed under the GNU General
+# Public License. Refer to the included COPYING for full text of license.
+
+# If $BACKUP_DUPLICITY_URL has been defined then we may assume we are using
+# only 'duplicity' to make the backup and not the wrapper duply
+[[ "$BACKUP_DUPLICITY_URL" || "$BACKUP_DUPLICITY_NETFS_URL" || "$BACKUP_DUPLICITY_NETFS_MOUNTCMD" ]] && return
+
+# if DUPLY_PROFILE="" then we have nonsense defined in our ReaR configuration
+[[ -z "$DUPLY_PROFILE" ]] && return
+
+DUPLY_PROFILE_FILE=$( ls /etc/duply/$DUPLY_PROFILE/conf /root/.duply/$DUPLY_PROFILE/conf 2>/dev/null )
+# Assuming we have a duply configuration we must have a path, right?
+[[ -z "$DUPLY_PROFILE_FILE" ]] && return
+find_duply_profile "$DUPLY_PROFILE_FILE"
+
+[[ ! -d $TARGET_FS_ROOT ]] && return  # must be recreated and mounted
+
+# We need $TARGET_FS_ROOT/tmp as temp dir during the duplicity recovery (where we have enough space)
+[[ ! -d $TARGET_FS_ROOT/tmp ]] && mkdir -m 1777 $TARGET_FS_ROOT/tmp
+
+# Now we are coming to the real task of this script and that is verifying the setting of TEMP_DIR in
+# the conf file and make sure that the TEMP_DIR is set to /mnt/local/tmp instead of /tmp
+# If the TEMP_DIR was already different we will *not* modify it
+if grep -q "^TEMP_DIR=/tmp" "$DUPLY_PROFILE_FILE" ; then
+    sed -i -e "s|TEMP_DIR=/tmp|TEMP_DIR=$TARGET_FS_ROOT/tmp|" "$DUPLY_PROFILE_FILE"
+else
+    # no variable found which means /tmp is used. We will define one for the restore sake.
+    echo "TEMP_DIR=$TARGET_FS_ROOT/tmp" >> "$DUPLY_PROFILE_FILE"
+fi

--- a/usr/share/rear/restore/DUPLICITY/default/150_restore_duply.sh
+++ b/usr/share/rear/restore/DUPLICITY/default/150_restore_duply.sh
@@ -13,6 +13,7 @@ if [ "$BACKUP_PROG" = "duply" ] && has_binary duply; then
 
         # we need to restore on a path that does not exist ;-/
         # that is why we add "restore" to $TARGET_FS_ROOT (by default /mnt/local)
+        LogPrint "Starting restore with duply/duplicity with profile $DUPLY_PROFILE"
         duply "$DUPLY_PROFILE" restore $TARGET_FS_ROOT/restore
         if (( $? > 1 )); then
             LogPrintIfError "duply $DUPLY_PROFILE restore $TARGET_FS_ROOT failed"


### PR DESCRIPTION
- moved function to find duply conf file to global-functions.sh as it is used by the prep and restore phase 

- new script (110_check_temp_dir_with_duply.sh) to make sure the TEMP_DIR is /mnt/local/tmp instead of tmp (to avoid out of disk space) and it must be located in the restore dir and not in the verify as /mnt/local is not created yet at that time

- Be a bit more verbose in script 150_restore_duply.sh
**_This should fix all implementation issues with the `duply` wrapper for duplicity (issue #1664)_**