### PR TITLE
Fixed, simplified and enhanced GRUB2 installation for PPC64/PPC64LE

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2398,6 +2398,11 @@ BOOTLOADER=""
 # are applied when devices in GRUB2_INSTALL_DEVICES match so that enforcing
 # MIGRATION_MODE helps to avoid that GRUB2 gets installed on a wrong disk
 # when more than one disk is used.
+# When GRUB2 is used on POWER architecture e.g. on PPC64 or PPC64LE
+# the GRUB2_INSTALL_DEVICES have to be PPC PReP partition(s).
+# On POWER architecture the OpenFirmware is configured to read
+# the ELF image embedded in the PReP partition (like how the MBR
+# is used by PC-BIOS to embed boot code).
 # When GRUB2_INSTALL_DEVICES is not specified, ReaR tries to automatically determine
 # where to install GRUB2 but then the bootloader installation could get wrong.
 # For details see the finalize/Linux-i386/620_install_grub2.sh script.

--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
@@ -41,7 +41,7 @@ for file in [b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* [b]oot/grub/{gru
             [e]tc/security/pam_mount.conf.xml [b]oot/efi/*/*/grub.cfg
     do
         # Skip directory or file not found:
-	test -f "$file" || continue
+        test -f "$file" || continue
         # sed -i bails on symlinks, so we follow the symlink and patch the result
         # absolute links are rebased on $TARGET_FS_ROOT (/etc/fstab => $TARGET_FS_ROOT/etc/fstab)
         # on dead links we warn and skip them

--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
@@ -2,7 +2,14 @@
 # Apply disk layout mappings to certain restored files.
 #
 
+# MAPPING_FILE is set in layout/prepare/default/300_map_disks.sh
+# only if MIGRATION_MODE is true.
 test -s "$MAPPING_FILE" || return 0
+
+# Do not apply layout mappings when there is a completely identical mapping in the mapping file
+# to avoid that files (in particular restored files) may get needlessly touched and modified
+# for identical mappings, see https://github.com/rear/rear/issues/1847
+is_completely_identical_layout_mapping && return 0
 
 LogPrint "Applying disk layout mappings in $MAPPING_FILE to certain restored files..."
 

--- a/usr/share/rear/finalize/Linux-i386/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/620_install_grub2.sh
@@ -6,7 +6,9 @@
 # * We don't know what the first disk will be, so we cannot be sure the MBR
 #   is written to the correct disk.
 #   If software RAID1 is used, several boot devices will be found and
-#   then GRUB2 needs to be installed on each of them.
+#   then GRUB2 needs to be installed on each of them because
+#   "You don't want to lose the first disk and suddenly discover your system won't reboot!"
+#   cf. https://raid.wiki.kernel.org/index.php/Setting_up_a_(new)_system
 #   This is the reason why we make all possible boot disks bootable
 #   as fallback unless GRUB2_INSTALL_DEVICES was specified.
 #   This is also the reason why more than one disk can be specified

--- a/usr/share/rear/finalize/Linux-i386/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/620_install_grub2.sh
@@ -4,9 +4,13 @@
 # However the following issues still exist:
 #
 # * We don't know what the first disk will be, so we cannot be sure the MBR
-#   is written to the correct disk. That's why we make all disks bootable
-#   as fallback unless GRUB2_INSTALL_DEVICES was specified. This is also the
-#   reason why more than one disk can be specified in GRUB2_INSTALL_DEVICES.
+#   is written to the correct disk.
+#   If software RAID1 is used, several boot devices will be found and
+#   then GRUB2 needs to be installed on each of them.
+#   This is the reason why we make all possible boot disks bootable
+#   as fallback unless GRUB2_INSTALL_DEVICES was specified.
+#   This is also the reason why more than one disk can be specified
+#   in GRUB2_INSTALL_DEVICES.
 #
 # * There is no guarantee that GRUB2 was the boot loader used originally.
 #   One solution is to save and restore the MBR for each disk, but this
@@ -123,6 +127,11 @@ if ! test "$disks" ; then
     return 1
 fi
 
+# We don't know what the first disk will be, so we cannot be sure the MBR
+# is written to the correct disk.
+# If software RAID1 is used, several boot devices will be found and
+# then GRUB2 needs to be installed on each of them.
+# This is the reason why we make all possible boot disks bootable here:
 for disk in $disks ; do
     # Installing GRUB2 on an LVM PV will wipe the metadata so we skip those:
     is_disk_a_pv "$disk" && continue
@@ -150,8 +159,7 @@ for disk in $disks ; do
             # consider it here as a successful bootloader installation when GRUB2
             # got installed on at least one boot disk:
             NOBOOTLOADER=''
-            # We don't know what the first disk will be, so we cannot be sure the MBR
-            # is written to the correct disk. That's why we make all disks bootable:
+            # Continue with the next possible boot disk:
             continue
         fi
         LogPrintError "Failed to install GRUB2 on possible boot disk $bootdisk"

--- a/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
@@ -11,7 +11,9 @@
 # * We don't know what the first disk will be, so we cannot be sure the MBR
 #   is written to the correct disk.
 #   If software RAID1 is used, several boot devices will be found and
-#   then GRUB2 needs to be installed on each of them.
+#   then GRUB2 needs to be installed on each of them because
+#   "You don't want to lose the first disk and suddenly discover your system won't reboot!"
+#   cf. https://raid.wiki.kernel.org/index.php/Setting_up_a_(new)_system
 #   This is the reason why we make all possible boot disks bootable
 #   as fallback unless GRUB2_INSTALL_DEVICES was specified.
 #   This is also the reason why more than one disk can be specified

--- a/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
@@ -1,75 +1,166 @@
-#  This  script is an improvement over the default grub-install '(hd0)'
+#
+# This script is an improvement over a blind "grub-install (hd0)".
+#
+##############################################################################
+# This script is based on finalize/Linux-i386/620_install_grub2.sh
+# but this script contains PPC64/PPC64LE specific code.
+##############################################################################
 #
 # However the following issues still exist:
 #
-#  * We don't know what the first disk will be, so we cannot be sure the MBR
-#    is written to the correct disk(s). That's why we make all disks bootable.
+# * We don't know what the first disk will be, so we cannot be sure the MBR
+#   is written to the correct disk.
+#   If software RAID1 is used, several boot devices will be found and
+#   then GRUB2 needs to be installed on each of them.
+#   This is the reason why we make all possible boot disks bootable
+#   as fallback unless GRUB2_INSTALL_DEVICES was specified.
+#   This is also the reason why more than one disk can be specified
+#   in GRUB2_INSTALL_DEVICES.
 #
-#  * There is no guarantee that GRUB was the boot loader used originally. One
-#    solution is to save and restore the MBR for each disk, but this does not
-#    guarantee a correct boot-order, or even a working boot-lader config (eg.
-#    GRUB stage2 might not be at the exact same location)
-################################################################
-# THIS SCRIPT CONTAINS PPC64/PPC64LE SPECIFIC
-#################################################################
-# skip if another bootloader was installed
-if [[ -z "$NOBOOTLOADER" ]] ; then
-    return
+# * There is no guarantee that GRUB2 was the boot loader used originally.
+#   One solution is to save and restore the MBR for each disk, but this
+#   does not guarantee a correct boot-order, or even a working bootloader config.
+#
+# This script does not error out because at this late state of "rear recover"
+# (i.e. after the backup was restored) I <jsmeix@suse.de> consider it too hard
+# to abort "rear recover" when it failed to install GRUB2 because in this case
+# the user gets an explicit WARNING via finalize/default/890_finish_checks.sh
+# so that after "rear recover" finished he can manually install the bootloader
+# as appropriate for his particular system.
+
+# Skip if another bootloader was already installed:
+# In this case NOBOOTLOADER is not true,
+# cf. finalize/default/050_prepare_checks.sh
+is_true $NOBOOTLOADER || return 0
+
+# For UEFI systems with grub2 we should use efibootmgr instead,
+# cf. finalize/Linux-i386/630_run_efibootmgr.sh
+# Perhaps this does not apply on PPC64/PPC64LE because
+# probably there is no UEFI on usual PPC64/PPC64LE systems
+# but https://github.com/andreiw/ppc64le-edk2 reads (excerpts):
+#   "TianoCore on PowerPC 64 Little-Endian (OPAL/PowerNV)
+#    This is 'UEFI' on top of OPAL firmware"
+# so that there could be UEFI via OPAL firmware on PPC64LE systems
+# which is the reason to keep this test here also for PPC64/PPC64LE
+# (if UEFI is not used the test condition will not become true):
+is_true $USING_UEFI_BOOTLOADER && return
+
+# Only for GRUB2 - GRUB Legacy will be handled by its own script.
+# GRUB2 is detected by testing for grub-probe or grub2-probe which does not exist in GRUB Legacy.
+# If neither grub-probe nor grub2-probe is there assume GRUB2 is not there:
+type -p grub-probe || type -p grub2-probe || return 0
+
+LogPrint "Installing GRUB2 boot loader on PPC64/PPC64LE..."
+
+# Check if we find GRUB2 where we expect it (GRUB2 can be in boot/grub or boot/grub2):
+grub_name="grub2"
+if ! test -d "$TARGET_FS_ROOT/boot/$grub_name" ; then
+    grub_name="grub"
+    if ! test -d "$TARGET_FS_ROOT/boot/$grub_name" ; then
+        LogPrintError "Cannot install GRUB2 (neither boot/grub nor boot/grub2 directory in $TARGET_FS_ROOT)"
+        return 1
+    fi
 fi
 
-# Only for GRUB2 - GRUB Legacy will be handled by its own script
-[[ $(type -p grub-probe) || $(type -p grub2-probe) ]] || return 0
+# Make /proc /sys /dev available in TARGET_FS_ROOT
+# so that later things work in the "chroot TARGET_FS_ROOT" environment,
+# cf. https://github.com/rear/rear/issues/1828#issuecomment-398717889
+# and do not umount them when leaving this script because
+# it is better when also after "rear recover" things still
+# work in the "chroot TARGET_FS_ROOT" environment so that
+# the user could more easily adapt things after "rear recover":
+for mount_device in proc sys dev ; do
+    umount $TARGET_FS_ROOT/$mount_device && sleep 1
+    mount --bind /$mount_device $TARGET_FS_ROOT/$mount_device
+done
 
-LogPrint "Installing GRUB2 boot loader"
-mount -t proc none $TARGET_FS_ROOT/proc
+# Generate GRUB configuration file anew to be on the safe side (this could be even mandatory in MIGRATION_MODE):
+if ! chroot $TARGET_FS_ROOT /bin/bash --login -c "$grub_name-mkconfig -o /boot/$grub_name/grub.cfg" ; then
+    LogPrintError "Failed to generate boot/$grub_name/grub.cfg in $TARGET_FS_ROOT - trying to install GRUB2 nevertheless"
+fi
 
-if [[ -r "$LAYOUT_FILE" ]]; then
+# Do not update nvram when system is running in PowerNV mode (BareMetal).
+# grub2-install will fail if not run with the --no-nvram option on a PowerNV system,
+# see https://github.com/rear/rear/pull/1742
+grub2_install_option=""
+if [[ $(awk '/platform/ {print $NF}' < /proc/cpuinfo) == PowerNV ]] ; then
+    grub2_install_option="--no-nvram"
+fi
 
-    # Check if we find GRUB where we expect it
-    [[ -d "$TARGET_FS_ROOT/boot" ]]
-    StopIfError "Could not find directory /boot"
-
-    # grub2 can be in /boot/grub or /boot/grub2
-    grub_name="grub2"
-    if [[ ! -d "$TARGET_FS_ROOT/boot/$grub_name" ]] ; then
-        grub_name="grub"
-        [[ -d "$TARGET_FS_ROOT/boot/$grub_name" ]]
-        StopIfError "Could not find directory /boot/$grub_name"
-    fi
-    [[ -r "$TARGET_FS_ROOT/boot/$grub_name/grub.cfg" ]]
-    LogIfError "Unable to find /boot/$grub_name/grub.cfg."
-
-    # Find PPC PReP Boot partition
-    part_list=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $LAYOUT_FILE )
-
-    # If software RAID1 is used, several boot device will be found
-    # need to install grub2 on each of them
-    for part in $part_list ; do
-        if [ -n "$part" ]; then
-            LogPrint "Boot partition found: $part"
-            dd if=/dev/zero of=$part
-
-            # Do not update nvram when system is running in PowerNV mode (BareMetal).
-            # grub2-install will failed if not run with the --no-nvram option on a PowerNV system.
-            # see https://github.com/rear/rear/pull/1742
-            if [[ $(awk '/platform/ {print $NF}' < /proc/cpuinfo) == PowerNV ]] ; then
-                grub2_install_option="--no-nvram"
-            fi
-
-            # Run grub-install/grub2-install directly in chroot without a login shell in between, see https://github.com/rear/rear/issues/862
-            # When software RAID1 is used, grub2 needs correct PATH to access other tools
-            if chroot $TARGET_FS_ROOT /usr/bin/env PATH=/sbin:/usr/sbin:/usr/bin:/bin $grub_name-install $grub2_install_option $part ; then
-                LogPrint "GRUB2 installed on $part"
-                NOBOOTLOADER=
-            else
-                LogPrint "Failed to install GRUB2 on $part"
-            fi
+# When GRUB2_INSTALL_DEVICES is specified by the user
+# install GRUB2 only there and nowhere else:
+if test "$GRUB2_INSTALL_DEVICES" ; then
+    grub2_install_failed="no"
+    for grub2_install_device in $GRUB2_INSTALL_DEVICES ; do
+        # In MIGRATION_MODE disk mappings (in var/lib/rear/layout/disk_mappings)
+        # are applied when devices in GRUB2_INSTALL_DEVICES match
+        # cf. https://github.com/rear/rear/issues/1437
+        # MAPPING_FILE (var/lib/rear/layout/disk_mappings)
+        # is set in layout/prepare/default/300_map_disks.sh
+        # only if MIGRATION_MODE is true:
+        if test -s "$MAPPING_FILE" ; then
+            # Cf. the function apply_layout_mappings() in lib/layout-functions.sh
+            while read source_disk target_disk junk ; do
+                # Skip lines that have wrong syntax:
+                test "$source_disk" -a "$target_disk" || continue
+                if test "$grub2_install_device" = "$source_disk" ; then
+                    LogPrint "Installing GRUB2 on $target_disk ($source_disk in GRUB2_INSTALL_DEVICES is mapped to $target_disk in $MAPPING_FILE)"
+                    grub2_install_device="$target_disk"
+                    break
+                fi
+            done < <( grep -v '^#' "$MAPPING_FILE" )
+        else
+            LogPrint "Installing GRUB2 on $grub2_install_device (specified in GRUB2_INSTALL_DEVICES)"
+        fi
+        if ! chroot $TARGET_FS_ROOT /bin/bash --login -c "$grub_name-install $grub2_install_option $grub2_install_device" ; then
+            LogPrintError "Failed to install GRUB2 on $grub2_install_device"
+            grub2_install_failed="yes"
         fi
     done
+    is_false $grub2_install_failed && NOBOOTLOADER=''
+    # return even if it failed to install GRUB2 on one of the specified GRUB2_INSTALL_DEVICES
+    # because then the user gets an explicit WARNING via finalize/default/890_finish_checks.sh
+    is_true $NOBOOTLOADER && return 1 || return 0
 fi
 
-if [[ "$NOBOOTLOADER" ]]; then
-    LogIfError "No bootloader configuration found. Install boot partition manually"
+# If GRUB2_INSTALL_DEVICES is not specified try to automatically determine where to install GRUB2:
+if ! test -r "$LAYOUT_FILE" ; then
+    LogPrintError "Cannot determine where to install GRUB2"
+    return 1
+fi
+LogPrint "Determining where to install GRUB2 (no GRUB2_INSTALL_DEVICES specified)"
+
+# Find PPC PReP Boot partitions:
+part_list=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $LAYOUT_FILE )
+if ! test "$part_list" ; then
+    LogPrintError "Cannot install GRUB2 (unable to find a PPC PReP boot partition)"
+    return 1
 fi
 
