### PR TITLE
Fixed, simplified and enhanced GRUB2 installation

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -371,8 +371,8 @@ fi
 # Source usr/share/rear/lib/_input-output-functions.sh because therein
 # the original STDIN STDOUT and STDERR file descriptors are saved as fd6 fd7 and fd8
 # so that ReaR functions for actually intended user messages can use fd7 and fd8
-# to show messages to the user regardless whereto STDOUT and STDERR are redirected
-# and fd6 to get input from the user regardless whereto STDIN is redirected:
+# to show messages to the user regardless where to STDOUT and STDERR are redirected
+# and fd6 to get input from the user regardless where to STDIN is redirected:
 source $SHARE_DIR/lib/_input-output-functions.sh
 
 # Keep old log file:

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2088,7 +2088,20 @@ readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/moved_away_after_backup_re
 # and /etc/udev/rules.d/70-persistent-net.rules is created and maintained
 # by systemd/udev (see https://github.com/rear/rear/issues/770):
 # BACKUP_RESTORE_MOVE_AWAY_FILES=( /var/tmp /etc/udev/rules.d/70-persistent-net.rules )
-BACKUP_RESTORE_MOVE_AWAY_FILES=()
+#
+# Move away outdated information from previous boot via GRUB2
+# to avoid a possible GRUB2 "error: invalid environment block."
+# cf. https://github.com/rear/rear/issues/1828
+# GRUB2 can use /boot/grub/grubenv or /boot/grub2/grubenv
+# to remember a small amount of information from one boot to the next.
+# But on a by "rear recover" recreated system there is no such thing
+# as a meaningful previous boot (because "rear recover" recreates a system
+# by reinstalling it completely from scratch) so that there is no meaningful
+# use-case to remember any information from a possible previous boot,
+# cf. https://github.com/rear/rear/issues/1828#issuecomment-399050741
+# Nevertheless that information from the last boot on the original system
+# could be still of interest for the user so that it is not deleted:
+BACKUP_RESTORE_MOVE_AWAY_FILES=( /boot/grub/grubenv /boot/grub2/grubenv )
 
 ##
 # DIRECTORY_ENTRIES_TO_RECOVER
@@ -2348,36 +2361,6 @@ GRUB_RESCUE_USER=""
 REBUILD_INITRAMFS="yes"
 
 ##
-# REAR_INITRD_COMPRESSION
-#
-# What compression to use when creating the initramfs/initrd for the ReaR rescue/recovery system.
-# By default and also as fallback an initrd.cgz with gzip default compression is created.
-# The default is known to work well in practice.
-# The ReaR rescue/recovery system initrd is loaded by various bootloaders (normally syslinux).
-# Usually any bootloader should be able to load any initrd file but then
-# the initrd must be usable by the kernel which means a specially compressed initrd
-# may not always work, in particular not with older kernels.
-# When booting on ppc64 with the yaboot bootloader the initrd must be less than 32MB (or 32MiB?)
-# so that in this case the lzma compression could be even required
-# see https://github.com/rear/rear/issues/1142
-# In genaral a smaller initrd is loaded faster by the ReaR rescue/recovery system bootloader
-# so that a small initrd could make the whole system recovery a bit faster.
-# With REAR_INITRD_COMPRESSION="fast"
-# an initrd.cgz with gzip --fast compression is created (fast creating but less compression).
-# With REAR_INITRD_COMPRESSION="best"
-# an initrd.cgz with gzip --best compression is created (best gzip compression but slower creating).
-# With REAR_INITRD_COMPRESSION="lzma"
-# an initrd.xz with xz using the lzma compression is created (very best compression but very slow).
-# With REAR_INITRD_COMPRESSION="lz4"
-# an initrd.lz4 with lz4 default -1 compression is created (fast speed but less compression).
-# An initrd.xz with lzma or lz4 compression may not work in this or that case.
-# An initrd.xz with lzma or lz4 compression is known not to work together with DRLM prior to version 2.1.1
-# see https://github.com/rear/rear/pull/1182#issuecomment-275423441
-# but at least lzma compression works with DRLM since version 2.1.1
-# see https://github.com/rear/rear/pull/1182#issuecomment-282252770
-REAR_INITRD_COMPRESSION=""
-
-##
 # BOOTLOADER
 #
 # What kind of bootloader is used on the original system
@@ -2397,19 +2380,29 @@ REAR_INITRD_COMPRESSION=""
 BOOTLOADER=""
 
 ##
-# GRUB2_INSTALL_DEVICE
+# GRUB2_INSTALL_DEVICES
 #
-# When GRUB2 is used as bootloader the device where to GRUB2 should be installed.
-# When GRUB2_INSTALL_DEVICE is specified, GRUB2 will be installed via a command like
-#   chroot /mnt/local /bin/bash --login -c "grub2-install $GRUB2_INSTALL_DEVICE"
-# When GRUB2_INSTALL_DEVICE is not specified, ReaR tries to automatically determine
+# When GRUB2 is used as bootloader GRUB2_INSTALL_DEVICES is a string of devices
+# where GRUB2 should be installed like GRUB2_INSTALL_DEVICES="/dev/sda /dev/sdb".
+# When GRUB2_INSTALL_DEVICES is specified, GRUB2 will be installed
+# on each grub2_install_device in GRUB2_INSTALL_DEVICES via a command like
+#   chroot /mnt/local /bin/bash --login -c "grub2-install $grub2_install_device"
+# Careful when you use more than one disk like /dev/sda for the system
+# plus a USB disk /dev/sdb for the ReaR recovery system and the backup.
+# The two disk devices may get interchanged on the replacement hardware
+# so that during "rear recover" /dev/sda could be the USB disk.
+# In this case GRUB2_INSTALL_DEVICES="/dev/sda" would install GRUB2
+# with the system's GRUB2 configuration on the USB disk which would
+# overwrite/destroy the ReaR recovery system bootloader,
+# cf. the MIGRATION_MODE description above.
+# When GRUB2_INSTALL_DEVICES is not specified, ReaR tries to automatically determine
 # where to install GRUB2 but then the bootloader installation could get wrong.
 # For details see the finalize/Linux-i386/620_install_grub2.sh script.
-# GRUB2_INSTALL_DEVICE is set to a default value here only
+# GRUB2_INSTALL_DEVICES is set to a default value here only
 # if not already set so that the user can set it also via
-#   export GRUB2_INSTALL_DEVICE="/dev/sda"
-# directly before he calls "rear recover":
-test "$GRUB2_INSTALL_DEVICE" || GRUB2_INSTALL_DEVICE=""
+#   export GRUB2_INSTALL_DEVICES="/dev/sdb"
+# to the right device directly before he calls "rear recover":
+test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
 
 ##
 # USING_UEFI_BOOTLOADER
@@ -2458,6 +2451,36 @@ UEFI_BOOTLOADER=""
 #
 # c.f. https://github.com/rear/rear/pull/1385
 SECURE_BOOT_BOOTLOADER=""
