### PR TITLE
Simpler and more fail-safe SLE btrfs example configs (issue 1714)

### DIFF
--- a/usr/share/rear/conf/examples/SLE12-SP1-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-SP1-btrfs-example.conf
@@ -53,12 +53,12 @@ COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib/snapper/installation-helper /etc/snappe
 # so that such files must be explicitly included to be in the backup.
 # Files in the following SLE12-SP1 default btrfs subvolumes are
 # in the below example not included to be in the backup
-#   /.snapshots/*  /var/crash/*
-# but files in /home/* are included to be in the backup.
+#   /.snapshots  /var/crash
+# but files in /home are included to be in the backup.
 # You may use a command like
-#   findmnt -n -r -t btrfs | cut -d ' ' -f 1 | grep -v '^/$' | egrep -v 'snapshots|crash' | sed -e "s/$/\/*'/" -e "s/^/'/" | tr '\n' ' '
+#   findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash'
 # to generate the values:
-BACKUP_PROG_INCLUDE=( '/var/tmp/*' '/srv/*' '/var/lib/pgsql/*' '/var/spool/*' '/var/lib/libvirt/images/*' '/var/opt/*' '/tmp/*' '/var/lib/named/*' '/var/log/*' '/boot/grub2/i386/*' '/var/lib/mariadb/*' '/home/*' '/var/lib/mailman/*' '/opt/*' '/usr/local/*' '/boot/grub2/x86_64/*' )
+BACKUP_PROG_INCLUDE=( /var/tmp /srv /var/lib/pgsql /var/spool /var/lib/libvirt/images /var/opt/ /tmp /var/lib/named /var/log /boot/grub2/i386 /var/lib/mariadb /home /var/lib/mailman /opt /usr/local /boot/grub2/x86_64 )
 # This option defines a root password to allow SSH connection
 # whithout a public/private key pair
 #SSH_ROOT_PASSWORD="password_on_the_rear_recovery_system"

--- a/usr/share/rear/conf/examples/SLE12-SP2-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-SP2-btrfs-example.conf
@@ -53,14 +53,14 @@ REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" snapper chattr lsattr )
 COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib/snapper/installation-helper /etc/snapper/config-templates/default )
 # Files in btrfs subvolumes are excluded by 'tar --one-file-system'
 # so that such files must be explicitly included to be in the backup.
-# Files in the following SLE12-SP1 and SP2 default btrfs subvolumes are
+# Files in the following SLE12-SP2 default btrfs subvolumes are
 # in the below example not included to be in the backup
-#   /.snapshots/*  /var/crash/*
-# but files in /home/* are included to be in the backup.
+#   /.snapshots  /var/crash
+# but files in /home are included to be in the backup.
 # You may use a command like
-#   findmnt -n -r -t btrfs | cut -d ' ' -f 1 | grep -v '^/$' | egrep -v 'snapshots|crash' | sed -e "s/$/\/*'/" -e "s/^/'/" | tr '\n' ' '
+#   findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash'
 # to generate the values:
-BACKUP_PROG_INCLUDE=( '/var/cache/*' '/var/lib/mailman/*' '/var/tmp/*' '/var/lib/pgsql/*' '/usr/local/*' '/opt/*' '/var/lib/libvirt/images/*' '/boot/grub2/i386/*' '/var/opt/*' '/srv/*' '/boot/grub2/x86_64/*' '/var/lib/mariadb/*' '/var/spool/*' '/var/lib/mysql/*' '/tmp/*' '/home/*' '/var/log/*' '/var/lib/named/*' '/var/lib/machines/*' )
+BACKUP_PROG_INCLUDE=( /var/cache /var/lib/mailman /var/tmp /var/lib/pgsql /usr/local /opt /var/lib/libvirt/images /boot/grub2/i386 /var/opt /srv /boot/grub2/x86_64 /var/lib/mariadb /var/spool /var/lib/mysql /tmp /home /var/log /var/lib/named /var/lib/machines )
 # The following POST_RECOVERY_SCRIPT implements during "rear recover"
 # btrfs quota setup for snapper if that is used in the original system:
 POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | grep -q "^QGROUP.*[0-9]/[0-9]" ; then snapper --no-dbus -r $TARGET_FS_ROOT set-config QGROUP= ; snapper --no-dbus -r $TARGET_FS_ROOT setup-quota && echo snapper setup-quota done || echo snapper setup-quota failed ; else echo snapper setup-quota not used ; fi' )

