### PR TITLE
Update hp_raid-functions.sh and 270_hpraid_layout.sh

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/270_hpraid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/270_hpraid_layout.sh
@@ -12,7 +12,7 @@ fi
 # Add $HPSSACLI to the rescue image
 PROGS=( "${PROGS[@]}" $HPSSACLI )
 eval $(grep ON_DIR= $(get_path $HPSSACLI))
-COPY_AS_IS=( "${COPY_AS_IS[@]}" "$HPACUCLI_BIN_INSTALLATION_DIR"  "$HPSSACLI_BIN_INSTALLATION_DIR" )
+COPY_AS_IS=( "${COPY_AS_IS[@]}" "$HPACUCLI_BIN_INSTALLATION_DIR" "$HPSSACLI_BIN_INSTALLATION_DIR" "$HPSSACLI_BIN_INSTALLATION_DIR")
 
 # determine the version of HPSSACLI - required to know for a bug with version '9.30.15' (see issue #455)
 HPSSACLI_VERSION=$( get_version $HPSSACLI version )

--- a/usr/share/rear/layout/save/GNU/Linux/270_hpraid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/270_hpraid_layout.sh
@@ -11,6 +11,14 @@ fi
 
 # Add $HPSSACLI to the rescue image
 PROGS=( "${PROGS[@]}" $HPSSACLI )
+# How the "eval $(grep ON_DIR= $(get_path $HPSSACLI))" command works:
+# Prerequisit: $HPSSACLI (e.g. /sbin/ssacli) is a shell script.
+# That $HPSSACLI script contains a command (e.g. in case of /sbin/ssacli) like
+#   export SSACLI_BIN_INSTALLATION_DIR=/opt/smartstorageadmin/ssacli/bin/
+# This command is searched for with "grep ON_DIR="
+# executed with eval so that the variable therein gets set
+# which is finally used/evaluated in the COPY_AS_IS array setting
+# cf. https://github.com/rear/rear/pull/1759#discussion_r175835287
 eval $(grep ON_DIR= $(get_path $HPSSACLI))
 COPY_AS_IS=( "${COPY_AS_IS[@]}" "$HPACUCLI_BIN_INSTALLATION_DIR" "$HPSSACLI_BIN_INSTALLATION_DIR" "$HPSSACLI_BIN_INSTALLATION_DIR")
 

--- a/usr/share/rear/layout/save/GNU/Linux/270_hpraid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/270_hpraid_layout.sh
@@ -20,7 +20,7 @@ PROGS=( "${PROGS[@]}" $HPSSACLI )
 # which is finally used/evaluated in the COPY_AS_IS array setting
 # cf. https://github.com/rear/rear/pull/1759#discussion_r175835287
 eval $(grep ON_DIR= $(get_path $HPSSACLI))
-COPY_AS_IS=( "${COPY_AS_IS[@]}" "$HPACUCLI_BIN_INSTALLATION_DIR" "$HPSSACLI_BIN_INSTALLATION_DIR" "$HPSSACLI_BIN_INSTALLATION_DIR")
+COPY_AS_IS=( "${COPY_AS_IS[@]}" "$HPACUCLI_BIN_INSTALLATION_DIR" "$HPSSACLI_BIN_INSTALLATION_DIR" "$SSACLI_BIN_INSTALLATION_DIR")
 
 # determine the version of HPSSACLI - required to know for a bug with version '9.30.15' (see issue #455)
 HPSSACLI_VERSION=$( get_version $HPSSACLI version )

--- a/usr/share/rear/lib/hp_raid-functions.sh
+++ b/usr/share/rear/lib/hp_raid-functions.sh
@@ -4,11 +4,13 @@
 #
 
 function define_HPSSACLI() {
-    # HP Smart Storage Administrator CLI is either hpacucli or hpssacli
+    # HP Smart Storage Administrator CLI is either hpacucli, hpssacli or ssacli
     if has_binary hpacucli ; then
         HPSSACLI=hpacucli
     elif has_binary hpssacli ; then
         HPSSACLI=hpssacli
+    elif has_binary ssacli ; then
+        HPSSACLI=ssacli
     fi
 }
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested?
Tested with ReaR 2.3 under RHEL7.4 on a HP DL360 Gen9 with SPP 2017.10 installed.

* Brief description of the changes in this pull request:
This change is required because in HP's SPP (Service Pack for Proliant) the hpacucli/hpssacli is now (recognised with Version 3.10) called "ssacli" and the installation directory's name has been renamed as well.