### PR TITLE
Fix Duplicity

### DIFF
--- a/usr/share/rear/backup/DUPLICITY/default/500_make_duplicity_backup.sh
+++ b/usr/share/rear/backup/DUPLICITY/default/500_make_duplicity_backup.sh
@@ -20,10 +20,10 @@ if [ "$BACKUP_PROG" = "duplicity" ] ; then
     # make backup using the DUPLICITY method with duplicity
     # by falk hoeppner
 
-	if [ -n "$BACKUP_DUPLICITY_ASK_PASSPHRASE" ]; then
-		LogPrint "Warning !
-	BACKUP_DUPLICITY_ASK_PASSPHRASE set, The Passphrase needs to be provided Interactively on Restore."
-	fi
+    if [ -n "$BACKUP_DUPLICITY_ASK_PASSPHRASE" ]; then
+        LogPrint "Warning !
+    BACKUP_DUPLICITY_ASK_PASSPHRASE set, The Passphrase needs to be provided Interactively on Restore."
+    fi
 
     LogPrint "Creating $BACKUP_PROG archives on '$BACKUP_DUPLICITY_URL'"
 
@@ -31,14 +31,9 @@ if [ "$BACKUP_PROG" = "duplicity" ] ; then
     BKP_URL="$BACKUP_DUPLICITY_URL"
     
     DUP_OPTIONS="$BACKUP_DUPLICITY_OPTIONS"
-    #
-    if [[ "${BACKUP_DUPLICITY_GPG_OPTIONS}" ]] ; then
-        GPG_OPT="--gpg-options ""${BACKUP_DUPLICITY_GPG_OPTIONS}"""
-        LogUserOutput "GPG_OPT = $GPG_OPT"
-    fi
 
     if [ -n "$BACKUP_DUPLICITY_GPG_ENC_KEY" ]; then
-		GPG_KEY="--encrypt-key $BACKUP_DUPLICITY_GPG_ENC_KEY"
+        GPG_KEY="--encrypt-key $BACKUP_DUPLICITY_GPG_ENC_KEY"
     fi
     PASSPHRASE="$BACKUP_DUPLICITY_GPG_ENC_PASSPHRASE"
 
