### PR TITLE
fedora28: syslinux needs libcom32.c32 to boot from HD

### DIFF
--- a/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
+++ b/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
@@ -55,6 +55,7 @@ if [[ ! -z "$PXE_TFTP_URL" ]] && [[ "$PXE_RECOVER_MODE" = "unattended" ]] ; then
     syslinux_modules_dir=$( find_syslinux_modules_dir menu.c32 )
     [[ -z "$syslinux_modules_dir" ]] && syslinux_modules_dir=$(dirname $PXELINUX_BIN)
     cp $v $syslinux_modules_dir/ldlinux.c32 $BUILD_DIR/tftpbootfs >&2
+    cp $v $syslinux_modules_dir/libcom32.c32 $BUILD_DIR/tftpbootfs >&2
     cp $v $syslinux_modules_dir/menu.c32 $BUILD_DIR/tftpbootfs >&2
     cp $v $syslinux_modules_dir/chain.c32 $BUILD_DIR/tftpbootfs >&2
     cp $v $syslinux_modules_dir/hdt.c32 $BUILD_DIR/tftpbootfs >&2


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):https://github.com/rear/rear/issues/1866

* How was this pull request tested?yes, via ReaR Automated Testing

* Brief description of the changes in this pull request: fixes PXE HD discovery

