### PR TITLE
Issue #1913 - NETFS+tar backup exit code testing insufficient (may fail to catch real backup errors)

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -71,45 +71,45 @@ LogPrint "Creating $BACKUP_PROG archive '$backuparchive'"
 ProgressStart "Preparing archive operation"
 (
 case "$(basename ${BACKUP_PROG})" in
-	# tar compatible programs here
-	(tar)
-		set_tar_features
-		Log $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
-			--no-wildcards-match-slash --one-file-system \
-			--ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}" \
-			$BACKUP_PROG_CREATE_NEWER_OPTIONS \
-			${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
-			-X $TMP_DIR/backup-exclude.txt -C / -c -f - \
-			$(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
-		$BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
-			--no-wildcards-match-slash --one-file-system \
-			--ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}" \
-			$BACKUP_PROG_CREATE_NEWER_OPTIONS \
-			${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
-			-X $TMP_DIR/backup-exclude.txt -C / -c -f - \
-			$(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE | $BACKUP_PROG_CRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $SPLIT_COMMAND
-	;;
-	(rsync)
-		# make sure that the target is a directory
-		mkdir -p $v "$backuparchive" >&2
-		Log $BACKUP_PROG --verbose "${BACKUP_RSYNC_OPTIONS[@]}" --one-file-system --delete \
-			--exclude-from=$TMP_DIR/backup-exclude.txt --delete-excluded \
-			$(cat $TMP_DIR/backup-include.txt) "$backuparchive"
-		$BACKUP_PROG --verbose "${BACKUP_RSYNC_OPTIONS[@]}" --one-file-system --delete \
-			--exclude-from=$TMP_DIR/backup-exclude.txt --delete-excluded \
-			$(cat $TMP_DIR/backup-include.txt) "$backuparchive" >&2
-	;;
-	(*)
-		Log "Using unsupported backup program '$BACKUP_PROG'"
-		Log $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
-			$BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
-			"${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
-			$(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
-		$BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
-			$BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
-			"${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
-			$(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
-	;;
+    # tar compatible programs here
+    (tar)
+        set_tar_features
+        Log $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
+            --no-wildcards-match-slash --one-file-system \
+            --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}" \
+            $BACKUP_PROG_CREATE_NEWER_OPTIONS \
+            ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
+            -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
+            $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
+        $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
+            --no-wildcards-match-slash --one-file-system \
+            --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}" \
+            $BACKUP_PROG_CREATE_NEWER_OPTIONS \
+            ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
+            -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
+            $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE | $BACKUP_PROG_CRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $SPLIT_COMMAND
+    ;;
+    (rsync)
+        # make sure that the target is a directory
+        mkdir -p $v "$backuparchive" >&2
+        Log $BACKUP_PROG --verbose "${BACKUP_RSYNC_OPTIONS[@]}" --one-file-system --delete \
+            --exclude-from=$TMP_DIR/backup-exclude.txt --delete-excluded \
+            $(cat $TMP_DIR/backup-include.txt) "$backuparchive"
+        $BACKUP_PROG --verbose "${BACKUP_RSYNC_OPTIONS[@]}" --one-file-system --delete \
+            --exclude-from=$TMP_DIR/backup-exclude.txt --delete-excluded \
+            $(cat $TMP_DIR/backup-include.txt) "$backuparchive" >&2
+    ;;
+    (*)
+        Log "Using unsupported backup program '$BACKUP_PROG'"
+        Log $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
+            $BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
+            "${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
+            $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
+        $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
+            $BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
+            "${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
+            $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
+    ;;
 esac 2> "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log"
 # important trick: the backup prog is the last in each case entry and the case .. esac is the last command
 # in the (..) subshell. As a result the return code of the subshell is the return code of the backup prog!
@@ -121,44 +121,44 @@ sleep 1 # Give the backup software a good chance to start working
 
 # return disk usage in bytes
 function get_disk_used() {
-	let "$(stat -f -c 'used=(%b-%f)*%S' $1)"
-	echo $used
+    let "$(stat -f -c 'used=(%b-%f)*%S' $1)"
+    echo $used
 }
 
 # While the backup runs in a sub-process, display some progress information to the user.
 # ProgressInfo texts have a space at the end to get the 'OK' from ProgressStop shown separated.
 test "$PROGRESS_WAIT_SECONDS" || PROGRESS_WAIT_SECONDS=1
 case "$( basename $BACKUP_PROG )" in
-	(tar)
-		while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null; do
-			#blocks="$(stat -c %b ${backuparchive})"
-			#size="$((blocks*512))"
-			size="$(stat -c %s ${backuparchive}* | awk '{s+=$1} END {print s}')"
-			ProgressInfo "Archived $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec] "
-		done
-		;;
-	(rsync)
-		# since we do not want to do a $(du -s) run every second we count disk usage instead
-		# this obviously leads to wrong results in case something else is writing to the same
-		# disk at the same time as is very likely with a networked file system. For local disks
-		# this should be good enough and in any case this is only some eye candy.
-		# TODO: Find a fast way to count the actual transfer data, preferrable getting the info from rsync.
-		let old_disk_used="$(get_disk_used "$backuparchive")"
-		while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null; do
-			let disk_used="$(get_disk_used "$backuparchive")" size=disk_used-old_disk_used
-			ProgressInfo "Archived $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec] "
-		done
-		;;
-	(*)
-		while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null; do
-			size="$(stat -c "%s" "$backuparchive")" || {
-				kill -9 $BackupPID
-				ProgressError
-				Error "$(basename $BACKUP_PROG) failed to create the archive file"
-			}
-			ProgressInfo "Archived $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec] "
-		done
-		;;
+    (tar)
+        while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null; do
+            #blocks="$(stat -c %b ${backuparchive})"
+            #size="$((blocks*512))"
+            size="$(stat -c %s ${backuparchive}* | awk '{s+=$1} END {print s}')"
+            ProgressInfo "Archived $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec] "
+        done
+        ;;
+    (rsync)
+        # since we do not want to do a $(du -s) run every second we count disk usage instead
+        # this obviously leads to wrong results in case something else is writing to the same
+        # disk at the same time as is very likely with a networked file system. For local disks
+        # this should be good enough and in any case this is only some eye candy.
+        # TODO: Find a fast way to count the actual transfer data, preferrable getting the info from rsync.
+        let old_disk_used="$(get_disk_used "$backuparchive")"
+        while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null; do
+            let disk_used="$(get_disk_used "$backuparchive")" size=disk_used-old_disk_used
+            ProgressInfo "Archived $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec] "
+        done
+        ;;
+    (*)
+        while sleep $PROGRESS_WAIT_SECONDS ; kill -0 $BackupPID 2>/dev/null; do
+            size="$(stat -c "%s" "$backuparchive")" || {
+                kill -9 $BackupPID
+                ProgressError
+                Error "$(basename $BACKUP_PROG) failed to create the archive file"
+            }
+            ProgressInfo "Archived $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec] "
+        done
+        ;;
 esac
 ProgressStop
 transfertime="$((SECONDS-starttime))"
@@ -212,10 +212,12 @@ esac
 
 tar_message="$(tac $RUNTIME_LOGFILE | grep -m1 '^Total bytes written: ')"
 if [ $backup_prog_rc -eq 0 -a "$tar_message" ] ; then
-	LogPrint "$tar_message in $transfertime seconds."
+    LogPrint "$tar_message in $transfertime seconds."
 elif [ "$size" ]; then
-	LogPrint "Archived $((size/1024/1024)) MiB in $((transfertime)) seconds [avg $((size/1024/transfertime)) KiB/sec]"
+    LogPrint "Archived $((size/1024/1024)) MiB in $((transfertime)) seconds [avg $((size/1024/transfertime)) KiB/sec]"
 fi
 
 ### Copy progress log to backup media
 cp $v "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log" "${opath}/${BACKUP_PROG_ARCHIVE}.log" >&2
+
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
The ReaR code is making the assumption that the $BACKUP_PROG return value is returned from the child process. This is true for **rsync** and unsupported methods, but not for **tar** because **tar** uses the following pipes:

~~~
tar ... | <encrypt> ... | <splitter>
~~~

which ends up for basic case with the following pipes:

~~~
tar ... | cat | dd of=backup.tar.gz
~~~

In fact, the return code is hence the one for **dd**.

When there is an error, e.g. ENOSPC, **dd** returns 1, causing ReaR to believe **tar** returned 1, which is non-critical (1 means there was file modifications while reading them).
Also, if **tar** suffered an issue, e.g. an invalid parameter was passed to **tar**, then **dd** would return 0, causing a fake success to be returned.

This code fixes all these issues by returning the exit code of the last pipe failing (can be **dd**, or **cat**, or **tar**).
It also enhances the exit code processing code, by displaying the command's output if possible.

---------------

# TEST CASES

## SUCCESS

### Config

~~~
# cat etc/rear/site.conf
OUTPUT=ISO
OUTPUT_URL=file:///backup
BACKUP=NETFS
BACKUP_URL=file:///backup
ONLY_INCLUDE_VG=( 'rhel' )
BACKUP_PROG_INCLUDE=( '/usr/bin' )
BACKUP_ONLY_INCLUDE="yes"
~~~

### Result

~~~
# ./usr/sbin/rear -v mkbackuponly
Relax-and-Recover 2.4 / Git
Running rear mkbackuponly (PID 339)
Using log file: /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.339.log
Using backup archive '/backup/vm-rhel7/backup.tar.gz'
Creating disk layout
Excluding Volume Group data
Excluding component fs:/backup
Using guessed bootloader 'GRUB' (found in first bytes on /dev/sda with GPT BIOS boot partition)
Creating tar archive '/backup/vm-rhel7/backup.tar.gz'
Archived 25 MiB [avg 4397 KiB/sec] OK
Archived 25 MiB in 7 seconds [avg 3769 KiB/sec]
Saving /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.339.log as /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.log
Exiting rear mkbackuponly (PID 339) and its descendant processes
Running exit tasks
~~~

## SUCCESS WITH WARNING

### Config

~~~
# cat etc/rear/site.conf
OUTPUT=ISO
OUTPUT_URL=file:///backup
BACKUP=NETFS
BACKUP_URL=file:///backup
ONLY_INCLUDE_VG=( 'rhel' )
BACKUP_PROG_INCLUDE=( '/usr/bin' "/proc/*" )
BACKUP_ONLY_INCLUDE="yes"
~~~

### Result

~~~
# ./usr/sbin/rear -v mkbackuponly
Relax-and-Recover 2.4 / Git
Running rear mkbackuponly (PID 29790)
Using log file: /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.29790.log
Using backup archive '/backup/vm-rhel7/backup.tar.gz'
Creating disk layout
Excluding Volume Group data
Excluding component fs:/backup
Using guessed bootloader 'GRUB' (found in first bytes on /dev/sda with GPT BIOS boot partition)
Creating tar archive '/backup/vm-rhel7/backup.tar.gz'
Archived 31 MiB [avg 6377 KiB/sec] OK
WARNING: tar ended with return code 1 and below output:
  ---snip---
  tar: /proc/sys/net/ipv6/route/flush: Warning: Cannot open: Permission denied
  tar: /proc/sys/vm/compact_memory: Warning: Cannot open: Permission denied
  tar: /proc/tty/driver/serial: file changed as we read it
  ----------
This means that files have been modified during the archiving
process. As a result the backup may not be completely consistent
or may not be a perfect copy of the system. Relax-and-Recover
will continue, however it is highly advisable to verify the
backup in order to be sure to safely recover this system.

Archived 31 MiB in 6 seconds [avg 5314 KiB/sec]
Saving /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.29790.log as /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.log
Exiting rear mkbackuponly (PID 29790) and its descendant processes
Running exit tasks
~~~

## No space on device

### Config

~~~
# cat etc/rear/site.conf
OUTPUT=ISO
OUTPUT_URL=file:///backup
BACKUP=NETFS
BACKUP_URL=file:///backup
ONLY_INCLUDE_VG=( 'rhel' )
~~~

`/backup` configured too small to host the backup.

### Result

~~~
# ./usr/sbin/rear -v mkbackuponly
Relax-and-Recover 2.4 / Git
Running rear mkbackuponly (PID 4267)
Using log file: /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.4267.log
Using backup archive '/backup/vm-rhel7/backup.tar.gz'
Creating disk layout
Excluding Volume Group data
Excluding component fs:/backup
Using guessed bootloader 'GRUB' (found in first bytes on /dev/sda with GPT BIOS boot partition)
Creating tar archive '/backup/vm-rhel7/backup.tar.gz'
Archived 756 MiB [avg 10754 KiB/sec] OK
ERROR: dd failed with return code 1 and below output:
  ---snip---
  dd: writing to '/backup/vm-rhel7/backup.tar.gz': No space left on device
  ----------
This means that the archiving process ended prematurely, or did
not even start. As a result it is unlikely you can recover this
system properly. Relax-and-Recover is therefore aborting execution.

Some latest log messages since the last called script 500_make_backup.sh:
...
Aborting due to an error, check /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.4267.log for details
Exiting rear mkbackuponly (PID 4267) and its descendant processes
Running exit tasks
Terminated
~~~

## TAR failing due to invalid option

### Config

~~~
# cat etc/rear/site.conf
OUTPUT=ISO
OUTPUT_URL=file:///backup
BACKUP=NETFS
BACKUP_URL=file:///backup
ONLY_INCLUDE_VG=( 'rhel' )
BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" --dummyoption )
~~~

### Result

~~~
# ./usr/sbin/rear -v mkbackuponly
Relax-and-Recover 2.4 / Git
Running rear mkbackuponly (PID 6300)
Using log file: /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.6300.log
Using backup archive '/backup/vm-rhel7/backup.tar.gz'
Creating disk layout
Excluding Volume Group data
Excluding component fs:/backup
Using guessed bootloader 'GRUB' (found in first bytes on /dev/sda with GPT BIOS boot partition)
Creating tar archive '/backup/vm-rhel7/backup.tar.gz'
Preparing archive operationOK
ERROR: tar failed with return code 64 and below output:
  ---snip---
  tar: unrecognized option '--dummyoption'
  ----------
This means that the archiving process ended prematurely, or did
not even start. As a result it is unlikely you can recover this
system properly. Relax-and-Recover is therefore aborting execution.

Some latest log messages since the last called script 500_make_backup.sh:
...
Aborting due to an error, check /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.6300.log for details
Exiting rear mkbackuponly (PID 6300) and its descendant processes
Running exit tasks
Terminated
~~~

## 2nd pipe failing (encryption, simulated here through code hacking)

### Config

~~~
# cat etc/rear/site.conf
OUTPUT=ISO
OUTPUT_URL=file:///backup
BACKUP=NETFS
BACKUP_URL=file:///backup
ONLY_INCLUDE_VG=( 'rhel' )
~~~

In `/usr/share/rear/backup/NETFS/default/500_make_backup.sh`, modify line 48 as shown below:

~~~
BACKUP_PROG_CRYPT_OPTIONS="cat --dummyoption"
~~~

### Result

~~~
# ./usr/sbin/rear -v mkbackuponly
Relax-and-Recover 2.4 / Git
Running rear mkbackuponly (PID 8019)
Using log file: /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.8019.log
Using backup archive '/backup/vm-rhel7/backup.tar.gz'
Creating disk layout
Excluding Volume Group data
Excluding component fs:/backup
Using guessed bootloader 'GRUB' (found in first bytes on /dev/sda with GPT BIOS boot partition)
Creating tar archive '/backup/vm-rhel7/backup.tar.gz'
Preparing archive operationOK
ERROR: cat failed with return code 1 and below output:
  ---snip---
  cat: unrecognized option '--dummyoption'
  ----------
This means that the archiving process ended prematurely, or did
not even start. As a result it is unlikely you can recover this
system properly. Relax-and-Recover is therefore aborting execution.

Some latest log messages since the last called script 500_make_backup.sh:
...
Aborting due to an error, check /home/rmetrich/GIT/rear/var/log/rear/rear-vm-rhel7.8019.log for details
Exiting rear mkbackuponly (PID 8019) and its descendant processes
Running exit tasks
Terminated
~~~