-umount $TARGET_FS_ROOT/proc
+# We don't know what the first disk will be, so we cannot be sure the MBR
+# is written to the correct disk.
+# If software RAID1 is used, several boot devices will be found and
+# then GRUB2 needs to be installed on each of them.
+# This is the reason why we make all possible boot disks bootable here:
+for part in $part_list ; do
+    # Install GRUB2 on the PPC PReP boot partition if one was found:
+    if test "$part" ; then
+        LogPrint "Found PPC PReP boot partition $part - installing GRUB2 there"
+        # Erase the first 512 bytes of the PPC PReP boot partition:
+        dd if=/dev/zero of=$part
+        if chroot $TARGET_FS_ROOT /bin/bash --login -c "$grub_name-install $grub2_install_option $part" ; then
+            # In contrast to the above behaviour when GRUB2_INSTALL_DEVICES is specified
+            # consider it here as a successful bootloader installation when GRUB2
+            # got installed on at least one PPC PReP boot partition:
+            NOBOOTLOADER=''
+            # Continue with the next PPC PReP boot partition:
+            continue
+        fi
+        LogPrintError "Failed to install GRUB2 on PPC PReP boot partition $part"
+    fi
+done
+
+is_true $NOBOOTLOADER || return 0
+LogPrintError "Failed to install GRUB2 - you may have to manually install it"
+return 1
+

