### PR TITLE
Fix partition replacement

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -83,6 +83,12 @@ blacklist {
         esac
     done
 
+    # start multipathd
+    if has_binary multipathd &> /dev/null ; then
+        LogPrint "Starting multipath daemon"
+        multipathd >&2 && LogPrint "multipathd started" || LogPrint "Failed to start multipathd"
+    fi
+
     # Search and list mpath device.
     if is_true $list_mpath_device ; then
         LogPrint "Listing multipath device found"

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -703,6 +703,8 @@ function get_part_device_name_format() {
             case $OS_MASTER_VENDOR in
 
                 (SUSE)
+                    # No need to check if user_friendly_names is activated or not as Suse always apply the same naming convention. 
+
                     # SUSE Linux SLE12 put a "-part" between [mpath device name] and [part number].
                     # For example /dev/mapper/3600507680c82004cf8000000000000d8-part1.
                     # But SLES11 uses a "_part" instead. (Let's assume it is the same for SLES10 )

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -681,8 +681,10 @@ function get_part_device_name_format() {
             ;;
         (*mapper[/!]*)
 
-            # check if multipath if using the "user_friendly_names" by default in the current configuration.
-            user_friendly_names=$(echo "show config" | multipathd -k | awk '/user_friendly_names/ { gsub("\"","") ; print $2 }' | head -n 1 )
+            if multipathd ; then
+                # check if multipath if using the "user_friendly_names" by default in the current configuration.
+                user_friendly_names=$(echo "show config" | multipathd -k | awk '/user_friendly_names/ { gsub("\"","") ; print $2 }' | head -n 1 )
+            fi
 
             case $OS_MASTER_VENDOR in
 
@@ -700,31 +702,41 @@ function get_part_device_name_format() {
                 ;;
 
                 (Fedora)
-                    # RHEL 7 and above seems to named partitions on multipathed devices with
-                    # [mpath device UUID/WWID] + p + [part number] when "user_friendly_names"
-                    # option is FALSE. 
-                    # For example: /dev/mapper/3600507680c82004cf8000000000000d8p1
                     if is_false "$user_friendly_names" ; then
+                        # RHEL 7 and above seems to named partitions on multipathed devices with
+                        # [mpath device UUID/WWID] + p + [part number] when "user_friendly_names"
+                        # option is FALSE. 
+                        # For example: /dev/mapper/3600507680c82004cf8000000000000d8p1
                         part_name="${device_name}p" # append p between main device and partitions
-                    fi
-
-                    # RHEL 7 and above seems to named partitions on multipathed devices with
-                    # [mpath device name] + [part number] like standard disk when "user_friendly_names"
-                    # option is used (default).
-                    # For example: /dev/mapper/mpatha1
-                    
-                    # But the scheme in RHEL 6 need a "p" between [mpath device name] and [part number].
-                    # For exemple: /dev/mapper/mpathap1
-                    if (( $OS_MASTER_VERSION < 7 )) ; then
-                        part_name="${device_name}p" # append p between main device and partitions
+                    else
+                        # RHEL 7 and above seems to named partitions on multipathed devices with
+                        # [mpath device name] + [part number] like standard disk when "user_friendly_names"
+                        # option is used (default).
+                        # For example: /dev/mapper/mpatha1
+                        
+                        # But the scheme in RHEL 6 need a "p" between [mpath device name] and [part number].
+                        # For exemple: /dev/mapper/mpathap1
+                        if (( $OS_MASTER_VERSION < 7 )) ; then
+                            part_name="${device_name}p" # append p between main device and partitions
+                        else
+                            part_name="${device_name}"
+                        fi
                     fi
                 ;;
 
                 (Debian)
-                    # Ubuntu 16.04 (need to check for other version) named muiltipathed partitions with
-                    # [mpath device name] + "-part" + [part number]
-                    # for example : /dev/mapper/mpatha-part1
-                    part_name="${device_name}-part" # append -part between main device and partitions
+                    if is_false "$user_friendly_names" ; then
+                        # Exceptional case for Debian/ubuntu
+                        # When user_friendly_names is disable, debian based system will name partition 
+                        # [mpath device UUID/WWID] + p + [part number]
+                        part_name="${device_name}p"
+                    else
+                        # Default case (user_friendly_name enable)
+                        # Ubuntu 16.04 (need to check for other version) named muiltipathed partitions with
+                        # [mpath device name] + "-part" + [part number]
+                        # for example : /dev/mapper/mpatha-part1
+                        part_name="${device_name}-part" # append -part between main device and partitions
+                    fi
                 ;;
 
                 (*)

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -780,9 +780,9 @@ function apply_layout_mappings() {
 
     # Replace all originals with their replacements.
     while read original replacement junk ; do
-        # Replace partitions (we normalize cciss/c0d0p1 to _REAR5_1)
-        part_base=$(get_part_device_name_format "$original")
-        sed -i -r "\|$original|s|${part_base}([0-9]+)|$replacement\1|g" "$file_to_migrate"
+        # Replace partitions with uniq replacement PATTERN (we normalize cciss/c0d0p1 to _REAR5_1)
+        # Due to multipath partion naming complexity, all known partition naming type (mpatha1,mpathap1,mpatha-part1,mpatha_part1) will be replaced by _REAR"X"_1 
+        sed -i -r "\|$original|s|$original(p)*([-_]part)*([0-9]+)|$replacement\3|g" "$file_to_migrate"
 
         # Replace whole devices
         ### note that / is a word boundary, so is matched by \<, hence the extra /

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -680,7 +680,21 @@ function get_part_device_name_format() {
             part_name="${device_name}p" # append p between main device and partitions
             ;;
         (*mapper[/!]*)
+            # Every Linux distribution / version has their own rule to name the multipthed partion device.
+            # 
+            # Suse:
+            #     Version <12 : always <device>_part<part_num> (same with/without user_friendly_names)
+            #     Version >=12 : always <device>-part<part_num> (same with/without user_friendly_names)
+            #     Question still open for sles10 ...
+            # RedHat:
+            #     Version <7 : always <device>p<part_num> (same with/without user_friendly_names)
+            #     Version >=7 : if user_friendly_names (default) <device><part_num> else <device>p<part_num>
+            # Debian:
+            #     if user_firendly_names (default) <device>-part<part_num>
+            #     if NOT user_firendly_names <device>p<part_num>
+            # 
 
+            # First we need to know if user_friendly_names is activated (for Fedora/RedHat and Debian/ubuntu)
             if multipathd ; then
                 # check if multipath if using the "user_friendly_names" by default in the current configuration.
                 user_friendly_names=$(echo "show config" | multipathd -k | awk '/user_friendly_names/ { gsub("\"","") ; print $2 }' | head -n 1 )


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact:  **Normal**

* Reference to related issue (URL):

* How was this pull request tested?
Tested in PowerVM environment, with RHEL7.4, with a disk Migration.

* Brief description of the changes in this pull request:
RedHat use to add **no** prefix between multipath device name a partition number (ex: `/dev/mapper/mpatha1"). In that case, multipath option `user_friendly_name` is activated (which is RedHat default).
When `user_friendly_name` is disabled, RedHat adds a **"p"** prefix between multipath device name (WWID in that case) and partition number. (ex: `/dev/mapper/3600507680c82004cf8000000000000d8p1`).

I propose the following:
- During the 1st replacement change, replace **ALL** known partition naming variant by **_REARX_**.
(/dev/mapper/mpatha1, /dev/mapper/mpathap1, /dev/mapper/maptha-part1, /dev/mapper/maptha_part1) will by _REAR1_1

- During the 2nd replacement, check if the current system is a Redhat with "user_friendly_name" deactivated, recreate the partition device by adding "p" between device name and partition number.

=> This will solve the issue when a user is using a RedHat with "user_friendly_name" deactivated.
And avoid a problem during a migration when a user wants to switch "user_friendly_name" during the restoration phase.
