### PR TITLE
Replace 400_autoresize_disks by 420_autoresize_last_partitions and 430_autoresize_all_partitions

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -361,6 +361,90 @@ RECOVERY_UPDATE_URL=""
 test "$MIGRATION_MODE" || MIGRATION_MODE=''
 
 ##
+# Resizing partitions in MIGRATION_MODE during "rear recover"
+#
+# AUTORESIZE_PARTITIONS
+# AUTORESIZE_EXCLUDE_PARTITIONS
+# AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE
+# AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE
+#
+# For details see the scripts
+# usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
+# and
+# usr/share/rear/layout/prepare/default/430_autoresize_all_partitions.sh
+#
+# When AUTORESIZE_PARTITIONS is false, no partition is resized.
+#
+# When AUTORESIZE_PARTITIONS is true, all active partitions on all active disks
+# get resized by the 430_autoresize_all_partitions.sh script
+# (except boot and swap partitions via some special hardcoded rules in that script)
+# if the disk size had changed (i.e. only in migration mode).
+# This does not resize volumes on top of the affected partitions.
+#
+# A true or false value must be the first one in the AUTORESIZE_PARTITIONS array.
+#
+# When the first value in AUTORESIZE_PARTITIONS is neither true nor false
+# only the last active partition on each active disk gets resized
+# by the 420_autoresize_last_partitions.sh script.
+#
+# The following appiles only when the last active partition on each active disk
+# gets resized by the 420_autoresize_last_partitions.sh script:
+#
+# In particular this does not resize volumes on top of the affected partitions.
+# To migrate volumes on disk where the disk size had changed the user must in advance
+# manually adapt his disklayout.conf file before he runs "rear recover".
+#
+# All other values in the AUTORESIZE_PARTITIONS array specify partition device nodes
+# e.g. as in AUTORESIZE_PARTITIONS=( /dev/sda2 /dev/sdb3 )
+# where last partitions with those partition device nodes should be resized
+# regardless of what is specified in the AUTORESIZE_EXCLUDE_PARTITIONS array.
+#
+# The values in the AUTORESIZE_EXCLUDE_PARTITIONS array specify partition device nodes
+# where partitions with those partition device nodes are excluded from being resized.
+# The special values 'boot', 'swap', and 'efi' specify that
+#  - partitions where its filesystem mountpoint contains 'boot' or 'bios' or 'grub'
+#    or where its GPT name or flags contain 'boot' or 'bios' or 'grub' (anywhere case insensitive)
+#  - partitions for which an active 'swap' entry exists in disklayout.conf
+#    or where its GPT name or flags contain 'swap' (anywhere case insensitive)
+#  - partitions where its filesystem mountpoint contains 'efi' or 'esp'
+#    or where its GPT name or flags contains 'efi' or 'esp' (anywhere case insensitive)
+# are excluded from being resized e.g. as in
+# AUTORESIZE_EXCLUDE_PARTITIONS=( boot swap efi /dev/sdb3 /dev/sdc4 )
+#
+# In general ReaR is not meant to somehow "optimize" a system during "rear recover".
+# ReaR is meant to recreate a system as much as possible exactly as it was before.
+# Accordingly the automated resizing by the 420_autoresize_last_partitions.sh script
+# implements a "minimal changes" approach:
+#
+# When the new disk is a bit smaller (at most AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE percent),
+# only the last (active) partition gets shrinked but all other partitions are not changed.
+# When the new disk is smaller than AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE percent it errors out.
+# To migrate onto a substantially smaller new disk the user must in advance
+# manually adapt his disklayout.conf file before he runs "rear recover".
+#
+# When the new disk is not much bigger (less than AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE percent),
+# no partition gets increased (which leaves the bigger disk space at the end of the disk unused).
+# When the new disk is substantially bigger (at least AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE percent),
+# only the last (active) partition gets increased but all other partitions are not changed.
+# To migrate various partitions onto a substantially bigger new disk the user must in advance
+# manually adapt his disklayout.conf file before he runs "rear recover".
+#
+# Because only the end value of the last partition may get changed, the partitioning alignment
+# of the original system is not changed, cf. https://github.com/rear/rear/issues/102
+#
+# Because only the last active (i.e. not commented in disklayout.conf) partition on a disk
+# may get changed, things go wrong if another partition is actually the last one on the disk
+# but that other partition is commented in disklayout.conf (e.g. because that partition
+# is a partition of another operating system that is not mounted during "rear mkrescue").
+# To migrate a system with a non-active last partition onto a bigger or smaller new disk
+# the user must in advance manually adapt his disklayout.conf file before he runs "rear recover".
+#
+AUTORESIZE_PARTITIONS=''
+AUTORESIZE_EXCLUDE_PARTITIONS=( boot swap efi )
+AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE=2
+AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE=10
+
+##
 # Support for TCG Opal 2-compliant Self-Encrypting Disks
 # (see doc/user-guide/13-tcg-opal-support.adoc)
 #

