### PR TITLE
Fix KEYMAPS_DEFAULT_DIRECTORY description (follow-up of pull request 1781)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1100,8 +1100,16 @@ COPY_AS_IS_EXCLUDE=( dev/shm dev/shm/\* dev/oracleasm dev/mapper dev/.udev $VAR_
 # Including and setting keyboard mappings in the ReaR recovery system,
 # cf. https://github.com/rear/rear/pull/1781
 # KEYMAPS_DEFAULT_DIRECTORY specifies the default directory for keyboard mapping files.
-# At least on SUSE systems /usr/share/kbd/keymaps is the default directory for keymaps
-# which is used by default (i.e. when KEYMAPS_DEFAULT_DIRECTORY is not set or empty):
+# Different Linux distributions use a different default directory for keymaps,
+# see https://github.com/rear/rear/pull/1781#issuecomment-384322051
+# and https://github.com/rear/rear/pull/1781#issuecomment-384331316
+# and https://github.com/rear/rear/pull/1781#issuecomment-384560856
+# so that we have this summary:
+#   /usr/share/kbd/keymaps is used by SUSE and Arch Linux
+#   /usr/share/keymaps is used by Debian and Ubuntu
+#   /lib/kbd/keymaps is used by Centos and Fedora and Red Hat
+# By default (i.e. when KEYMAPS_DEFAULT_DIRECTORY is not set or empty)
+# it uses the first one of those directories that exist:
 KEYMAPS_DEFAULT_DIRECTORY=""
 # KEYMAPS_DIRECTORIES is a string of directories that contain keyboard mapping files
 # or plain keyboard mapping files to be included in the recovery system, for example like


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/1781
and therein in particular this commit
https://github.com/rear/rear/pull/1781/commits/ef5aea6efb96233eaebe30ffc6fbbdf0baf2dd22
which is incomplete because the KEYMAPS_DEFAULT_DIRECTORY description
in default.cong was not updated accordingly which is provided by this pull request here.
