### PR TITLE
Avoid falsely detected changed layout (issues 1657 and 1658)

### DIFF
--- a/usr/share/rear/layout/compare/default/500_compare_layout.sh
+++ b/usr/share/rear/layout/compare/default/500_compare_layout.sh
@@ -1,11 +1,20 @@
-# Test if ORIG_LAYOUT and TEMP_LAYOUT are the same
+# Test if ORIG_LAYOUT and TEMP_LAYOUT are the same.
 
-diff -u <(grep -v '^#' $ORIG_LAYOUT) <(grep -v '^#' $TEMP_LAYOUT) >/dev/null
+# Usually ORIG_LAYOUT is of the form var/lib/rear/layout/disklayout.conf
+# and TEMP_LAYOUT is of the form /tmp/rear.XXXX/tmp/checklayout.conf
+# see lib/checklayout-workflow.sh
 
-if [ $? -eq 0 ] ; then
-    LogPrint "Disk layout is identical."
+# In case of btrfs the ordering of the btrfsmountedsubvol entries is random
+# so that plain 'cmp' would detect changes unless the entries were sorted
+# see https://github.com/rear/rear/issues/1657
+if cmp -s <( grep -v '^#' $ORIG_LAYOUT | sort ) <( grep -v '^#' $TEMP_LAYOUT | sort ) ; then
+    LogPrint "Disk layout is identical"
 else
-    LogPrint "Disk layout has changed."
-    diff -u <(grep -v '^#' $ORIG_LAYOUT) <(grep -v '^#' $TEMP_LAYOUT) >&2
+    # The 'cmp' exit status is 0 if inputs are the same, 1 if different, 2 if trouble.
+    # In case of 'trouble' do the same as when the layout has changed to be on the safe side:
+    LogPrint "Disk layout has changed"
+    # In the log file show the changes in the right ordering in the layout files:
+    diff -U0 <( grep -v '^#' $ORIG_LAYOUT ) <( grep -v '^#' $TEMP_LAYOUT ) 1>&2
     EXIT_CODE=1
 fi
+

--- a/usr/share/rear/layout/precompare/default/110_check_layout_file.sh
+++ b/usr/share/rear/layout/precompare/default/110_check_layout_file.sh
@@ -1,4 +1,4 @@
-# Check if the disk layout file exists.
 
-[[ -e "$ORIG_LAYOUT" ]]
-StopIfError "Please create an initial rescue image of this server !"
+# Check if an original disk layout file already exists:
+test -s "$ORIG_LAYOUT" || Error "No (non-empty) $ORIG_LAYOUT file (needs to be created before e.g. via 'rear mkrescue/mkbackup')"
+

--- a/usr/share/rear/lib/checklayout-workflow.sh
+++ b/usr/share/rear/lib/checklayout-workflow.sh
@@ -8,14 +8,25 @@
 WORKFLOW_checklayout_DESCRIPTION="check if the disk layout has changed"
 WORKFLOWS=( ${WORKFLOWS[@]} checklayout )
 LOCKLESS_WORKFLOWS=( ${LOCKLESS_WORKFLOWS[@]} checklayout )
+
 function WORKFLOW_checklayout () {
     ORIG_LAYOUT=$VAR_DIR/layout/disklayout.conf
     TEMP_LAYOUT=$TMP_DIR/checklayout.conf
 
     SourceStage "layout/precompare"
 
+    # In case of e.g. BACKUP_URL=file:///mybackup/ automatically exclude the matching component 'fs:/mybackup'
+    # otherwise 'rear checklayout' would always detect a changed layout with BACKUP_URL=file:///...
+    # because during 'rear mkrescue/mkbackup' such a component was automatically excluded this way
+    # so that such a component is already disabled in the ORIG_LAYOUT file and because
+    # 400_automatic_exclude_recreate.sh adds such a component to the EXCLUDE_RECREATE array
+    # such a component will get also disabled in the TEMP_LAYOUT file in the "layout/save" stage
+    # see https://github.com/rear/rear/issues/1658
+    Source $SHARE_DIR/prep/NETFS/default/400_automatic_exclude_recreate.sh
+
     DISKLAYOUT_FILE=$TEMP_LAYOUT
     SourceStage "layout/save"
 
     SourceStage "layout/compare"
 }
+


### PR DESCRIPTION
Sort layout entries before comparing
to avoid a falsely detected changed layout.
This should fix https://github.com/rear/rear/issues/1657

Tomorrow I try to also fix https://github.com/rear/rear/issues/1658
but that looks more complicated...
