### PR TITLE
Copy backup restore log into recreated system (related to pull request 1797)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -862,11 +862,18 @@ BACKUP_PROG_CRYPT_ENABLED=0
 BACKUP_PROG_CRYPT_KEY=""
 BACKUP_PROG_CRYPT_OPTIONS="/usr/bin/openssl des3 -salt -k "
 BACKUP_PROG_DECRYPT_OPTIONS="/usr/bin/openssl des3 -d -k "
-# One can create a dynamic name like BACKUP_PROG_ARCHIVE="backup_$( date -Iseconds )"
+# One might even create a dynamic name like BACKUP_PROG_ARCHIVE="backup_$( date -Iseconds )"
 # in particular one can use BACKUP_PROG_ARCHIVE="$( date '+%Y-%m-%d-%H%M' )-F"
 # to get the same full backup file name for BACKUP_TYPE="" as what is used
-# for BACKUP_TYPE=incremental and/or BACKUP_TYPE=differential (see below):
-BACKUP_PROG_ARCHIVE="backup"
+# for BACKUP_TYPE=incremental and/or BACKUP_TYPE=differential (see below).
+# But then one must specify the right existing BACKUP_PROG_ARCHIVE
+# for "rear recover" so that the backup can be found and restored
+# (i.e. during "rear recover" a dynamic name does not make sense).
+# BACKUP_PROG_ARCHIVE is set to a default value here only
+# if not already set so that the user can set it also like
+#   export BACKUP_PROG_ARCHIVE="mybackup"
+# directly before he calls "rear ...":
+test "$BACKUP_PROG_ARCHIVE" || BACKUP_PROG_ARCHIVE="backup"
 # BACKUP_PROG_EXCLUDE is an array of strings that get written into a backup-exclude.txt file
 # that is used e.g. in 'tar -X backup-exclude.txt' to get things excluded from the backup.
 # Proper quoting of the BACKUP_PROG_EXCLUDE array members is crucial to avoid bash expansions.

--- a/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
+++ b/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
@@ -43,7 +43,7 @@ if ! test "incremental" = "$BACKUP_TYPE" -o "differential" = "$BACKUP_TYPE" ; th
     # This script is also run during "rear recover/restoreonly" where RESTORE_ARCHIVES must be set.
     local backup_restore_workflows=( "recover" "restoreonly" )
     if IsInArray $WORKFLOW ${backup_restore_workflows[@]} ; then
-        # Only set RESTORE_ARCHIVES the backup archive is actually accessible
+        # Only set RESTORE_ARCHIVES when the backup archive is actually accessible
         # cf. https://github.com/rear/rear/issues/1166
         if test -r "$backuparchive" ; then
             RESTORE_ARCHIVES=( "$backuparchive" )

--- a/usr/share/rear/restore/TSM/default/400_restore_with_tsm.sh
+++ b/usr/share/rear/restore/TSM/default/400_restore_with_tsm.sh
@@ -4,15 +4,25 @@
 local num=0
 local filespace=""
 local dsmc_exit_code=0
-Print "File restore progression can be followed with tail -f \"$TMP_DIR/TSM-restore.log\""
+
+# Create common backup restore log file name prefix (same for each filespace):
+mkdir -p $VAR_DIR/restore
+local backup_restore_log_file=""
+local backup_restore_log_file_prefix=$BACKUP
+# Cf. how the contains_visible_char() function in lib/global-functions.sh is implemented:
+test "$CONFIG_APPEND_FILES" && backup_restore_log_file_prefix=$backup_restore_log_file_prefix-$( tr -d -c '[:graph:]' <<<"$CONFIG_APPEND_FILES" )
+
 for num in $TSM_RESTORE_FILESPACE_NUMS ; do
     filespace="${TSM_FILESPACES[$num]}"
+    LogUserOutput "Restoring TSM filespace $filespace"
+    # Create backup restore log file name (a different one for each filespace):
+    backup_restore_log_file=$VAR_DIR/restore/$backup_restore_log_file_prefix-$filespace-restore.log
+    UserOutput "Filespace '$filespace' restore progress can be followed with 'tail -f $backup_restore_log_file'"
     # Make sure filespace has a trailing / (for dsmc):
     test "${filespace:0-1}" == "/" || filespace="$filespace/"
