### PR TITLE
Also include other keyboard mappings to support non-US keyboards

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1103,16 +1103,33 @@ COPY_AS_IS_EXCLUDE=( dev/shm dev/shm/\* dev/oracleasm dev/mapper dev/.udev $VAR_
 # At least on SUSE systems /usr/share/kbd/keymaps is the default directory for keymaps
 # which is used by default (i.e. when KEYMAPS_DEFAULT_DIRECTORY is not set or empty):
 KEYMAPS_DEFAULT_DIRECTORY=""
-# KEYMAPS_DIRECTORIES is a string of directories for keyboard mapping files
-# that should get included in the recovery system, for example like
-# KEYMAPS_DIRECTORIES="/usr/share/kbd/keymaps/legacy /usr/share/kbd/keymaps/xkb"
-# to also support non-US keyboards because without the right keyboard mapping
+# KEYMAPS_DIRECTORIES is a string of directories that contain keyboard mapping files
+# or plain keyboard mapping files to be included in the recovery system, for example like
+# KEYMAPS_DIRECTORIES="/usr/share/kbd/keymaps/legacy /usr/src/linux/drivers/char/defkeymap.map"
+# The main intent is to support non-US keyboards because without a right keyboard mapping
 # it could become an awful annoyance to work in the recovery system.
 # When KEYMAPS_DIRECTORIES is specified it is not sufficient to include
 # e.g. only a '/usr/share/kbd/keymaps/legacy/i386/' sub-directory because
-# the include files in '/usr/share/kbd/keymaps/legacy/include/' are also needed
-# so that by default (i.e. when KEYMAPS_DIRECTORIES is not set or empty)
-# the whole KEYMAPS_DEFAULT_DIRECTORY is included to be on the safe side:
+# include files in '/usr/share/kbd/keymaps/legacy/include/' are also needed.
+# For example to find out what 'loadkeys de-latin1-nodeadkeys' needs one may run
+# "strace -f -e open loadkeys de-latin1-nodeadkeys" and inspect its output
+# which keymap files are used which results e.g. on openSUSE Leap 42.3 those files:
+#   /usr/share/kbd/keymaps/legacy/i386/qwertz/de-latin1-nodeadkeys.map.gz
+#   /usr/share/kbd/keymaps/legacy/i386/qwertz/de-latin1.map.gz
+#   /usr/share/kbd/keymaps/legacy/i386/include/qwertz-layout.inc
+#   /usr/share/kbd/keymaps/legacy/i386/include/compose.inc
+#   /usr/share/kbd/keymaps/legacy/i386/include/linux-with-alt-and-altgr.inc
+#   /usr/share/kbd/keymaps/legacy/i386/include/linux-keys-bare.inc
+#   /usr/share/kbd/keymaps/legacy/i386/include/euro2.map.gz
+#   /usr/share/kbd/keymaps/legacy/include/compose.latin1
+# cf. https://github.com/rear/rear/pull/1781#issuecomment-384574103
+# Specifying those files in KEYMAPS_DIRECTORIES results a minimal recovery system
+# that contains only what is needed to use the de-latin1-nodeadkeys keyboard mapping.
+# In some cases (e.g. on ppc64 with the yaboot bootloader) a minimal recovery system
+# is required (cf. the section about REAR_INITRD_COMPRESSION below).
+# By default (i.e. when KEYMAPS_DIRECTORIES is not set or empty)
+# the whole KEYMAPS_DEFAULT_DIRECTORY is included to be on the safe side and
+# to get a recovery system that can be used with various usual keyboards:
 KEYMAPS_DIRECTORIES=""
 # KEYMAP is a keymap file to be set via 'loadkeys $KEYMAP' in the recovery system
 # to specify the exact keymap that should be set and used for example like:

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1097,6 +1097,37 @@ COPY_AS_IS=( $SHARE_DIR $VAR_DIR )
 # Copying the content of this directory makes ReaR avoid the migration process.
 COPY_AS_IS_EXCLUDE=( dev/shm dev/shm/\* dev/oracleasm dev/mapper dev/.udev $VAR_DIR/output/\* )
 
+# Including and setting keyboard mappings in the ReaR recovery system,
+# cf. https://github.com/rear/rear/pull/1781
+# KEYMAPS_DEFAULT_DIRECTORY specifies the default directory for keyboard mapping files.
+# At least on SUSE systems /usr/share/kbd/keymaps is the default directory for keymaps
+# which is used by default (i.e. when KEYMAPS_DEFAULT_DIRECTORY is not set or empty):
+KEYMAPS_DEFAULT_DIRECTORY=""
+# KEYMAPS_DIRECTORIES is a string of directories for keyboard mapping files
+# that should get included in the recovery system, for example like
+# KEYMAPS_DIRECTORIES="/usr/share/kbd/keymaps/legacy /usr/share/kbd/keymaps/xkb"
+# to also support non-US keyboards because without the right keyboard mapping
+# it could become an awful annoyance to work in the recovery system.
+# When KEYMAPS_DIRECTORIES is specified it is not sufficient to include
+# e.g. only a '/usr/share/kbd/keymaps/legacy/i386/' sub-directory because
+# the include files in '/usr/share/kbd/keymaps/legacy/include/' are also needed
+# so that by default (i.e. when KEYMAPS_DIRECTORIES is not set or empty)
+# the whole KEYMAPS_DEFAULT_DIRECTORY is included to be on the safe side:
+KEYMAPS_DIRECTORIES=""
+# KEYMAP is a keymap file to be set via 'loadkeys $KEYMAP' in the recovery system
+# to specify the exact keymap that should be set and used for example like:
+# KEYMAP="de-latin1-nodeadkeys"
+# During recovery system startup with topmost priority it tries to set
+# what is specified as KEYMAP but that may fail when needed keymap files
+# are missing in the recovery system (e.g. include files, see above).
+# With second priority it tries to set the keymap of the original system
+# which was dumped during "rear mkrescue/mkbackup", for details
+# see the rescue/GNU/Linux/500_clone_keyboard_mappings.sh script.
+# As fallback it tries to set the default 'defkeymap' (US keyboad) keymap.
+# Be default (i.e. when KEYMAP is not set or empty) the keymap of the original system
+# while "rear mkrescue/mkbackup" was run is also used in the recovery system:
+KEYMAP=""
+
 # Users and groups to copy into the ReaR recovery system.
 # Users and groups must exist in the original system (i.e. one cannot create new ones).
 # Specified users and groups that do not exist in the original system are ignored.

--- a/usr/share/rear/rescue/GNU/Linux/500_clone_keyboard_mappings.sh
+++ b/usr/share/rear/rescue/GNU/Linux/500_clone_keyboard_mappings.sh
@@ -1,6 +1,25 @@
-# Dump current keyboard mappings to default
+
+# Dump current keyboard mapping to etc/dumpkeys.out so that it can be set during recovery system startup
+# by etc/scripts/system-setup.d/10-console-setup.sh via "loadkeys /etc/dumpkeys.out"
+# but depending on the keyboard mapping the "loadkeys /etc/dumpkeys.out" command
+# may not work in the recovery system so that some other keyboard mapping files
+# are also included so that the user can manually set his keyboard mapping:
 dumpkeys -f1 >$ROOTFS_DIR/etc/dumpkeys.out
 
-# Also include the US keyboard mappings
-# Adding RHEL, SLES and Ubuntu qwerty flavours
-COPY_AS_IS=( "${COPY_AS_IS[@]}" /lib/k?d/keymaps/i386/qwerty/defkeymap.map.gz /usr/share/k?d/keymaps/i386/qwerty/defkeymap.map.gz /usr/share/ke?maps/i386/qwerty/defkeymap.map.gz )
+# At least include the default US keyboard mapping:
+defkeymap_file="$( find /usr/share/kbd/keymaps -name 'defkeymap.*' | head -n1 )"
+if test $defkeymap_file ; then
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" $defkeymap_file )
+else
+    # If no defkeymap file was found in /usr/share/kbd/keymaps try some RHEL, SLES and Ubuntu qwerty flavours.
+    # The funny ? makes 'shopt -s nullglob' remove this file from the list if it does not exist:
+    COPY_AS_IS=( "${COPY_AS_IS[@]}" /lib/k?d/keymaps/i386/qwerty/defkeymap.map.gz /usr/share/k?d/keymaps/i386/qwerty/defkeymap.map.gz /usr/share/ke?maps/i386/qwerty/defkeymap.map.gz )
+fi
+
+# Additionally include the legacy keyboard mappings to also support users with a non-US keyboard
+# who can then manually switch to their keyboard mapping (e.g. via a command like "loadkeys de-latin1").
+# It is not sufficient to include only map.gz or only i386 files because all the include files are also needed.
+# This increases the recovery system size by about 1 MB (an usual recovery system size is about 500 MB uncompressed)
+# but without the right keyboard mapping it could become an awful annoyance to work in the recovery system:
+test -d /usr/share/kbd/keymaps/legacy && COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/kbd/keymaps/legacy )
+

