### PR TITLE
Trace broken symbolic links in rootfs

### DIFF
--- a/usr/share/rear/build/default/985_find_broken_links.sh
+++ b/usr/share/rear/build/default/985_find_broken_links.sh
@@ -1,0 +1,11 @@
+# build/default/985_find_broken_links.sh
+# Check for broken symbolic links in our ROOTFS_DIR area - issue #1638
+
+pushd $ROOTFS_DIR >/dev/null
+    find . -xtype l | grep -v "/dev/" | while read SYMLINK
+    do
+        mising_file=$( ls -l $SYMLINK | awk '{print $11}' | sed -e 's/\.//g' )
+        test -d $(dirname ./$mising_file) || mkdir -m 755 -p $(dirname ./$mising_file)
+        cp -v $mising_file ./$mising_file >&2
+    done
+popd >/dev/null


### PR DESCRIPTION
# copy the mising symbolic files to ROOTFS_DIR (we do skip broken links in /dev/)

* Type: **Bug Fix** 

* Impact:  **Normal** 

* Reference to related issue (URL): https://github.com/rear/rear/issues/1638

* How was this pull request tested? Script only on saved rootfs dir with `pushd`

* Brief description of the changes in this pull request: Issue was detected via ReaR Automated Testing - see issue https://github.com/gdha/rear-automated-testing/issues/47

