### PR TITLE
Replace pstree by ps command (issue#1755)

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -77,6 +77,7 @@ uname
 sleep
 logger
 ps
+pstree
 ln
 dirname
 basename


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1755

* How was this pull request tested?
On my SLES11 and SLES12 systems.

* Brief description of the changes in this pull request:
Show descendant processes PIDs with their commands in the log
so that later the plain PIDs in the log get more comprehensible.
What works sufficiently on all systems is "pstree -Aplau $MASTER_PID"
but the pstree command is not available in the ReaR recovery system
so that the ps command is used as fallback.
