### PR TITLE
Update for using diffrent ssh port

### DIFF
--- a/usr/share/rear/prep/BORG/default/300_init_archive.sh
+++ b/usr/share/rear/prep/BORG/default/300_init_archive.sh
@@ -24,12 +24,19 @@ rc=$?
 # `borg init` has to be triggered in "prep" stage if user decides to include
 # keyfiles to Relax-and-Recover rescue/recovery system using COPY_AS_IS_BORG.
 if [ $rc -ne 0 ]; then
-    LogPrint "Failed to list $BORGBACKUP_REPO"
-    LogPrint "Creating new Borg repository $BORGBACKUP_REPO"
-
-    borg init $BORGBACKUP_OPT_ENCRYPTION $BORGBACKUP_OPT_REMOTE_PATH \
-    $BORGBACKUP_OPT_UMASK ${borg_dst_dev}${BORGBACKUP_REPO}
-    rc=$?
+        if [ ! -z $BORGBACKUP_PORT ]; then
+                LogPrint "Failed to list $BORGBACKUP_REPO on $BORGBACKUP_HOST:$BORGBACKUP_PORT"
+                 LogPrint "Creating new Borg repository $BORGBACKUP_REPO on $BORGBACKUP_HOST:$BORGBACKUP_PORT"
+                borg init $BORGBACKUP_OPT_ENCRYPTION $BORGBACKUP_OPT_REMOTE_PATH \
+                ssh://$BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_PORT/$BORGBACKUP_REPO
+                rc=$?
+    else
+                LogPrint "Failed to list $BORGBACKUP_REPO on $BORGBACKUP_HOST"
+                LogPrint "Creating new Borg repository $BORGBACKUP_REPO on $BORGBACKUP_HOST"
+                borg init $BORGBACKUP_OPT_ENCRYPTION $BORGBACKUP_OPT_REMOTE_PATH \
+                $BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_REPO
+                rc=$?
+    fi
 fi
 
 # Borg repository initialization failed in previous step,


### PR DESCRIPTION
File need to be modified to use a different port for a remote borg backup.
`BORGBACKUP_PORT=<REMOTE PORT>` need to be put in /etc/rear/local.conf

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?**
Enhancement
* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent**
Low
* Reference to related issue (URL):

* How was this pull request tested?
On a new server with new installation and success of "`rear mkbackup`"
* Brief description of the changes in this pull request:
I'm using a remote borg server with limited borg access (no deletion in repository), limited by the authorized_keys. 
`command="borg serve --append-only --restrict-to-path /backup/rear_test" ssh-ed25519 <CLIENT KEY>`
the borg server process is launch when the user connect on the server.