@@ -73,26 +68,25 @@ if [ "$BACKUP_PROG" = "duplicity" ] ; then
     # maybe better done in an if or case statement
     #
     if [[ $BKP_URL == ssh://* ]] || [[ $BKP_URL == rsync://* ]] || [[ $BKP_URL == fish://* ]] ; then
-		LogPrint "Checking backup-path at server ..."
-		ssh ${DUPLICITY_USER}@${DUPLICITY_HOST} "test -d ${DUPLICITY_PATH}/${HOSTNAME} || mkdir -p ${DUPLICITY_PATH}/${HOSTNAME}"
-	fi
-	
+        LogPrint "Checking backup-path at server ..."
+        ssh ${DUPLICITY_USER}@${DUPLICITY_HOST} "test -d ${DUPLICITY_PATH}/${HOSTNAME} || mkdir -p ${DUPLICITY_PATH}/${HOSTNAME}"
+    fi
+
     # first remove everything older than $BACKUP_DUPLICITY_MAX_TIME
     if [ -n "$BACKUP_DUPLICITY_MAX_TIME" ] ; then
-		LogPrint "Removing the old stuff from server with CMD:
-	$DUPLICITY_PROG remove-older-than $BACKUP_DUPLICITY_MAX_TIME -v5 $BKP_URL/$HOSTNAME"
-		$DUPLICITY_PROG remove-older-than $BACKUP_DUPLICITY_MAX_TIME -v5 $BKP_URL/$HOSTNAME >> ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log
+        LogPrint "Removing the old stuff from server with CMD:
+    $DUPLICITY_PROG remove-older-than $BACKUP_DUPLICITY_MAX_TIME -v5 $BKP_URL/$HOSTNAME"
+        $DUPLICITY_PROG remove-older-than $BACKUP_DUPLICITY_MAX_TIME -v5 $BKP_URL/$HOSTNAME >> ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log
     fi
 
     # do the backup
-    LogPrint "Running CMD: $DUPLICITY_PROG -v5 $DUP_OPTIONS $GPG_KEY $GPG_OPT $EXCLUDES \
-     / $BKP_URL/$HOSTNAME >> ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log "
-
     if [[ "$BACKUP_DUPLICITY_GPG_OPTIONS" ]] ; then
+        LogPrint "Running CMD: $DUPLICITY_PROG -v5 $DUP_OPTIONS $GPG_KEY --gpg-options ${BACKUP_DUPLICITY_GPG_OPTIONS} $EXCLUDES / $BKP_URL/$HOSTNAME >> ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log "
         $DUPLICITY_PROG -v5 $DUP_OPTIONS $GPG_KEY --gpg-options "${BACKUP_DUPLICITY_GPG_OPTIONS}" $EXCLUDES \
            / $BKP_URL/$HOSTNAME >> ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log 2>&1
     else
-        $DUPLICITY_PROG -v5 $DUP_OPTIONS $GPG_KEY $GPG_OPT $EXCLUDES \
+        LogPrint "Running CMD: $DUPLICITY_PROG -v5 $DUP_OPTIONS $GPG_KEY $EXCLUDES / $BKP_URL/$HOSTNAME >> ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log "
+        $DUPLICITY_PROG -v5 $DUP_OPTIONS $GPG_KEY $EXCLUDES \
            / $BKP_URL/$HOSTNAME >> ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log 2>&1
     fi
 

--- a/usr/share/rear/prep/DUPLICITY/Debian/100_debian_lib.sh
+++ b/usr/share/rear/prep/DUPLICITY/Debian/100_debian_lib.sh
@@ -1,0 +1,5 @@
+#librsync may be in different Directories on Debian, depending on the Architecture
+LIBS=(
+"${LIBS[@]}"
+$(find /usr/lib /usr/lib64 -name librsync.so.1 || LogPrint "Warning: librsync.so.1 not found! Restore may not work!")
+)

--- a/usr/share/rear/prep/DUPLICITY/Debian/100_debian_lib.sh
+++ b/usr/share/rear/prep/DUPLICITY/Debian/100_debian_lib.sh
@@ -1,5 +1,0 @@
-#librsync may be in different Directories on Debian, depending on the Architecture
-LIBS=(
-"${LIBS[@]}"
-$(find /usr/lib /usr/lib64 -name librsync.so.1 || LogPrint "Warning: librsync.so.1 not found! Restore may not work!")
-)

--- a/usr/share/rear/prep/DUPLICITY/default/050_prep_duplicity.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/050_prep_duplicity.sh
@@ -53,11 +53,12 @@ COPY_AS_IS=(
 
 LIBS=(
 "${LIBS[@]}"
-/usr/lib/librsync.so.1.0.2
-/usr/lib64/librsync.so.1
-/usr/lib64/libexpat.so.1
-/lib/libexpat.so.1
-/lib/x86_64-linux-gnu/libexpat.so.1
+/usr/lib/librsync.so*
+/usr/lib64/librsync.so*
+/usr/lib/*/librsync.so*
+/lib/libexpat.so*
+/usr/lib64/libexpat.so*
+/lib/*/libexpat.so*
 /usr/lib/cruft
 )
 

--- a/usr/share/rear/prep/DUPLICITY/default/050_prep_duplicity.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/050_prep_duplicity.sh
@@ -55,7 +55,6 @@ LIBS=(
 "${LIBS[@]}"
 /usr/lib/librsync.so.1.0.2
 /usr/lib64/librsync.so.1
-/usr/lib/x86_64-linux-gnu/librsync.so.1
 /usr/lib64/libexpat.so.1
 /lib/libexpat.so.1
 /lib/x86_64-linux-gnu/libexpat.so.1


### PR DESCRIPTION
This will stop the Duplicity restore from Erroring out if the Temporary Directory is on an Ramdisk. Also I've cleaned some things up and Fixed an Issue with the librsync library on Debian. 