--- a/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/620_install_grub2.sh
@@ -6,10 +6,31 @@
 # but this script contains PPC64/PPC64LE specific code.
 ##############################################################################
 #
+# The generic way how to install GRUB2 when one is not "inside" the system
+# but "outside" like in the ReaR recovery system or in a rescue system is
+# to install GRUB2 from within the target system environment via 'chroot'
+# basically via commands like the following:
+#
+#   mount --bind /proc /mnt/local/proc
+#   mount --bind /sys /mnt/local/sys
+#   mount --bind /dev /mnt/local/dev
+#   chroot /mnt/local /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+#   chroot /mnt/local /usr/sbin/grub2-install /dev/sda
+#
+# Using 'grub2-install --root-directory' instead of 'chroot' is not a good idea,
+# see https://github.com/rear/rear/issues/1828#issuecomment-398717889
+#
+# The procedure is the same when GRUB2 is used on POWER architecture
+# e.g. on PPC64 or PPC64LE but there the GRUB2 install device
+# has to be a PPC PReP boot partition.
+# On POWER architecture the Open Firmware is configured
+# to read the ELF image embedded in the PReP boot partition
+# (like how the MBR is used by PC x86 BIOS to embed boot code).
+#
 # However the following issues still exist:
 #
-# * We don't know what the first disk will be, so we cannot be sure the MBR
-#   is written to the correct disk.
+# * We do not know what the first boot device will be, so we cannot be sure
+#   GRUB2 is installed on the correct boot device.
 #   If software RAID1 is used, several boot devices will be found and
 #   then GRUB2 needs to be installed on each of them because
 #   "You don't want to lose the first disk and suddenly discover your system won't reboot!"
