### PR TITLE
Issue #1380 - ReaR recovery fails when the OS contains a Thin Pool/Volume

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -149,6 +149,10 @@ create_lvmvol() {
 
         lvopts="${lvopts:+$lvopts }--type mirror -L $size"
 
+    elif [[ ,$layout, == *,striped,* ]] ; then
+
+        lvopts="${lvopts:+$lvopts }--type striped -L $size"
+
     elif [[ ,$layout, == *,raid,* ]] ; then
 
         local found=0

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -7,6 +7,8 @@ fi
 Log "Saving LVM layout."
 
 (
+    header_printed=0
+
     ## Get physical_device configuration
     # format: lvmdev <volume_group> <device> [<uuid>] [<size(bytes)>]
     lvm 8>&- 7>&- pvdisplay -c | while read line ; do
@@ -17,6 +19,12 @@ Log "Saving LVM layout."
             continue
         fi
 
+        if [ $header_printed -eq 0 ] ; then
+            echo "# Format for LVM PVs"
+            echo "# lvmdev <volume_group> <device> [<uuid>] [<size(bytes)>]"
+            header_printed=1
+        fi
+
         vgrp=$(echo $line | cut -d ":" -f "2")
         size=$(echo $line | cut -d ":" -f "3")
         uuid=$(echo $line | cut -d ":" -f "12")
@@ -24,6 +32,8 @@ Log "Saving LVM layout."
         pdev=$(get_device_mapping $pdev)  # xlate through diskbyid_mappings file
         echo "lvmdev /dev/$vgrp $(get_device_name $pdev) $uuid $size"
     done
+
+    header_printed=0
 
     ## Get the volume group configuration
     # format: lvmgrp <volume_group> <extentsize> [<size(extents)>] [<size(bytes)>]
@@ -33,29 +43,53 @@ Log "Saving LVM layout."
         extentsize=$(echo $line | cut -d ":" -f "13")
         nrextents=$(echo $line | cut -d ":" -f "14")
 
+        if [ $header_printed -eq 0 ] ; then
+            echo "# Format for LVM VGs"
+            echo "# lvmgrp <volume_group> <extentsize> [<size(extents)>] [<size(bytes)>]"
+            header_printed=1
+        fi
+
         echo "lvmgrp /dev/$vgrp $extentsize $nrextents $size"
     done
+
+    header_printed=0
 
     ## Get all logical volumes
     # format: lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]
 
-    lvm 8>&- 7>&- lvs --separator=":" --noheadings --units b --nosuffix -o origin,lv_name,vg_name,lv_size,lv_layout,pool_lv,chunk_size,stripes | while read line ; do
-        origin=$(echo $line | awk -F ':' '{ print $1 }')
-        # Skip snapshots
-        [ -z "$origin" ] || continue
+    lvm 8>&- 7>&- lvs --separator=":" --noheadings --units b --nosuffix -o origin,lv_name,vg_name,lv_size,lv_layout,pool_lv,chunk_size,stripes,stripe_size | while read line ; do
 
-        lv=$(echo $line | awk -F ':' '{ print $2 }')
-        vg=$(echo $line | awk -F ':' '{ print $3 }')
-        size=$(echo $line | awk -F ':' '{ print $4 }')
-        layout=$(echo $line | awk -F ':' '{ print $5 }')
-        thinpool=$(echo $line | awk -F ':' '{ print $6 }')
-        chunksize=$(echo $line | awk -F ':' '{ print $7 }')
-        stripes=$(echo $line | awk -F ':' '{ print $8 }')
+        if [ $header_printed -eq 0 ] ; then
+            echo "# Format for LVM LVs"
+            echo "# lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]"
+            header_printed=1
+        fi
+
+        origin="$(echo "$line" | awk -F ':' '{ print $1 }')"
+        # Skip snapshots (useless) or caches (dont know how to handle that)
+        if [ -n "$origin" ] ; then
+            echo "# Skipped snapshot of cache information '$line'"
+            continue
+        fi
+
+        lv="$(echo "$line" | awk -F ':' '{ print $2 }')"
+        vg="$(echo "$line" | awk -F ':' '{ print $3 }')"
+        size="$(echo "$line" | awk -F ':' '{ print $4 }')"
+        layout="$(echo "$line" | awk -F ':' '{ print $5 }')"
+        thinpool="$(echo "$line" | awk -F ':' '{ print $6 }')"
+        chunksize="$(echo "$line" | awk -F ':' '{ print $7 }')"
+        stripes="$(echo "$line" | awk -F ':' '{ print $8 }')"
+        stripesize="$(echo "$line" | awk -F ':' '{ print $9 }')"
 
         kval=""
         [ -z "$thinpool" ] || kval="${kval:+$kval }thinpool:$thinpool"
         [ $chunksize -eq 0 ] || kval="${kval:+$kval }chunksize:${chunksize}b"
-        [[ ,$layout, != ,mirror, ]] || kval="${kval:+$kval }mirrors:$(($stripes - 1))"
+        [ $stripesize -eq 0 ] || kval="${kval:+$kval }stripesize:${stripesize}b"
+        if [[ ,$layout, == *,mirror,* ]] ; then
+            kval="${kval:+$kval }mirrors:$(($stripes - 1))"
+        elif [[ ,$layout, == *,striped,* ]] ; then
+            kval="${kval:+$kval }stripes:$stripes"
+        fi
 
         echo "lvmvol /dev/$vg $lv ${size}b $layout $kval"
     done

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -37,13 +37,28 @@ Log "Saving LVM layout."
     done
 
     ## Get all logical volumes
-    # format: lvmvol <volume_group> <name> <size(extents)> [<size(bytes)>]
-    lvm 8>&- 7>&- lvdisplay -c | while read line ; do
-        lvol=$(echo $line | cut -d ":" -f "1" | cut -d "/" -f "4")
-        vgrp=$(echo $line | cut -d ":" -f "2")
-        size=$(echo $line | cut -d ":" -f "7")
-        extents=$(echo $line | cut -d ":" -f "8")
+    # format: lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]
 
-        echo "lvmvol /dev/$vgrp $lvol $extents $size "
+    lvm 8>&- 7>&- lvs --separator=":" --noheadings --units b --nosuffix -o origin,lv_name,vg_name,lv_size,lv_layout,pool_lv,chunk_size,stripes | while read line ; do
+        origin=$(echo $line | awk -F ':' '{ print $1 }')
+        # Skip snapshots
+        [ -z "$origin" ] || continue
+
+        lv=$(echo $line | awk -F ':' '{ print $2 }')
+        vg=$(echo $line | awk -F ':' '{ print $3 }')
+        size=$(echo $line | awk -F ':' '{ print $4 }')
+        layout=$(echo $line | awk -F ':' '{ print $5 }')
+        thinpool=$(echo $line | awk -F ':' '{ print $6 }')
+        chunksize=$(echo $line | awk -F ':' '{ print $7 }')
+        stripes=$(echo $line | awk -F ':' '{ print $8 }')
+
+        kval=""
+        [ -z "$thinpool" ] || kval="${kval:+$kval }thinpool:$thinpool"
+        [ $chunksize -eq 0 ] || kval="${kval:+$kval }chunksize:${chunksize}b"
+        [[ ,$layout, != ,mirror, ]] || kval="${kval:+$kval }mirrors:$(($stripes - 1))"
+
+        echo "lvmvol /dev/$vg $lv ${size}b $layout $kval"
     done
 ) >> $DISKLAYOUT_FILE
+
+# vim: set et ts=4 sw=4:

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -57,42 +57,102 @@ Log "Saving LVM layout."
     ## Get all logical volumes
     # format: lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]
 
-    lvm 8>&- 7>&- lvs --separator=":" --noheadings --units b --nosuffix -o origin,lv_name,vg_name,lv_size,lv_layout,pool_lv,chunk_size,stripes,stripe_size | while read line ; do
+    # Check for 'lvs' support of lv_layout
 
-        if [ $header_printed -eq 0 ] ; then
-            echo "# Format for LVM LVs"
-            echo "# lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]"
-            header_printed=1
-        fi
+    if lvm lvs -o lv_layout >/dev/null 2>&1; then
 
-        origin="$(echo "$line" | awk -F ':' '{ print $1 }')"
-        # Skip snapshots (useless) or caches (dont know how to handle that)
-        if [ -n "$origin" ] ; then
-            echo "# Skipped snapshot of cache information '$line'"
-            continue
-        fi
+        lvm 8>&- 7>&- lvs --separator=":" --noheadings --units b --nosuffix -o origin,lv_name,vg_name,lv_size,lv_layout,pool_lv,chunk_size,stripes,stripe_size | while read line ; do
 
-        lv="$(echo "$line" | awk -F ':' '{ print $2 }')"
-        vg="$(echo "$line" | awk -F ':' '{ print $3 }')"
-        size="$(echo "$line" | awk -F ':' '{ print $4 }')"
-        layout="$(echo "$line" | awk -F ':' '{ print $5 }')"
-        thinpool="$(echo "$line" | awk -F ':' '{ print $6 }')"
-        chunksize="$(echo "$line" | awk -F ':' '{ print $7 }')"
-        stripes="$(echo "$line" | awk -F ':' '{ print $8 }')"
-        stripesize="$(echo "$line" | awk -F ':' '{ print $9 }')"
+            if [ $header_printed -eq 0 ] ; then
+                echo "# Format for LVM LVs"
+                echo "# lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]"
+                header_printed=1
+            fi
 
-        kval=""
-        [ -z "$thinpool" ] || kval="${kval:+$kval }thinpool:$thinpool"
-        [ $chunksize -eq 0 ] || kval="${kval:+$kval }chunksize:${chunksize}b"
-        [ $stripesize -eq 0 ] || kval="${kval:+$kval }stripesize:${stripesize}b"
-        if [[ ,$layout, == *,mirror,* ]] ; then
-            kval="${kval:+$kval }mirrors:$(($stripes - 1))"
-        elif [[ ,$layout, == *,striped,* ]] ; then
-            kval="${kval:+$kval }stripes:$stripes"
-        fi
+            origin="$(echo "$line" | awk -F ':' '{ print $1 }')"
+            # Skip snapshots (useless) or caches (dont know how to handle that)
+            if [ -n "$origin" ] ; then
+                echo "# Skipped snapshot of cache information '$line'"
+                continue
+            fi
 
-        echo "lvmvol /dev/$vg $lv ${size}b $layout $kval"
-    done
+            lv="$(echo "$line" | awk -F ':' '{ print $2 }')"
+            vg="$(echo "$line" | awk -F ':' '{ print $3 }')"
+            size="$(echo "$line" | awk -F ':' '{ print $4 }')"
+            layout="$(echo "$line" | awk -F ':' '{ print $5 }')"
+            thinpool="$(echo "$line" | awk -F ':' '{ print $6 }')"
+            chunksize="$(echo "$line" | awk -F ':' '{ print $7 }')"
+            stripes="$(echo "$line" | awk -F ':' '{ print $8 }')"
+            stripesize="$(echo "$line" | awk -F ':' '{ print $9 }')"
+
+            kval=""
+            [ -z "$thinpool" ] || kval="${kval:+$kval }thinpool:$thinpool"
+            [ $chunksize -eq 0 ] || kval="${kval:+$kval }chunksize:${chunksize}b"
+            [ $stripesize -eq 0 ] || kval="${kval:+$kval }stripesize:${stripesize}b"
+            if [[ ,$layout, == *,mirror,* ]] ; then
+                kval="${kval:+$kval }mirrors:$(($stripes - 1))"
+            elif [[ ,$layout, == *,striped,* ]] ; then
+                kval="${kval:+$kval }stripes:$stripes"
+            fi
+
+            echo "lvmvol /dev/$vg $lv ${size}b $layout $kval"
+        done
+
+    else
+        # Compatibility with older LVM versions (e.g. <= 2.02.98)
+        # No support for 'lv_layout', too bad, do our best!
+
+        lvm 8>&- 7>&- lvs --separator=":" --noheadings --units b --nosuffix -o origin,lv_name,vg_name,lv_size,modules,pool_lv,chunk_size,stripes,stripe_size | while read line ; do
+
+            if [ $header_printed -eq 0 ] ; then
+                echo "# Format for LVM LVs"
+                echo "# lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]"
+                header_printed=1
+            fi
+
+            origin="$(echo "$line" | awk -F ':' '{ print $1 }')"
+            # Skip snapshots (useless) or caches (dont know how to handle that)
+            if [ -n "$origin" ] ; then
+                echo "# Skipped snapshot of cache information '$line'"
+                continue
+            fi
+
+            lv="$(echo "$line" | awk -F ':' '{ print $2 }')"
+            vg="$(echo "$line" | awk -F ':' '{ print $3 }')"
+            size="$(echo "$line" | awk -F ':' '{ print $4 }')"
+            modules="$(echo "$line" | awk -F ':' '{ print $5 }')"
+            thinpool="$(echo "$line" | awk -F ':' '{ print $6 }')"
+            chunksize="$(echo "$line" | awk -F ':' '{ print $7 }')"
+            stripes="$(echo "$line" | awk -F ':' '{ print $8 }')"
+            stripesize="$(echo "$line" | awk -F ':' '{ print $9 }')"
+
+            kval=""
+            [ -z "$thinpool" ] || kval="${kval:+$kval }thinpool:$thinpool"
+            [ $chunksize -eq 0 ] || kval="${kval:+$kval }chunksize:${chunksize}b"
+            [ $stripesize -eq 0 ] || kval="${kval:+$kval }stripesize:${stripesize}b"
+            if [[ "$modules" == "" ]] ; then
+                layout="linear"
+                [ $stripes -eq 0 ] || kval="${kval:+$kval }stripes:$stripes"
+            elif [[ ,$modules, == *,mirror,* ]] ; then
+                layout="mirror"
+                kval="${kval:+$kval }mirrors:$(($stripes - 1))"
+            elif [[ ,$modules, == *,thin-pool,* ]] ; then
+                if [ -z "$thinpool" ] ; then
+                    layout="thin,pool"
+                else
+                    layout="thin,sparse"
+                fi
+            elif [[ ,$modules, == *,raid,* ]] ; then
+                LogPrint "Warning: don't know how to collect RAID information for LV '$lv'. Automatic disk layout recovery may fail."
+                layout="raid,RAID_UNKNOWNTYPE"
+                kval="${kval:+$kval }stripes:$stripes"
+            fi
+
+            echo "lvmvol /dev/$vg $lv ${size}b $layout $kval"
+        done
+
+    fi
+
 ) >> $DISKLAYOUT_FILE
 
 # vim: set et ts=4 sw=4:

