### PR TITLE
Verify md5sums of files in recovery system (issue #1859)

### DIFF
--- a/usr/share/rear/build/default/995_md5sums_rootfs.sh
+++ b/usr/share/rear/build/default/995_md5sums_rootfs.sh
@@ -1,0 +1,34 @@
+
+# build/default/995_md5sums_rootfs.sh
+#
+# Create md5sums for all regular files in ROOTFS_DIR
+# and store the result in ROOTFS_DIR as md5sums.txt
+# so that in the recovery system one can test via
+#   pushd / ; md5sum --quiet --check md5sums.txt ; popd
+# if the regular files in the recovery system are intact.
+# That test must happen first of all during recovery system startup
+# before files may get changed by recovery system startup scripts
+# see skel/default/etc/scripts/system-setup for details.
+# The reason behind is that there could be errors during loading/unpacking
+# of the initrd/initramfs which are reported (if one knows how to look for them)
+# but at least some errors do not abort the boot process so that
+# it could happen that files in the recovery system are corrupt
+# but the user may not notice the actual error and get any kind
+# of inexplicable errors later when using the recovery system,
+# see https://github.com/rear/rear/issues/1859
+# and https://github.com/rear/rear/issues/1724
+
+# Skip that if the user had specified to exclude md5sums for all files:
+test "all" = "$EXCLUDE_MD5SUM_VERIFICATION" && return || Log "Creating md5sums for regular files in $ROOTFS_DIR"
+
+local md5sums_file="md5sums.txt"
+# Careful in case of 'return' after 'pushd' (must call the matching 'popd' before 'return'):
+pushd $ROOTFS_DIR 1>&2
+    cat /dev/null >$md5sums_file
+    # Do not provide a md5sums.txt in the recovery system if it was not successfully created here.
+    # Exclude the md5sums.txt file itself and all .gitignore files here in any case.
+    # Excluding particular files from being verified during recovery system startup
+    # happens via EXCLUDE_MD5SUM_VERIFICATION in skel/default/etc/scripts/system-setup
+    find . -xdev -type f | egrep -v '/md5sums\.txt|/\.gitignore' | xargs md5sum >>$md5sums_file || cat /dev/null >$md5sums_file
+popd 1>&2
+

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1319,7 +1319,7 @@ NON_FATAL_BINARIES_WITH_MISSING_LIBRARY=''
 # of inexplicable errors later when using the recovery system,
 # see https://github.com/rear/rear/issues/1859
 # and https://github.com/rear/rear/issues/1724
-# EXCLUDE_MD5SUM_VERIFICATION is a 'egrep' pattern
+# EXCLUDE_MD5SUM_VERIFICATION is a 'egrep -v' pattern
 # like EXCLUDE_MD5SUM_VERIFICATION='/path/to/myfile|/path/to/mydir/'
 # for files or directories in md5sums.txt that should be excluded from being verified.
 # With the special value EXCLUDE_MD5SUM_VERIFICATION='all'

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1303,6 +1303,34 @@ SSH_UNPROTECTED_PRIVATE_KEYS='no'
 # For details see the build/default/980_verify_rootfs.sh script.
 NON_FATAL_BINARIES_WITH_MISSING_LIBRARY=''
 
+##
+# EXCLUDE_MD5SUM_VERIFICATION
+#
+# What files should be excluded from being verified during recovery system startup.
+# During "rear mkrescue/mkbackup" the build/default/995_md5sums_rootfs.sh script
+# creates md5sums for all regular files in the ReaR rescue/recovery system
+# and stores the result as /md5sums.txt in the ReaR rescue/recovery system.
+# During recovery system startup the md5sums of the files in /md5sums.txt are verified.
+# The reason behind is that there could be errors during loading/unpacking
+# of the initrd/initramfs which are reported (if one knows how to look for them)
+# but at least some errors do not abort the boot process so that
+# it could happen that files in the recovery system are corrupt
+# but the user may not notice the actual error and get any kind
+# of inexplicable errors later when using the recovery system,
+# see https://github.com/rear/rear/issues/1859
+# and https://github.com/rear/rear/issues/1724
+# EXCLUDE_MD5SUM_VERIFICATION is a 'egrep' pattern
+# like EXCLUDE_MD5SUM_VERIFICATION='/path/to/myfile|/path/to/mydir/'
+# for files or directories in md5sums.txt that should be excluded from being verified.
+# With the special value EXCLUDE_MD5SUM_VERIFICATION='all'
+# creating md5sums and verification can be completely skipped.
+# The by default empty EXCLUDE_MD5SUM_VERIFICATION means that certain files
+# get excluded where it is known that their md5sum verification will fail
+# (i.e. the already known false positives are excluded by default).
+# For details see the build/default/995_md5sums_rootfs.sh
+# and skel/default/etc/scripts/system-setup scripts.
+EXCLUDE_MD5SUM_VERIFICATION=''
+
 # Time synchronisation, could be NTP, CHRONY, NTPDATE, RDATE or empty:
 TIMESYNC=
 # Set a timesync source, mostly needed for NTPDATE and RDATE:

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -9,11 +9,6 @@
 # (e.g. "ls foo*bar" becomes plain "ls" without "foo*bar: No such file or directory" error).
 shopt -s nullglob
 
-# Sourcing user and rescue configuration as we need some variables.
-for conf in local site rescue ; do
-    test -f /etc/rear/$conf.conf && source /etc/rear/$conf.conf
-done
-
 # Use an artificial array to get the kernel command line parameters as array elements
 kernel_command_line=( $( cat /proc/cmdline ) )
 
@@ -49,7 +44,8 @@ function automatic_recovery() {
 # that at least on SLES12 some initial output lines of this script would get lost
 # (perhaps somewhere in systemd's nowhere land) which results that in partricular
 # in Relax-and-Recover debug mode the user sits in front of an empty screen wondering
-# why nothing happens because in partricular the read prompt "Press ENTER ..." was lost:
+# why nothing happens because in partricular the read prompt "Press ENTER ..." was lost,
+# cf. the 'if rear_debug' part below:
 sleep 1
 
 if rear_debug ; then
@@ -68,6 +64,49 @@ if rear_debug ; then
             echo -e "\nStarted debug mode shell on tty9\n"
             ;;
     esac
+fi
+
+# Sourcing user and rescue configuration as we need some variables
+# (EXCLUDE_MD5SUM_VERIFICATION right now and other variables in the system setup scripts):
+for conf in local site rescue ; do
+    test -f /etc/rear/$conf.conf && source /etc/rear/$conf.conf
+done
+
+# Verifying md5sums must happen first of all during recovery system startup
+# before files may get changed by the recovery system startup scripts below
+# otherwise one may get false positives like
+#   ./var/log/lastlog: FAILED
+#   ./etc/resolv.conf: FAILED
+#   ./etc/udev/rules.d/70-persistent-net.rules: FAILED
+#   ./etc/inittab: FAILED
+#   ./etc/issue: FAILED
+# The /md5sums.txt file would be empty if the md5sums were not successfully created
+# during "rear mkrescue/mkbackup" by the build/default/995_md5sums_rootfs.sh script:
+if test -s "/md5sums.txt" ; then
+    echo -e "\nVerifying md5sums of the files in the Relax-and-Recover rescue system\n"
+    # /etc/issue is always excluded to avoid that verifying its md5sum fails with "./etc/issue: FAILED"
+    # when there is no rsa SSH host key /etc/ssh/ssh_host_rsa_key in the recovery system
+    # because then /etc/scripts/run-sshd creates one and adds its SSH fingerprint to /etc/issue
+    # and /etc/scripts/run-sshd is run by SysVinit or systemd
+    # (via /etc/inittab and /etc/init/start-sshd.conf or /usr/lib/systemd/system/sshd.service)
+    # so that /etc/issue may get modified before its md5sum is verified here:
+    egrep_pattern="/etc/issue"
+    test "$EXCLUDE_MD5SUM_VERIFICATION" && egrep_pattern="$egrep_pattern|$EXCLUDE_MD5SUM_VERIFICATION"
+    # Regardless of '--quiet' md5sum shows "FAILED" messages nevertheless (cf. 'man md5sum'):
+    if grep -E -v "$egrep_pattern" md5sums.txt | md5sum --quiet --check ; then
+        echo -e "md5sums are OK\n"
+    else
+        # In case of a FAILED md5sum inform the user:
+        echo "Possibly corrupted Relax-and-Recover rescue system"
+        if rear_debug ; then
+            # In debug mode let the user confirm to proceed:
+            read -p "Press ENTER to proceed 'bona fide' nevertheless "
+        else
+            # In non-debug mode wait 10 seconds so that the user can read the md5sum output:
+            echo -e "Proceeding 'bona fide' nevertheless...\n"
+            sleep 10
+        fi
+    fi
 fi
 
 echo -e "\nConfiguring Relax-and-Recover rescue system\n"


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **High**
I think the impact is `high` regardless that in practice it should be rarely needed
but when files in the recovery system are corrupt it is basically a must to detect them.

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1859
and
https://github.com/rear/rear/issues/1724

* How was this pull request tested?
By me on my usual simple SLES12 QEMU/KVM test system.
I expect some more false positives where it fails to verify the md5sum of certain files
on other systems and in particular in more complicated environments.

* Brief description of the changes in this pull request:
During "rear mkrescue/mkbackup" the new script
build/default/995_md5sums_rootfs.sh
creates md5sums for all regular files in in the recovery system
and stores the result as /md5sums.txt in the recovery system.
During recovery system startup a new section in the
skel/default/etc/scripts/system-setup script
verifies the md5sums of the files in /md5sums.txt.
Via the new config variable EXCLUDE_MD5SUM_VERIFICATION
the user can specify what files should be excluded from being verified
during recovery system startup or alternatively via
EXCLUDE_MD5SUM_VERIFICATION='all'
the whole stuff can be completely skipped.
By default certain files get excluded where it is known that their md5sum verification
will fail (i.e. the already known false positives are excluded by default).
