### PR TITLE
exclude docker FS from layout #1749

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -49,16 +49,17 @@ fi
 # The sorting relies on that mount and findmnt output the first mounted thing first
 # so that in particular what is mounted at '/' is output before other stuff.
 read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
+
+# docker daemon mounts file systems for its docker containers
+# see also https://docs.docker.com/storage/storagedriver/device-mapper-driver/#configure-direct-lvm-mode-for-production
+# As it is for container usage only we do not to backup these up or recreate as this disk device is completely under
+# control by docker itself (even the recreation of it incl, the creation of the volume group). Usually this is
+# done via a kind of cookbook (Chef, puppet or ansible)
+docker_is_running=""
+service docker status >/dev/null 2>&1 && docker_is_running="yes"
+
 # Begin writing output to DISKLAYOUT_FILE:
 (
-    # docker daemon mounts file systems for its docker containers
-    # see also https://docs.docker.com/storage/storagedriver/device-mapper-driver/#configure-direct-lvm-mode-for-production
-    # As it is for container usage only we do not to backup these up or recreate as this disk device is completely under
-    # control by docker itself (even the recreation of it incl, the creation of the volume group). Usually this is
-    # done via a kind of cookbook (Chef, puppet or ansible)
-    docker_is_running=""
-    service docker status >/dev/null 2>&1 && docker_is_running="yes"
-    #
     echo "# Filesystems (only $supported_filesystems are supported)."
     echo "# Format: fs <device> <mountpoint> <fstype> [uuid=<uuid>] [label=<label>] [<attributes>]"
     # Read the output of the read_filesystems_command:

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -79,6 +79,14 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
             Log "$device is CD/DVD type device [fstype=$fstype], skipping."
             continue
         fi
+        # docker specific exclude part
+        if service docker status >/dev/null 2>&1  ; then
+            # docker daemon/service is running
+            docker_root_dir=$( docker info 2>/dev/null | grep 'Docker Root Dir' | awk '{print $4}' )
+            # if $docker_root_dir is the begining of the $mountpoint then FS is under docker control
+            # and we better exclude from saving the layout
+            echo "$mountpoint" | grep -q "^$docker_root_dir" && continue
+        fi
         # Replace a symbolic link /dev/disk/by-uuid/a1b2c3 -> ../../sdXn
         # by the fully canonicalized target of the link e.g. /dev/sdXn
         if [[ $device == /dev/disk/by-uuid* ]]; then


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/1749

* How was this pull request tested? on AWS docker system

* Brief description of the changes in this pull request: The file systems used by the docker images should not be saved in the `diskalyout.conf` file

