### PR TITLE
Fixed invalid reported return code (always 0) upon NBU restoration failure

### DIFF
--- a/usr/share/rear/restore/NBU/default/400_restore_with_nbu.sh
+++ b/usr/share/rear/restore/NBU/default/400_restore_with_nbu.sh
@@ -18,7 +18,8 @@ fi
 LogPrint "RUN: /usr/openv/netbackup/bin/bprestore $bprestore_args"
 LogPrint "Restore progress: see $TMP_DIR/bplog.restore"
 LANG=C /usr/openv/netbackup/bin/bprestore $bprestore_args
-if (( $? > 1 )) ; then
-    Error "bprestore failed (return code = $?)"
+rc=$?
+if (( $rc > 1 )) ; then
+    Error "bprestore failed (return code = $rc)"
 fi
 


### PR DESCRIPTION
When NetBackup restoration fails, the error code printed was always `0`, due to a bad use of the `$?` variable.