@@ -19,9 +40,8 @@
 #   This is also the reason why more than one disk can be specified
 #   in GRUB2_INSTALL_DEVICES.
 #
-# * There is no guarantee that GRUB2 was the boot loader used originally.
-#   One solution is to save and restore the MBR for each disk, but this
-#   does not guarantee a correct boot-order, or even a working bootloader config.
+# * There is no guarantee that GRUB2 was used as bootloader on the original system.
+#   The solution is to specify the BOOTLOADER config variable.
 #
 # This script does not error out because at this late state of "rear recover"
 # (i.e. after the backup was restored) I <jsmeix@suse.de> consider it too hard
@@ -139,8 +159,8 @@ if ! test "$part_list" ; then
     return 1
 fi
 
-# We don't know what the first disk will be, so we cannot be sure the MBR
-# is written to the correct disk.
+# We do not know what the first boot device will be, so we cannot be sure
+# GRUB2 is installed on the correct boot device.
 # If software RAID1 is used, several boot devices will be found and
 # then GRUB2 needs to be installed on each of them.
 # This is the reason why we make all possible boot disks bootable here:

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -784,7 +784,7 @@ function get_part_device_name_format() {
 
     echo "$part_name"
 }
-#
+
 # apply_layout_mappings function migrate disk device reference from an old system and
 # replace them with new one (from current system).
 # the relationship between OLD and NEW device is provided by $MAPPING_FILE