--- a/usr/share/rear/prep/GNU/Linux/220_include_lvm_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/220_include_lvm_tools.sh
@@ -13,3 +13,9 @@ fsadm
 COPY_AS_IS=( "${COPY_AS_IS[@]}"
 /etc/lvm
 )
+
+if lvs --noheadings -o thin_count | grep -q -v "^\s*$" ; then
+    # There are Thin Pools on the system, include required binaries
+    PROGS=( "${PROGS[@]}" /usr/sbin/thin_* )
+    LIBS=( "${LIBS[@]}" /usr/lib64/*lvm2* )
+fi

--- a/usr/share/rear/prep/GNU/Linux/220_include_lvm_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/220_include_lvm_tools.sh
@@ -17,5 +17,11 @@ COPY_AS_IS=( "${COPY_AS_IS[@]}"
 if lvs --noheadings -o thin_count | grep -q -v "^\s*$" ; then
     # There are Thin Pools on the system, include required binaries
     PROGS=( "${PROGS[@]}" /usr/sbin/thin_* )
-    LIBS=( "${LIBS[@]}" /usr/lib64/*lvm2* )
 fi
+
+if lvs --noheadings -o modules | grep -q -v "^\s*$" ; then
+    # There are non-linear LVs on the system, include required libraries
+    LIBS=( "${LIBS[@]}" /lib64/*lvm2* )
+fi
+
+# vim: set et ts=4 sw=4:

--- a/usr/share/rear/prep/GNU/Linux/220_include_lvm_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/220_include_lvm_tools.sh
@@ -16,7 +16,7 @@ COPY_AS_IS=( "${COPY_AS_IS[@]}"
 
 if lvs --noheadings -o thin_count | grep -q -v "^\s*$" ; then
     # There are Thin Pools on the system, include required binaries
-    PROGS=( "${PROGS[@]}" /usr/sbin/thin_* )
+    PROGS=( "${PROGS[@]}" thin_check )
 fi
 
 if lvs --noheadings -o modules | grep -q -v "^\s*$" ; then


### PR DESCRIPTION
Using 'vgcfgrestore' to restore Thin LVs doesn't work, because there
isn't the metadata in the configuration file.
To be able to use Thin LVs, upon failure of 'vgcfgrestore' (or migration),
traditional 'vgcreate/lvcreate' are used instead.

This approach is sub-optimal because it requires to know all the
possible options to 'lvcreate', which is hard/impossible to do.
Nonetheless, this is better than nothing since the issue with 'lvcreate'
options was already there in case of migration.

The code using 'lvcreate' only runs upon 'vgcfgrestore' failure, which
typically happens only with Thin LVs (IMHO). Hence, on most setups, the
optimized code will still run, preventing any regression to happen.

Signed-off-by: Renaud Métrich <rmetrich@redhat.com>

PLEASE TEST MORE.

I tested as follows:
- regular system with 1 VG, no thin pool
- system with 1 VG, and root filesystem on thin pool + some special LVs (mirror, raid1, raid5, etc).

I plan to test tomorrow on a system with 1 VG, no thin pool but some special LVs (mirror, raid, etc) to verify that `vgcfgrestore` also works with special LVs.