--- a/usr/share/rear/rescue/GNU/Linux/500_clone_keyboard_mappings.sh
+++ b/usr/share/rear/rescue/GNU/Linux/500_clone_keyboard_mappings.sh
@@ -4,25 +4,42 @@
 local original_system_dumpkeys_file="/etc/dumpkeys.out"
 dumpkeys -f >$ROOTFS_DIR$original_system_dumpkeys_file
 
-# At least on SUSE systems /usr/share/kbd/keymaps is the default directory for keymaps:
-local keymaps_default_directory="/usr/share/kbd/keymaps"
-
+# Determine the default directory for keymaps:
+# Different Linux distributions use a different default directory for keymaps,
+# see https://github.com/rear/rear/pull/1781#issuecomment-384322051
+# and https://github.com/rear/rear/pull/1781#issuecomment-384331316
+# and https://github.com/rear/rear/pull/1781#issuecomment-384560856
+# that read (excerpts):
+#   SUSE systems: /usr/share/kbd/keymaps
+#   Debian 9.2 (stretch): /usr/share/keymaps
+#   Centos 7.3.1611 (Core): /lib/kbd/keymaps
+#   Fedora release 26 (Twenty Six): /lib/kbd/keymaps
+#   Arch Linux: /usr/share/kbd/keymaps
+#   Ubuntu 12.04.5 LTS (Precise): /usr/share/keymaps
+#   RHEL 6/7: /lib/kbd/keymaps
+# so that we have this summary:
+#   /usr/share/kbd/keymaps is used by SUSE and Arch Linux
+#   /usr/share/keymaps is used by Debian and Ubuntu
+#   /lib/kbd/keymaps is used by Centos and Fedora and Red Hat
+# We do not test and distinguish by Linux distribution identifier strings
+# because such tests result an endless nightmare to keep them up-to-date.
+# We prefer (whenever possible) to generically test "some real thing".
+# Accordingly we test known directories and use the first one that exist.
+# The last '' is there to keep keymaps_default_directory empty if none of the directories exist
+# which is (currently) not strictly requied by the code below but it is cleaner code here:
+local keymaps_default_directory=""
+for keymaps_default_directory in /usr/share/kbd/keymaps /usr/share/keymaps /lib/kbd/keymaps '' ; do
+    test -d $keymaps_default_directory && break
+done
 # Use KEYMAPS_DEFAULT_DIRECTORY if it is explicitly specified by the user:
 test $KEYMAPS_DEFAULT_DIRECTORY && keymaps_default_directory="$KEYMAPS_DEFAULT_DIRECTORY"
