### PR TITLE
Add /usr/local/ibm/gsk8 to TSM_LD_LIBRARY_PATH

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1189,7 +1189,7 @@ COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
 COPY_AS_IS_EXCLUDE_TSM=( )
 PROGS_TSM=(dsmc)
 # TSM library PATH that need to be added to LD_LIBRARY_PATH.
-TSM_LD_LIBRARY_PATH="/opt/tivoli/tsm/client/ba/bin:/opt/tivoli/tsm/client/api/bin64:/opt/tivoli/tsm/client/api/bin:/opt/tivoli/tsm/client/api/bin64/cit/bin"
+TSM_LD_LIBRARY_PATH="/opt/tivoli/tsm/client/ba/bin:/opt/tivoli/tsm/client/api/bin64:/opt/tivoli/tsm/client/api/bin:/opt/tivoli/tsm/client/api/bin64/cit/bin:/usr/local/ibm/gsk8/lib64"
 # where to copy the resulting files to and save them with TSM
 TSM_RESULT_FILE_PATH=/opt/tivoli/tsm/rear
 #


### PR DESCRIPTION
Add `/usr/local/ibm/gsk8` to TSM_LD_LIBRARY_PATH in default.conf.

This solves issue #1688