### PR TITLE
add support for Slackware UEFI/USB

### DIFF
--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -6,7 +6,12 @@ is_true $USING_UEFI_BOOTLOADER || return 0
 Log "Configuring device for EFI boot"
 
 # $BUILD_DIR is not present at this stage, temp dir will be used instead
-EFI_MPT=$(mktemp -d /tmp/rear-efi.XXXXX)
+# Slackware version of mktemp requires 6 Xs in template
+if [ -f /etc/slackware-version ] ; then
+    EFI_MPT=$(mktemp -d /tmp/rear-efi.XXXXXX)
+else
+    EFI_MPT=$(mktemp -d /tmp/rear-efi.XXXXX)
+fi
 StopIfError "Failed to create mount point ${EFI_MPT}"
 
 uefi_bootloader_basename=$( basename "$UEFI_BOOTLOADER" )

--- a/usr/share/rear/pack/Linux-i386/300_copy_kernel.sh
+++ b/usr/share/rear/pack/Linux-i386/300_copy_kernel.sh
@@ -10,7 +10,13 @@
 # Using another kernel is a TODO for now
 
 if [ ! -s "$KERNEL_FILE" ]; then
-    if [ -r "/boot/vmlinuz-$KERNEL_VERSION" ]; then
+    # add slackware test on top to prevent error on get_kernel_version
+    if [ -f /etc/slackware-version ]; then
+        # check under /boot/efi/EFI/Slackware
+        [ -f "/boot/efi/EFI/Slackware/vmlinuz" ]
+        StopIfError "Could not find a matching kernel in /boot/efi/EFI/Slackware !"
+        KERNEL_FILE="/boot/efi/EFI/Slackware/vmlinuz"
+    elif [ -r "/boot/vmlinuz-$KERNEL_VERSION" ]; then
         KERNEL_FILE="/boot/vmlinuz-$KERNEL_VERSION"
     elif has_binary get_kernel_version; then
         for src in /boot/* ; do


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): N/A

* How was this pull request tested?
Tested on laptop running Slackware 14.2 with grub upgraded to v2.02.
Used "rear -d -D mkbackup" to successfully create a bootable USB drive.  Booted ReaR rescue image but did not run recover.  The backup tar was available on the USB.

* Brief description of the changes in this pull request:
Changed two files to add support for Slackware 14.2 distro.
