### PR TITLE
added mods for slackware support - mkbackup working with UEFI/USB

### DIFF
--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -6,7 +6,8 @@ is_true $USING_UEFI_BOOTLOADER || return 0
 Log "Configuring device for EFI boot"
 
 # $BUILD_DIR is not present at this stage, temp dir will be used instead
-EFI_MPT=$(mktemp -d /tmp/rear-efi.XXXXX)
+# Slackware version of mktemp requires 6 Xs in template
+EFI_MPT=$(mktemp -d /tmp/rear-efi.XXXXXX)
 StopIfError "Failed to create mount point ${EFI_MPT}"
 
 uefi_bootloader_basename=$( basename "$UEFI_BOOTLOADER" )
@@ -88,7 +89,8 @@ EOF
 
                 # Create bootloader, this overwrite BOOTX64.efi copied in previous step ...
                 # Fail if BOOTX64.efi can't be created
-                ${GRUB_MKIMAGE} -o ${EFI_DST}/BOOTX64.efi -p ${EFI_DIR} -O x86_64-efi linux part_gpt ext2 normal gfxterm gfxterm_background gfxterm_menu test all_video loadenv fat
+                # Slackware grub doesnt have gfxterm_background or gfxterm_menu...
+                ${GRUB_MKIMAGE} -o ${EFI_DST}/BOOTX64.efi -p ${EFI_DIR} -O x86_64-efi linux part_gpt ext2 normal gfxterm gfxmenu test all_video loadenv fat
                 StopIfError "Failed to create BOOTX64.efi"
 
                 # Create config for grub 2.0

--- a/usr/share/rear/pack/Linux-i386/300_copy_kernel.sh
+++ b/usr/share/rear/pack/Linux-i386/300_copy_kernel.sh
@@ -10,7 +10,13 @@
 # Using another kernel is a TODO for now
 
 if [ ! -s "$KERNEL_FILE" ]; then
-    if [ -r "/boot/vmlinuz-$KERNEL_VERSION" ]; then
+    # add slackware test on top to prevent error on get_kernel_version
+    if [ -f /etc/slackware-version ]; then
+        # check under /boot/efi/EFI/Slackware
+        [ -f "/boot/efi/EFI/Slackware/vmlinuz" ]
+        StopIfError "Could not find a matching kernel in /boot/efi/EFI/Slackware !"
+        KERNEL_FILE="/boot/efi/EFI/Slackware/vmlinuz"
+    elif [ -r "/boot/vmlinuz-$KERNEL_VERSION" ]; then
         KERNEL_FILE="/boot/vmlinuz-$KERNEL_VERSION"
     elif has_binary get_kernel_version; then
         for src in /boot/* ; do


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
http://lists.relax-and-recover.org/pipermail/rear-users/2018-July/003572.html

* How was this pull request tested?
Tested on laptop running Slackware 14.2 with UEFI.  Used "rear -v mkbackup" to USB drive.  The USB drive booted OK but I did not test recover function yet.  The backup tar was available on the drive.

* Brief description of the changes in this pull request:
Added code to support Slackware 14.2 distribution.  This was a brute force approach and my mktemp changes may break compatibility with other OSs.  Requesting feedback to improve quality.