+
+##
+# REAR_INITRD_COMPRESSION
+#
+# What compression to use when creating the initramfs/initrd for the ReaR rescue/recovery system.
+# By default and also as fallback an initrd.cgz with gzip default compression is created.
+# The default is known to work well in practice.
+# The ReaR rescue/recovery system initrd is loaded by various bootloaders (normally syslinux).
+# Usually any bootloader should be able to load any initrd file but then
+# the initrd must be usable by the kernel which means a specially compressed initrd
+# may not always work, in particular not with older kernels.
+# When booting on ppc64 with the yaboot bootloader the initrd must be less than 32MB (or 32MiB?)
+# so that in this case the lzma compression could be even required
+# see https://github.com/rear/rear/issues/1142
+# In genaral a smaller initrd is loaded faster by the ReaR rescue/recovery system bootloader
+# so that a small initrd could make the whole system recovery a bit faster.
+# With REAR_INITRD_COMPRESSION="fast"
+# an initrd.cgz with gzip --fast compression is created (fast creating but less compression).
+# With REAR_INITRD_COMPRESSION="best"
+# an initrd.cgz with gzip --best compression is created (best gzip compression but slower creating).
+# With REAR_INITRD_COMPRESSION="lzma"
+# an initrd.xz with xz using the lzma compression is created (very best compression but very slow).
+# With REAR_INITRD_COMPRESSION="lz4"
+# an initrd.lz4 with lz4 default -1 compression is created (fast speed but less compression).
+# An initrd.xz with lzma or lz4 compression may not work in this or that case.
+# An initrd.xz with lzma or lz4 compression is known not to work together with DRLM prior to version 2.1.1
+# see https://github.com/rear/rear/pull/1182#issuecomment-275423441
+# but at least lzma compression works with DRLM since version 2.1.1
+# see https://github.com/rear/rear/pull/1182#issuecomment-282252770
+REAR_INITRD_COMPRESSION=""
 
 ##
 # advanced handling of Relax-and-Recover result (boot image)

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2393,8 +2393,11 @@ BOOTLOADER=""
 # so that during "rear recover" /dev/sda could be the USB disk.
 # In this case GRUB2_INSTALL_DEVICES="/dev/sda" would install GRUB2
 # with the system's GRUB2 configuration on the USB disk which would
-# overwrite/destroy the ReaR recovery system bootloader,
-# cf. the MIGRATION_MODE description above.
+# overwrite/destroy the ReaR recovery system bootloader.
+# In MIGRATION_MODE disk mappings (in var/lib/rear/layout/disk_mappings)
+# are applied when devices in GRUB2_INSTALL_DEVICES match so that enforcing
+# MIGRATION_MODE helps to avoid that GRUB2 gets installed on a wrong disk
+# when more than one disk is used.
 # When GRUB2_INSTALL_DEVICES is not specified, ReaR tries to automatically determine
 # where to install GRUB2 but then the bootloader installation could get wrong.
 # For details see the finalize/Linux-i386/620_install_grub2.sh script.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1912,7 +1912,7 @@ ZYPPER_INSTALL_RPMS=""
 # The COPY_AS_IS_ZYPPER array contains by default basically what
 #   rpm -qc zypper ; rpm -ql libzypp | egrep -v 'locale|man'
 # shows (currently determined on openSUSE Leap 42.1)
-# plus the special /etc/products.d/baseproduct link and whereto it points
+# plus the special /etc/products.d/baseproduct link and where to it points
 # and rpm because that is required by zypper/libzypp and
 # finally all kernel modules because otherwise modules like 'isofs' and some 'nls*' modules
 # that are needed to mount a iso9660 image (e.g. a SUSE installation medium in a CDROM drive)
@@ -2348,6 +2348,36 @@ GRUB_RESCUE_USER=""
 REBUILD_INITRAMFS="yes"
 
 ##
+# REAR_INITRD_COMPRESSION
+#
+# What compression to use when creating the initramfs/initrd for the ReaR rescue/recovery system.
+# By default and also as fallback an initrd.cgz with gzip default compression is created.
+# The default is known to work well in practice.
+# The ReaR rescue/recovery system initrd is loaded by various bootloaders (normally syslinux).
+# Usually any bootloader should be able to load any initrd file but then
+# the initrd must be usable by the kernel which means a specially compressed initrd
+# may not always work, in particular not with older kernels.
+# When booting on ppc64 with the yaboot bootloader the initrd must be less than 32MB (or 32MiB?)
+# so that in this case the lzma compression could be even required
+# see https://github.com/rear/rear/issues/1142
+# In genaral a smaller initrd is loaded faster by the ReaR rescue/recovery system bootloader
+# so that a small initrd could make the whole system recovery a bit faster.
+# With REAR_INITRD_COMPRESSION="fast"
+# an initrd.cgz with gzip --fast compression is created (fast creating but less compression).
+# With REAR_INITRD_COMPRESSION="best"
+# an initrd.cgz with gzip --best compression is created (best gzip compression but slower creating).
+# With REAR_INITRD_COMPRESSION="lzma"
+# an initrd.xz with xz using the lzma compression is created (very best compression but very slow).
+# With REAR_INITRD_COMPRESSION="lz4"
+# an initrd.lz4 with lz4 default -1 compression is created (fast speed but less compression).
+# An initrd.xz with lzma or lz4 compression may not work in this or that case.
+# An initrd.xz with lzma or lz4 compression is known not to work together with DRLM prior to version 2.1.1
+# see https://github.com/rear/rear/pull/1182#issuecomment-275423441
+# but at least lzma compression works with DRLM since version 2.1.1
+# see https://github.com/rear/rear/pull/1182#issuecomment-282252770
+REAR_INITRD_COMPRESSION=""
+
+##
 # BOOTLOADER
 #
 # What kind of bootloader is used on the original system
@@ -2365,6 +2395,21 @@ REBUILD_INITRAMFS="yes"
 # - ARM-ALLWINNER is for Allwinner devices and will backup and restore the 2nd stage bootloader
 # With an unknown or unsupported bootloader value setting ReaR would fail:
 BOOTLOADER=""
+
+##
+# GRUB2_INSTALL_DEVICE
+#
+# When GRUB2 is used as bootloader the device where to GRUB2 should be installed.
+# When GRUB2_INSTALL_DEVICE is specified, GRUB2 will be installed via a command like
+#   chroot /mnt/local /bin/bash --login -c "grub2-install $GRUB2_INSTALL_DEVICE"
+# When GRUB2_INSTALL_DEVICE is not specified, ReaR tries to automatically determine
+# where to install GRUB2 but then the bootloader installation could get wrong.
+# For details see the finalize/Linux-i386/620_install_grub2.sh script.
+# GRUB2_INSTALL_DEVICE is set to a default value here only
+# if not already set so that the user can set it also via
+#   export GRUB2_INSTALL_DEVICE="/dev/sda"
+# directly before he calls "rear recover":
+test "$GRUB2_INSTALL_DEVICE" || GRUB2_INSTALL_DEVICE=""
 
 ##
 # USING_UEFI_BOOTLOADER
