### PR TITLE
Added exclusion of zram devices from device mapping

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2287,7 +2287,7 @@ EXCLUDE_RESTORE=()
 # by the user during 'rear recover' (cf. layout/prepare/default/300_map_disks.sh).
 # The EXCLUDE_DEVICE_MAPPING array contains 'case' patterns that must match
 # the basename of block devices in the /sys/block/ directory:
-EXCLUDE_DEVICE_MAPPING=( 'loop*' 'ram*' )
+EXCLUDE_DEVICE_MAPPING=( 'loop*' 'ram*' 'zram*' )
 
 # Exclude RUNTIME_LOGFILE (useful for debugging) from initramfs
 EXCLUDE_RUNTIME_LOGFILE='no'


### PR DESCRIPTION
Signed-off-by: Renaud Métrich <rmetrich@redhat.com>

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Brief description of the changes in this pull request:

by default zram devices (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/blockdev/zram.txt) are not to be mapped, exactly as it is done for ramdisk and loop devices.