### PR TITLE
use grub2-install --no-nvram on PowerNV system

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
@@ -51,6 +51,7 @@ if [[ -r "$LAYOUT_FILE" ]]; then
 
             # Do not update nvram when system is running in PowerNV mode (BareMetal).
             # grub2-install will failed if not run with the --no-nvram option on a PowerNV system.
+            # see https://github.com/rear/rear/pull/1742
             if [[ $(awk '/platform/ {print $NF}' < /proc/cpuinfo) == PowerNV ]] ; then
                 grub2_install_option="--no-nvram"
             fi

--- a/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
@@ -48,9 +48,16 @@ if [[ -r "$LAYOUT_FILE" ]]; then
         if [ -n "$part" ]; then
             LogPrint "Boot partition found: $part"
             dd if=/dev/zero of=$part
+
+            # Do not update nvram when system is running in PowerNV mode (BareMetal).
+            # grub2-install will failed if not run with the --no-nvram option on a PowerNV system.
+            if [[ $(awk '/platform/ {print $NF}' < /proc/cpuinfo) == PowerNV ]] ; then
+                grub2_install_option="--no-nvram"
+            fi
+
             # Run grub-install/grub2-install directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
             # When software RAID1 is used, grub2 needs correct PATH to access other tools
-            if chroot $TARGET_FS_ROOT /usr/bin/env PATH=/sbin:/usr/sbin:/usr/bin:/bin $grub_name-install $part ; then
+            if chroot $TARGET_FS_ROOT /usr/bin/env PATH=/sbin:/usr/sbin:/usr/bin:/bin $grub_name-install $grub2_install_option $part ; then
                 LogPrint "GRUB2 installed on $part"
                 NOBOOTLOADER=
             else


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):  https://github.com/rear/rear/issues/1710
https://www.suse.com/fr-fr/support/update/announcement/2017/suse-ru-20170617-1/

* How was this pull request tested?
Tested on RHEL 7 BareMetal (PowerNV) [ReaR Backup + restore with NFS+PXE]
Tested on RHEL 7 KVM Guest for non-regression test [ReaR Backup + restore with NFS+PXE]
Tested on RHEL 7 LPAR (PowerVM) for non-regression test [ReaR Backup + restore with NFS+PXE]

* Brief description of the changes in this pull request:
**Problem description:** grub2-install failed on PowerNV (BareMetal System).
grub2-install for power (ppc64le) always try to update firmware boot order during grub2-install by using `ofpathname` command. Unfortunatly, this `ofpathname` command is not supported on BareMetal system (PowerNV). (https://www.suse.com/fr-fr/support/update/announcement/2017/suse-ru-20170617-1/).  
Using `--no-nvram` grub2-install option is a workaround for PowerNV system.