-
 # Report when there is no keymaps default directory because other keyboard mappings (at least 'defkeymap') should get included
 # but that is not a severe error because the current keyboard mapping is dumped and gets used by default and as fallback:
 test -d $keymaps_default_directory || LogPrintError "Cannot include keyboard mappings (no keymaps default directory $keymaps_default_directory)"
 
-# Try to include at least the default US keyboard mapping:
+# Try to find and include at least the default US keyboard mapping:
 local defkeymap_file="$( find $keymaps_default_directory -name 'defkeymap.*' | head -n1 )"
-if test $defkeymap_file ; then
-    COPY_AS_IS=( "${COPY_AS_IS[@]}" $defkeymap_file )
-else
-    # If no defkeymap file was found in $keymaps_default_directory try some RHEL, SLES and Ubuntu qwerty flavours.
-    # The funny ? makes 'shopt -s nullglob' remove such a file from the list if it does not exist:
-    COPY_AS_IS=( "${COPY_AS_IS[@]}" /lib/k?d/keymaps/i386/qwerty/defkeymap.map.gz /usr/share/k?d/keymaps/i386/qwerty/defkeymap.map.gz /usr/share/ke?maps/i386/qwerty/defkeymap.map.gz )
-fi
+test $defkeymap_file && COPY_AS_IS=( "${COPY_AS_IS[@]}" $defkeymap_file )
 
 # Additionally include other keyboard mappings to also support users with a non-US keyboard
 # who can then manually switch to their keyboard mapping (e.g. via a command like "loadkeys de-latin1")