--- a/usr/share/rear/conf/examples/SLE12-SP2-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-SP2-btrfs-example.conf
@@ -60,7 +60,7 @@ COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib/snapper/installation-helper /etc/snappe
 # You may use a command like
 #   findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash'
 # to generate the values:
-BACKUP_PROG_INCLUDE=( /var/cache /var/lib/mailman /var/tmp /var/lib/pgsql /usr/local /opt /var/lib/libvirt/images /boot/grub2/i386 /var/opt /srv /boot/grub2/x86_64 /var/lib/mariadb /var/spool /var/lib/mysql /tmp /home /var/log /var/lib/named /var/lib/machines )
+BACKUP_PROG_INCLUDE=( /var/cache /var/lib/mailman /var/tmp /var/lib/pgsql /usr/local /opt /var/lib/libvirt/images /boot/grub2/i386-pc /var/opt /srv /boot/grub2/x86_64-efi /var/lib/mariadb /var/spool /var/lib/mysql /tmp /home /var/log /var/lib/named /var/lib/machines )
 # The following POST_RECOVERY_SCRIPT implements during "rear recover"
 # btrfs quota setup for snapper if that is used in the original system:
 POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | grep -q "^QGROUP.*[0-9]/[0-9]" ; then snapper --no-dbus -r $TARGET_FS_ROOT set-config QGROUP= ; snapper --no-dbus -r $TARGET_FS_ROOT setup-quota && echo snapper setup-quota done || echo snapper setup-quota failed ; else echo snapper setup-quota not used ; fi' )

--- a/usr/share/rear/conf/examples/SLE12-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-btrfs-example.conf
@@ -32,9 +32,12 @@ NETFS_KEEP_OLD_BACKUP_COPY=yes
 # so that such files must be explicitly included to be in the backup.
 # Files in the following SLE12 default btrfs subvolumes are
 # in the below example not included to be in the backup
-#   /.snapshots/*  /var/crash/*
-# but files in /home/* are included to be in the backup.
-BACKUP_PROG_INCLUDE=( '/home/*' '/var/tmp/*' '/var/spool/*' '/var/opt/*' '/var/log/*' '/var/lib/pgsql/*' '/var/lib/mailman/*' '/var/lib/named/*' '/usr/local/*' '/tmp/*' '/srv/*' '/boot/grub2/x86_64-efi/*' '/opt/*' '/boot/grub2/i386-pc/*' )
+#   /.snapshots  /var/crash
+# but files in /home are included to be in the backup.
+# You may use a command like
+#   findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash'
+# to generate the values:
+BACKUP_PROG_INCLUDE=( /home /var/tmp /var/spool /var/opt /var/log /var/lib/pgsql /var/lib/mailman /var/lib/named /usr/local /tmp /srv /boot/grub2/x86_64-efi /opt /boot/grub2/i386-pc )
 # This option defines a root password to allow SSH connection
 # whithout a public/private key pair
 #SSH_ROOT_PASSWORD="password_on_the_rear_recovery_system"


### PR DESCRIPTION
Simpler `findmnt` command example in comment
<pre>
findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash'
</pre>
and more fail-safe BACKUP_PROG_INCLUDE example array
that contains now plain directories `/dir` instead of `/dir/*`
so that now also the directory itself and dot-files `/dir/.file`
get included in the backup, see
https://github.com/rear/rear/issues/1714