--- a/usr/share/rear/layout/prepare/default/010_prepare_files.sh
+++ b/usr/share/rear/layout/prepare/default/010_prepare_files.sh
@@ -17,7 +17,7 @@ fi
 mkdir -p $LAYOUT_TOUCHDIR
 
 if [ -e $LAYOUT_FILE ] ; then
-    backup_file $LAYOUT_FILE
+    save_original_file $LAYOUT_FILE
 fi
 
 if [ -e $CONFIG_DIR/disklayout.conf ] ; then

--- a/usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
+++ b/usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
@@ -82,6 +82,9 @@ save_original_file "$LAYOUT_FILE"
 test "$AUTORESIZE_EXCLUDE_PARTITIONS" || AUTORESIZE_EXCLUDE_PARTITIONS=( boot swap efi )
 test "$AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE" || AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE=10
 test "$AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE" || AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE=2
+# Avoid 'set -e -u' exit because of "AUTORESIZE_PARTITIONS[@]: unbound variable"
+# note that an empty array AUTORESIZE_PARTITIONS=() does not help here:
+test "$AUTORESIZE_PARTITIONS" || AUTORESIZE_PARTITIONS=''
 
 # Try to care about possible errors
 # see https://github.com/rear/rear/wiki/Coding-Style

--- a/usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
+++ b/usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
@@ -1,0 +1,267 @@
+#
+# layout/prepare/default/420_autoresize_last_partitions.sh
+#
+# Try to automatically resize active last partitions on all active disks
+# if the disk size had changed (i.e. only in migration mode).
+#
+# When AUTORESIZE_PARTITIONS is false, no partition is resized.
+#
+# When AUTORESIZE_PARTITIONS is true, all active partitions on all active disks
+# get resized by the separated 430_autoresize_all_partitions.sh script. 
+#
+# A true or false value must be the first one in the AUTORESIZE_PARTITIONS array.
+#
+# When the first value in AUTORESIZE_PARTITIONS is neither true nor false
+# only the last active partition on each active disk gets resized.
+#
+# All other values in the AUTORESIZE_PARTITIONS array specify partition device nodes
+# e.g. as in AUTORESIZE_PARTITIONS=( /dev/sda3 /dev/sdb1 /dev/sdb2 )
+# where partitions with those partition device nodes should be resized
+# regardless of what is specified in the AUTORESIZE_EXCLUDE_PARTITIONS array.
+#
+# The values in the AUTORESIZE_EXCLUDE_PARTITIONS array specify partition device nodes
+# where partitions with those partition device nodes are excluded from being resized.
+# The special values 'boot', 'swap', and 'efi' specify that
+#  - partitions where its filesystem mountpoint contains 'boot' or 'bios' or 'grub'
+#    or where its GPT name or flags contain 'boot' or 'bios' or 'grub' (anywhere case insensitive)
+#  - partitions for which an active 'swap' entry exists in disklayout.conf
+#    or where its GPT name or flags contain 'swap' (anywhere case insensitive)
+#  - partitions where its filesystem mountpoint contains 'efi' or 'esp'
+#    or where its GPT name or flags contains 'efi' or 'esp' (anywhere case insensitive)
+# are excluded from being resized e.g. as in
+# AUTORESIZE_EXCLUDE_PARTITIONS=( boot swap efi /dev/sda2 /dev/sdb3 )
+#
+# The last active partition on each active disk gets resized but nothing more.
+# In particular this does not resize volumes on top of the affected partitions.
+# To migrate volumes on disk where the disk size had changed the user must in advance
+# manually adapt his disklayout.conf file before he runs "rear recover".
+#
+# In general ReaR is not meant to somehow "optimize" a system during "rear recover".
+# ReaR is meant to recreate a system as much as possible exactly as it was before.
+# Accordingly this automated resizing implements a "minimal changes" approach:
+#
+# When the new disk is a bit smaller (at most AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE percent),
+# only the last (active) partition gets shrinked but all other partitions are not changed.
+# When the new disk is smaller than AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE percent it errors out.
+# To migrate onto a substantially smaller new disk the user must in advance
+# manually adapt his disklayout.conf file before he runs "rear recover".
+#
+# When the new disk is only a bit bigger (less than AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE percent),
+# no partition gets increased (which leaves the bigger disk space at the end of the disk unused).
+# When the new disk is substantially bigger (at least AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE percent),
+# only the last (active) partition gets increased but all other partitions are not changed.
+# To migrate various partitions onto a substantially bigger new disk the user must in advance
+# manually adapt his disklayout.conf file before he runs "rear recover".
+#
+# Because only the end value of the last partition may get changed, the partitioning alignment
+# of the original system is not changed, cf. https://github.com/rear/rear/issues/102
+#
+# Because only the last active (i.e. not commented in disklayout.conf) partition on a disk
+# may get changed, things go wrong if another partition is actually the last one on the disk
+# but that other partition is commented in disklayout.conf (e.g. because that partition
+# is a partition of another operating system that is not mounted during "rear mkrescue").
+# To migrate a system with a non-active last partition onto a bigger or smaller new disk
+# the user must in advance manually adapt his disklayout.conf file before he runs "rear recover".
+
+# Skip if not in migration mode:
+is_true "$MIGRATION_MODE" || return 0
+
+# Skip if automatically resize partitions is explicity unwanted:
+is_false "$AUTORESIZE_PARTITIONS" && return 0
+
+# Skip resizing only the last partition if resizing all partitions is explicity wanted
+# which is done by the separated 430_autoresize_all_partitions.sh script:
+is_true "$AUTORESIZE_PARTITIONS" && return 0
+
+# Write new disklayout with resized partitions to LAYOUT_FILE.resized_last_partition:
+local disklayout_resized_last_partition="$LAYOUT_FILE.resized_last_partition"
+cp "$LAYOUT_FILE" "$disklayout_resized_last_partition"
+backup_file "$LAYOUT_FILE"
+
+# Set fallbacks if mandatory values are not set (should be set in default.conf):
+test "$AUTORESIZE_EXCLUDE_PARTITIONS" || AUTORESIZE_EXCLUDE_PARTITIONS=( boot swap efi )
+test "$AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE" || AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE=10
+test "$AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE" || AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE=2
+
+local component_type junk
+local disk_device old_disk_size
+local sysfsname new_disk_size
+local max_part_start last_part_dev last_part_start last_part_size last_part_type last_part_flags
+local disk_dev part_size part_start part_type part_flags part_dev
+local last_part_is_resizeable last_part_filesystem_entry last_part_filesystem_mountpoint egrep_pattern
+local last_part_is_boot last_part_is_swap last_part_is_efi
+local MiB new_disk_size_MiB first_byte_after_last_MiB_on_disk new_last_part_size
+local disk_size_difference increase_threshold_difference max_shrink_difference
+
+# Example 'disk' entry in disklayout.conf:
+#   # Disk /dev/sda
+#   # Format: disk <devname> <size(bytes)> <partition label type>
+#   disk /dev/sda 21474836480 msdos
+while read component_type disk_device old_disk_size junk ; do
+    Log "Examining $disk_device to automatically resize its last active partition"
+
+    sysfsname=$( get_sysfs_name $disk_device )
+    test "$sysfsname" || Error "Failed to get_sysfs_name() for $disk_device"
+    test -d "/sys/block/$sysfsname" || Error "No '/sys/block/$sysfsname' directory for $disk_device"
+
+    new_disk_size=$( get_disk_size "$sysfsname" )
+    is_positive_integer $new_disk_size || Error "Failed to get_disk_size() for $disk_device"
+    # Skip if the size of the new disk (e.g. sda) is same as the size of the old disk (e.g. also sda):
+    if test $new_disk_size -eq $old_disk_size ; then
+        Log "Skipping $disk_device (size of new disk same as size of old disk)"
+        continue
+    fi
+
+    # Find the last partition for the current disk in disklayout.conf:
+    # Example partitions 'part' entries in disklayout.conf:
+    #   # Partitions on /dev/sda
+    #   # Format: part <device> <partition size(bytes)> <partition start(bytes)> <partition type|name> <flags> /dev/<partition>
+    #   part /dev/sda 1569718272 1048576 primary none /dev/sda1
+    #   part /dev/sda 19904069632 1570766848 primary boot /dev/sda2
+    # The last partition is the /dev/<partition> with biggest <partition start(bytes)> value.
+    max_part_start=0
+    last_part_dev=""
+    last_part_start=0
+    last_part_size=0
+    while read component_type disk_dev part_size part_start part_type part_flags part_dev junk ; do
+        Log "Checking $part_dev if it is the last partition on $disk_device"
+        if test $part_start -ge $max_part_start ; then
+            max_part_start=$part_start
+            last_part_dev="$part_dev"
+            last_part_start="$part_start"
+            last_part_size="$part_size"
+            last_part_type="$part_type"
+            last_part_flags="$part_flags"
+        fi
+    done < <( grep "^part $disk_device" "$LAYOUT_FILE" )
+    test "$last_part_dev" || Error "Failed to determine /dev/<partition> for last partition on $disk_device"
+    is_positive_integer $last_part_start || Error "Failed to determine partition start for $last_part_dev"
+    Log "Found $last_part_dev as last partition on $disk_device"
+
+    # Determine if the last partition is resizeable:
+    Log "Determining if last partition $last_part_dev is resizeable"
+    last_part_is_resizeable=""
+    if IsInArray "$last_part_dev" ${AUTORESIZE_PARTITIONS[@]} ; then
+        last_part_is_resizeable="yes"
+        Log "Last partition should be resized ($last_part_dev in AUTORESIZE_PARTITIONS)"
+    else
+        # Example filesystem 'fs' entry in disklayout.conf (excerpt):
+        #  # Format: fs <device> <mountpoint> <fstype> ...
+        #  fs /dev/sda3 /boot/efi vfat ...
+        last_part_filesystem_entry=( $( grep "^fs $last_part_dev " "$LAYOUT_FILE" ) )
+        last_part_filesystem_mountpoint="${last_part_filesystem_entry[2]}"
+        # Intentionally all tests to exclude a partition from being resized are run
+        # to get all reasons shown (in the log) why one same partition is not resizeable.
+        # Do not resize partitions that are explicitly specified to be excluded from being resized:
+        if IsInArray "$last_part_dev" ${AUTORESIZE_EXCLUDE_PARTITIONS[@]} ; then
+            last_part_is_resizeable="no"
+            Log "Last partition $last_part_dev not resizeable (excluded from being resized in AUTORESIZE_EXCLUDE_PARTITIONS)"
+        fi
+        # Do not resize partitions that are used during boot:
+        if IsInArray "boot" ${AUTORESIZE_EXCLUDE_PARTITIONS[@]} ; then
+            last_part_is_boot=''
+            # A partition is considered to be used during boot
+            # when its GPT name or flags contain 'boot' or 'bios' or 'grub' (anywhere case insensitive):
+            egrep_pattern='boot|bios|grub'
+            grep -E -i "$egrep_pattern" <<< $( echo $last_part_type ) && last_part_is_boot="yes"
+            grep -E -i "$egrep_pattern" <<< $( echo $last_part_flags ) && last_part_is_boot="yes"
+            # Also test if the mountpoint of the filesystem of the partition
+            # contains 'boot' or 'bios' or 'grub' (anywhere case insensitive)
+            # because it is not reliable to assume that the boot flag is set in the partition table,
+            # cf. https://github.com/rear/rear/commit/91a6d2d11d2d605e7657cbeb95847497b385e148
+            grep -E -i "$egrep_pattern" <<< $( echo $last_part_filesystem_mountpoint ) && last_part_is_boot="yes"
+            if is_true "$last_part_is_boot" ; then
+                last_part_is_resizeable="no"
+                Log "Last partition $last_part_dev not resizeable (used during boot)"
+            fi
+        fi
+        # Do not resize partitions that are used as swap partitions:
+        if IsInArray "swap" ${AUTORESIZE_EXCLUDE_PARTITIONS[@]} ; then
+            last_part_is_swap=''
+            # Do not resize a partition for which an active 'swap' entry exists,
+            # cf. https://github.com/rear/rear/issues/71
+            grep "^swap $last_part_dev " "$LAYOUT_FILE" && last_part_is_swap="yes"
+            # A partition is considered to be used as swap partition
+            # when its GPT name or flags contain 'swap' (anywhere case insensitive):
+            grep -i 'swap' <<< $( echo $last_part_type ) && last_part_is_swap="yes"
+            grep -i 'swap' <<< $( echo $last_part_flags ) && last_part_is_swap="yes"
+            if is_true "$last_part_is_swap" ; then
+                last_part_is_resizeable="no"
+                Log "Last partition $last_part_dev not resizeable (used as swap partition)"
+            fi
+        fi
+        # Do not resize partitions that are used for UEFI:
+        if IsInArray "efi" ${AUTORESIZE_EXCLUDE_PARTITIONS[@]} ; then
+            last_part_is_efi=''
+            # A partition is considered to be used for UEFI
+            # when its GPT name or flags contain 'efi' or 'esp' (anywhere case insensitive):
+            egrep_pattern='efi|esp'
+            grep -E -i "$egrep_pattern" <<< $( echo $last_part_type ) && last_part_is_efi="yes"
+            grep -E -i "$egrep_pattern" <<< $( echo $last_part_flags ) && last_part_is_efi="yes"
+            # Also test if the mountpoint of the filesystem of the partition
+            # contains 'efi' or 'esp' (anywhere case insensitive):
+            grep -E -i "$egrep_pattern" <<< $( echo $last_part_filesystem_mountpoint ) && last_part_is_efi="yes"
+            if is_true "$last_part_is_efi" ; then
+                last_part_is_resizeable="no"
+                Log "Last partition $last_part_dev not resizeable (used for UEFI)"
+            fi
+        fi
+    fi
+
+    # Determine the new size of the last partition (with 1 MiB alignment):
+    Log "Determining new size for last partition $last_part_dev"
+    MiB=$( mathlib_calculate "1024 * 1024" )
+    # mathlib_calculate cuts integer remainder so that for a disk of e.g. 12345.67 MiB size new_disk_size_MiB = 12345
+    new_disk_size_MiB=$( mathlib_calculate "$new_disk_size / $MiB" )
+    # For a disk of 12345.67 MiB size the first_byte_after_last_MiB_on_disk = 12944670720
+    first_byte_after_last_MiB_on_disk=$( mathlib_calculate "$new_disk_size_MiB * $MiB" )
+    # When last_part_start is e.g. at 12300.00 MiB = at the byte 12897484800
+    # then new_last_part_size = 12944670720 - 12897484800 = 45.00 MiB
+    # so that on a disk of e.g. 12345.67 MiB size the last 0.67 MiB is left unused (as intended for 1 MiB alignment):
+    new_last_part_size=$( mathlib_calculate "$first_byte_after_last_MiB_on_disk - $last_part_start" )
+    # Note that new_last_part_size could be zero or negative here (that error condition is tested below).
+
+    # Determine if the last partition actually needs to be increased or shrinked and
+    # go on or error out or continue with the next disk depending on the particular case:
+    Log "Determining if last partition $last_part_dev actually needs to be increased or shrinked"
+    disk_size_difference=$( mathlib_calculate "$new_disk_size - $old_disk_size" )
+    if test $disk_size_difference -gt 0 ; then
+        # The size of the new disk is bigger than the size of the old disk:
+        increase_threshold_difference=$( mathlib_calculate "$old_disk_size / 100 * $AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE" )
+        if test $disk_size_difference -lt $increase_threshold_difference ; then
+            if is_true "$last_part_is_resizeable" ; then
+                # Inform the user when last partition cannot be resized regardless of his setting in AUTORESIZE_PARTITIONS:
+                LogPrint "Last partition $last_part_dev cannot be resized (new disk less than $AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE% bigger)"
+            else
+                Log "Skip increasing last partition $last_part_dev (new disk less than $AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE% bigger)"
+            fi
+            # Continue with next disk:
+            continue
+        fi
+        if is_false "$last_part_is_resizeable" ; then
+            Log "Skip increasing last partition $last_part_dev (not resizeable)"
+            # Continue with next disk:
+            continue
+        fi
+        LogPrint "Increasing last partition $last_part_dev up to end of disk (new disk at least $AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE% bigger)"
+        test $new_last_part_size -ge $last_part_size || BugError "New last partition size $new_last_part_size is not bigger than old size $last_part_size"
+    else
+        # The size of the new disk is smaller than the size of the old disk:
+        max_shrink_difference=$( mathlib_calculate "$old_disk_size / 100 * $AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE" )
+        # Currently disk_size_difference is negative but the next test needs its absolute value:
+        disk_size_difference=$( mathlib_calculate "0 - $disk_size_difference" )
+        test $disk_size_difference -gt $max_shrink_difference || Error "New $disk_device more than $AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE% smaller"
+        LogPrint "Shrinking last partition $last_part_dev to end of disk (new disk at most $AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE% smaller)"
+        is_false "$last_part_is_resizeable" && Error "Cannot shrink $last_part_dev (non-resizeable partition)"
+        is_positive_integer $( mathlib_calculate "$new_last_part_size - $MiB - 1" ) || Error "New last partition size $new_last_part_size less than 1 MiB"
+    fi
+
+    # Replace the size value of the last partition by its new size value in LAYOUT_FILE.resized_last_partition:
+    sed -r -i "s|^part $disk_device $last_part_size $last_part_start (.+) $last_part_dev\$|part $disk_device $new_last_part_size $last_part_start \1 $last_part_dev|" "$disklayout_resized_last_partition"
+    LogPrint "Changed last partition $last_part_dev size from $last_part_size to $new_last_part_size bytes"
+
+done < <( grep "^disk " "$LAYOUT_FILE" )
+
+# Use the new LAYOUT_FILE.resized_last_partition with the resized partitions:
+mv "$disklayout_resized_last_partition" "$LAYOUT_FILE"
+

