### PR TITLE
Run exit tasks code with default bash flags and options (issues #700 and #1747)

### DIFF
--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -88,6 +88,15 @@ function descendants_pids () {
 
 # Do all exit tasks:
 function DoExitTasks () {
+    # First of all restore the ReaR default bash flags and options (see usr/sbin/rear)
+    # because otherwise in case of a bash error exit when e.g. "set -e -u -o pipefail" was set
+    # all the exit tasks related code would also run with "set -e -u -o pipefail" still set
+    # which may abort exit tasks related code anywhere with a "sudden death" bash error exit
+    # where in particular no longer the EXIT_FAIL_MESSAGE (cf. below) would be shown
+    # so that for the user ReaR would "just somehow silently abort" in this case
+    # cf. https://github.com/rear/rear/issues/1747#issuecomment-371055121
+    # and https://github.com/rear/rear/issues/700#issuecomment-327755633
+    apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"
     LogPrint "Exiting $PROGRAM $WORKFLOW (PID $MASTER_PID) and its descendant processes"
     # First of all wait one second to let descendant processes terminate on their own
     # e.g. after Ctrl+C by the user descendant processes should terminate on their own


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1747#issuecomment-371055121
https://github.com/rear/rear/issues/700#issuecomment-327755633

* How was this pull request tested?
In usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
use an unbound variable for testing e.g. as follows
<pre>
set -e -u -o pipefail
echo "$DOESNOTEXIST"
</pre>
which lets that script abort.
Without the fix it looks during "rear recover"
<pre>
RESCUE d57:~ # rear -D recover
...
Confirm or edit the disk mapping
1) Confirm disk mapping and continue 'rear recover'
2) Edit disk mapping (/var/lib/rear/layout/disk_mappings)
3) Use Relax-and-Recover shell and return back to here
4) Abort 'rear recover'
(default '1' timeout 300 seconds)

UserInput: No real user input (empty or only spaces) - using default input
UserInput: Valid choice number result 'Confirm disk mapping and continue 'rear recover''
User confirmed disk mapping
Exiting rear recover (PID 851) and its descendant processes
RESCUE d57:~ #
</pre>
With the fix it looks during "rear recover"
<pre>
RESCUE d57:~ # rear -D recover
...
Confirm or edit the disk mapping
1) Confirm disk mapping and continue 'rear recover'
2) Edit disk mapping (/var/lib/rear/layout/disk_mappings)
3) Use Relax-and-Recover shell and return back to here
4) Abort 'rear recover'
(default '1' timeout 300 seconds)

UserInput: No real user input (empty or only spaces) - using default input
UserInput: Valid choice number result 'Confirm disk mapping and continue 'rear recover''
User confirmed disk mapping
Exiting rear recover (PID 871) and its descendant processes
Running exit tasks
rear recover failed, check /var/log/rear/rear-d57.log for details
RESCUE d57:~ #
</pre>

* Brief description of the changes in this pull request:
In the DoExitTasks() function first of all restore the ReaR default bash flags and options
because otherwise in case of a bash error exit when e.g. "set -e -u -o pipefail" was set
all the exit tasks related code would also run with "set -e -u -o pipefail" still set
which may abort exit tasks related code anywhere with a "sudden death" bash error exit
where in particular no longer the EXIT_FAIL_MESSAGE would be shown
so that for the user ReaR would "just somehow silently abort" in this case.
