### PR TITLE
Relax Debian dependencies (change 'Recommends' to 'Suggests')

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -10,6 +10,6 @@ Package: rear
 Architecture: i386 ia64 amd64 ppc64el
 Provides: rear
 Depends: syslinux[!ppc64el], syslinux-common[!ppc64el], ethtool, ${shlibs:Depends}, lsb-release, iproute, iputils-ping, dosfstools, binutils, parted, openssl, gawk, attr, bc, ${misc:Depends}
-Recommends: nfs-client, portmap, xorriso, isolinux
+Suggests: nfs-client, portmap, xorriso, isolinux, gdisk, syslinux-efi[!ppc64el]
 Description: Relax-and-Recover is a bare metal disaster recovery and system
  migration framework. See http://relax-and-recover.org/ for all the details.


### PR DESCRIPTION
As of ReaR version 2.3, a Debian installation pulls in packages which are only used in specific configurations: `nfs-client, portmap, xorriso, isolinux`. Along with indirect dependencies, this installs lots of unnecessary packages on systems not requiring the respective functionality.

This PR aims to reduce dependency bloat by default. Unlike recommended packages, suggested packages will not be installed by default, but can be pulled in on demand via the `apt` option `--install-suggests`.

The PR includes additional dependencies for #1659.

Maybe even some required dependencies could be relaxed to suggestions, for example: `syslinux[!ppc64el], syslinux-common[!ppc64el]`