### PR TITLE
RAWDISK output portability improvements (fix #1846)

### DIFF
--- a/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
@@ -73,7 +73,7 @@ local boot_partition="${disk_device}p1"
 
 # 1. partprobe
 if [[ ! -b "$boot_partition" ]] && has_binary partprobe; then
-    partprobe "$disk_device" || Error "partprobe failed to make the kernel recognize loop device partitions"
+    partprobe "$disk_device" || LogPrintError "partprobe failed to make the kernel recognize loop device partitions"
 fi
 
 # 2. Heuristic: wait

--- a/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
@@ -67,8 +67,34 @@ disk_device="$(losetup --show --find "$disk_image")"
 StopIfError "Could not create loop device on $disk_image"
 AddExitTask "losetup -d $disk_device >&2"
 
-partprobe "$disk_device" || Error "Could not make the kernel recognize loop device partitions"
 local boot_partition="${disk_device}p1"
+
+# Try several methods to make the kernel recognize partitions on the loop device, if not already done automatically:
+
+# 1. partprobe
+if [[ ! -b "$boot_partition" ]] && has_binary partprobe; then
+    partprobe "$disk_device" || Error "partprobe failed to make the kernel recognize loop device partitions"
+fi
+
+# 2. Heuristic: wait
+[[ ! -b "$boot_partition" ]] && sleep 5
+
+# 3. kpartx
+local use_kpartx=no
+if [[ ! -b "$boot_partition" ]]; then
+    if has_binary kpartx; then
+        kpartx -us "$disk_device"  # detect partitions, create device nodes - synchronized (wait until done)
+        StopIfError "kpartx could not create loop partition device nodes from loop device $disk_device"
+        AddExitTask "kpartx -d $disk_device >&2"
+        use_kpartx=yes
+    else
+        LogPrintError "It seems that the current linux kernel does not support loop device partitions."
+        LogPrintError "TIP: You might achieve loop device partition support by installing the 'kpartx' tool, if available."
+    fi
+fi
+
+# If unsuccessful, say so.
+[[ -b "$boot_partition" ]] || Error "Cannot prepare boot file system for the RAWDISK image: Missing OS support for loop device partitions."
 
 
 ### Create and populate the boot file system
@@ -144,6 +170,10 @@ fi
 
 umount "$boot_partition_root" || Error "Could not unmount boot file system"
 RemoveExitTask "umount $boot_partition_root >&2"
+if is_true $use_kpartx; then
+    kpartx -d "$disk_device" || Error "Could not delete  partition device nodes from loop device $disk_device"
+    RemoveExitTask "kpartx -d $disk_device >&2"
+fi
 losetup -d "$disk_device" || Error "Could not delete loop device"
 RemoveExitTask "losetup -d $disk_device >&2"
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/1846

* How was this pull request tested? Generated RAWDISK output on Ubuntu 16.04.4 LTS and CentOS 6.10

* Brief description of the changes in this pull request: Enables RAWDISK output for kernels which do not recognize loop device partitions. Should work with any distribution where the `kpartx` tool is available.