### PR TITLE
LVM: specifying uuid for 'lvmdev' is optional when recovering.

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -28,7 +28,7 @@ fi
 # Create a new PV.
 create_lvmdev() {
     local lvmdev vgrp device uuid junk
-    read lvmdev vgrp device uuid junk < <(grep "^lvmdev.*${1#pv:} " "$LAYOUT_FILE")
+    read lvmdev vgrp device uuid junk < <(grep -w "^lvmdev.*${1#pv:}" "$LAYOUT_FILE")
 
     local vg=${vgrp#/dev/}
 

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -637,7 +637,7 @@ blkid_label_of_device() {
 # Returns 0 otherwise or if the device doesn't exists
 is_disk_a_pv() {
     disk=$1
-    if grep -q "^lvmdev .* ${disk} " $LAYOUT_FILE ; then
+    if grep -qw "^lvmdev .* ${disk}" $LAYOUT_FILE ; then
         return 0
     else
         return 1


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?** Bug Fix

* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent** Low

* Reference to related issue (URL):

* How was this pull request tested? Tested on RHEL 7 during LVM migration

* Brief description of the changes in this pull request:

Due to this, the `grep` must be adjusted to not expect a trailing blank at the end of the line.
This is typically used when migrating a PV to another disk while it already exists on the first disk. In such case, the uuid cannot be reused.

Example of disklayout.conf line before removing the uuid:

`lvmdev /dev/rhel /dev/sda2 w6XFUx-DeeL-uAEY-0nEn-1A3o-pLp1-qcwYdO 12345678`

When removing the uuid (and unused size), the current code was breaking if there was no trailing space:

`lvmdev /dev/rhel /dev/sda2<space>` : OK
`lvmdev /dev/rhel /dev/sda2` : BAD

The new code also supports the second line, which is better for robustness.
