### PR TITLE
Add gsk libs to TSM_LD_LIBRARY_PATH

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1189,7 +1189,8 @@ COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
 COPY_AS_IS_EXCLUDE_TSM=( )
 PROGS_TSM=(dsmc)
 # TSM library PATH that need to be added to LD_LIBRARY_PATH.
-TSM_LD_LIBRARY_PATH="/opt/tivoli/tsm/client/ba/bin:/opt/tivoli/tsm/client/api/bin64:/opt/tivoli/tsm/client/api/bin:/opt/tivoli/tsm/client/api/bin64/cit/bin:/usr/local/ibm/gsk8/lib64"
+# gsk lib PATH are detected and automatically added by usr/share/rear/prep/TSM/default/400_prep_tsm.sh
+TSM_LD_LIBRARY_PATH="/opt/tivoli/tsm/client/ba/bin:/opt/tivoli/tsm/client/api/bin64:/opt/tivoli/tsm/client/api/bin:/opt/tivoli/tsm/client/api/bin64/cit/bin"
 # where to copy the resulting files to and save them with TSM
 TSM_RESULT_FILE_PATH=/opt/tivoli/tsm/rear
 #

--- a/usr/share/rear/prep/TSM/default/400_prep_tsm.sh
+++ b/usr/share/rear/prep/TSM/default/400_prep_tsm.sh
@@ -13,6 +13,6 @@ PROGS=( "${PROGS[@]}" "${PROGS_TSM[@]}" )
 
 # Find gsk lib diriectory and add it to the TSM_LD_LIBRARY_PATH
 # see issue https://github.com/rear/rear/issues/1688
-for gsk_dir in $(ls -d /usr/local/ibm/gsk*/bin* /usr/local/ibm/gsk*/lib* ) ; do
+for gsk_dir in $(ls -d /usr/local/ibm/gsk*/lib* ) ; do
 	TSM_LD_LIBRARY_PATH=$TSM_LD_LIBRARY_PATH:$gsk_dir
 done

--- a/usr/share/rear/prep/TSM/default/400_prep_tsm.sh
+++ b/usr/share/rear/prep/TSM/default/400_prep_tsm.sh
@@ -10,3 +10,9 @@ COPY_AS_IS=( "${COPY_AS_IS[@]}" "${COPY_AS_IS_TSM[@]}"
 	)
 COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" "${COPY_AS_IS_EXCLUDE_TSM[@]}" )
 PROGS=( "${PROGS[@]}" "${PROGS_TSM[@]}" )
+
+# Find gsk lib diriectory and add it to the TSM_LD_LIBRARY_PATH
+# see issue https://github.com/rear/rear/issues/1688
+for gsk_dir in $(ls -d /usr/local/ibm/gsk*/bin* /usr/local/ibm/gsk*/lib* ) ; do
+	TSM_LD_LIBRARY_PATH=$TSM_LD_LIBRARY_PATH:$gsk_dir
+done


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/1688

* How was this pull request tested?
tested on RHEL7.4 ppc64le with TSM 8.1

* Brief description of the changes in this pull request:
detect gsk lib PATH and add it into `TSM_LD_LIBRARY_PATH` (in `usr/share/rear/prep/TSM/default/400_prep_tsm.sh`)