--- a/usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
+++ b/usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
@@ -76,7 +76,7 @@ is_true "$AUTORESIZE_PARTITIONS" && return 0
 # Write new disklayout with resized partitions to LAYOUT_FILE.resized_last_partition:
 local disklayout_resized_last_partition="$LAYOUT_FILE.resized_last_partition"
 cp "$LAYOUT_FILE" "$disklayout_resized_last_partition"
-backup_file "$LAYOUT_FILE"
+save_original_file "$LAYOUT_FILE"
 
 # Set fallbacks if mandatory values are not set (should be set in default.conf):
 test "$AUTORESIZE_EXCLUDE_PARTITIONS" || AUTORESIZE_EXCLUDE_PARTITIONS=( boot swap efi )

--- a/usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
+++ b/usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
@@ -15,8 +15,8 @@
 # only the last active partition on each active disk gets resized.
 #
 # All other values in the AUTORESIZE_PARTITIONS array specify partition device nodes
-# e.g. as in AUTORESIZE_PARTITIONS=( /dev/sda3 /dev/sdb1 /dev/sdb2 )
-# where partitions with those partition device nodes should be resized
+# e.g. as in AUTORESIZE_PARTITIONS=( /dev/sda2 /dev/sdb3 )
+# where last partitions with those partition device nodes should be resized
 # regardless of what is specified in the AUTORESIZE_EXCLUDE_PARTITIONS array.
 #
 # The values in the AUTORESIZE_EXCLUDE_PARTITIONS array specify partition device nodes
