### PR TITLE
exclude multipath device that does not have mounted fs

### DIFF
--- a/usr/share/rear/layout/save/default/320_autoexclude.sh
+++ b/usr/share/rear/layout/save/default/320_autoexclude.sh
@@ -73,7 +73,7 @@ if is_true "$AUTOEXCLUDE_DISKS" ; then
             continue
         fi
 
-        # looking for parent disk or multipath device of a fs:mountpoint
+        # looking for parent in disk AND multipath device for a given fs:mountpoint
         disks=$(find_disk_and_multipath fs:$mountpoint)
         for disk in $disks ; do
             if ! IsInArray "$disk" "${used_disks[@]}" ; then

--- a/usr/share/rear/layout/save/default/320_autoexclude.sh
+++ b/usr/share/rear/layout/save/default/320_autoexclude.sh
@@ -38,7 +38,11 @@ if [[ "$AUTOEXCLUDE_USB_PATH" ]] ; then
 fi
 
 # Automatically exclude disks that do not have filesystems mounted.
-if [[ "$AUTOEXCLUDE_DISKS" =~ ^[yY1] ]] ; then
+# [multipath case]: 
+#   multipath device (like: /dev/mapper/maptha) must be considered as 
+#   a disk because it is the base (or parent) of device like "partition",
+#   "LVM physical volume" or "Filesystem".
+if is_true "$AUTOEXCLUDE_DISKS" ; then 
     used_disks=()
     # List disks used by swap devices
     while read swap device uuid label junk ; do
@@ -69,6 +73,7 @@ if [[ "$AUTOEXCLUDE_DISKS" =~ ^[yY1] ]] ; then
             continue
         fi
 
+        # looking for parent disk or multipath device of a fs:mountpoint
         disks=$(find_disk_and_multipath fs:$mountpoint)
         for disk in $disks ; do
             if ! IsInArray "$disk" "${used_disks[@]}" ; then
@@ -86,6 +91,7 @@ if [[ "$AUTOEXCLUDE_DISKS" =~ ^[yY1] ]] ; then
             mark_as_done "opaldisk:$name"
             mark_tree_as_done "$name"
         fi
+    # looping over each disk or multipath device in layout file.
     done < <(grep -E "^disk|^multipath" $LAYOUT_FILE)
 
 fi

--- a/usr/share/rear/layout/save/default/320_autoexclude.sh
+++ b/usr/share/rear/layout/save/default/320_autoexclude.sh
@@ -69,7 +69,7 @@ if [[ "$AUTOEXCLUDE_DISKS" =~ ^[yY1] ]] ; then
             continue
         fi
 
-        disks=$(find_disk fs:$mountpoint)
+        disks=$(find_disk_and_multipath fs:$mountpoint)
         for disk in $disks ; do
             if ! IsInArray "$disk" "${used_disks[@]}" ; then
                 used_disks=( "${used_disks[@]}" "$disk" )
@@ -86,7 +86,7 @@ if [[ "$AUTOEXCLUDE_DISKS" =~ ^[yY1] ]] ; then
             mark_as_done "opaldisk:$name"
             mark_tree_as_done "$name"
         fi
-    done < <(grep ^disk $LAYOUT_FILE)
+    done < <(grep -E "^disk|^multipath" $LAYOUT_FILE)
 
 fi
 

--- a/usr/share/rear/layout/save/default/320_autoexclude.sh
+++ b/usr/share/rear/layout/save/default/320_autoexclude.sh
@@ -74,7 +74,7 @@ if is_true "$AUTOEXCLUDE_DISKS" ; then
         fi
 
         # looking for parent disk or multipath device of a fs:mountpoint
-        disks=$(find_disk_and_multipat fs:$mountpoint)
+        disks=$(find_disk_and_multipath fs:$mountpoint)
         for disk in $disks ; do
             if ! IsInArray "$disk" "${used_disks[@]}" ; then
                 used_disks=( "${used_disks[@]}" "$disk" )

--- a/usr/share/rear/layout/save/default/320_autoexclude.sh
+++ b/usr/share/rear/layout/save/default/320_autoexclude.sh
@@ -51,7 +51,7 @@ if is_true "$AUTOEXCLUDE_DISKS" ; then
             continue
         fi
 
-        disks=$(find_disk swap:$device)
+        disks=$(find_disk_and_multipath swap:$device)
         for disk in $disks ; do
             if ! IsInArray "$disk" "${used_disks[@]}" ; then
                 used_disks=( "${used_disks[@]}" "$disk" )
@@ -74,7 +74,7 @@ if is_true "$AUTOEXCLUDE_DISKS" ; then
         fi
 
         # looking for parent disk or multipath device of a fs:mountpoint
-        disks=$(find_disk_and_multipath fs:$mountpoint)
+        disks=$(find_disk_and_multipat fs:$mountpoint)
         for disk in $disks ; do
             if ! IsInArray "$disk" "${used_disks[@]}" ; then
                 used_disks=( "${used_disks[@]}" "$disk" )


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1767

* How was this pull request tested?
SLES12SP2 on POWER with multipath devices

* Brief description of the changes in this pull request:
The actual code without this patch just exclude "real disk" which doesn't have fs mounted, not mutlipath devices.
This path check if fs has parent device in disk AND multipath, then exclude disk and multipath with no fs mounted.