@@ -2413,36 +2458,6 @@ UEFI_BOOTLOADER=""
 #
 # c.f. https://github.com/rear/rear/pull/1385
 SECURE_BOOT_BOOTLOADER=""
-
-##
-# REAR_INITRD_COMPRESSION
-#
-# What compression to use when creating the initramfs/initrd for the ReaR rescue/recovery system.
-# By default and also as fallback an initrd.cgz with gzip default compression is created.
-# The default is known to work well in practice.
-# The ReaR rescue/recovery system initrd is loaded by various bootloaders (normally syslinux).
-# Usually any bootloader should be able to load any initrd file but then
-# the initrd must be usable by the kernel which means a specially compressed initrd
-# may not always work, in particular not with older kernels.
-# When booting on ppc64 with the yaboot bootloader the initrd must be less than 32MB (or 32MiB?)
-# so that in this case the lzma compression could be even required
-# see https://github.com/rear/rear/issues/1142
-# In genaral a smaller initrd is loaded faster by the ReaR rescue/recovery system bootloader
-# so that a small initrd could make the whole system recovery a bit faster.
-# With REAR_INITRD_COMPRESSION="fast"
-# an initrd.cgz with gzip --fast compression is created (fast creating but less compression).
-# With REAR_INITRD_COMPRESSION="best"
-# an initrd.cgz with gzip --best compression is created (best gzip compression but slower creating).
-# With REAR_INITRD_COMPRESSION="lzma"
-# an initrd.xz with xz using the lzma compression is created (very best compression but very slow).
-# With REAR_INITRD_COMPRESSION="lz4"
-# an initrd.lz4 with lz4 default -1 compression is created (fast speed but less compression).
-# An initrd.xz with lzma or lz4 compression may not work in this or that case.
-# An initrd.xz with lzma or lz4 compression is known not to work together with DRLM prior to version 2.1.1
-# see https://github.com/rear/rear/pull/1182#issuecomment-275423441
-# but at least lzma compression works with DRLM since version 2.1.1
-# see https://github.com/rear/rear/pull/1182#issuecomment-282252770
-REAR_INITRD_COMPRESSION=""
 
 ##
 # advanced handling of Relax-and-Recover result (boot image)