--- a/usr/share/rear/rescue/GNU/Linux/500_clone_keyboard_mappings.sh
+++ b/usr/share/rear/rescue/GNU/Linux/500_clone_keyboard_mappings.sh
@@ -1,25 +1,41 @@
 
-# Dump current keyboard mapping to etc/dumpkeys.out so that it can be set during recovery system startup
-# by etc/scripts/system-setup.d/10-console-setup.sh via "loadkeys /etc/dumpkeys.out"
-# but depending on the keyboard mapping the "loadkeys /etc/dumpkeys.out" command
-# may not work in the recovery system so that some other keyboard mapping files
-# are also included so that the user can manually set his keyboard mapping:
-dumpkeys -f1 >$ROOTFS_DIR/etc/dumpkeys.out
+# Dump current keyboard mapping so that it can be set during recovery system startup
+# by etc/scripts/system-setup.d/10-console-setup.sh via "loadkeys /etc/dumpkeys.out":
+local original_system_dumpkeys_file="/etc/dumpkeys.out"
+dumpkeys -f >$ROOTFS_DIR$original_system_dumpkeys_file
 
-# At least include the default US keyboard mapping:
-defkeymap_file="$( find /usr/share/kbd/keymaps -name 'defkeymap.*' | head -n1 )"
+# At least on SUSE systems /usr/share/kbd/keymaps is the default directory for keymaps:
+local keymaps_default_directory="/usr/share/kbd/keymaps"
+
+# Use KEYMAPS_DEFAULT_DIRECTORY if it is explicitly specified by the user:
+test $KEYMAPS_DEFAULT_DIRECTORY && keymaps_default_directory="$KEYMAPS_DEFAULT_DIRECTORY"
+
+# Report when there is no keymaps default directory because other keyboard mappings (at least 'defkeymap') should get included
+# but that is not a severe error because the current keyboard mapping is dumped and gets used by default and as fallback:
+test -d $keymaps_default_directory || LogPrintError "Cannot include keyboard mappings (no keymaps default directory $keymaps_default_directory)"
+
+# Try to include at least the default US keyboard mapping:
+local defkeymap_file="$( find $keymaps_default_directory -name 'defkeymap.*' | head -n1 )"
 if test $defkeymap_file ; then
     COPY_AS_IS=( "${COPY_AS_IS[@]}" $defkeymap_file )
 else
-    # If no defkeymap file was found in /usr/share/kbd/keymaps try some RHEL, SLES and Ubuntu qwerty flavours.
-    # The funny ? makes 'shopt -s nullglob' remove this file from the list if it does not exist:
+    # If no defkeymap file was found in $keymaps_default_directory try some RHEL, SLES and Ubuntu qwerty flavours.
+    # The funny ? makes 'shopt -s nullglob' remove such a file from the list if it does not exist:
     COPY_AS_IS=( "${COPY_AS_IS[@]}" /lib/k?d/keymaps/i386/qwerty/defkeymap.map.gz /usr/share/k?d/keymaps/i386/qwerty/defkeymap.map.gz /usr/share/ke?maps/i386/qwerty/defkeymap.map.gz )
 fi
 
-# Additionally include the legacy keyboard mappings to also support users with a non-US keyboard
-# who can then manually switch to their keyboard mapping (e.g. via a command like "loadkeys de-latin1").
+# Additionally include other keyboard mappings to also support users with a non-US keyboard
+# who can then manually switch to their keyboard mapping (e.g. via a command like "loadkeys de-latin1")
+# or who had specdified the KEYMAP that should be used in the recovery system.
 # It is not sufficient to include only map.gz or only i386 files because all the include files are also needed.
