### PR TITLE
Remove overwrite of $HOSTNAME in 400_restore_duplicity.sh

### DIFF
--- a/usr/share/rear/restore/DUPLICITY/default/400_restore_duplicity.sh
+++ b/usr/share/rear/restore/DUPLICITY/default/400_restore_duplicity.sh
@@ -22,10 +22,6 @@ if [ "$BACKUP_PROG" = "duplicity" ]; then
         export PASSPHRASE="$BACKUP_DUPLICITY_GPG_ENC_PASSPHRASE"
     fi
 
-    #export PYTHONHOME=/usr/lib64/python2.6
-    #export PYTHONPATH=/usr/lib64/python2.6:/usr/lib64/python2.6/lib-dynload:/usr/lib64/python2.6/site-packages:/usr/lib64/python2.6/site-packages/duplicity
-    export HOSTNAME=$(hostname)
-
     if [[ -n "$BACKUP_DUPLICITY_GPG_ENC_KEY" ]]; then
         GPG_KEY="--encrypt-key $BACKUP_DUPLICITY_GPG_ENC_KEY"
     fi


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1879

* How was this pull request tested?
Via partial restore

* Brief description of the changes in this pull request:
This removes the overwriting of $HOSTNAME in 400_restore_duplicity.sh.
Just removing the Line should be enough especially because $HOSTNAME isn't overwritten on Duplicity Backup. 