### PR TITLE
Again support partition names with blanks issues 212 and 1563

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -127,7 +127,8 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
                 max_mounts=$( $tunefs -l $device | tr -d '[:blank:]' | grep -i 'Maximummountcount:[0-9]*' | cut -d ':' -f 2 )
                 echo -n " max_mounts=$max_mounts"
                 check_interval=$( $tunefs -l $device | tr -d '[:blank:]' | grep -i 'Checkinterval:[0-9]*' | cut -d ':' -f 2 | cut -d '(' -f1 )
-                check_interval=$( is_numeric $check_interval )  # if non-numeric 0 is returned
+                # is_integer outputs '0' if its (first) argument is not an integer (or empty)
+                check_interval=$( is_integer $check_interval )
                 # translate check_interval from seconds to days
                 let check_interval=$check_interval/86400
                 echo -n " check_interval=${check_interval}d"

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -5,20 +5,44 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
+# Extract the real content from a config file provided as argument.
+# In other words it strips comments and new lines:
 function read_and_strip_file () {
-# extracts content from config files. In other words: strips the comments and new lines
     if test -s "$1" ; then
         sed -e '/^[[:space:]]/d;/^$/d;/^#/d' "$1"
     fi
 }
 
-function is_numeric () {
-    # simple test if var is an integer
-    if expr $1 + 0 >/dev/null 2>&1 ; then
-        echo $1
-    else
-        echo 0
+# Test if the (first) argument is an integer.
+# If yes output the argument value and return 0
+# otherwise output '0' and return 1:
+function is_integer () {
+    local argument="$1"
+    if test "$argument" -eq "$argument" 2>/dev/null ; then
+        # The arithmetic expansion removes a possible leading '+' in the output
+        # so that e.g. "is_integer +12" outputs '12' (and not '+12')
+        # and "is_integer -0" outputs '0' (and not '-0'):
+        echo $(( argument + 0 ))
+        return 0
     fi
+    echo 0
+    return 1
+}
+
+# Test if the (first) argument is a positive integer (i.e. test for '> 0')
+# If yes output the argument value and return 0
+# otherwise output '0' and return 1
+# (in particular "is_positive_integer 0" outputs '0' but returns 1):
+function is_positive_integer () {
+    local argument="$1"
+    if test "$argument" -gt 0 2>/dev/null ; then
+        # The arithmetic expansion removes a possible leading '+' in the output
+        # so that e.g. "is_positive_integer +12" outputs '12' (and not '+12'):
+        echo $(( argument + 0 ))
+        return 0
+    fi
+    echo 0
+    return 1
 }
 
 # A function to test whether or not its arguments contain at least one 'real value'

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -6,11 +6,12 @@
 # Public License. Refer to the included COPYING for full text of license.
 
 # Extract the real content from a config file provided as argument.
-# In other words it strips comments and new lines:
+# It outputs non-empty and non-comment lines that do not start with a space.
+# In other words it strips comments, empty lines, and lines with leading space(s):
 function read_and_strip_file () {
-    if test -s "$1" ; then
-        sed -e '/^[[:space:]]/d;/^$/d;/^#/d' "$1"
-    fi
+    local filename="$1"
+    test -s "$filename" || return 1
+    sed -e '/^[[:space:]]/d;/^$/d;/^#/d' "$filename"
 }
 
 # Test if the (first) argument is an integer.

--- a/usr/share/rear/verify/default/040_validate_variables.sh
+++ b/usr/share/rear/verify/default/040_validate_variables.sh
@@ -1,10 +1,9 @@
 # verify/default/040_validate_variables.sh
 
-# test if variable WAIT_SECS is an integer, if not, give it the default value
-if [[ ! -z "$WAIT_SECS" ]]; then
-    WAIT_SECS=$( is_numeric $WAIT_SECS )  # if 0 then bsize was not numeric
-    [[ $WAIT_SECS -eq 0 ]] && WAIT_SECS=30
-else
-    WAIT_SECS=30
-fi
+# Test if variable WAIT_SECS is a positive integer,
+# if not, give it the default value from default.conf.
+
+# is_positive_integer outputs '0' and returns 1
+# if its (first) argument is not a positive integer (or empty):
+is_positive_integer $WAIT_SECS 1>/dev/null || WAIT_SECS=30
 


### PR DESCRIPTION
Implemeted two new general useful functions percent_encode() and percent_decode()
but currently percent_encode() fails for me on SLES11-SP4 with GNU bash version 3.2.57
in case of UTF-8 encoded strings (hopefully nobody uses a UTF-8 encoded GPT partition name)
cf. https://github.com/rear/rear/issues/1563#issuecomment-359797990

Those functions are used to again support GPT partition names with blanks and
re-implemented some quoting hell to provide what parted command line calls need
according to
https://github.com/rear/rear/issues/1563#issuecomment-359784102

By the way I additionally
replaced is_numeric() with hopefully new more generally usable functions
is_integer() and is_positive_integer() that also return a useful return code
and I better documented what read_and_strip_file() actually does
(it also skips lines with leading spaces) and let it return a useful return code
to be more generally usable.

Currently it is not tested.
I did the pull request nevertheless so that you can have an early look.
