### PR TITLE
Avoid false alarm during md5sum verification (related to issue1883)

### DIFF
--- a/usr/share/rear/build/default/995_md5sums_rootfs.sh
+++ b/usr/share/rear/build/default/995_md5sums_rootfs.sh
@@ -27,8 +27,19 @@ pushd $ROOTFS_DIR 1>&2
     cat /dev/null >$md5sums_file
     # Do not provide a md5sums.txt in the recovery system if it was not successfully created here.
     # Exclude the md5sums.txt file itself and all .gitignore files here in any case.
+    # Also exclude all regular files in /dev/ (device nodes get already excluded by 'find -type f')
+    # because sometimes it could happen that there are regular files in /dev/ in ROOTFS_DIR
+    # which won't get copied into the recovery system so that those regular files in /dev/
+    # are missing when etc/scripts/system-setup tries to verify their md5sums, for example
+    # see https://github.com/rear/rear/issues/1883#issuecomment-409875733
+    # and https://github.com/rear/rear/issues/1891#issue-347952166
+    # that both read (excerpts):
+    #   md5sum: ./dev/.SRC-Semaphore: No such file or directory
+    #   ./dev/.SRC-Semaphore: FAILED open or read
+    # where /dev/.SRC-Semaphore seems to be related to IBM Reliable Scalable Cluster Technology (RSCT)
+    # see http://www-01.ibm.com/support/docview.wss?uid=isg1IV35736
     # Excluding particular files from being verified during recovery system startup
     # happens via EXCLUDE_MD5SUM_VERIFICATION in skel/default/etc/scripts/system-setup
-    find . -xdev -type f | egrep -v '/md5sums\.txt|/\.gitignore' | xargs md5sum >>$md5sums_file || cat /dev/null >$md5sums_file
+    find . -xdev -type f | egrep -v '/md5sums\.txt|/\.gitignore|/dev/' | xargs md5sum >>$md5sums_file || cat /dev/null >$md5sums_file
 popd 1>&2
 

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -89,8 +89,11 @@ if test -s "/md5sums.txt" ; then
     # because then /etc/scripts/run-sshd creates one and adds its SSH fingerprint to /etc/issue
     # and /etc/scripts/run-sshd is run by SysVinit or systemd
     # (via /etc/inittab and /etc/init/start-sshd.conf or /usr/lib/systemd/system/sshd.service)
-    # so that /etc/issue may get modified before its md5sum is verified here:
-    egrep_pattern="/etc/issue"
+    # so that /etc/issue may get modified before its md5sum is verified here.
+    # Also /etc/udev/rules.d/70-persistent-net.rules is always excluded to avoid false alarm
+    # because it seems it can be modified even before this md5sum verification here runs,
+    # see https://github.com/rear/rear/issues/1883#issuecomment-409875733
+    egrep_pattern="/etc/issue|/etc/udev/rules.d/70-persistent-net.rules"
     test "$EXCLUDE_MD5SUM_VERIFICATION" && egrep_pattern="$egrep_pattern|$EXCLUDE_MD5SUM_VERIFICATION"
     # Regardless of '--quiet' md5sum shows "FAILED" messages nevertheless (cf. 'man md5sum'):
     if grep -E -v "$egrep_pattern" md5sums.txt | md5sum --quiet --check ; then


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**
Technically the impact is zero (only false alarm)
but to the user the impact is 'normal' because false alarm confuses the user.
I think essentially false alarm is like a WARNING message, cf.
https://blog.schlomo.schapiro.org/2015/04/warning-is-waste-of-my-time.html

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1883#issuecomment-409875733

* How was this pull request tested?
By me on my SLES12 KVM system.

* Brief description of the changes in this pull request:

Now also exclude all regular files in /dev/
(device nodes get already excluded by 'find -type f')
because sometimes it could happen that there are
regular files in /dev/ in ROOTFS_DIR
which won't get copied into the recovery system
so that those regular files in /dev/ are missing
when etc/scripts/system-setup tries to verify their md5sums,
for example see
https://github.com/rear/rear/issues/1883#issuecomment-409875733
and
https://github.com/rear/rear/issues/1891#issue-347952166
that both read (excerpts):
<pre>
md5sum: ./dev/.SRC-Semaphore: No such file or directory
./dev/.SRC-Semaphore: FAILED open or read
md5sum: WARNING: 1 listed file could not be read
</pre>
where /dev/.SRC-Semaphore seems to be related to
IBM Reliable Scalable Cluster Technology (RSCT), see
http://www-01.ibm.com/support/docview.wss?uid=isg1IV35736

Additionally /etc/udev/rules.d/70-persistent-net.rules is always excluded
to avoid false alarm because it seems it can be modified
even before the md5sum verification runs, see
https://github.com/rear/rear/issues/1883#issuecomment-409875733
that reads  (excerpt):
<pre>
./etc/udev/rules.d/70-persistent-net.rules: FAILED
md5sum: WARNING: 1 computed checksum did NOT match
</pre>

Nice WARNING messages from md5sum ;-)
