### PR TITLE
Wait for systemd-udevd to avoid broken pipe error in 40-start-udev-or-load-modules.sh

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
@@ -22,7 +22,17 @@ test "$systemd_version" || systemd_version=0
 
 if [[ $systemd_version -gt 190 ]] || [[ -s /etc/udev/rules.d/00-rear.rules ]] ; then
     # systemd-udevd case: systemd-udevd is started by systemd
-    if ps ax | grep -v grep | grep -q systemd-udevd ; then
+    # Wait up to 10 seconds for systemd-udevd:
+    for countdown in 4 3 2 1 0 ; do
+        # The first sleep waits one second in any case so that systemd-udevd should be usually there
+        # when 'pidof' test for it so that usually there is no "Waiting for systemd-udevd" message:
+        sleep 1
+        pidof systemd-udevd &>/dev/null && break
+        echo "Waiting for systemd-udevd ($countdown) ... "
+        # The second sleep results a total wait of two seconds for each for loop run:
+        sleep 1
+    done
+    if pidof -s systemd-udevd &>/dev/null ; then
         # check if daemon is actually running
         my_udevtrigger
         echo -n "Waiting for udev ... "
@@ -32,12 +42,12 @@ if [[ $systemd_version -gt 190 ]] || [[ -s /etc/udev/rules.d/00-rear.rules ]] ; 
     else
         # found our "special" module-auto-load rule
         # clean away old device nodes from source system
-        #   except Slackware since it uses eudev and relies on the kernel to create sda
+        # except Slackware since it uses eudev and relies on the kernel to create sda
         if ! grep Slackware /etc/os-release ; then
             rm -Rf /dev/{sd*,hd*,sr*,cc*,disk}
         else
             # Slackware eudev already has a rule to load modules
-            rm -f /etc/udev/rules.d/00-rear.rules 
+            rm -f /etc/udev/rules.d/00-rear.rules
         fi
         mkdir -p /dev/disk/by-{id,name,path,label}
         # everybody does that even though it seems to be empty by default..


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1832

* How was this pull request tested?
by me on my SLES12 test system
with `debug` kernel command line parameter
when booting the ReaR recovery system
and the `set -x` output of system-setup.d/40-start-udev-or-load-modules.sh
looks good to me.

* Brief description of the changes in this pull request:
Now system-setup.d/40-start-udev-or-load-modules.sh
waits up to 10 seconds for systemd-udevd to ensure
this needed deamon has sufficient time to start up
which by the way avoids an broken pipe error
of the too fast test that was done before.
