### PR TITLE
Move EMC Avamar daemon starting to rescue step

### DIFF
--- a/usr/share/rear/finalize/AVA/default/990_copy_avagentlog.sh
+++ b/usr/share/rear/finalize/AVA/default/990_copy_avagentlog.sh
@@ -1,3 +1,3 @@
-# 99_copy_bprestorelog.sh
+# 99_copy_avagentlog.sh
 # copy the logfile to the recovered system, at least the part that has been written till now.
-cp -f /tmp/avagent.log /mnt/local/opt/avamar/var/avagent.log
+cp -f /tmp/avagent.log $TARGET_FS_ROOT/opt/avamar/var/avagent.log

--- a/usr/share/rear/rescue/AVA/default/450_prepare_avagent_startup.sh
+++ b/usr/share/rear/rescue/AVA/default/450_prepare_avagent_startup.sh
@@ -1,0 +1,10 @@
+# 450_prepare_avagent_startup.sh
+# make sure avagent gets started up in the rescue image
+
+cat >$ROOTFS_DIR/etc/scripts/system-setup.d/90-avagent.sh <<-EOF
+echo "Starting EMC Avamar daemon ..."
+$AVA_ROOT_DIR/bin/avagent.bin --bindir="$AVA_ROOT_DIR/bin" --vardir="$AVA_ROOT_DIR/var" --sysdir="$AVA_ROOT_DIR/etc" --logfile="/tmp/avagent.log"
+EOF
+
+chmod +x $ROOTFS_DIR/etc/scripts/system-setup.d/90-avagent.sh
+Log "Created the EMC Avamar avagent start-up script (90-avagent.sh) for ReaR"

--- a/usr/share/rear/restore/AVA/default/200_prompt_user_to_start_restore.sh
+++ b/usr/share/rear/restore/AVA/default/200_prompt_user_to_start_restore.sh
@@ -1,7 +1,7 @@
 # the user has to do the main part here :-)
 #
 #
-/opt/avamar/bin/avagent.bin --bindir="/opt/avamar/bin" --vardir="/opt/avamar/var" --sysdir="/opt/avamar/etc" --logfile="/tmp/avagent.log"
+$AVA_ROOT_DIR/bin/avagent.bin --bindir="$AVA_ROOT_DIR/bin" --vardir="$AVA_ROOT_DIR/var" --sysdir="$AVA_ROOT_DIR/etc" --logfile="/tmp/avagent.log" 0<&6 1>&7 2>&8
 LogPrint "Please restore your backup in the Avamar WebGui (to path '/mnt/local/').
 When finished enter 'touch /mnt/local/.autorelabel' to ensure that SELinux relabels the files on the next boot.
 Afterwards type 'exit' in the shell to continue recovery, and then 'reboot'"


### PR DESCRIPTION
 Starting of the avagent.bin used to be done at boot time by "restore\AVA\default\200_prompt_user_to_start_restore.sh", but as the AVA_ROOT_DIR variable declared in default.conf is not present resulted in error. Instead now a script is created during mkresuce (-> rescue\AVA\default\450_prepare_avagent_startup.sh), which does the same. Simialr NSR/EMC Networker script used as example.