### PR TITLE
Correction to the 650_check_iso_recoverable.sh for NSR_CLIENT_MODE

### DIFF
--- a/usr/share/rear/layout/save/NSR/default/650_check_iso_recoverable.sh
+++ b/usr/share/rear/layout/save/NSR/default/650_check_iso_recoverable.sh
@@ -1,3 +1,10 @@
+# 650_check_iso_recoverable.sh
+#
+# In case NSR_CLIENT_MODE is enabled return else continue ...
+if is_true "$NSR_CLIENT_MODE"; then
+    return
+fi
+    
 NSRSERVER=$(cat $VAR_DIR/recovery/nsr_server )
 CLIENTNAME=$(hostname)
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: Bug Fix

* Impact: Low

* Reference to related issue (URL): none.

* How was this pull request tested?
I tested the pull request on a CentOS 6.9 VM and a RHEL6 and 7 based server.

* Brief description of the changes in this pull request:
The script `650_check_iso_recoverable.sh` exits with FALSE if it cannot find an ISO image stored on the NSR_SERVER.
In case the "NSR_CLIENT_MODE" is set to "yes" saving an ISO image to the NSR_SERVER is not allowed. Because of this `rear checklayout` (in the cronjob "rear") is always FALSE in this mode and a rescue image is created daily even if not required.
This pull request shall correct the behaviour with skipping the ISO check in the mode NSR_CLIENT_MODE=yes.
