### PR TITLE
#1884 - Partition information recorded is unexpected when disk has 4K block size

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -184,6 +184,7 @@ env
 w
 dosfslabel
 sysctl
+blockdev
 )
 
 # the lib* serves to cover both 32bit and 64bit libraries!


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): [https://github.com/rear/rear/issues/1884](#1884)

* How was this pull request tested? Tested on AIX/LPAR/PPC64le

* Brief description of the changes in this pull request:

    - Use `blockdev` to retrieve the size of the disk and block size (unused)
    - Compute partition start using 512 bytes blocks (this is hardcoded in the Linux kernel)
