### PR TITLE
430 prepare timesync.sh chronyd support

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1072,7 +1072,7 @@ SSH_UNPROTECTED_PRIVATE_KEYS='no'
 # For details see the build/default/980_verify_rootfs.sh script.
 NON_FATAL_BINARIES_WITH_MISSING_LIBRARY=''
 
-# Time synchronisation, could be NTP, NTPDATE, RDATE or empty:
+# Time synchronisation, could be NTP, CHRONY, NTPDATE, RDATE or empty:
 TIMESYNC=
 # Set a timesync source, mostly needed for NTPDATE and RDATE:
 TIMESYNC_SOURCE=

--- a/usr/share/rear/rescue/default/430_prepare_timesync.sh
+++ b/usr/share/rear/rescue/default/430_prepare_timesync.sh
@@ -4,7 +4,11 @@ case "$TIMESYNC" in
 	NTP)
 		PROGS=( "${PROGS[@]}" ntpd )
 		COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/ntp.conf "/etc/ntp" )
-		echo "NT:2345:respawn:/bin/ntpd -n -g -p /var/run/ntpd.pid" >>$ROOTFS_DIR/etc/inittab
+		if [ ! -x /bin/systemctl ] ; then
+			echo "NT:2345:respawn:/bin/ntpd -n -g -p /var/run/ntpd.pid" >>$ROOTFS_DIR/etc/inittab
+		else
+			echo "System is systemd-based, not updating $ROOTFS_DIR/etc/inittab ..."
+		fi
 		cat >$ROOTFS_DIR/etc/scripts/system-setup.d/90-timesync.sh <<-EOF
 			echo "Setting system time via NTP ..."
 			ntpd -q -g & # allow for big jumps
@@ -18,6 +22,27 @@ case "$TIMESYNC" in
 				fi
 				i=\$(( \$i + 1 ))
 				sleep 1
+			done
+		EOF
+		;;
+	CHRONY)
+		PROGS=( "${PROGS[@]}" chronyd )
+		COPY_AS_IS=( "${COPY_AS_IS[@]}" "/etc/chrony*" "/var/lib/chrony" )
+		cat >$ROOTFS_DIR/etc/scripts/system-setup.d/90-timesync.sh <<-EOF
+			echo "Setting system time via CHRONY ..."
+			# Older chronyd does not have a timeout parameter.  Newer ones can be set to timeout with '-t <sec>'.
+			# Must run as root since we don't have a "chrony" account.  Besides, we don't run chronyd long enough to drop privs.
+			chronyd -q -u root &
+			chronyd_pid=\$!
+			i=0
+			while kill -0 \$chronyd_pid 2>/dev/null; do
+			 	if [[ \$i -ge 10 ]]; then
+			 		echo "Gave up on CHRONY after 10 seconds."
+			 		kill \$chronyd_pid
+			 		break
+			 	fi
+			 	i=\$(( \$i + 1 ))
+			 	sleep 1
 			done
 		EOF
 		;;

--- a/usr/share/rear/rescue/default/430_prepare_timesync.sh
+++ b/usr/share/rear/rescue/default/430_prepare_timesync.sh
@@ -52,7 +52,7 @@ case "$TIMESYNC" in
 		PROGS=( "${PROGS[@]}" rdate )
 		cat >$ROOTFS_DIR/etc/scripts/system-setup.d/90-timesync.sh <<-EOF
 			echo "Setting system time via RDATE ..."
-			rdate -s "$TIMESYNC_SOURCE" # allow for big jumps
+			rdate -l -p -s "$TIMESYNC_SOURCE" # allow for big jumps
 		EOF
 
 		;;


### PR DESCRIPTION
##### Pull Request Details:

* Type:  **Enhancement** 

* Impact: **Low** 

* Reference to related issue (URL): 

#1622 and #1623

* How was this pull request tested? 

Created CentOS 6 (init-based) and CentOS 7 (systemd-based) VMs in Virtualbox and tested rescue ISOs for all 4 TIMESYNC options on both systems.

* Brief description of the changes in this pull request:

Added chrony support so that newer systems that ship with chrony vs ntp, like RHEL/CentOS 7, are able to sync system time during rescue/restore.

430_prepare_timesync.sh will also not update ROOTFS_DIR/etc/inittab if the system is systemd-based.

While I was here, I updated the options for rdate to include -l (use syslog) and -p (print remote system time) so that rdate output is as close to the other 3 TIMESYNC options.