### PR TITLE
change the logic of the continue with function is_disk_a_pv during grub2 config

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/610_install_grub.sh
+++ b/usr/share/rear/finalize/Linux-i386/610_install_grub.sh
@@ -81,9 +81,8 @@ if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]] ; then
 
     for disk in $disks ; do
         # Installing grub on an LVM PV will wipe the metadata so we skip those
-        if is_disk_a_pv "$disk" ; then
-            continue
-        fi
+        # function is_disk_a_pv returns with 1 if disk is a PV
+        is_disk_a_pv "$disk"  ||  continue
         # Use first boot partition by default
         part=$( echo $bootparts | cut -d' ' -f1 )
 

--- a/usr/share/rear/finalize/Linux-i386/620_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/620_install_grub2.sh
@@ -149,7 +149,8 @@ fi
 # This is the reason why we make all possible boot disks bootable here:
 for disk in $disks ; do
     # Installing GRUB2 on an LVM PV will wipe the metadata so we skip those:
-    is_disk_a_pv "$disk" && continue
+    # function is_disk_a_pv returns with 1 if disk is a PV
+    is_disk_a_pv "$disk"  ||  continue
 
     # Use first boot partition by default:
     part=$( echo $bootparts | cut -d' ' -f1 )


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **High** 

* Reference to related issue (URL): #1902 

* How was this pull request tested? yes via https://github.com/gdha/rear-automated-testing/issues/65

* Brief description of the changes in this pull request:
  Recovery fails during grub-config with GRUB2_INSTALL_DEVICES empty
  See script 620_install_grub2.sh

  @schabrolles could you review this in the absence of Johannes?