### PR TITLE
copy the Bareos plugin directory 

### DIFF
--- a/usr/share/rear/prep/BAREOS/default/570_check_bareos_plugin_dir.sh
+++ b/usr/share/rear/prep/BAREOS/default/570_check_bareos_plugin_dir.sh
@@ -1,0 +1,8 @@
+# prep/BAREOS/default/570_check_bareos_plugin_dir.sh
+# Purpose: check if the Bareos 'plugin' directory exists? I so, then add it to the COPY_AS_IS array
+
+if [[ -d /usr/lib/bareos/plugins ]] ; then
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib/bareos/plugins )
+elif [[ -d /usr/lib64/bareos/plugins ]] ; then
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib64/bareos/plugins )
+fi

--- a/usr/share/rear/prep/BAREOS/default/570_check_bareos_plugin_dir.sh
+++ b/usr/share/rear/prep/BAREOS/default/570_check_bareos_plugin_dir.sh
@@ -1,5 +1,5 @@
 # prep/BAREOS/default/570_check_bareos_plugin_dir.sh
-# Purpose: check if the Bareos 'plugin' directory exists? I so, then add it to the COPY_AS_IS array
+# Purpose: check if the Bareos 'plugin' directory exists? If so, then add it to the COPY_AS_IS array
 
 if [[ -d /usr/lib/bareos/plugins ]] ; then
     COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib/bareos/plugins )


### PR DESCRIPTION
New script 570_check_bareos_plugin_dir.sh is to copy the Bareos plugin directory to the rescue image - issue #1692