@@ -803,7 +803,7 @@ function apply_layout_mappings() {
     test -s "$file_to_migrate" || return 0
     # --End Of TEST section--
 
-    # Generate unique words (where unique means that those generated words cannot exist in file_to_migrate)
+    # Generate unique words (where unique means that those generated words cannot already exist in file_to_migrate)
     # as replacement placeholders to correctly handle circular replacements e.g. for "sda -> sdb and sdb -> sda"
     # in the mapping file those generated unique words would be _REAR0_ for sda and _REAR1_ for sdb.
     # The replacement strategy is:
@@ -819,7 +819,7 @@ function apply_layout_mappings() {
     # so that the circular replacement "sda -> sdb and sdb -> sda" is done in file_to_migrate.
     # Step 3:
     # In file_to_migrate verify that there are none of those temporary replacement words from step 1 left
-    # to ensure the replacement was done correctly and complete.
+    # to ensure the replacement was done correctly and completely.
 
     # Replacement_file initialization.
     replacement_file="$TMP_DIR/replacement_file"
@@ -827,8 +827,8 @@ function apply_layout_mappings() {
 
     function add_replacement() {
         # We temporarily map all devices in the mapping to new names _REAR[0-9]+_
-        echo "$1 _REAR${replaced_count}_" >> "$replacement_file"
-        let replaced_count++
+        echo "$1 _REAR${replacement_count}_" >> "$replacement_file"
+        let replacement_count++
     }
 
     function has_replacement() {
@@ -852,7 +852,7 @@ function apply_layout_mappings() {
     #   /dev/sdb _REAR1_
     #   /dev/sdd _REAR2_
     #   /dev/sdc _REAR3_
-    replaced_count=0
+    replacement_count=0
     while read source target junk ; do
         # Skip lines that have wrong syntax:
         test "$source" -a "$target" || continue
@@ -911,7 +911,7 @@ function apply_layout_mappings() {
 
     # Step 3:
     # Verify that there are none of those temporary replacement words from step 1 left in file_to_migrate
-    # to ensure the replacement was done correctly and complete (cf. the above example where '_REAR3_' is left).
+    # to ensure the replacement was done correctly and completely (cf. the above example where '_REAR3_' is left).
     apply_layout_mappings_succeeded="yes"
     while read original replacement junk ; do
         # Skip lines that have wrong syntax:


### PR DESCRIPTION
Fixed, simplified and enhanced GRUB2 installation for PPC64/PPC64LE

* Type: **Bug Fix** and **Enhancement**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/1843
and
https://github.com/rear/rear/issues/1828

* How was this pull request tested?
Not at all by me because I have no PPC64/PPC64LE system.

* Brief description of the changes in this pull request:
Fixed finalize/Linux-ppc64le/620_install_grub2.sh according to
https://github.com/rear/rear/issues/1828#issuecomment-398717889

Enhanced GRUB2 installation by the new config variable
GRUB2_INSTALL_DEVICES so that now the user can specify
what he wants if needed.

Aligned code in finalize/Linux-ppc64le/620_install_grub2.sh
with the code in finalize/Linux-i386/620_install_grub2.sh
as far as I could from plain looking at the code
without actual knowledge about PPC64/PPC64LE.


