### PR TITLE
Print multipath device name during rescue  when firendly_name is off

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -96,8 +96,8 @@ blacklist {
 
         # Search and list mpath device.
         LogPrint "Listing multipath device found"
-        LogPrint "$(multipath -l | awk '$3~/dm-/{ DEVICES=$0} ; $1~/size=/ { print DEVICES" "$1 }' 2>&1)"
-    fi
+        LogPrint "$(multipath -l | awk '/dm-/{ DEVICES=$0 } ; $1~/size=/ { print DEVICES" "$1 }' 2>&1)"
+    f
 fi
 
 ### Create multipath devices (at least partitions on them).

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -95,6 +95,15 @@ blacklist {
         fi
 
         # Search and list mpath device.
+        # If multipath is used with "friendly_name" option, the output of "multipath -l" is
+        #   <friendly_mpath_name> (<mpath UUID>) <dm-name> <Vendor,type>
+        #   rootvg (3600507680c82004cf800000000000306) dm-2 IBM,2145 
+        # while it is a bit different when "friendly_name" is disabled
+        #   <mpath UUID> <dm-name> <Vendor,type>
+        #   36005076400810051380000000000007b dm-2 IBM,2145
+        # so that "dm-" can be the 3rd or 2nd field which means
+        # we let awk print the line where "dm-" appears
+        # cf. https://github.com/rear/rear/pull/1889
         LogPrint "Listing multipath device found"
         LogPrint "$(multipath -l | awk '/dm-/{ DEVICES=$0 } ; $1~/size=/ { print DEVICES" "$1 }' 2>&1)"
     fi

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -97,7 +97,7 @@ blacklist {
         # Search and list mpath device.
         LogPrint "Listing multipath device found"
         LogPrint "$(multipath -l | awk '/dm-/{ DEVICES=$0 } ; $1~/size=/ { print DEVICES" "$1 }' 2>&1)"
-    f
+    fi
 fi
 
 ### Create multipath devices (at least partitions on them).


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): https://github.com/rear/rear/issues/1883

* How was this pull request tested?
 tested with SLES12SP3

* Brief description of the changes in this pull request:
When loading multipath devices in rescue mode, ReaR rescue print to the user the name / UUID / size of the discovered multipath device.
if multipath is used with "friendly_name" option, the output of the command `multipath -l` is 
```
<friendly_mpath_name> (<mpath UUID>) <dm-name> <Vendor, type>
rootvg (3600507680c82004cf800000000000306) dm-2 IBM     ,2145 
```

while it is a bit different when "friendly_name" is disabled
```
<mpath UUID> <dm-name> <Vendor, type>
36005076400810051380000000000007b dm-2 IBM,2145
```
=> "dm-" can be the 3rd or 2nd field.....
This means we have to adjust the awk to print the line where "dm-" appears and not when "dm-" is the 3rd field.