### PR TITLE
Update 270_hpraid_layout.sh

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/270_hpraid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/270_hpraid_layout.sh
@@ -12,7 +12,7 @@ fi
 # Add $HPSSACLI to the rescue image
 PROGS=( "${PROGS[@]}" $HPSSACLI )
 eval $(grep ON_DIR= $(get_path $HPSSACLI))
-COPY_AS_IS=( "${COPY_AS_IS[@]}" "$HPACUCLI_BIN_INSTALLATION_DIR"  "$HPSSACLI_BIN_INSTALLATION_DIR" )
+COPY_AS_IS=( "${COPY_AS_IS[@]}" "$HPACUCLI_BIN_INSTALLATION_DIR" "$HPSSACLI_BIN_INSTALLATION_DIR" "$SSACLI_BIN_INSTALLATION_DIR")
 
 # determine the version of HPSSACLI - required to know for a bug with version '9.30.15' (see issue #455)
 HPSSACLI_VERSION=$( get_version $HPSSACLI version )


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested?
Tested with ReaR 2.3 under RHEL7.4 on a HP DL360 Gen9 with SPP 2017.10 installed.

* Brief description of the changes in this pull request:
This change is required because in HP's SPP (Service Pack for Proliant) the hpacucli/hpssacli is now (recognised with Version 3.10) called "ssacli" and the installation directory's name has been renamed as well.
