### PR TITLE
Add dbus user and group by default

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -273,6 +273,6 @@ COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" '/etc/pki/tls/private' '/etc/pki
 # some stuff for the Linux command line
 KERNEL_CMDLINE="$KERNEL_CMDLINE selinux=0"
 # common users and groups
-CLONE_USERS=( "${CLONE_USERS[@]:-}" daemon rpc usbmuxd usbmux vcsa nobody)
-CLONE_GROUPS=( "${CLONE_GROUPS[@]:-}" tty usbmuxd usbmux fuse kvm oinstall )
+CLONE_USERS=( "${CLONE_USERS[@]:-}" daemon rpc usbmuxd usbmux vcsa nobody dbus )
+CLONE_GROUPS=( "${CLONE_GROUPS[@]:-}" tty usbmuxd usbmux fuse kvm oinstall dbus )
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): https://github.com/rear/rear/issues/1710

* How was this pull request tested? 
Tested on RHEL 7 BareMetal (PowerNV) [ReaR Backup + restore with NFS+PXE]
Tested on RHEL 7 KVM Guest for non-regression test [ReaR Backup + restore with NFS+PXE]
Tested on RHEL 7 LPAR (PowerVM) for non-regression test [ReaR Backup + restore with NFS+PXE]

* Brief description of the changes in this pull request:
Add by default dbus user and group in the rescue image.
dbus is used by systemd to startup some services (like serial console detection) 
