### PR TITLE
Added default value (0) for crc variable (XFS).

### DIFF
--- a/usr/share/rear/lib/filesystems-functions.sh
+++ b/usr/share/rear/lib/filesystems-functions.sh
@@ -217,8 +217,13 @@ function xfs_parse
                 continue
             fi
 
-            # crc and ftype are mutually exclusive
-            if [ $crc -eq 1 ] && [ $var = "ftype" ]; then
+            # crc and ftype are mutually exclusive.
+            # crc option might be even completely missing in older versions of
+            # xfsprogs, which would cause behaviour like described in
+            # https://github.com/rear/rear/issues/1915.
+            # To avoid messages like "[: -eq: unary operator expected",
+            # we will set default value for $crc variable to 0.
+            if [ ${crc:-0} -eq 1 ] && [ $var = "ftype" ]; then
                 i=$((i+1))
                 continue
             fi


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): https://github.com/rear/rear/issues/1915

* How was this pull request tested?
Full backup restore of:
Centos6 (xfsprogs-3.1)
Fedora26 (xfsprogs-4.10)

* Brief description of the changes in this pull request:

This patch will help to avoid messages like:
`"[: -eq: unary operator expected"` when using with older versions of xfsprogs. 