-    LogUserOutput "Restoring TSM filespace $filespace"
     Log "Running 'LC_ALL=$LANG_RECOVER dsmc restore $filespace $TARGET_FS_ROOT/$filespace -subdir=yes -replace=all -tapeprompt=no ${TSM_DSMC_RESTORE_OPTIONS[@]}'"
     # Regarding usage of '0<&6 1>&7 2>&8' see "What to do with stdin, stdout, and stderr" in https://github.com/rear/rear/wiki/Coding-Style
-    LC_ALL=$LANG_RECOVER dsmc restore "$filespace" "$TARGET_FS_ROOT/$filespace" -subdir=yes -replace=all -tapeprompt=no "${TSM_DSMC_RESTORE_OPTIONS[@]}" 0<&6 1>"$TMP_DIR/TSM-restore.log" 2>&8
+    LC_ALL=$LANG_RECOVER dsmc restore "$filespace" "$TARGET_FS_ROOT/$filespace" -subdir=yes -replace=all -tapeprompt=no "${TSM_DSMC_RESTORE_OPTIONS[@]}" 0<&6 1>"$backup_restore_log_file" 2>&8
     dsmc_exit_code=$?
     # When 'dsmc restore' results a non-zero exit code inform the user but do not abort the whole "rear recover" here
     # because it could be an unimportant reason why 'dsmc restore' finished with a non-zero exit code.

--- a/usr/share/rear/restore/TSM/default/400_restore_with_tsm.sh
+++ b/usr/share/rear/restore/TSM/default/400_restore_with_tsm.sh
@@ -4,6 +4,7 @@
 local num=0
 local filespace=""
 local dsmc_exit_code=0
+local log_message=""
 
 # Create common backup restore log file name prefix (same for each filespace):
 local backup_restore_log_dir="$VAR_DIR/restore"
@@ -28,12 +29,26 @@ for num in $TSM_RESTORE_FILESPACE_NUMS ; do
     # (see above why <<<"$filespace" does not work here so that a 'echo -n $filespace' pipe is also used here):
     backup_restore_log_filespace=$( echo -n $filespace | tr -d -c '[:alnum:]/[:space:]' | tr -s '/[:space:]' ':_' )
     backup_restore_log_file=$backup_restore_log_dir/$backup_restore_log_prefix.$backup_restore_log_filespace.$MASTER_PID.$backup_restore_log_suffix
+    cat /dev/null >$backup_restore_log_file
     UserOutput "Filespace '$filespace' restore progress can be followed with 'tail -f $backup_restore_log_file'"
     # Make sure filespace has a trailing / (for dsmc):
     test "${filespace:0-1}" == "/" || filespace="$filespace/"
-    Log "Running 'LC_ALL=$LANG_RECOVER dsmc restore $filespace $TARGET_FS_ROOT/$filespace -subdir=yes -replace=all -tapeprompt=no ${TSM_DSMC_RESTORE_OPTIONS[@]}'"
-    # Regarding usage of '0<&6 1>&7 2>&8' see "What to do with stdin, stdout, and stderr" in https://github.com/rear/rear/wiki/Coding-Style
-    LC_ALL=$LANG_RECOVER dsmc restore "$filespace" "$TARGET_FS_ROOT/$filespace" -subdir=yes -replace=all -tapeprompt=no "${TSM_DSMC_RESTORE_OPTIONS[@]}" 0<&6 1>"$backup_restore_log_file" 2>&8
+    Log "Running 'LC_ALL=$LANG_RECOVER dsmc restore $filespace $TARGET_FS_ROOT/$filespace -subdir=yes -replace=all -tapeprompt=no -errorlogname=\"$backup_restore_log_file\" ${TSM_DSMC_RESTORE_OPTIONS[@]}'"
+    # Regarding things like '0<&6 1>&7 2>&8' see "What to do with stdin, stdout, and stderr" in https://github.com/rear/rear/wiki/Coding-Style
+    # Both stdout and stderr are redirected into the backup restore log file
+    # to have all backup restore program messages in one same log file and
+    # in the right ordering because with 2>&1 both streams are correctly merged
+    # cf. https://github.com/rear/rear/issues/885#issuecomment-310082587
+    # which also means that in '-D' debugscript mode some 'set -x' messages of this code here
+    # appear in the backup restore log file which is perfectly fine because in the normal log file
+    # the above UserOutput tells via "restore progress can be followed with 'tail -f $backup_restore_log_file'"
+    # where to look and it is helpful for debugging to also have the related 'set -x' messages in the same log file.
+    # To be more on the safe side append to the log file '>>' instead of plain writing to it '>'
+    # because when a program (bash in this case) is plain writing to the log file it can overwrite
+    # output of a possibly simultaneously running process that likes to append to the log file
+    # (e.g. when background processes run that also uses the log file for logging)
+    # cf. https://github.com/rear/rear/issues/885#issuecomment-310308763
+    LC_ALL=$LANG_RECOVER dsmc restore "$filespace" "$TARGET_FS_ROOT/$filespace" -subdir=yes -replace=all -tapeprompt=no -errorlogname=\"$backup_restore_log_file\" "${TSM_DSMC_RESTORE_OPTIONS[@]}" 0<&6 1>>"$backup_restore_log_file" 2>&1
     dsmc_exit_code=$?
     # When 'dsmc restore' results a non-zero exit code inform the user but do not abort the whole "rear recover" here
     # because it could be an unimportant reason why 'dsmc restore' finished with a non-zero exit code.
