### PR TITLE
Verify if dm-X is a partition before adding to sysfs_paths

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -33,7 +33,12 @@ extract_partitions() {
         if [[ $device = *'/mapper/'* ]]; then
             ### /sys/block/dm-X/holders directory contains partition name in dm-X format.
             if [ -d /sys/block/$sysfs_name/holders ]; then
-                sysfs_paths=( /sys/block/$sysfs_name/holders/* )
+                for potential_partition in /sys/block/$sysfs_name/holders/*; do
+                    uuid=$( cat $potential_partition/dm/uuid )
+                    if [[ $uuid = part* ]]; then
+                        sysfs_paths=( "${sysfs_paths[@]}" "$potential_partition" )
+                    fi
+                done
             else
                 ### if the holders directory does not exisits 
                 ### failback to partition name guessing method.


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1767

* How was this pull request tested?
tested with rhel6, rhel7, ubunut16.04, sles12sp2, sles11sp4 on POWER

* Brief description of the changes in this pull request:
The changes brought by #1802  doesn't work when a full disk without partition is used as LVM physical volume. In that special case, the `holders` doesn't contain list of dm devices pointing to disk partitions, but a list of dm devices pointing to LVM logical volumes. 
This PR verify that the type of dm is a partition (by checking if the dm uuid starts with "part*") before adding it to the `sysfs_path` array.

The UUID name starting with `part` is verified with rhel6, rhel7, sles11, sles12, ubuntu.
