### PR TITLE
Show last programs messages in Error function (related to issue1875)

### DIFF
--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -345,6 +345,20 @@ function get_path () {
 function Error () {
     LogPrintError "ERROR: $*"
     LogToSyslog "ERROR: $*"
+    # Show some additional hopefully meaningful output on the user's terminal
+    # (no need to log that again here because it is already in the log file)
+    # in particular the normal stdout and stderr messages of the last called programs
+    # to make the root cause more obvious to the user without the need to analyze the log file
+    # cf. https://github.com/rear/rear/issues/1875#issuecomment-407039065
+    PrintError "Log messages of latest run programs (most significant ones at the bottom):"
+    # Skip 'set -x' lines (i.e. lines that start with one or more '+' characters) and
+    # skip lines of the 'Log' function (the 'Log' function timestamp contains 'date +%Y-%m-%d')
+    # so that only the stdout and stderr messages of the called programs should be left.
+    # Shown only the last 5 lines because more older stuff may cause more confusion than help.
+    # Add two spaces indentation for better readability what those log file lines are.
+    # Some messages could be much too long to be usefully shown on the user's terminal
+    # so that the messages are truncated after 200 bytes:
+    PrintError "$( grep -E -v "^\+|$( date +%Y-%m-%d )" $RUNTIME_LOGFILE | tail -n 5 | sed -e 's/^/  /' | cut -b-200 )"
     # TODO: I <jsmeix@suse.de> wonder if the "has_binary caller" test is still needed nowadays
     # because for me on SLE10 with bash-3.1-24 up to SLE12 with bash-4.2 'caller' is a shell builtin:
     if has_binary caller ; then

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -396,7 +396,7 @@ function Error () {
     # to make the root cause more obvious to the user without the need to analyze the log file
     # cf. https://github.com/rear/rear/issues/1875#issuecomment-407039065
     PrintError "Some latest log messages from the last called script $caller_script_basename:"
-    # Show lines after the last called script was sourced (logged as 'Including /path/to/script.sh').
+    # Show lines after the last called script was sourced (logged as 'Including sub-path/to/script.sh').
     # Skip 'set -x' lines (i.e. lines that start with one or more '+' characters).
     # Shown at most the last 5 lines because more older stuff may cause more confusion than help.
     # Add two spaces indentation for better readability what those log file lines are.

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -412,9 +412,9 @@ function Error () {
     # we simply use last_sourced_script_filename in the sed expression.
     # Extract at most up to a line that is usually logged as '++ Error ...' or '++ BugError ...'
     # (but do not stop at lines that are logged like '++ StopIfError ...' or '++ PrintError ...')
-    # if such a '+ Error' or '+ BugError' line exists, otherwise 'sed' proceeds to the end
+    # if such a '+ Error' or '+ BugError' line exists, otherwise sed proceeds to the end
     # (the sed pattern '[Bug]*Error' is fuzzy because it would also match things like 'uuggError').
-    # The reason to stop at a line that contains '+ .*Error ' is that in debugscripts mode '-D'
+    # The reason to stop at a line that contains '+ [Bug]*Error ' is that in debugscripts mode '-D'
     # a BugError or Error function call with a multi line error message (e.g. BugError does that)
     # results 'set -x' debug output of that function call in the log file that looks like:
     #   ++ [Bug]Error 'first error message line
@@ -425,9 +425,9 @@ function Error () {
     # Because of the newlines in the error message subsequent lines appear without a leading '+' character
     # so that those debug output lines are indistinguishable from normal stdout/stderr output of programs,
     # cf. https://github.com/rear/rear/pull/1877
-    # Thereafter ('+ .*Error ' lines were needed above) skip 'set -x' lines (lines that start with a '+' character).
-    # Show at most the last 8 lines because more older stuff may cause more confusion than help.
-    # Add two spaces indentation for better readability what those log file lines are.
+    # Thereafter ('+ [Bug]*Error ' lines were needed before) skip 'set -x' lines (lines that start with a '+' character).
+    # Show at most the last 8 lines because too much before the actual error may cause more confusion than help.
+    # Add two spaces indentation for better readability what those extracted log file lines are.
     # Some messages could be too long to be usefully shown on the user's terminal so that they are truncated after 200 bytes:
     PrintError "$( sed -n -e "/Including .*$last_sourced_script_filename/,/+ [Bug]*Error /p" $RUNTIME_LOGFILE | grep -v '^+' | tail -n 8 | sed -e 's/^/  /' | cut -b-200 )"
     Log "ERROR: $*"

--- a/usr/share/rear/output/default/200_make_prefix_dir.sh
+++ b/usr/share/rear/output/default/200_make_prefix_dir.sh
@@ -1,10 +1,15 @@
 
-# Create $OUTPUT_PREFIX directory under the mounted network filesystem share.
+# Create $OUTPUT_PREFIX directory.
 # The $OUTPUT_PREFIX directory defaults to $HOSTNAME.
+#
+# This happens usually under a mounted network filesystem share
+# e.g. in case of BACKUP_URL=nfs://NFS.server.IP.address/remote/nfs/share
+# but it is also happens for local stuff like BACKUP_URL=usb:///dev/disk/by-label/REAR-000
 #
 # Do not do this for tapes and special attention for file:///path
 
-# Generate url variable name that depends on the current stage, e.g. BACKUP_URL:
+# Generate url variable name that depends on the current stage,
+# e.g. BACKUP_URL or OUTPUT_URL:
 url="$( echo $stage | tr '[:lower:]' '[:upper:]' )_URL"
 
 local scheme=$( url_scheme ${!url} )
@@ -14,9 +19,9 @@ local opath=$( output_path $scheme $path )
 # If $opath is empty return silently (e.g. scheme tape):
 test "$opath" || return 0
 
-# Create $OUTPUT_PREFIX sub-directory under the mounted network filesystem share:
-mkdir -p $v -m0750 "$opath" && return 0
+# Create $OUTPUT_PREFIX sub-directory:
+mkdir -p $v -m0750 "$opath" && return
 
 # A failure to cerate the $OUTPUT_PREFIX sub-directory is fatal: 
-Error "Failed to create '$OUTPUT_PREFIX' directory under the mounted network filesystem share"
+Error "Failed to create '$opath' directory for $url=${!url}"
 

--- a/usr/share/rear/output/default/200_make_prefix_dir.sh
+++ b/usr/share/rear/output/default/200_make_prefix_dir.sh
@@ -1,14 +1,19 @@
-# if set, create $OUTPUT_PREFIX under the mounted network filesystem share. This defaults
-# to $HOSTNAME
 
-# do not do this for tapes and special attention for file:///path
-url="$( echo $stage | tr '[:lower:]' '[:upper:]')_URL"
-local scheme=$(url_scheme ${!url})
-local path=$(url_path ${!url})
-local opath=$(output_path $scheme $path)
+# Create $OUTPUT_PREFIX under the mounted network filesystem share.
+# This defaults to $HOSTNAME
 
-# if $opath is empty return silently (e.g. scheme tape)
-[ -z "$opath" ] && return 0
+# Do not do this for tapes and special attention for file:///path
+url="$( echo $stage | tr '[:lower:]' '[:upper:]' )_URL"
+local scheme=$( url_scheme ${!url} )
+local path=$( url_path ${!url} )
+local opath=$( output_path $scheme $path )
 
-mkdir -p $v -m0750 "${opath}" >&2
-StopIfError "Could not mkdir '${opath}'"
+# If $opath is empty return silently (e.g. scheme tape):
+test "$opath" || return 0
+
+# Create $OUTPUT_PREFIX sub-directory under the mounted network filesystem share:
+mkdir -p $v -m0750 "$opath" && return 0 || LogPrintError "Could not mkdir '$opath'"
+
+# A failure to cerate the $OUTPUT_PREFIX sub-directory is fatal: 
+Error "Failed to create '$OUTPUT_PREFIX' directory under the mounted network filesystem share"
+

--- a/usr/share/rear/output/default/200_make_prefix_dir.sh
+++ b/usr/share/rear/output/default/200_make_prefix_dir.sh
@@ -1,9 +1,12 @@
 
-# Create $OUTPUT_PREFIX under the mounted network filesystem share.
-# This defaults to $HOSTNAME
-
+# Create $OUTPUT_PREFIX directory under the mounted network filesystem share.
+# The $OUTPUT_PREFIX directory defaults to $HOSTNAME.
+#
 # Do not do this for tapes and special attention for file:///path
+
+# Generate url variable name that depends on the current stage, e.g. BACKUP_URL:
 url="$( echo $stage | tr '[:lower:]' '[:upper:]' )_URL"
+
 local scheme=$( url_scheme ${!url} )
 local path=$( url_path ${!url} )
 local opath=$( output_path $scheme $path )
@@ -12,7 +15,7 @@ local opath=$( output_path $scheme $path )
 test "$opath" || return 0
 
 # Create $OUTPUT_PREFIX sub-directory under the mounted network filesystem share:
-mkdir -p $v -m0750 "$opath" && return 0 || LogPrintError "Could not mkdir '$opath'"
+mkdir -p $v -m0750 "$opath" && return 0
 
 # A failure to cerate the $OUTPUT_PREFIX sub-directory is fatal: 
 Error "Failed to create '$OUTPUT_PREFIX' directory under the mounted network filesystem share"

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -132,7 +132,7 @@ sleep 2
 # Because the kernel command line option 'debug' means 'set -x' for the system setup scripts
 # it also means '-D' (i.e. 'set -x') for the automated 'rear recover' run:
 if rear_debug ; then
-    rear_debug_options='-d -D'
+    rear_debug_options='-D'
 else
     rear_debug_options=''
 fi

--- a/usr/share/rear/verify/USB/NETFS/default/540_choose_backup_archive.sh
+++ b/usr/share/rear/verify/USB/NETFS/default/540_choose_backup_archive.sh
@@ -64,7 +64,7 @@ fi
 # Let the user choose the backup that should be restored:
 LogPrint "Select a backup archive."
 # Disable printing commands and their arguments as they are executed on stderr
-# which could have been enabled when running e.g. "rear -d -D recover"
+# which could have been enabled when running e.g. "rear -D recover"
 # to not disturb the select output which also happens on stderr.
 # When 'set -x' is set even calling 'set +x 2>/dev/null' would output '+ set +x' but
 # http://stackoverflow.com/questions/13195655/bash-set-x-without-it-being-printed


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1875#issuecomment-407039065
and subsequent comment

* How was this pull request tested?
By me as in https://github.com/rear/rear/issues/1875#issuecomment-406987662

* Brief description of the changes in this pull request:

Now the `Error` function shows the last 5 lines of stdout and stderr messages
of the called programs on the user's terminal that should hopefully
make the root cause of an eooro exit more obvious to the user
without the need to analyze the log file in any case.

Additionally I adapted output/default/200_make_prefix_dir.sh
to provide a better Error function text that now talks about
`Failed to create ... directory under the mounted network filesystem share`.

How it looks on my SLES12 test system when I reproduce it as in
https://github.com/rear/rear/issues/1875#issuecomment-406987662
<pre>
Could not mkdir '/tmp/rear.SKQq4qAbCh3GIg4/outputfs/f144'
ERROR: Failed to create 'f144' directory under the mounted network filesystem share
Log messages of latest run programs (most significant ones at the bottom):
  mount.nfs: trying text-based options 'nfsvers=3,nolock,addr=10.160.4.244'
  mount.nfs: prog 100003, trying vers=3, prot=6
  mount.nfs: prog 100005, trying vers=3, prot=17
  mkdir: created directory '/tmp/rear.SKQq4qAbCh3GIg4/tmp/boot'
  mkdir: cannot create directory '/tmp/rear.SKQq4qAbCh3GIg4/outputfs/f144': Permission denied
Aborting due to an error, check /root/rear.github.master/var/log/rear/rear-f144.log for details
Exiting rear mkrescue (PID 21235) and its descendant processes
</pre>