-# This increases the recovery system size by about 1 MB (an usual recovery system size is about 500 MB uncompressed)
-# but without the right keyboard mapping it could become an awful annoyance to work in the recovery system:
-test -d /usr/share/kbd/keymaps/legacy && COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/share/kbd/keymaps/legacy )
+# Including the whole keymaps default directory increases the recovery system size by about 3 MB
+# and including only the 'legacy' subdirectory increases the recovery system size by about 1 MB
+# (an usual recovery system size is about 500 MB uncompressed where about 250 MB are firmware files)
+# but without the right keyboard mapping it could become an awful annoyance to work in the recovery system
+# so that by default and as fallback the whole keymaps default directory is included to be on the safe side,
+# cf. https://github.com/rear/rear/pull/1781#issuecomment-384232695
+local keymaps_directories=$keymaps_default_directory
+# Use KEYMAPS_DIRECTORIES if it is explicitly specified by the user:
+contains_visible_char "$KEYMAPS_DIRECTORIES" && keymaps_directories="$KEYMAPS_DIRECTORIES"
+COPY_AS_IS=( "${COPY_AS_IS[@]}" $keymaps_directories )
 

--- a/usr/share/rear/rescue/GNU/Linux/500_clone_keyboard_mappings.sh
+++ b/usr/share/rear/rescue/GNU/Linux/500_clone_keyboard_mappings.sh
@@ -29,13 +29,14 @@ dumpkeys -f >$ROOTFS_DIR$original_system_dumpkeys_file
 # which is (currently) not strictly requied by the code below but it is cleaner code here:
 local keymaps_default_directory=""
 for keymaps_default_directory in /usr/share/kbd/keymaps /usr/share/keymaps /lib/kbd/keymaps '' ; do
-    test -d $keymaps_default_directory && break
+    test -d "$keymaps_default_directory" && break
 done
 # Use KEYMAPS_DEFAULT_DIRECTORY if it is explicitly specified by the user:
 test $KEYMAPS_DEFAULT_DIRECTORY && keymaps_default_directory="$KEYMAPS_DEFAULT_DIRECTORY"
 # Report when there is no keymaps default directory because other keyboard mappings (at least 'defkeymap') should get included
-# but that is not a severe error because the current keyboard mapping is dumped and gets used by default and as fallback:
-test -d $keymaps_default_directory || LogPrintError "Cannot include keyboard mappings (no keymaps default directory $keymaps_default_directory)"
+# but that is not a severe error because the current keyboard mapping is dumped and gets used by default and as fallback.
+# test -d without a (possibly empty) argument would falsely result true (while plain test without argument results false):
+test -d "$keymaps_default_directory" || LogPrintError "Cannot include keyboard mappings (no keymaps default directory $keymaps_default_directory)"
 
 # Try to find and include at least the default US keyboard mapping:
 local defkeymap_file="$( find $keymaps_default_directory -name 'defkeymap.*' | head -n1 )"

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/10-console-setup.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/10-console-setup.sh
@@ -1,17 +1,20 @@
-# Console keyboad mapping setup
+
+# Console keyboad mapping setup.
+#
+# With topmost priority it tries to set what the user specified as KEYMAP
+# which may fail when needed keymap files are missing (e.g. include files).
+# With second priority it tries to set the keymap of the original system.
+# As fallback it tries to set at least the default (US keyboad) keymap.
 
 default_keymap="defkeymap"
 original_system_dumpkeys_file="/etc/dumpkeys.out"
 
-keymap=""
-# Use KEYMAP if it is explicitly specified by the user:
-test $KEYMAP && keymap="$KEYMAP"
-
-# Load keymap:
-if test $keymap ; then
-    echo "Using $keymap keymap"
-    if ! loadkeys $keymap ; then
-        echo "Failed to set $keymap keymap" 1>&2 
+# Set KEYMAP if it is explicitly specified by the user:
+if test $KEYMAP ; then
+    echo "Using $KEYMAP keymap"
+    if ! loadkeys $KEYMAP ; then
+        # If setting KEYMAP failed try to set the keymap of the original system:
+        echo "Failed to set $KEYMAP keymap" 1>&2 
         if test -s $original_system_dumpkeys_file ; then
             echo "Using keymap of the original system" 1>&2
             if ! loadkeys $original_system_dumpkeys_file ; then
@@ -20,11 +23,13 @@ if test $keymap ; then
                 loadkeys $default_keymap || echo "Even failed to set $default_keymap" 1>&2
             fi
         else