@@ -29,7 +29,7 @@
 #  - partitions where its filesystem mountpoint contains 'efi' or 'esp'
 #    or where its GPT name or flags contains 'efi' or 'esp' (anywhere case insensitive)
 # are excluded from being resized e.g. as in
-# AUTORESIZE_EXCLUDE_PARTITIONS=( boot swap efi /dev/sda2 /dev/sdb3 )
+# AUTORESIZE_EXCLUDE_PARTITIONS=( boot swap efi /dev/sdb3 /dev/sdc4 )
 #
 # The last active partition on each active disk gets resized but nothing more.
 # In particular this does not resize volumes on top of the affected partitions.

--- a/usr/share/rear/layout/prepare/default/430_autoresize_all_partitions.sh
+++ b/usr/share/rear/layout/prepare/default/430_autoresize_all_partitions.sh
@@ -1,10 +1,27 @@
-# Try to automatically resize disks.
+#
+# layout/prepare/default/430_autoresize_all_partitions.sh
+#
+# Try to automatically resize all active partitions on all active disks
+# (except boot and swap partitions via some special hardcoded rules)
+# if the disk size had changed (i.e. only in migration mode).
+# This does not resize volumes on top of the affected partitions.
+#
+# When AUTORESIZE_PARTITIONS is false, no partition is resized.
+#
+# When AUTORESIZE_PARTITIONS is neither true nor false (the default behaviour)
+# only the last active partition on each active disk gets resized
+# by the separated 420_autoresize_last_partitions.sh script.
+#
+# To automatically resize all active partitions on all active disks
+# AUTORESIZE_PARTITIONS must be explicity set to true.
+#
+# A true or false value must be the first one in the AUTORESIZE_PARTITIONS array.
 
 # Skip if not in migration mode:
 is_true "$MIGRATION_MODE" || return 0
 
