### PR TITLE
mods to allow slackware ISO image and udev sda fix

### DIFF
--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -46,6 +46,11 @@ function build_bootx86_efi {
         Log "Did not find grub-mkimage (cannot build bootx86.efi)"
         return
     fi
-    $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs
+    if [ -f /etc/slackware-version ] ; then
+        # slackware grub doesn't have linuxefi module
+        $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs
+    else
+        $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs
+    fi
     StopIfError "Error occurred during $gmkimage of BOOTX64.efi"
 }

--- a/usr/share/rear/output/ISO/Linux-i386/820_create_iso_image.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/820_create_iso_image.sh
@@ -4,7 +4,12 @@ LogPrint "Making ISO image"
 
 if is_true $USING_UEFI_BOOTLOADER ; then
     # initialized with 1
-    EFIBOOT="-eltorito-alt-boot -e boot/efiboot.img -no-emul-boot"
+    if [ -f /etc/slackware-version ] ; then
+        # slackware mkisofs uses different command line options
+        EFIBOOT="-eltorito-alt-boot -no-emul-boot -eltorito-platform efi -eltorito-boot boot/efiboot.img"
+    else
+        EFIBOOT="-eltorito-alt-boot -e boot/efiboot.img -no-emul-boot"
+    fi
     Log "Including ISO UEFI boot (as triggered by USING_UEFI_BOOTLOADER=1)"
 else
     EFIBOOT=""

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
@@ -32,7 +32,13 @@ if [[ $systemd_version -gt 190 ]] || [[ -s /etc/udev/rules.d/00-rear.rules ]] ; 
     else
         # found our "special" module-auto-load rule
         # clean away old device nodes from source system
-        rm -Rf /dev/{sd*,hd*,sr*,cc*,disk}
+        #   except Slackware since it uses eudev and relies on the kernel to create sda
+        if ! grep Slackware /etc/os-release ; then
+            rm -Rf /dev/{sd*,hd*,sr*,cc*,disk}
+        else
+            # Slackware eudev already has a rule to load modules
+            rm -f /etc/udev/rules.d/00-rear.rules 
+        fi
         mkdir -p /dev/disk/by-{id,name,path,label}
         # everybody does that even though it seems to be empty by default..
         test -w /sys/kernel/uevent_helper && echo >/sys/kernel/uevent_helper


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): N/A

* How was this pull request tested?
Tested on laptop running Slackware 14.2 with grub upgraded to v2.02.
Used "rear -d -D mkrescue" to successfully create a bootable ISO image burned to DVD. Booted ReaR rescue image but did not run recover. 

* Brief description of the changes in this pull request:
Changed 3 files to add support for Slackware ISO rescue image. 
