### PR TITLE
Remove the os.conf creation in the rear.spec file

### DIFF
--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -134,50 +134,6 @@ fi
 
 echo "30 1 * * * root /usr/sbin/rear checklayout || /usr/sbin/rear mkrescue" >rear.cron
 
-### Add a specific os.conf so we do not depend on LSB dependencies
-%{?fedora:echo -e "OS_VENDOR=Fedora\nOS_VERSION=%{?fedora}" >etc/rear/os.conf}
-%{?mdkversion:echo -e "OS_VENDOR=Mandriva\nOS_VERSION=%{distro_rel}" >etc/rear/os.conf}
-%{?rhel:echo -e "OS_VENDOR=RedHatEnterpriseServer\nOS_VERSION=%{?rhel}" >etc/rear/os.conf}
-#%{?sles_version:echo -e "OS_VENDOR=SUSE_LINUX\nOS_VERSION=%{?sles_version}" >etc/rear/os.conf}
-#%{?suse_version:echo -e "OS_VENDOR=SUSE_LINUX\nOS_VERSION=%{?suse_version}" >etc/rear/os.conf}
-%if 0%{?suse_version} == 1110
-# SLE 11
-OS_VERSION="11"
-%endif
-%if 0%{?suse_version} == 1130
-# openSUSE 11.3
-OS_VERSION="11.3"
-%endif
-%if 0%{?suse_version} == 1140
-# openSUSE 11.4
-OS_VERSION="11.4"
-%endif
-%if 0%{?suse_version} == 1210
-# openSUSE 12.1
-OS_VERSION="12.1"
-%endif
-%if 0%{?suse_version} == 1220
-# openSUSE 12.2
-OS_VERSION="12.2"
-%endif
-%if 0%{?suse_version} == 1230
-# openSUSE 12.3
-OS_VERSION="12.3"
-%endif
-%if 0%{?suse_version} == 1310
-# openSUSE 13.1
-OS_VERSION="13.1"
-%endif
-%if 0%{?suse_version} == 1315
-# SLE 12
-OS_VERSION="12"
-%endif
-%if 0%{?suse_version} == 1320
-# openSUSE 13.2
-OS_VERSION="13.2"
-%endif
-%{?suse_version:echo -e "OS_VENDOR=SUSE_LINUX\nOS_VERSION=$OS_VERSION" >etc/rear/os.conf}
-
 %build
 
 %install

--- a/usr/share/rear/init/default/005_verify_os_conf.sh
+++ b/usr/share/rear/init/default/005_verify_os_conf.sh
@@ -1,0 +1,10 @@
+# usr/share/rear/init/default/005_verify_os_conf.sh
+# Purpose is to verify if the /etc/rear/os.conf file has been created already and if this is the first time
+# then we will create a new os.conf file with the values found by the main script 'rear' (via the function
+# SetOSVendorAndVersion)
+if [[ ! -f "$CONFIG_DIR/os.conf" ]] ; then
+    echo "OS_VENDOR=$OS_VENDOR"    > "$CONFIG_DIR/os.conf"
+    echo "OS_VERSION=$OS_VERSION" >> "$CONFIG_DIR/os.conf"
+    Log "Created the $CONFIG_DIR/os.conf file with content:"
+    cat "$CONFIG_DIR/os.conf" >&2
+fi

--- a/usr/share/rear/lib/config-functions.sh
+++ b/usr/share/rear/lib/config-functions.sh
@@ -19,9 +19,9 @@ function SetOSVendorAndVersion () {
         # Recent Linux distro's with systemd has the /etc/os-release file
         # Try to find all the required information from that file
         if [[ -f /etc/os-release ]] ; then
+            grep -q -i 'fedora' /etc/os-release && OS_VENDOR=Fedora
             grep -q -i -E '(centos|redhat|scientific|oracle)' /etc/os-release && OS_VENDOR=RedHatEnterpriseServer
             grep -q -i 'suse' /etc/os-release && OS_VENDOR=SUSE_LINUX
-            grep -q -i 'fedora' /etc/os-release && OS_VENDOR=Fedora
             grep -q -i 'debian' /etc/os-release && OS_VENDOR=Debian
             grep -q -i -E '(ubuntu|linuxmint)' /etc/os-release && OS_VENDOR=Ubuntu
             grep -q -i 'arch' /etc/os-release && OS_VENDOR=Arch
@@ -31,9 +31,9 @@ function SetOSVendorAndVersion () {
         # For non-systemd distro's try the /etc/system-release file
         if test "$OS_VENDOR" = generic ; then
             if [[ -f /etc/system-release ]] ; then
+                grep -q -i 'fedora' /etc/system-release && OS_VENDOR=Fedora
                 grep -q -i -E '(centos|redhat|scientific|oracle)' /etc/system-release && OS_VENDOR=RedHatEnterpriseServer
                 grep -q -i 'suse' /etc/system-release && OS_VENDOR=SUSE_LINUX
-                grep -q -i 'fedora' /etc/system-release && OS_VENDOR=Fedora
                 grep -q -i 'mandriva' /etc/system-release && OS_VENDOR=Mandriva
                 majornr=$( grep -o -E '[0-9]+' /etc/system-release | head -1 )
                 minornr=$( grep -o -E '[0-9]+' /etc/system-release | head -2 | tail -1 )


### PR DESCRIPTION
Remove the os.conf creation in the rear.spec file and fixed in function SetOSVendorAndVersion the proper detection of RedHatEnterpriseServer. Added new script usr/share/rear/init/default/005_verify_os_conf.sh to create the os.conf if it did not exist yet - issue #1639