### PR TITLE
Tentative support for OBDR on ppc64le (issue #1868)

### DIFF
--- a/usr/share/rear/output/OBDR/Linux-ppc64le/300_create_grub2.sh
+++ b/usr/share/rear/output/OBDR/Linux-ppc64le/300_create_grub2.sh
@@ -1,0 +1,1 @@
+../../ISO/Linux-ppc64le/300_create_grub2.sh

--- a/usr/share/rear/output/OBDR/Linux-ppc64le/800_create_isofs.sh
+++ b/usr/share/rear/output/OBDR/Linux-ppc64le/800_create_isofs.sh
@@ -1,0 +1,1 @@
+../../ISO/Linux-ppc64le/800_create_isofs.sh


### PR DESCRIPTION
* Type: **Bug Fix** **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1868

* How was this pull request tested?
I neither have any tape device nor can I use OBDR
so that I cannot test or reproduce anything that is specific for OBDR.

* Brief description of the changes in this pull request:
Initial tentative support for OBDR on ppc64le
via a new `output/OBDR/Linux-ppc64le` sub-directory
that contains currently only two symlinks to existing scripts
<pre>
output/OBDR/Linux-ppc64le/300_create_grub2.sh -> ../../ISO/Linux-ppc64le/300_create_grub2.sh
output/OBDR/Linux-ppc64le/800_create_isofs.sh -> ../../ISO/Linux-ppc64le/800_create_isofs.sh
</pre>
cf. https://github.com/rear/rear/issues/1868#issuecomment-405613322
