### PR TITLE
#1886 - LPAR/PPC64 bootlist is incorrectly set when having multiple 'prep' partitions

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64le/680_install_PPC_bootlist.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/680_install_PPC_bootlist.sh
@@ -48,7 +48,7 @@ fi
 if [[ ${#boot_list[@]} -gt 0 ]]; then
     LogPrint "Set LPAR bootlist to '${boot_list[@]}'"
     bootlist -m normal $boot_list
-    LogIfError "Unable to set bootlist. You will have to start in SMS to set it up manually."
+    LogPrintIfError "Unable to set bootlist. You will have to start in SMS to set it up manually."
 fi
 
 # vim: set et ts=4 sw=4:

--- a/usr/share/rear/finalize/Linux-ppc64le/680_install_PPC_bootlist.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/680_install_PPC_bootlist.sh
@@ -9,9 +9,12 @@ if grep -q "PowerNV" /proc/cpuinfo || grep -q "emulated by qemu" /proc/cpuinfo ;
 fi
 
 # Look for the PPC PReP Boot Partition.
-part=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $LAYOUT_FILE )
+part_list=$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $7}}' $LAYOUT_FILE )
 
-if [ -n "$part" ]; then
+# All the possible boot devices
+boot_list=()
+
+for part in $part_list ; do
     LogPrint "PPC PReP Boot partition found: $part"
 
     # Using $LAYOUT_DEPS file to find the disk device containing the partition.
@@ -29,14 +32,23 @@ if [ -n "$part" ]; then
     # If yes, get the list of path which are part of the multipath device.
     # Limit to the first 5 PATH (see #876)
     if dmsetup ls --target multipath | grep -w ${bootdev#/dev/mapper/} >/dev/null 2>&1; then
-        LogPrint "Limiting bootlist to 5 entries..."
-        bootlist_path=$(dmsetup deps $bootdev -o devname | awk -F: '{gsub (" ",""); gsub("\\(","/dev/",$2) ; gsub("\\)"," ",$2) ; print $2}' | cut -d" " -f-5)
-        LogPrint "Set LPAR bootlist to $bootlist_path"
-        bootlist -m normal $bootlist_path
+        LogPrint "Limiting bootlist to 5 entries as a maximum..."
+        boot_list+=( $(dmsetup deps $bootdev -o devname | awk -F: '{gsub (" ",""); gsub("\\(","/dev/",$2) ; gsub("\\)"," ",$2) ; print $2}' | cut -d" " -f-5) )
     else
         # Single Path device found
-        LogPrint "Set LPAR bootlist to $bootdev"
-        bootlist -m normal $bootdev
+        boot_list+=( $bootdev )
     fi
+done
+
+if [[ ${#boot_list[@]} -gt 5 ]]; then
+    LogPrint "Too many entries for bootlist command, limiting to first 5 entries..."
+    boot_list=( ${boot_list[@]:0:5} )
+fi
+
+if [[ ${#boot_list[@]} -gt 0 ]]; then
+    LogPrint "Set LPAR bootlist to '${boot_list[@]}'"
+    bootlist -m normal $boot_list
     LogIfError "Unable to set bootlist. You will have to start in SMS to set it up manually."
 fi
+
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): [https://github.com/rear/rear/issues/1886](#1886)

* How was this pull request tested?

    Tested on AIX/LPAR/PPC64le with 2 prep partitions, but no multipath on older ReaR 2.00 version

* Brief description of the changes in this pull request:

    - Added handling of multiple *prep* partitions
    - Enhanced handling of multiple *prep* partitions and multipath