-# Resize all partitions, except the boot partition.
-# This does not resize volumes on top of the affected partitions.
+# Skip if resizing all partitions is not explicity wanted:
+is_true "$AUTORESIZE_PARTITIONS" || return 0
 
 cp "$LAYOUT_FILE" "$LAYOUT_FILE.tmp"
 backup_file "$LAYOUT_FILE"

--- a/usr/share/rear/layout/prepare/default/430_autoresize_all_partitions.sh
+++ b/usr/share/rear/layout/prepare/default/430_autoresize_all_partitions.sh
@@ -24,7 +24,7 @@ is_true "$MIGRATION_MODE" || return 0
 is_true "$AUTORESIZE_PARTITIONS" || return 0
 
 cp "$LAYOUT_FILE" "$LAYOUT_FILE.tmp"
-backup_file "$LAYOUT_FILE"
+save_original_file "$LAYOUT_FILE"
 
 while read type device size junk ; do
     sysfsname=$(get_sysfs_name $device)

--- a/usr/share/rear/layout/prepare/default/540_generate_device_code.sh
+++ b/usr/share/rear/layout/prepare/default/540_generate_device_code.sh
@@ -1,7 +1,10 @@
 # Use the dependencies to order device creation and generate code for them.
 
-# $LAYOUT_CODE will contain the script to restore the environment.
-backup_file "$LAYOUT_CODE"
+# LAYOUT_CODE is the script to recreate the disk layout (diskrestore.sh).
+
+save_original_file "$LAYOUT_CODE"
+
+# Initialize diskrestore.sh:
 cat <<EOF >"$LAYOUT_CODE"
 #!/bin/bash
 
