### PR TITLE
Issue #1722 - Cannot restore disk built on multipath + md

### DIFF
--- a/usr/share/rear/build/GNU/Linux/110_touch_empty_files.sh
+++ b/usr/share/rear/build/GNU/Linux/110_touch_empty_files.sh
@@ -9,4 +9,5 @@ pushd $ROOTFS_DIR >/dev/null
 	touch var/log/lastlog
 	touch var/lib/nfs/state
 	touch etc/mtab
+	touch etc/udev/rules.d/65-md-incremental.rules
 popd >/dev/null

--- a/usr/share/rear/build/default/502_include_mdadm_conf.sh
+++ b/usr/share/rear/build/default/502_include_mdadm_conf.sh
@@ -1,0 +1,9 @@
+grep -q blocks /proc/mdstat 2>/dev/null || return 0
+
+# Include /etc/mdadm.conf without building arrays automatically
+if [ -e "/etc/mdadm.conf" ] ; then
+	(
+		echo "AUTO -all"
+		sed "s/^ARRAY/#ARRAY/g" /etc/mdadm.conf
+	) > $ROOTFS_DIR/etc/mdadm.conf
+fi

--- a/usr/share/rear/prep/GNU/Linux/230_include_md_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/230_include_md_tools.sh
@@ -7,6 +7,3 @@ Log "Software RAID detected. Including mdadm tools."
 PROGS=( "${PROGS[@]}"
 mdadm
 )
-COPY_AS_IS=( "${COPY_AS_IS[@]}"
-/etc/mdadm.conf
-)


### PR DESCRIPTION
Trying to restore a backup of a system booting with multipath + software
raid, at the rescue prompt, after starting multipathd or executing "rear
recover", the multipath devices are not found.
This is due to mdadm building the array at boot, preventing multipath
from grabbing the disks later.

Solution: Disable automatic building of software raids (mdadm) by
ignoring the corresponding udev rule.

Tested on RHEL7 and RHEL6.
**Requires additional testing on Ubuntu and SLES (sorry I don't have
these).**

Signed-off-by: Renaud Métrich <rmetrich@redhat.com>

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?**

Enhancement

* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent**

Normal

* Reference to related issue (URL):

https://github.com/rear/rear/issues/1722

* How was this pull request tested?

RHEL6 and RHEL7 restoration of multipath+md systems

* Brief description of the changes in this pull request:

Disable automatic building of software raids (mdadm) by
ignoring the corresponding udev rule.
