### PR TITLE
borg ssh port addition

### DIFF
--- a/usr/share/rear/prep/BORG/default/100_set_vars.sh
+++ b/usr/share/rear/prep/BORG/default/100_set_vars.sh
@@ -13,8 +13,13 @@ borg_set_vars
 # combined string of "BORGBACKUP_USERNAME@BORGBACKUP_HOST".
 # borg_dst_dev directory will be created in later stage
 # (if not already present) by 250_mount_usb.sh script.
+
 if [[ -n $BORGBACKUP_HOST ]]; then
-    borg_dst_dev=$BORGBACKUP_USERNAME@$BORGBACKUP_HOST:
-else
-    borg_dst_dev=$BUILD_DIR/borg_backup
+   borg_dst_dev=$BORGBACKUP_USERNAME@$BORGBACKUP_HOST:
+   # We have to test if anoher port is used.
+      if [[ -n $BORGBACKUP_PORT ]]; then
+        borg_dst_dev=ssh://$BORGBACKUP_USERNAME@$BORGBACKUP_HOST:$BORGBACKUP_PORT/
+      fi
+  else
+      borg_dst_dev=$BUILD_DIR/borg_backup
 fi


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?**
Enhancement
* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent**
Normal
* Reference to related issue (URL):

* How was this pull request tested?
This modification has been tested on a new server with the **BORGBACKUP_PORT** in _/etc/rear/local.conf_. The command _rear mkbackup_ has been working and both iso file and borg backup finished without errors. The backup on the borg server can be listed with others, not made with rear.
* Brief description of the changes in this pull request:
The change is only to add a new value for having the possibility to change the ssh port used. When you make this change you have to modify the syntax of the **borg_dst_dev**
