### PR TITLE
Sesam integration: add sesam bin directory to LD_LIBRARY_PATH

### DIFF
--- a/usr/share/rear/build/default/980_verify_rootfs.sh
+++ b/usr/share/rear/build/default/980_verify_rootfs.sh
@@ -46,6 +46,11 @@ if test "$BACKUP" = "TSM" ; then
     # see https://github.com/rear/rear/issues/1533
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TSM_LD_LIBRARY_PATH
 fi
+if test "$BACKUP" = "SESAM" ; then
+    # Use a SEP sesam-specific LD_LIBRARY_PATH to find sesam client
+    # related libraries
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SESAM_LD_LIBRARY_PATH
+fi
 # Actually test all binaries for 'not found' libraries.
 # Find all binaries and libraries also e.g. those that are copied via COPY_AS_IS into other paths:
 for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ); do

--- a/usr/share/rear/lib/sesam-functions.sh
+++ b/usr/share/rear/lib/sesam-functions.sh
@@ -9,6 +9,11 @@ if ! test -r $sesam2000ini_file ; then
     return 0
 fi
 
+# for later use in default/980_verify_rootfs.sh to avoid issues
+# with missing library dependencies during rootfs check
+source $sesam2000ini_file
+SESAM_LD_LIBRARY_PATH=$SM_BIN_SESAM
+
 SM_INI="$( grep SM_INI $sesam2000ini_file 2>/dev/null | cut -d '=' -f 2 )"
 test -z "$SM_INI" && return 0
 


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact:  **Normal** /

*

On some systems (for example centos6 and/or ubuntu) REAR backup with Backup type SESAM
fails during verify of the rootfs due to missing libraries:

```
/opt/sesam/bin/sesam/Crypto.Hash._SHA256.so requires additional libraries (fatal error)
libpython2.7.so.1.0 => not found
/opt/sesam/bin/sesam/cPickle.so requires additional libraries (fatal error)
libpython2.7.so.1.0 => not found
ERROR: ReaR recovery system in '/tmp/rear.LyKD3Rt2V4XgYs2/rootfs' not usable
```

these libraries are part of the Sesam client integration itself but unfortunately are not found
due to the sesam installation directory not beeing part of LD_LIBRARY_PATH.

For TSM an alike issue has already been fixed as TSM sets the LD_LIBRARY_PATH:

```
./usr/share/rear/prep/TSM/default/400_prep_tsm.sh:# Find gsk lib diriectory and add it to the TSM_LD_LIBRARY_PATH
./usr/share/rear/prep/TSM/default/400_prep_tsm.sh:      TSM_LD_LIBRARY_PATH=$TSM_LD_LIBRARY_PATH:$gsk_dir

```

This patch does the same for the sesam client, installation directory is used from the
configuration file and not hardcoded.