@@ -60,12 +75,18 @@ for num in $TSM_RESTORE_FILESPACE_NUMS ; do
     #   For example, suppose a macro consists of these commands: If the first command completes with return code 0; the second command completes with return code 8;
     #   and the third command completes with return code 4, the return code for the macro will be 8.
     if test $dsmc_exit_code -eq 0 ; then
-        LogUserOutput "Restoring TSM filespace $filespace completed successfully"
+        log_message="Restoring TSM filespace $filespace completed successfully"
+        LogUserOutput "$log_message"
+        echo "$log_message" >>"$backup_restore_log_file"
     else
-        LogUserOutput "Restoring TSM filespace $filespace completed with 'dsmc restore' exit code $dsmc_exit_code"
-        test $dsmc_exit_code -eq 4 && LogUserOutput "Restoring $filespace completed successfully, but some files (e.g. in an exclude list) were not processed"
-        test $dsmc_exit_code -eq 8 && LogUserOutput "Restoring $filespace completed with at least one warning message (review the TSM Error Log)"
-        test $dsmc_exit_code -eq 12 && LogUserOutput "Restoring $filespace completed with at least one error message (review the TSM Error Log)"
+        log_message="Restoring TSM filespace $filespace completed with 'dsmc restore' exit code $dsmc_exit_code"
+        LogUserOutput "$log_message"
+        echo "$log_message" >>"$backup_restore_log_file"
+        test $dsmc_exit_code -eq 4 && log_message="Restoring $filespace completed successfully, but some files (e.g. in an exclude list) were not processed"
+        test $dsmc_exit_code -eq 8 && log_message="Restoring $filespace completed with at least one warning message (review $backup_restore_log_file)"
+        test $dsmc_exit_code -eq 12 && log_message="Restoring $filespace completed with at least one error message (review $backup_restore_log_file)"
+        LogUserOutput "$log_message"
+        echo "$log_message" >>"$backup_restore_log_file"
     fi
 done
 

--- a/usr/share/rear/wrapup/default/990_copy_logfile.sh
+++ b/usr/share/rear/wrapup/default/990_copy_logfile.sh
@@ -35,14 +35,18 @@ ln -s $recover_log_dir/$final_logfile_name $recovery_system_roots_home_dir/rear-
 # (see AddExitTask in _input-output-functions.sh) the ordering of how AddExitTask is called
 # must begin with the to-be-last-run exit task and end with the to-be-first-run exit task:
 if test "$( echo $VAR_DIR/restore/* )" ; then
-    copy_restore_log_exit_task="mkdir $recovery_system_recover_log_dir/restore && cp -pr $VAR_DIR/restore/* $recovery_system_recover_log_dir/restore || true"
+    # Using 'mkdir -p' primarily because that causes no error if the directory already exists
+    # cf. https://github.com/rear/rear/pull/1803#discussion_r187299984
+    copy_restore_log_exit_task="mkdir -p $recovery_system_recover_log_dir/restore && cp -pr $VAR_DIR/restore/* $recovery_system_recover_log_dir/restore || true"
     AddExitTask "$copy_restore_log_exit_task"
 fi
 
 # Do not copy layout and recovery related files for the 'restoreonly' workflow:
 if ! test $WORKFLOW = "restoreonly" ; then
