### PR TITLE
Do not start multipathd when not needed

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -64,6 +64,9 @@ blacklist {
 
                 # Avoid to list mpath device.
                 list_mpath_device=0
+                # unload multipath module
+                LogPrint "Unload dm-multipath module"
+                rmmod dm-multipath
                 break
                 ;;
             (${choices[1]})
@@ -83,14 +86,15 @@ blacklist {
         esac
     done
 
-    # start multipathd
-    if has_binary multipathd &> /dev/null ; then
-        LogPrint "Starting multipath daemon"
-        multipathd >&2 && LogPrint "multipathd started" || LogPrint "Failed to start multipathd"
-    fi
-
-    # Search and list mpath device.
     if is_true $list_mpath_device ; then
+
+        # start multipathd
+        if has_binary multipathd &> /dev/null ; then
+            LogPrint "Starting multipath daemon"
+            multipathd >&2 && LogPrint "multipathd started" || LogPrint "Failed to start multipathd"
+        fi
+
+        # Search and list mpath device.
         LogPrint "Listing multipath device found"
         LogPrint "$(dmsetup ls --target multipath 2>&1)"
     fi

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -96,7 +96,7 @@ blacklist {
 
         # Search and list mpath device.
         LogPrint "Listing multipath device found"
-        LogPrint "$(dmsetup ls --target multipath 2>&1)"
+        LogPrint "$(multipath -l | awk '$3~/dm-/{ DEVICES=$0} ; $1~/size=/ { print DEVICES" "$1 }' 2>&1)"
     fi
 fi
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested?
  tested on POWER with sles11sp4 

* Brief description of the changes in this pull request:
Having multipathd daemon started when not needed could bring some side-effect on some linux distribution (like sles11sp4). 
This could happen if you recover a system that previously used mutlipathed (with BOOT_ON_SAN=y) 
The purpose of the PR is to unload dm-multipath module (when user confirm that multipath is not needed) and only start multipath deamon if needed. 