@@ -18,6 +21,7 @@ set -x
 
 EOF
 
+# Populate diskrestore.sh with further code to (re)-create all disk layout components:
 all_done=
 while [ -z "$all_done" ] ; do
     # Cycle through all components and find one that can be created.

--- a/usr/share/rear/layout/save/GNU/Linux/510_current_disk_usage.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/510_current_disk_usage.sh
@@ -1,6 +1,24 @@
-# This file is part of Relax-and-Recover, licensed under the GNU General
-# Public License. Refer to the included COPYING for full text of license.
+# This file is part of Relax-and-Recover,
+# licensed under the GNU General Public License.
+# Refer to the included COPYING for full text of license.
 
-# Save the current disk usage (POSIX output format) in the rescue image
-# excluding target (ESP) partition(s)
-df -Plh -x encfs -x tmpfs -x devtmpfs |  egrep  --invert-match "^(`readlink -f "/dev/disk/by-label/$USB_DEVICE_FILESYSTEM_LABEL"`|`readlink -f /dev/disk/by-label/REAR-EFI`)" > $VAR_DIR/layout/config/df.txt
+# Save the current disk usage (in POSIX output format) in the rescue image
+# excluding possibly mounted ReaR target USB data and USB ESP partitions:
+local original_disk_space_usage_file="$VAR_DIR/layout/config/df.txt"
+local rear_USB_data_partition="$( readlink -f "/dev/disk/by-label/$USB_DEVICE_FILESYSTEM_LABEL" )"
+local rear_USB_ESP_partition="$( readlink -f /dev/disk/by-label/REAR-EFI )"
+# Careful with "egrep -v" patterns because with an empty pattern egrep -v '' discards all lines:
+local egrep_pattern=""
+test "$rear_USB_data_partition" && egrep_pattern="^$rear_USB_data_partition"
+if test "$rear_USB_ESP_partition" ; then
+    test "$egrep_pattern" && egrep_pattern="$egrep_pattern|^$rear_USB_ESP_partition" || egrep_pattern="^$rear_USB_ESP_partition"
+fi
+# The disk usage must be in MiB units '-BM' (and not in arbitrary human readable units via '-h')
+# because the values are used in 420_autoresize_last_partitions.sh to calculate whether or not
+# the current disk usage still fits on a smaller disk when the last partition must be shrinked:
+if test "$egrep_pattern" ; then
+    df -Pl -BM -x encfs -x tmpfs -x devtmpfs | egrep -v "$egrep_pattern" >$original_disk_space_usage_file
+else
+    df -Pl -BM -x encfs -x tmpfs -x devtmpfs >$original_disk_space_usage_file
+fi
+