-    copy_layout_files_exit_task="mkdir $recovery_system_recover_log_dir/layout && cp -pr $VAR_DIR/layout/* $recovery_system_recover_log_dir/layout || true"
-    copy_recovery_files_exit_task="mkdir $recovery_system_recover_log_dir/recovery && cp -pr $VAR_DIR/recovery/* $recovery_system_recover_log_dir/recovery || true"
+    # Using 'mkdir -p' primarily because that causes no error if one of the directories already exists
+    # cf. https://github.com/rear/rear/pull/1803#discussion_r187300107
+    copy_layout_files_exit_task="mkdir -p $recovery_system_recover_log_dir/layout && cp -pr $VAR_DIR/layout/* $recovery_system_recover_log_dir/layout || true"
+    copy_recovery_files_exit_task="mkdir -p $recovery_system_recover_log_dir/recovery && cp -pr $VAR_DIR/recovery/* $recovery_system_recover_log_dir/recovery || true"
     AddExitTask "$copy_recovery_files_exit_task"
     AddExitTask "$copy_layout_files_exit_task"
 fi

--- a/usr/share/rear/wrapup/default/990_copy_logfile.sh
+++ b/usr/share/rear/wrapup/default/990_copy_logfile.sh
@@ -18,7 +18,7 @@ IsInArray $WORKFLOW ${recovery_workflows[@]} || return 0
 final_logfile_name=$( basename $LOGFILE )
 recover_log_dir=$LOG_DIR/recover
 recovery_system_recover_log_dir=$TARGET_FS_ROOT/$recover_log_dir
-# Create the directory with mode 0700 (rwx------) so that only root can access files and subdirectories therein
+# Create the directories with mode 0700 (rwx------) so that only root can access files and subdirectories therein
 # because in particular logfiles could contain security relevant information.
 # It is no real error when the following exit tasks fail so that they return 'true' in any case:
 copy_log_file_exit_task="mkdir -p -m 0700 $recovery_system_recover_log_dir && cp -p $RUNTIME_LOGFILE $recovery_system_recover_log_dir/$final_logfile_name || true"
@@ -29,17 +29,24 @@ recovery_system_roots_home_dir=$TARGET_FS_ROOT/root
 test -d $recovery_system_roots_home_dir || mkdir $verbose -m 0700 $recovery_system_roots_home_dir >&2
 ln -s $recover_log_dir/$final_logfile_name $recovery_system_roots_home_dir/rear-$( date -Iseconds ).log || true
 
+# Copy backup restore related files (in particular the backup restore log file) if exists.
+# This will be done as the last one of the exit tasks of this script because
+# the exit tasks are executed in reverse ordering of how AddExitTask is called
+# (see AddExitTask in _input-output-functions.sh) the ordering of how AddExitTask is called
+# must begin with the to-be-last-run exit task and end with the to-be-first-run exit task:
+if test "$( echo $VAR_DIR/restore/* )" ; then
+    copy_restore_log_exit_task="mkdir $recovery_system_recover_log_dir/restore && cp -pr $VAR_DIR/restore/* $recovery_system_recover_log_dir/restore || true"
+    AddExitTask "$copy_restore_log_exit_task"
+fi
+
 # Do not copy layout and recovery related files for the 'restoreonly' workflow:
 if ! test $WORKFLOW = "restoreonly" ; then
     copy_layout_files_exit_task="mkdir $recovery_system_recover_log_dir/layout && cp -pr $VAR_DIR/layout/* $recovery_system_recover_log_dir/layout || true"
     copy_recovery_files_exit_task="mkdir $recovery_system_recover_log_dir/recovery && cp -pr $VAR_DIR/recovery/* $recovery_system_recover_log_dir/recovery || true"
-    # Because the exit tasks are executed in reverse ordering of how AddExitTask is called
-    # (see AddExitTask in _input-output-functions.sh) the ordering of how AddExitTask is called
-    # must begin with the to-be-last-run exit task and end with the to-be-first-run exit task:
     AddExitTask "$copy_recovery_files_exit_task"
     AddExitTask "$copy_layout_files_exit_task"
 fi
 
-# Finally add the copy_log_file_exit_task:
+# Finally add the copy_log_file_exit_task (to be done first):
 AddExitTask "$copy_log_file_exit_task"
 


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/1797

* How was this pull request tested?
Works for me with BACKUP=NETFS.
Not tested BACKUP=TSM but also changed for that
@schabrolles please have a look regarding TSM
in particular related to https://github.com/rear/rear/pull/1799

* Brief description of the changes in this pull request:
Have backup restore log in the new separated directory $VAR_DIR/restore/
and copy that directory contents into the recreated system a the end of
"rear recover" via usr/share/rear/wrapup/default/990_copy_logfile.sh

