### PR TITLE
Solve problem with some variables loading config from DRLM drlm issue  brainupdaters/drlm#68

### DIFF
--- a/usr/share/rear/lib/drlm-functions.sh
+++ b/usr/share/rear/lib/drlm-functions.sh
@@ -26,7 +26,7 @@ function drlm_import_runtime_config() {
                 local DRLM_CFG="/tmp/$config_append_file"
                 local http_response_code=$(curl $verbose -f -s -S -w '%{http_code}' $DRLM_REST_OPTS -o $DRLM_CFG https://$DRLM_SERVER/clients/$DRLM_ID/config/$config_append_file)
                 test "200" = "$http_response_code" || Error "DRLM_MANAGED: curl failed with HTTP response code '$http_response_code' trying to load '$config_append_file' from DRLM."
-                eval $(cat $DRLM_CFG)
+                source $DRLM_CFG
                 rm $DRLM_CFG
             done
         else
@@ -34,7 +34,7 @@ function drlm_import_runtime_config() {
             local DRLM_CFG="/tmp/drlm_config"
             local http_response_code=$(curl $verbose -f -s -S -w '%{http_code}' $DRLM_REST_OPTS -o $DRLM_CFG https://$DRLM_SERVER/clients/$DRLM_ID/config)
             test "200" = "$http_response_code" || Error "DRLM_MANAGED: curl failed with HTTP response code '$http_response_code' trying to load configuration from DRLM."
-            eval $(cat $DRLM_CFG)
+            source $DRLM_CFG
             rm $DRLM_CFG
         fi
     else


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**
* Reference to related issue (URL): https://github.com/brainupdaters/drlm/issues/68

* How was this pull request tested?
Tested on RHEL and Debian based systems.

* Brief description of the changes in this pull request:
With source instead of eval makes more sense ans solves the issue. 
Before latest changes on DRLM API was necessary to eval the received config but now we are downloading config to file and source is more convenient and solves the issue.
