### PR TITLE
Better way to get multiapth partion name.

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -30,14 +30,21 @@ extract_partitions() {
 
     declare path sysfs_path
     if [[ ${#sysfs_paths[@]} -eq 0 ]] ; then
-        ### try to find partitions like /dev/mapper/datalun1p1
         if [[ ${device/mapper//} != ${device} ]] ; then
-            for path in ${device}p[0-9]* ${device}[0-9]* ${device}-part* ${device}_part*; do
-                sysfs_path=$(get_sysfs_name $path)
-                if [[ "$sysfs_path" ]] && [[ -e "/sys/block/$sysfs_path" ]] ; then
-                    sysfs_paths=( "${sysfs_paths[@]}" "/sys/block/$sysfs_path" )
-                fi
-            done
+            ### look like /sys/block/dm-X/holders directory contains partition name in dm-X format.
+            if [ -d /sys/block/$sysfs_name/holders ]; then
+                sysfs_paths=(/sys/block/$sysfs_name/holders/*)
+            else
+                ### if the holders directory does not exisits 
+                ### failback to partition name guessing method.
+                ### try to find partitions like /dev/mapper/datalun1p1
+                for path in ${device}p[0-9]* ${device}[0-9]* ${device}-part* ${device}_part*; do
+                    sysfs_path=$(get_sysfs_name $path)
+                    if [[ "$sysfs_path" ]] && [[ -e "/sys/block/$sysfs_path" ]] ; then
+                        sysfs_paths=( "${sysfs_paths[@]}" "/sys/block/$sysfs_path" )
+                    fi
+                done
+            fi
         fi
     fi
 

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -30,7 +30,7 @@ extract_partitions() {
 
     declare path sysfs_path
     if [[ ${#sysfs_paths[@]} -eq 0 ]] ; then
-        if [[ ${device/mapper//} != ${device} ]] ; then
+        if [[ $device = *'/mapper/'* ]]; then
             ### /sys/block/dm-X/holders directory contains partition name in dm-X format.
             if [ -d /sys/block/$sysfs_name/holders ]; then
                 sysfs_paths=( /sys/block/$sysfs_name/holders/* )

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -32,7 +32,7 @@ extract_partitions() {
     if [[ ${#sysfs_paths[@]} -eq 0 ]] ; then
         ### try to find partitions like /dev/mapper/datalun1p1
         if [[ ${device/mapper//} != ${device} ]] ; then
-            for path in ${device}p[0-9]* ${device}[0-9] ${device}-part* ${device}_part*; do
+            for path in ${device}p[0-9]* ${device}[0-9]* ${device}-part* ${device}_part*; do
                 sysfs_path=$(get_sysfs_name $path)
                 if [[ "$sysfs_path" ]] && [[ -e "/sys/block/$sysfs_path" ]] ; then
                     sysfs_paths=( "${sysfs_paths[@]}" "/sys/block/$sysfs_path" )

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -31,9 +31,9 @@ extract_partitions() {
     declare path sysfs_path
     if [[ ${#sysfs_paths[@]} -eq 0 ]] ; then
         if [[ ${device/mapper//} != ${device} ]] ; then
-            ### look like /sys/block/dm-X/holders directory contains partition name in dm-X format.
+            ### /sys/block/dm-X/holders directory contains partition name in dm-X format.
             if [ -d /sys/block/$sysfs_name/holders ]; then
-                sysfs_paths=(/sys/block/$sysfs_name/holders/*)
+                sysfs_paths=( /sys/block/$sysfs_name/holders/* )
             else
                 ### if the holders directory does not exisits 
                 ### failback to partition name guessing method.


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1766
https://github.com/rear/rear/issues/1796

* How was this pull request tested?
    - SLES12SP2 (ppc64le) with multipath devices
    - RHEL7 (ppc64le) with multiapth devices
* Brief description of the changes in this pull request:
This patch use `/sys/block/dm-X/holders` directory of the multipathed device to get `dm-` name of its partions.