### PR DESCRIPTION
* Type: **Bug Fix** **Enhancement**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1731

* How was this pull request tested?
Currently this is in a "submit early" state
where subsequent "submit often" commits will follow
that is currently mainly intended for others to see what I have up to now
which is currently only a little bit tested by me

* Brief description of the changes in this pull request:

Renamed 400_autoresize_disks.sh into 430_autoresize_all_partitions.sh
to keep full backward compatible old weird behaviour but now that
needs to be explicity wanted by the user via the new config variable
AUTORESIZE_PARTITIONS=true
and
implemented new default 420_autoresize_last_partitions.sh
that only resizes the last partition on each disk (if at all).

* Longer description of the changes in this pull request:

The new default behaviour is to only resize the last partition on each disk
which means to only change the end vaule of the last partitions.

This way ReaR should behave now fail save.

I think ReaR is meant to recreate a system as much as possible
exactly as it was before and not to do a complete repartitioning.

I talked to colleagues in general about resizing partitions during disaster recovery
and got consensus that the general expectation is that by default the recreated
system should be "the same" regardless if a replacement disk is bigger.
In particular nobody wants changed partitions when the replacement disk
is only a bit bigger (e.g. some small disk model specific differences).

The new automated resizing implements a "minimal changes" approach
in the new 420_autoresize_last_partitions.sh script.