--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
@@ -38,8 +38,11 @@ for file in     [b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* [b]oot/grub/
         fi
 
         if test -s "$file" ; then
-            apply_layout_mappings "$file"
+            # Inform the user but do not error out here at this late state of "rear recover"
+            # when it failed to apply the layout mappings to one particular file:
+            apply_layout_mappings "$file" || LogPrintError "Failed to apply layout mappings to $file"
         else
             LogPrint "Not Patching empty file ($file)"
         fi
 done
+

--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
@@ -1,48 +1,72 @@
-### Apply chosen migrations to files on the disk.
+#
+# Apply disk layout mappings to certain restored files.
+#
 
-if [[ ! -s "$MAPPING_FILE" ]] ; then
-    return
-fi
+test -s "$MAPPING_FILE" || return 0
+
+LogPrint "Applying disk layout mappings in $MAPPING_FILE to certain restored files..."
 
 # FIXME: Why is there is no matching popd for this pushd?
 # Cf. finalize/GNU/Linux/150_migrate_uuid_tags.sh where a popd is at the end.
 # If there is intentionally no popd here an explanation why there is no popd is missing.
 pushd $TARGET_FS_ROOT >/dev/null
-# the funny [] around the first letter make sure that shopt -s nullglob removes this file from the list if it does not exist
-# the files without a [] are mandatory, like fstab
-for file in     [b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* [b]oot/grub/{grub.conf,menu.lst,device.map} \
-		[b]oot/grub2/{grub.conf,grub.cfg,menu.lst,device.map} \
-                [e]tc/sysconfig/grub [e]tc/sysconfig/bootloader \
-                [e]tc/lilo.conf \
-                [e]tc/yaboot.conf \
-                [e]tc/mtab [e]tc/fstab \
-                [e]tc/mtools.conf \
-                [e]tc/smartd.conf [e]tc/sysconfig/smartmontools \
-                [e]tc/sysconfig/rawdevices \
-                [e]tc/security/pam_mount.conf.xml [b]oot/efi/*/*/grub.cfg
-        do
 
-	[[ ! -f $file ]] && continue # skip directory or file not found
+# Save the original restored files because in general any user data is sacrosanct,
+# cf. how BACKUP_RESTORE_MOVE_AWAY is implemented in restore/default/990_move_away_restored_files.sh
+save_original_file_dir="$VAR_DIR/saved_original_files/"
+# Strip leading '/' to get a relative path that is needed inside the recovery system:
+save_original_file_dir="${save_original_file_dir#/}"
+# Create the save_original_file_dir with mode 0700 (rwx------)
+# so that only root can access files and subdirectories therein
+# because the files therein could contain security relevant information:
+mkdir -p -m 0700 $save_original_file_dir
+LogPrint "The original restored files get saved in $save_original_file_dir (in $TARGET_FS_ROOT)"
+
+# The funny [] around the first letter make sure that shopt -s nullglob removes this file from the list if it does not exist.
+# Files without a [] are mandatory, like fstab:
+for file in [b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* [b]oot/grub/{grub.conf,menu.lst,device.map} \
+            [b]oot/grub2/{grub.conf,grub.cfg,menu.lst,device.map} \
+            [e]tc/sysconfig/grub [e]tc/sysconfig/bootloader \
+            [e]tc/lilo.conf \
+            [e]tc/yaboot.conf \
+            [e]tc/mtab [e]tc/fstab \
+            [e]tc/mtools.conf \
+            [e]tc/smartd.conf [e]tc/sysconfig/smartmontools \
+            [e]tc/sysconfig/rawdevices \
+            [e]tc/security/pam_mount.conf.xml [b]oot/efi/*/*/grub.cfg
+    do
+        # Skip directory or file not found:
+	test -f "$file" || continue
         # sed -i bails on symlinks, so we follow the symlink and patch the result
-        # - absolute link are rebased on $TARGET_FS_ROOT (/etc/fstab => $TARGET_FS_ROOT/etc/fstab)
-        # - on dead links we warn and skip them
-        if [[ -L "$file" ]] ; then
-                linkdest="$(readlink -m "$file" | sed -e "s#^/#$TARGET_FS_ROOT/#" )"
-                if test -f "$linkdest" ; then
-                    LogPrint "Patching '$linkdest' instead of '$file'"
-                    file="$linkdest"
-                else
-                    LogPrint "Not patching dead link '$file' -> '$linkdest'"
-                    continue
-                fi
+        # absolute links are rebased on $TARGET_FS_ROOT (/etc/fstab => $TARGET_FS_ROOT/etc/fstab)
+        # on dead links we warn and skip them
+        if test -L "$file" ; then
+            linkdest="$( readlink -m "$file" | sed -e "s#^/#$TARGET_FS_ROOT/#" )"
+            if test -f "$linkdest" ; then
+                LogPrint "Using symlink '$file' destination '$linkdest'"
+                file="$linkdest"
+            else
+                LogPrint "Skipping dead symlink '$file'"
+                continue
+            fi
         fi
-
-        if test -s "$file" ; then
-            # Inform the user but do not error out here at this late state of "rear recover"
-            # when it failed to apply the layout mappings to one particular file:
-            apply_layout_mappings "$file" || LogPrintError "Failed to apply layout mappings to $file"
+        # Skip empty files:
+        test -s "$file" || continue
+        # Save the original file:
+        # Clean up already existing stuff in save_original_file_dir
+        # that would be (partially) overwritten by the current copy
+        # (such stuff is considered as outdated leftover e.g. from a previous recovery)
+        # but keep already existing stuff in the save_original_file_dir because
+        # any user data is sacrosanct (also outdated stuff from a previous recovery):
+        rm -rf "$save_original_file_dir/$file"
+        # Copy the original file with its directory path:
+        cp -a --parents "$file" $save_original_file_dir
+        # Inform the user but do not error out here at this late state of "rear recover"
+        # when it failed to apply the layout mappings to one particular restored file:
+        if apply_layout_mappings "$file" ; then
+            LogPrint "Applied disk layout mappings to restored '$file' (in $TARGET_FS_ROOT)"
         else
-            LogPrint "Not Patching empty file ($file)"
+            LogPrintError "Failed to apply disk layout mappings to restored '$file' (in $TARGET_FS_ROOT)"
         fi
 done
 

--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
@@ -6,10 +6,8 @@ test -s "$MAPPING_FILE" || return 0
 
 LogPrint "Applying disk layout mappings in $MAPPING_FILE to certain restored files..."
 
-# FIXME: Why is there is no matching popd for this pushd?
-# Cf. finalize/GNU/Linux/150_migrate_uuid_tags.sh where a popd is at the end.
-# If there is intentionally no popd here an explanation why there is no popd is missing.
-pushd $TARGET_FS_ROOT >/dev/null
+# Careful in case of 'return' after 'pushd' (must call the matching 'popd' before 'return'):
+pushd $TARGET_FS_ROOT >&2
 
 # Save the original restored files because in general any user data is sacrosanct,
 # cf. how BACKUP_RESTORE_MOVE_AWAY is implemented in restore/default/990_move_away_restored_files.sh
@@ -69,4 +67,6 @@ for file in [b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* [b]oot/grub/{gru
             LogPrintError "Failed to apply disk layout mappings to restored '$file' (in $TARGET_FS_ROOT)"
         fi
 done
+
+popd >&2
 

--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_lun_wwid.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_lun_wwid.sh
@@ -14,12 +14,15 @@ done < <(sort -u $LUN_WWID_MAP)
 # debug line:
 Log "$SED_SCRIPT"
 
-# now run sed
+# Careful in case of 'return' after 'pushd' (must call the matching 'popd' before 'return'):
 pushd $TARGET_FS_ROOT >&2
+
+# now run sed
+
 # the funny [] around the first letter make sure that shopt -s nullglob removes this file from the list if it does not exist
 # the files without a [] are mandatory, like fstab
 for file in [e]tc/elilo.conf \
-            [e]tc/fstab 
+            [e]tc/fstab
         do
 
         #[[ -d "$file" ]] && continue # skip directory
@@ -44,4 +47,5 @@ for file in [e]tc/elilo.conf \
         StopIfError "Patching '$file' with sed failed."
 done
 
-popd >&2 
+popd >&2
+

--- a/usr/share/rear/finalize/GNU/Linux/260_rename_diskbyid.sh
+++ b/usr/share/rear/finalize/GNU/Linux/260_rename_diskbyid.sh
@@ -35,7 +35,7 @@ NEW_ID_FILE="$TMP_DIR/diskbyid_mappings"
 # cf. https://github.com/rear/rear/issues/1845
 # but hopefully the code below is sufficiently robust
 # so that things work at least for those entries that are correct:
-apply_layout_mappings "$OLD_ID_FILE" ||  LogPrintError "Failed to apply layout mappings to $OLD_ID_FILE"
+apply_layout_mappings "$OLD_ID_FILE" ||  LogPrintError "Failed to apply layout mappings to $OLD_ID_FILE (may cause failures during 'rename_diskbyid')"
 
 # replace the device names with the real devices
 

--- a/usr/share/rear/finalize/GNU/Linux/260_rename_diskbyid.sh
+++ b/usr/share/rear/finalize/GNU/Linux/260_rename_diskbyid.sh
@@ -28,7 +28,14 @@ NEW_ID_FILE="$TMP_DIR/diskbyid_mappings"
 
 # Apply device mapping to replace device in case of migration.
 # apply_layout_mappings() function defined in lib/layout-function.sh
-apply_layout_mappings "$OLD_ID_FILE"
+# Inform the user when it failed to apply the layout mappings
+# but do not error out here at this late state of "rear recover"
+# regardless that when apply_layout_mappings failed
+# some entries in OLD_ID_FILE got possibly corrupted,
+# cf. https://github.com/rear/rear/issues/1845
+# but hopefully the code below is sufficiently robust
+# so that things work at least for those entries that are correct:
+apply_layout_mappings "$OLD_ID_FILE" ||  LogPrintError "Failed to apply layout mappings to $OLD_ID_FILE"
 
 # replace the device names with the real devices
 
@@ -108,3 +115,4 @@ for file in $FILES; do
 done
 
 unset ID DEV_NAME ID_NEW SYMLINKS ID_FULL ID_NEW_FULL
+

--- a/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
+++ b/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
@@ -14,8 +14,11 @@ done < <(sort -u $FS_UUID_MAP)
 # debug line:
 Log "$SED_SCRIPT"
 
+# Careful in case of 'return' after 'pushd' (must call the matching 'popd' before 'return'):
+pushd $TARGET_FS_ROOT >&2
+
 # now run sed
-pushd $TARGET_FS_ROOT >/dev/null
+
 # the funny [] around the first letter make sure that shopt -s nullglob removes this file from the list if it does not exist
 # the files without a [] are mandatory, like fstab
 for file in 	[b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* \
@@ -53,4 +56,5 @@ for file in 	[b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* \
 	StopIfError "Patching '$file' with sed failed."
 done
 
-popd >/dev/null
+popd >&2
+

--- a/usr/share/rear/finalize/Linux-i386/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/620_install_grub2.sh
@@ -1,108 +1,126 @@
-#  This  script is an improvement over the default grub-install '(hd0)'
+#
+# This  script is an improvement over a blind "grub-install (hd0)".
 #
 # However the following issues still exist:
 #
-#  * We don't know what the first disk will be, so we cannot be sure the MBR
-#    is written to the correct disk(s). That's why we make all disks bootable.
+# * We don't know what the first disk will be, so we cannot be sure the MBR
+#   is written to the correct disk. That's why we make all disks bootable
+#   as fallback unless GRUB2_INSTALL_DEVICE was specified.
 #
-#  * There is no guarantee that GRUB was the boot loader used originally. One
-#    solution is to save and restore the MBR for each disk, but this does not
-#    guarantee a correct boot-order, or even a working boot-lader config (eg.
-#    GRUB stage2 might not be at the exact same location)
+# * There is no guarantee that GRUB2 was the boot loader used originally.
+#   One solution is to save and restore the MBR for each disk, but this
+#   does not guarantee a correct boot-order, or even a working bootloader config.
 
-# skip if another bootloader was installed
-if [[ -z "$NOBOOTLOADER" ]] ; then
-    return 0
+# Skip if another bootloader was already installed:
+# In this case NOBOOTLOADER is not true,
+# cf. finalize/default/050_prepare_checks.sh
+is_true $NOBOOTLOADER || return 0
+
+# For UEFI systems with grub2 we should use efibootmgr instead,
+# cf. finalize/Linux-i386/630_run_efibootmgr.sh
+is_true $USING_UEFI_BOOTLOADER && return 
+
+# Only for GRUB2 - GRUB Legacy will be handled by its own script.
+# GRUB2 is detected by testing for grub-probe or grub2-probe which does not exist in GRUB Legacy.
+# If neither grub-probe nor grub2-probe is there assume GRUB2 is not there:
+type -p grub-probe || type -p grub2-probe || return 0
+
+LogPrint "Installing GRUB2 boot loader..."
+
+# Make /proc /sys /dev available in TARGET_FS_ROOT
+# so that later things work in the "chroot TARGET_FS_ROOT" environment,
+# cf. https://github.com/rear/rear/issues/1828#issuecomment-398717889
+# and do not umount them because it is better when also after "rear recover"
+# things still work in the "chroot TARGET_FS_ROOT" environment
+# so that the user could more easily adapt things after "rear recover":
+for mount_device in proc sys dev ; do
+    umount $TARGET_FS_ROOT/$mount_device && sleep 1
+    mount --bind /$mount_device $TARGET_FS_ROOT/$mount_device
+done
+
+# Check if we find GRUB2 where we expect it (GRUB2 can be in boot/grub or boot/grub2):
+grub_name="grub2"
+if ! test -d "$TARGET_FS_ROOT/boot/$grub_name" ; then
+    grub_name="grub"
+    if ! test -d "$TARGET_FS_ROOT/boot/$grub_name" ; then
+        LogPrintError "Cannot install GRUB2 (neither boot/grub nor boot/grub2 directory in $TARGET_FS_ROOT)"
+        return 1
+    fi
 fi
 
-# for UEFI systems with grub2 we should use efibootmgr instead
-is_true $USING_UEFI_BOOTLOADER && return # when set to 1
+# Generate GRUB configuration file anew to be on the safe side (this could be even mandatory in MIGRATION_MODE):
+if ! chroot $TARGET_FS_ROOT /bin/bash --login -c "$grub_name-mkconfig -o /boot/$grub_name/grub.cfg" ; then
+    LogPrintError "Failed to generate boot/$grub_name/grub.cfg in $TARGET_FS_ROOT - trying to install GRUB2 nevertheless"
+fi
 
-# Only for GRUB2 - GRUB Legacy will be handled by its own script
-[[ $(type -p grub-probe) || $(type -p grub2-probe) ]] || return 0
-
-LogPrint "Installing GRUB2 boot loader"
-mount -t proc none $TARGET_FS_ROOT/proc
-#for virtual_filesystem in /dev /dev/pts /proc /sys ; do mount -B $virtual_filesystem $TARGET_FS_ROOT$virtual_filesystem ; done
-
-if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]]; then
-
-    # Check if we find GRUB where we expect it
-    [[ -d "$TARGET_FS_ROOT/boot" ]]
-    StopIfError "Could not find directory /boot"
-
-    # grub2 can be in /boot/grub or /boot/grub2
-    grub_name="grub2"
-    if [[ ! -d "$TARGET_FS_ROOT/boot/$grub_name" ]] ; then
-        grub_name="grub"
-        [[ -d "$TARGET_FS_ROOT/boot/$grub_name" ]]
-        StopIfError "Could not find directory /boot/$grub_name"
+# When GRUB2_INSTALL_DEVICE is explicitly specified by the user install GRUB2 there:
+if test "$GRUB2_INSTALL_DEVICE" ; then
+    LogPrint "Installing GRUB2 on $GRUB2_INSTALL_DEVICE (specified as GRUB2_INSTALL_DEVICE)"
+    if chroot $TARGET_FS_ROOT /bin/bash --login -c "$grub_name-install $GRUB2_INSTALL_DEVICE" ; then
+        NOBOOTLOADER=''
+        return
     fi
-    [[ -r "$TARGET_FS_ROOT/boot/$grub_name/grub.cfg" ]]
-    LogIfError "Unable to find /boot/$grub_name/grub.cfg."
+    LogPrintError "Failed to install GRUB2 on the specified $GRUB2_INSTALL_DEVICE"
+fi
 
-    # Find exclusive partition(s) belonging to /boot
-    # or / (if /boot is inside root filesystem)
-    if [[ "$( filesystem_name $TARGET_FS_ROOT/boot )" == "$TARGET_FS_ROOT" ]]; then
-        bootparts=$(find_partition fs:/)
-        grub_prefix=/boot/grub2
-    else
-        bootparts=$(find_partition fs:/boot)
-        grub_prefix=/grub2
-    fi
-    # Should never happen
-    [[ "$bootparts" ]]
-    BugIfError "Unable to find any /boot partitions"
+# If GRUB2_INSTALL_DEVICE is not specified or it failed to install GRUB2 there
+# try to automatically determine where to install GRUB2:
+if ! test -r "$LAYOUT_FILE" -a -r "$LAYOUT_DEPS" ; then
+    LogPrintError "Cannot determine where to install GRUB2"
+    return 1
+fi
+test "$GRUB2_INSTALL_DEVICE" && LogPrint "Determining where to install GRUB2" || LogPrint "Determining where to install GRUB2 (no GRUB2_INSTALL_DEVICE specified)"
 
-    # Find the disks that need a new GRUB MBR
-    disks=$(grep '^disk \|^multipath ' $LAYOUT_FILE | cut -d' ' -f2)
-    [[ "$disks" ]]
-    StopIfError "Unable to find any disks"
+# Find exclusive partition(s) belonging to /boot or / (if /boot is inside root filesystem):
+if test "$( filesystem_name $TARGET_FS_ROOT/boot )" = "$TARGET_FS_ROOT" ; then
+    bootparts=$( find_partition fs:/ )
+else
+    bootparts=$( find_partition fs:/boot )
+fi
+if ! test "$bootparts" ; then
+    LogPrintError "Cannot install GRUB2 (unable to find a /boot or / partition)"
+    return 1
+fi
 
-    for disk in $disks; do
-        # Installing grub on an LVM PV will wipe the metadata so we skip those
-        if is_disk_a_pv "$disk" ; then
-            continue
-        fi
-        # Use first boot partition by default
-        part=$(echo $bootparts | cut -d' ' -f1)
+# Find the disks that need a new GRUB2 MBR:
+disks=$( grep '^disk \|^multipath ' $LAYOUT_FILE | cut -d' ' -f2 )
+if ! test "$disks" ; then
+    LogPrintError "Cannot install GRUB2 (unable to find a disk)"
+    return 1
+fi
 
-        # Use boot partition that matches with this disk, if any
-        for bootpart in $bootparts; do
-            bootdisk=$(find_disk_and_multipath "$bootpart")
-            if [[ "$disk" == "$bootdisk" ]]; then
-                part=$bootpart
-                break
-            fi
-        done
+for disk in $disks ; do
+    # Installing GRUB2 on an LVM PV will wipe the metadata so we skip those:
+    is_disk_a_pv "$disk" && continue
 
-        # Find boot-disk and partition number
-        bootdisk=$(find_disk_and_multipath "$part")
-        partnr=${part#$bootdisk}
-        partnr=${partnr#p}
-        partnr=$((partnr - 1))
+    # Use first boot partition by default:
+    part=$( echo $bootparts | cut -d' ' -f1 )
 
-        if [[ "$bootdisk" == "$disk" ]]; then
-            #chroot $TARGET_FS_ROOT $grub_name-mkconfig -o /boot/$grub_name/grub.cfg
-	    #chroot $TARGET_FS_ROOT $grub_name-install "$bootdisk"
-	    $grub_name-install --root-directory=$TARGET_FS_ROOT $bootdisk
-        else
-            chroot $TARGET_FS_ROOT $grub_name-mkconfig -o /boot/$grub_name/grub.cfg
-	    #chroot $TARGET_FS_ROOT $grub_name-install "$bootdisk"
-	    $grub_name-install --root-directory=$TARGET_FS_ROOT $bootdisk
-        fi
-
-        if (( $? == 0 )); then
-            NOBOOTLOADER=
+    # Use boot partition that matches this disk, if any:
+    for bootpart in $bootparts ; do
+        bootdisk=$( find_disk_and_multipath "$bootpart" )
+        if test "$disk" = "$bootdisk" ; then
+            part=$bootpart
+            break
         fi
     done
-fi
 
-if [[ "$NOBOOTLOADER" ]]; then
-    if chroot $TARGET_FS_ROOT grub2-install "$disk" >&2 ; then
-        NOBOOTLOADER=
+    # Find boot disk and partition number:
+    bootdisk=$( find_disk_and_multipath "$part" )
+
+    # Install GRUB2 on the boot disk if one was found:
+    if test "$bootdisk" ; then
+        LogPrint "Found possible boot disk $bootdisk - installing GRUB2 there"
+        if chroot $TARGET_FS_ROOT /bin/bash --login -c "$grub_name-install $bootdisk" ; then
+            NOBOOTLOADER=''
+            # We don't know what the first disk will be, so we cannot be sure the MBR
+            # is written to the correct disk. That's why we make all disks bootable:
+            continue
+        fi
+        LogPrintError "Failed to install GRUB2 on $bootdisk"
     fi
-fi
+done
 
-#for virtual_filesystem in /dev /dev/pts /proc /sys ; do umount $TARGET_FS_ROOT$virtual_filesystem ; done
-umount $TARGET_FS_ROOT/proc
+is_true $NOBOOTLOADER && LogPrintError "Failed to install GRUB2 - you may have to manually install it"
+return 1
+

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -142,12 +142,12 @@ while read keyword orig_device orig_size junk ; do
         # Add the current device as possible choice for the user:
         possible_targets=( "${possible_targets[@]}" "$preferred_target_device_name" )
     done
-    # Continue with next original device when no appropriate current block device is found whereto it could be mapped:
+    # Continue with next original device when no appropriate current block device is found where to it could be mapped:
     if ! test "${possible_targets[*]}" ; then
-        LogUserOutput "No device found whereto $preferred_orig_device_name could be mapped so that it will not be recreated"
+        LogUserOutput "No device found where to $preferred_orig_device_name could be mapped so that it will not be recreated"
         continue
     fi
-    # Automatically map when only one appropriate current block device is found whereto it could be mapped.
+    # Automatically map when only one appropriate current block device is found where to it could be mapped.
     # At the end the mapping file is shown and the user can edit it if he does not like an automated mapping:
     if test "1" -eq "${#possible_targets[@]}" ; then
         add_mapping "$orig_device" "$possible_targets"

--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -3,5 +3,5 @@
 # Skip if not in migration mode:
 is_true "$MIGRATION_MODE" || return 0
 
-apply_layout_mappings "$LAYOUT_FILE" || Error "Failed to apply layout mappings to $LAYOUT_FILE"
+apply_layout_mappings "$LAYOUT_FILE" || Error "Failed to apply disklayout mappings to $LAYOUT_FILE"
 

--- a/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prepare/default/320_apply_mappings.sh
@@ -3,5 +3,5 @@
 # Skip if not in migration mode:
 is_true "$MIGRATION_MODE" || return 0
 
-apply_layout_mappings "$LAYOUT_FILE"
+apply_layout_mappings "$LAYOUT_FILE" || Error "Failed to apply layout mappings to $LAYOUT_FILE"
 

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -207,8 +207,8 @@ builtin trap "DoExitTasks" EXIT
 # (which is usually the keyboard and display of the user who launched 'rear')
 # the original STDIN STDOUT and STDERR file descriptors are saved as fd6 fd7 and fd8
 # so that ReaR functions for actually intended user messages can use fd7 and fd8
-# to show messages to the user regardless whereto STDOUT and STDERR are redirected
-# and fd6 to get input from the user regardless whereto STDIN is redirected.
+# to show messages to the user regardless where to STDOUT and STDERR are redirected
+# and fd6 to get input from the user regardless where to STDIN is redirected.
 # Duplicate STDIN to fd6 to be used by 'read' in the UserInput function
 # cf. http://tldp.org/LDP/abs/html/x17974.html
 exec 6<&0

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -924,7 +924,6 @@ function apply_layout_mappings() {
     # It is the responsibility of the caller of this apply_layout_mappings function what to do when it failed
     # (e.g. error out, retry, show a user dialog, or whatever is appropriate in the caller's environment):
     is_true $apply_layout_mappings_succeeded && return 0 || return 1
-
 }
 
 # vim: set et ts=4 sw=4:

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -701,7 +701,7 @@ function get_part_device_name_format() {
             ;;
         (*mapper[/!]*)
             # Every Linux distribution / version has their own rule to name the multipthed partion device.
-            # 
+            #
             # Suse:
             #     Version <12 : always <device>_part<part_num> (same with/without user_friendly_names)
             #     Version >=12 : always <device>-part<part_num> (same with/without user_friendly_names)
@@ -712,7 +712,7 @@ function get_part_device_name_format() {
             # Debian:
             #     if user_firendly_names (default) <device>-part<part_num>
             #     if NOT user_firendly_names <device>p<part_num>
-            # 
+            #
 
             # First we need to know if user_friendly_names is activated (for Fedora/RedHat and Debian/ubuntu)
             if multipathd ; then
@@ -723,7 +723,7 @@ function get_part_device_name_format() {
             case $OS_MASTER_VENDOR in
 
                 (SUSE)
-                    # No need to check if user_friendly_names is activated or not as Suse always apply the same naming convention. 
+                    # No need to check if user_friendly_names is activated or not as Suse always apply the same naming convention.
 
                     # SUSE Linux SLE12 put a "-part" between [mpath device name] and [part number].
                     # For example /dev/mapper/3600507680c82004cf8000000000000d8-part1.
@@ -741,7 +741,7 @@ function get_part_device_name_format() {
                     if is_false "$user_friendly_names" ; then
                         # RHEL 7 and above seems to named partitions on multipathed devices with
                         # [mpath device UUID/WWID] + p + [part number] when "user_friendly_names"
-                        # option is FALSE. 
+                        # option is FALSE.
                         # For example: /dev/mapper/3600507680c82004cf8000000000000d8p1
                         part_name="${device_name}p" # append p between main device and partitions
                     else
@@ -749,7 +749,6 @@ function get_part_device_name_format() {
                         # [mpath device name] + [part number] like standard disk when "user_friendly_names"
                         # option is used (default).
                         # For example: /dev/mapper/mpatha1
-                        
                         # But the scheme in RHEL 6 need a "p" between [mpath device name] and [part number].
                         # For exemple: /dev/mapper/mpathap1
                         if (( $OS_MASTER_VERSION < 7 )) ; then
@@ -763,7 +762,7 @@ function get_part_device_name_format() {
                 (Debian)
                     if is_false "$user_friendly_names" ; then
                         # Exceptional case for Debian/ubuntu
-                        # When user_friendly_names is disable, debian based system will name partition 
+                        # When user_friendly_names is disable, debian based system will name partition
                         # [mpath device UUID/WWID] + p + [part number]
                         part_name="${device_name}p"
                     else
@@ -797,17 +796,30 @@ function apply_layout_mappings() {
 
     local file_to_migrate="$1"
 
-    # apply_layout_mappings need one argument.
-    [ "$file_to_migrate" ] || BugError "apply_layout_mappings function called without argument (file_to_migrate)."
+    # apply_layout_mappings needs one argument:
+    test "$file_to_migrate" || BugError "apply_layout_mappings function called without argument (file_to_migrate)."
 
     # Only apply layout mapping on non-empty file:
     test -s "$file_to_migrate" || return 0
     # --End Of TEST section--
 
-    # Generate unique words as replacement placeholders to correctly handle circular replacements (e.g. sda -> sdb and sdb -> sda).
-    # Replacement strategy is
-    # 1) replace all source devices with a unique word (the "replacement" )
-    # 2) replace all unique replacement words with the target device
+    # Generate unique words (where unique means that those generated words cannot exist in file_to_migrate)
+    # as replacement placeholders to correctly handle circular replacements e.g. for "sda -> sdb and sdb -> sda"
+    # in the mapping file those generated unique words would be _REAR0_ for sda and _REAR1_ for sdb.
+    # The replacement strategy is:
+    # Step 0:
+    # For each original device in the mapping file generate a unique word (the "replacement").
+    # Step 1:
+    # In file_to_migrate temporarily replace all original devices with their matching unique word.
+    # E.g. "disk sda and disk sdb" would become "disk _REAR0_ and disk _REAR1_" temporarily in file_to_migrate.
+    # Step 2:
+    # In file_to_migrate replace all unique replacement words with the matching target device of the source device.
+    # E.g. for "sda -> sdb and sdb -> sda" in the mapping file and the unique words _REAR0_ for sda and _REAR1_ for sdb
+    # "disk _REAR0_ and disk _REAR1_" would become "disk sdb and disk sda" in the final file_to_migrate
+    # so that the circular replacement "sda -> sdb and sdb -> sda" is done in file_to_migrate.
+    # Step 3:
+    # In file_to_migrate verify that there are none of those temporary replacement words from step 1 left
+    # to ensure the replacement was done correctly and complete.
 
     # Replacement_file initialization.
     replacement_file="$TMP_DIR/replacement_file"
@@ -820,52 +832,99 @@ function apply_layout_mappings() {
     }
 
     function has_replacement() {
-        if grep -q "^$1 " "$replacement_file" ; then
-            return 0
-        else
-            return 1
-        fi
+        grep -q "^$1 " "$replacement_file"
     }
 
-    # Step-1 replace all source devices with a unique word (the "replacement")
-    let replaced_count=0
+    function get_replacement() {
+        local item replacement junk
+        read item replacement junk < <( grep "^$1 " $replacement_file )
+        test "$replacement" && echo "$replacement" || return 1
+    }
+
+    # Step 0:
+    # For each original device in the mapping file generate a unique word (the "replacement").
+    # E.g. when the mapping file content is
+    #   /dev/sda /dev/sdb
+    #   /dev/sdb /dev/sda
+    #   /dev/sdd /dev/sdc
+    # the replacement file will contain
+    #   /dev/sda _REAR0_
+    #   /dev/sdb _REAR1_
+    #   /dev/sdd _REAR2_
+    #   /dev/sdc _REAR3_
+    replaced_count=0
     while read source target junk ; do
-        if ! has_replacement "$source" ; then
-            add_replacement "$source"
-        fi
+        # Skip lines that have wrong syntax:
+        test "$source" -a "$target" || continue
+        has_replacement "$source" || add_replacement "$source"
+        has_replacement "$target" || add_replacement "$target"
+    done < <( grep -v '^#' "$MAPPING_FILE" )
 
-        if ! has_replacement "$target" ; then
-            add_replacement "$target"
-        fi
-    done < "$MAPPING_FILE"
-
-    # Replace all originals with their replacements.
+    # Step 1:
+    # Replace all original devices with their replacements.
+    # E.g. when the file_to_migrate content is
+    #   disk /dev/sda
+    #   disk /dev/sdb
+    #   disk /dev/sdc
+    #   disk /dev/sdd
+    # it will get temporarily replaced (with the replacement file content in step 0 above) by
+    #   disk _REAR0_
+    #   disk _REAR1_
+    #   disk _REAR3_
+    #   disk _REAR2_
     while read original replacement junk ; do
-        # Replace partitions with uniq replacement PATTERN (we normalize cciss/c0d0p1 to _REAR5_1)
-        # Due to multipath partion naming complexity, all known partition naming type (mpatha1,mpathap1,mpatha-part1,mpatha_part1) will be replaced by _REAR"X"_1 
+        # Skip lines that have wrong syntax:
+        test "$original" -a "$replacement" || continue
+        # Replace partitions with unique replacement PATTERN (we normalize cciss/c0d0p1 to _REAR5_1)
+        # Due to multipath partion naming complexity, all known partition naming type (mpatha1,mpathap1,mpatha-part1,mpatha_part1) will be replaced by _REAR"X"_1
         sed -i -r "\|$original|s|$original(p)*([-_]part)*([0-9]+)|$replacement\3|g" "$file_to_migrate"
-
         # Replace whole devices
-        ### note that / is a word boundary, so is matched by \<, hence the extra /
+        # Note that / is a word boundary, so is matched by \<, hence the extra /
         sed -i -r "\|$original|s|/\<${original#/}\>|${replacement}|g" "$file_to_migrate"
     done < "$replacement_file"
 
-    # Step-2 replace all unique replacement words with the target device
-    function get_replacement() {
-        local item replacement junk
-        read item replacement junk < <(grep "^$1 " $replacement_file)
-        echo "$replacement"
-    }
-
+    # Step 2:
+    # Replace all unique replacement words with the matching target device of the source device in the mapping file.
+    # E.g. when the file_to_migrate content was in step 1 above temporarily changed to
+    #   disk _REAR0_
+    #   disk _REAR1_
+    #   disk _REAR3_
+    #   disk _REAR2_
+    # it will now get finally replaced (with the replacement file and mapping file contents in step 0 above) by
+    #   disk /dev/sdb
+    #   disk /dev/sda
+    #   disk _REAR3_
+    #   disk /dev/sdc
+    # where the temporary replacement "disk _REAR3_" from step 1 above is left because
+    # there is (erroneously) no mapping for /dev/sdc (as source device) in the mapping file (in step 0 above).
     while read source target junk ; do
-        replacement=$(get_replacement "$source")
-        # Replace whole device
+        # Skip lines that have wrong syntax:
+        test "$source" -a "$target" || continue
+        # Skip when there is no replacement:
+        replacement=$( get_replacement "$source" ) || continue
+        # Replace whole device:
         sed -i -r "\|$replacement|s|$replacement\>|$target|g" "$file_to_migrate"
-
-        # Replace partitions
-        target=$(get_part_device_name_format "$target")
+        # Replace partitions:
+        target=$( get_part_device_name_format "$target" )
         sed -i -r "\|$replacement|s|$replacement([0-9]+)|$target\1|g" "$file_to_migrate"
-    done < "$MAPPING_FILE"
+    done < <( grep -v '^#' "$MAPPING_FILE" )
+
+    # Step 3:
+    # Verify that there are none of those temporary replacement words from step 1 left in file_to_migrate
+    # to ensure the replacement was done correctly and complete (cf. the above example where '_REAR3_' is left).
+    apply_layout_mappings_succeeded="yes"
+    while read original replacement junk ; do
+        # Skip lines that have wrong syntax:
+        test "$original" -a "$replacement" || continue
+        if grep -q "$replacement" "$file_to_migrate" ; then
+            apply_layout_mappings_succeeded="no"
+            LogPrintError "Failed to apply layout mappings to $file_to_migrate for $original (probably no mapping for $original in $MAPPING_FILE)"
+        fi
+    done < "$replacement_file"
+    # It is the responsibility of the caller of this apply_layout_mappings function what to do when it failed
+    # (e.g. error out, retry, show a user dialog, or whatever is appropriate in the caller's environment):
+    is_true $apply_layout_mappings_succeeded && return 0 || return 1
+
 }
 
 # vim: set et ts=4 sw=4:

--- a/usr/share/rear/output/ISO/Linux-ia64/800_create_isofs.sh
+++ b/usr/share/rear/output/ISO/Linux-ia64/800_create_isofs.sh
@@ -20,7 +20,10 @@ StopIfError "Could not create ISO ouput directory ($ISO_DIR)"
 mkdir -p $v "$TMP_DIR/isofs" >&2
 mkdir -p $v "$TMP_DIR/isofs/boot" >&2
 mv -f $v $TMP_DIR/boot.img "$TMP_DIR/isofs/boot" >&2
-pushd $TMP_DIR/isofs >/dev/null # so that relative paths will work
+
+# Careful in case of 'return' after 'pushd' (must call the matching 'popd' before 'return'):
+pushd $TMP_DIR/isofs >&2 # so that relative paths will work
+
 $ISO_MKISOFS_BIN $v -o "$ISO_DIR/$ISO_PREFIX.iso" -b boot/boot.img -c boot/boot.catalog \
 	-no-emul-boot -R -T -J -volid "$ISO_VOLID" -v . >/dev/null
 StopIfError "Could not create ISO image"
@@ -30,3 +33,6 @@ LogPrint "Wrote ISO image: $ISO_DIR/$ISO_PREFIX.iso ($iso_image_size)"
 
 # Add ISO image to result files
 RESULT_FILES=( "${RESULT_FILES[@]}" "$ISO_DIR/$ISO_PREFIX.iso" )
+
+popd >&2
+

--- a/usr/share/rear/wrapup/default/990_copy_logfile.sh
+++ b/usr/share/rear/wrapup/default/990_copy_logfile.sh
@@ -22,7 +22,7 @@ recovery_system_recover_log_dir=$TARGET_FS_ROOT/$recover_log_dir
 # because in particular logfiles could contain security relevant information.
 # It is no real error when the following exit tasks fail so that they return 'true' in any case:
 copy_log_file_exit_task="mkdir -p -m 0700 $recovery_system_recover_log_dir && cp -p $RUNTIME_LOGFILE $recovery_system_recover_log_dir/$final_logfile_name || true"
-# To be backward compatible with whereto the logfile was copied before
+# To be backward compatible with where to the logfile was copied before
 # have it as a symbolic link that points to where the logfile actually is:
 # ( "roots" in recovery_system_roots_home_dir means root's but ' in a variable name is not so good ;-)
 recovery_system_roots_home_dir=$TARGET_FS_ROOT/root


### PR DESCRIPTION
Fixed, simplified and enhanced GRUB2 installation
plus fixed typos 'whereto' -> 'where to'

* Type: **Bug Fix** and **Enhancement**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1828

* How was this pull request tested?
Currently tested only on SLES12 to keep backward compatibility
(as far as I can test it with reasonable effort for me).
I need to also test it on SLES15 (tomorrow).

* Brief description of the changes in this pull request:

Fixed finalize/Linux-i386/620_install_grub2.sh according to
https://github.com/rear/rear/issues/1828#issuecomment-398717889

Enhanced GRUB2 installation by the new config variable
GRUB2_INSTALL_DEVICES so that now the user can specify
what he wants if needed.

Cleaned up finalize/Linux-i386/620_install_grub2.sh
from old inconsistent and even contradictory looking code.