+            # When setting KEYMAP failed and there is no original_system_dumpkeys_file set the default keymap:
             echo "Using $default_keymap (US keyboad)" 1>&2
             loadkeys $default_keymap || echo "Also failed to set $default_keymap" 1>&2
         fi
     fi
 else
+    # When there no KEYMAP specified try to set the keymap of the original system:
     if test -s $original_system_dumpkeys_file ; then
         echo "Using keymap of the original system"
         if ! loadkeys $original_system_dumpkeys_file ; then
@@ -32,6 +37,10 @@ else
             echo "Failed to set original system keymap, using $default_keymap (US keyboad)" 1>&2
             loadkeys $default_keymap || echo "Also failed to set $default_keymap" 1>&2
         fi
+    else
+        # When there is neither KEYMAP nor original_system_dumpkeys_file set the default keymap:
+        echo "Using $default_keymap (US keyboad)"
+        loadkeys $default_keymap || echo "Failed to set $default_keymap" 1>&2
     fi
 fi
 

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/10-console-setup.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/10-console-setup.sh
@@ -1,6 +1,37 @@
-# console setup
+# Console keyboad mapping setup
 
-# load keymap
-test -s /etc/dumpkeys.out && loadkeys /etc/dumpkeys.out
+default_keymap="defkeymap"
+original_system_dumpkeys_file="/etc/dumpkeys.out"
 
+keymap=""
+# Use KEYMAP if it is explicitly specified by the user:
+test $KEYMAP && keymap="$KEYMAP"
+
+# Load keymap:
+if test $keymap ; then
+    echo "Using $keymap keymap"
+    if ! loadkeys $keymap ; then
+        echo "Failed to set $keymap keymap" 1>&2 
+        if test -s $original_system_dumpkeys_file ; then
+            echo "Using keymap of the original system" 1>&2
+            if ! loadkeys $original_system_dumpkeys_file ; then
+                # To be on the safe side when loadkeys failed try to set at least the default keymap:
+                echo "Also failed to set original system keymap, using $default_keymap (US keyboad)" 1>&2
+                loadkeys $default_keymap || echo "Even failed to set $default_keymap" 1>&2
+            fi
+        else
+            echo "Using $default_keymap (US keyboad)" 1>&2
+            loadkeys $default_keymap || echo "Also failed to set $default_keymap" 1>&2
+        fi
+    fi
+else
+    if test -s $original_system_dumpkeys_file ; then
+        echo "Using keymap of the original system"
+        if ! loadkeys $original_system_dumpkeys_file ; then
+            # To be on the safe side when loadkeys failed try to set at least the default keymap:
+            echo "Failed to set original system keymap, using $default_keymap (US keyboad)" 1>&2
+            loadkeys $default_keymap || echo "Also failed to set $default_keymap" 1>&2
+        fi
+    fi
+fi
 


### PR DESCRIPTION
Also include other keyboard mappings to also support users with a non-US keyboard
because without the right keyboard mapping it could become an awful annoyance
to work in the recovery system.

* Type: **Bug Fix** and **Enhancement**
Actually this provides a workaround when in
etc/scripts/system-setup.d/10-console-setup.sh
the `loadkeys /etc/dumpkeys.out` fails.

* Impact: **Low** and **High**
For US-keyboard users the impact is at most low,
for non-US-keyboard users the impact could be even critical.

* How was this pull request tested?
It works for me on a SUSE system.
I don't know where on other systems the other keyboard mapping files are stored.
But it is now at least a starting point that can be easily enhanced for other systems.

* Brief description of the changes in this pull request:

By default the current keyboard mapping is dumped to etc/dumpkeys.out
so that it can be set during recovery system startup by
etc/scripts/system-setup.d/10-console-setup.sh
via `loadkeys /etc/dumpkeys.out`.

But depending on the keyboard mapping
the `loadkeys /etc/dumpkeys.out` command
may not work in the recovery system
so that some other keyboard mapping files
are also included so that the user can manually set
his keyboard mapping (e.g. via a command like `loadkeys de-latin1`).

This increases the recovery system size by about 1 MB
(an usual recovery system size is about 500 MB uncompressed)
but without the right keyboard mapping it could be an awful annoyance
to work in the recovery system.
