### PR TITLE
Complete EMC Avamar integration

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1242,9 +1242,9 @@ PROGS_NBU=( )
 # BACKUP=AVA stuff (EMC Avamar)
 ##
 #
-# AVA_ROOT_DIR is relocatable - default location is /opt/avamar
+# AVA_ROOT_DIR is relocatable - default location is either /usr/local/avamar or /opt/avamar
 AVA_ROOT_DIR=/opt/avamar
-COPY_AS_IS_AVA=( $AVA_ROOT_DIR/* )
+COPY_AS_IS_AVA=( $AVA_ROOT_DIR/* /var/avamar/avagent.cfg /var/avamar/cid.bin /etc/init.d/functions /etc/rc.d/init.d/avagent )
 COPY_AS_IS_EXCLUDE_AVA=( "$AVA_ROOT_DIR/var/*" )
 PROGS_AVA=( )
 

--- a/usr/share/rear/finalize/AVA/default/990_append_avagentlog.sh
+++ b/usr/share/rear/finalize/AVA/default/990_append_avagentlog.sh
@@ -1,0 +1,3 @@
+# 990_append_avagentlog.sh
+# append the logfile to the recovered system, at least the part that has been written till now.
+cat /var/avamar/avagent.log >> $TARGET_FS_ROOT/var/avamar/avagent.log

--- a/usr/share/rear/finalize/AVA/default/990_copy_avagentlog.sh
+++ b/usr/share/rear/finalize/AVA/default/990_copy_avagentlog.sh
@@ -1,3 +1,0 @@
-# 99_copy_avagentlog.sh
-# copy the logfile to the recovered system, at least the part that has been written till now.
-cp -f /tmp/avagent.log $TARGET_FS_ROOT/opt/avamar/var/avagent.log

--- a/usr/share/rear/rescue/AVA/default/450_prepare_avagent_startup.sh
+++ b/usr/share/rear/rescue/AVA/default/450_prepare_avagent_startup.sh
@@ -1,9 +1,12 @@
 # 450_prepare_avagent_startup.sh
-# make sure avagent gets started up in the rescue image
+# make sure avagent startup scripts gets included in the rescue image
+
+mkdir -p $ROOTFS_DIR/etc/systemd/system
+cp /run/systemd/generator.late/avagent.service $ROOTFS_DIR/etc/systemd/system/avagent.service
 
 cat >$ROOTFS_DIR/etc/scripts/system-setup.d/90-avagent.sh <<-EOF
 echo "Starting EMC Avamar daemon ..."
-$AVA_ROOT_DIR/bin/avagent.bin --bindir="$AVA_ROOT_DIR/bin" --vardir="$AVA_ROOT_DIR/var" --sysdir="$AVA_ROOT_DIR/etc" --logfile="/tmp/avagent.log"
+systemctl start avagent
 EOF
 
 chmod +x $ROOTFS_DIR/etc/scripts/system-setup.d/90-avagent.sh

--- a/usr/share/rear/restore/AVA/default/200_prompt_user_to_start_restore.sh
+++ b/usr/share/rear/restore/AVA/default/200_prompt_user_to_start_restore.sh
@@ -3,5 +3,5 @@
 #
 LogPrint "Please restore your backup in the Avamar WebGui (to path '$TARGET_FS_ROOT').
 When finished enter 'touch /mnt/local/.autorelabel' to ensure that SELinux relabels the files on the next boot.
-Afterwards type 'exit' in the shell to continue recovery, and then 'reboot'"
+Afterwards type 'exit' in the shell to finish recovery."
 rear_shell "Did you restore the backup to '$TARGET_FS_ROOT'? Are you ready to continue recovery?"


### PR DESCRIPTION
Avamar agent has to be started via "systemctl start avagent" to function properly, otherwise the Avamar server does not recognize the client correctly and cannot restore with the function "Restore everything to a different location" (which is needed to restore to /mnt/local). This pull request includes the necessary patches, so that the necessary scripts are included into the ReaR image. 