The old 430_autoresize_all_partitions.sh and
the new 420_autoresize_last_partitions.sh
are mutually excluding each other via the AUTORESIZE_PARTITIONS value.

Because only the end value of the last partition may get changed,
the partitioning alignment of the original system is not changed,
cf. https://github.com/rear/rear/issues/102
so that with the new default behaviour "rear recover" can no longer result
a partitioning that is worse than what it was on the original system.

Additionally there are limits via the new config variables
AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE and
AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE
when the last partition will be changed at all to avoid changes
when the new disk is only a little bit bigger and to avoid that
the backup cannot be restored when the new disk is much smaller.

When the new disk is a bit smaller
(at most AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE percent),
the last (active - i.e. not commented in disklayout.conf) partition
gets shrinked but all other partitions are not changed.
When the new disk is smaller than
AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE percent it errors out.
To migrate onto a substantially smaller new disk the user must in advance
manually adapt his disklayout.conf file before he runs "rear recover".

When the new disk is only a bit bigger
(less than AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE percent),
no partition gets increased (which leaves the bigger disk space
at the end of the disk unused).
When the new disk is substantially bigger
(at least AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE percent),
the last (active) partition gets increased but all other partitions are not changed.
To migrate various partitions onto a substantially bigger new disk the user must
in advance manually adapt his disklayout.conf file before he runs "rear recover".

Furthermore the user has the final power because via the new config variables
AUTORESIZE_EXCLUDE_PARTITIONS and AUTORESIZE_PARTITIONS
the user can specify what partitions should be explicitly excluded or inculed
to be resized.

The new config variables apply only to the new 420_autoresize_last_partitions.sh
because currently the old 430_autoresize_all_partitions.sh is there
to keep full backward compatible old weird behaviour.

Perhaps later - if there is really no use-case for the old weird behaviour - the
430_autoresize_all_partitions.sh could be enhanced to resize more than
only the last partition in a fail-safe way, but currently this is not at all
my scope or my intention of this pull request.

I tried two times to enhance the old 400_autoresize_disks.sh into something
that works both backward compatible and reasonably fail-safe
but I failed two times so that I will no longer try to enhance that script
in any way - of course would I appreciate it if others could do it.
