### PR TITLE
remove BuildRoot and clean section from rear.spec 

### DIFF
--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -17,7 +17,7 @@ URL: http://relax-and-recover.org/
 # as GitHub stopped with download section we need to go back to Sourceforge for downloads
 Source: https://sourceforge.net/projects/rear/files/rear/%{version}/rear-%{version}.tar.gz
 
-BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+#BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 # rear contains only bash scripts plus documentation so that on first glance it could be "BuildArch: noarch"
 # but actually it is not "noarch" because it only works on those architectures that are explicitly supported.
@@ -141,11 +141,9 @@ echo "30 1 * * * root /usr/sbin/rear checklayout || /usr/sbin/rear mkrescue" >re
 %{__make} install DESTDIR="%{buildroot}"
 %{__install} -Dp -m0644 rear.cron %{buildroot}%{_sysconfdir}/cron.d/rear
 
-%clean
-%{__rm} -rf %{buildroot}
 
 %files
-%defattr(-, root, root, 0755)
+#%defattr(-, root, root, 0755)
 %doc MAINTAINERS COPYING README.adoc doc/*.txt
 %doc %{_mandir}/man8/rear.8*
 %config(noreplace) %{_sysconfdir}/cron.d/rear


### PR DESCRIPTION
* Type: *Enhancement** 

* Impact: **Low** 

* Reference to related issue (URL): #1855 

* How was this pull request tested? on local laptop

* Brief description of the changes in this pull request: To be compliant with RPM specs we need to remove the BuildRoot and clean section.

