### PR TITLE
Added option BORGBACKUP_UMASK.

### DIFF
--- a/usr/share/rear/backup/BORG/default/500_make_backup.sh
+++ b/usr/share/rear/backup/BORG/default/500_make_backup.sh
@@ -25,7 +25,7 @@ test "$verbose" && borg_progress='--progress --stats'
 
 # Start actual Borg backup.
 borg create --one-file-system $borg_progress $verbose \
-$BORGBACKUP_OPT_COMPRESSION $BORGBACKUP_OPT_REMOTE_PATH \
+$BORGBACKUP_OPT_COMPRESSION $BORGBACKUP_OPT_REMOTE_PATH $BORGBACKUP_OPT_UMASK \
 --exclude-from $TMP_DIR/backup-exclude.txt \
 $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO::\
 ${BORGBACKUP_ARCHIVE_PREFIX}_$BORGBACKUP_SUFFIX \

--- a/usr/share/rear/backup/BORG/default/800_prune_old_backups.sh
+++ b/usr/share/rear/backup/BORG/default/800_prune_old_backups.sh
@@ -8,7 +8,8 @@ if [ ! -z $BORGBACKUP_OPT_PRUNE ]; then
     LogPrint "Purging old Borg archives in repository $BORGBACKUP_REPO"
 
     borg prune --list ${BORGBACKUP_OPT_PRUNE[@]} \
-    $BORGBACKUP_OPT_REMOTE_PATH --prefix ${BORGBACKUP_ARCHIVE_PREFIX}_ \
+    $BORGBACKUP_OPT_REMOTE_PATH $BORGBACKUP_OPT_UMASK \
+    --prefix ${BORGBACKUP_ARCHIVE_PREFIX}_ \
     $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO
     StopIfError "Failed to purge old backups"
 else

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1405,6 +1405,9 @@ BORGBACKUP_COMPRESSION=""
 BORGBACKUP_ENC_TYPE="none"
 # When set, use the given path/filename as remote path (default is "borg")
 BORGBACKUP_REMOTE_PATH=""
+# Set archive umask
+# Default: 0077
+BORGBACKUP_UMASK=""
 # Borg retention strategy
 BORGBACKUP_PRUNE_HOURLY=
 BORGBACKUP_PRUNE_DAILY=
@@ -1562,7 +1565,7 @@ DUPLY_PROFILE=""
 #
 # On restore, Duplicity may temporarely need lots of Space (in worst case a bit more than the biggest file in the Backup),
 # so by default an Temporary Directory will be created on the root Filesystem (and deleted afterwards). If that is not wanted
-# (and you have enough Ram), you can fill the following Variable to create an Temporary Ramdisk instead which will also speed 
+# (and you have enough Ram), you can fill the following Variable to create an Temporary Ramdisk instead which will also speed
 # up restore a bit:
 #
 # BACKUP_DUPLICITY_TEMP_RAMDISK="1"

--- a/usr/share/rear/lib/borg-functions.sh
+++ b/usr/share/rear/lib/borg-functions.sh
@@ -45,6 +45,13 @@ function borg_set_vars {
         BORGBACKUP_OPT_REMOTE_PATH="--remote-path $BORGBACKUP_REMOTE_PATH"
     fi
 
+    # Prepare option for Borg umask.
+    # Empty BORGBACKUP_UMASK will default to 0077.
+    BORGBACKUP_OPT_UMASK=""
+    if [ ! -z $BORGBACKUP_UMASK ]; then
+        BORGBACKUP_OPT_UMASK="--umask $BORGBACKUP_UMASK"
+    fi
+
     # Set archive cache file
     BORGBACKUP_ARCHIVE_CACHE=$TMP_DIR/borg_archive
 }

--- a/usr/share/rear/prep/BORG/default/300_init_archive.sh
+++ b/usr/share/rear/prep/BORG/default/300_init_archive.sh
@@ -27,6 +27,7 @@ if [ $rc -ne 0 ]; then
     LogPrint "Failed to list $BORGBACKUP_REPO on $BORGBACKUP_HOST"
     LogPrint "Creating new Borg repository $BORGBACKUP_REPO on $BORGBACKUP_HOST"
     borg init $BORGBACKUP_OPT_ENCRYPTION $BORGBACKUP_OPT_REMOTE_PATH \
+    $BORGBACKUP_OPT_UMASK \
     $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO
     rc=$?
 fi


### PR DESCRIPTION
Borg common options have possibility to set umask (--umask) for archive operations.
Until this commit, there was no way to adapt umask for Borg archives from within ReaR.
C.f. https://github.com/rear/rear/issues/1699