### PR TITLE
Check if CONFIG_DIR is not a file #1815

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -428,6 +428,7 @@ fi
 # Combine configuration files:
 Debug "Combining configuration files"
 # Use this file to manually override the OS detection:
+test -f "$CONFIG_DIR" && Error "Configuration directory $CONFIG_DIR is not a directory" || true
 test -r "$CONFIG_DIR/os.conf" && Source "$CONFIG_DIR/os.conf" || true
 test -r "$CONFIG_DIR/$WORKFLOW.conf" && Source "$CONFIG_DIR/$WORKFLOW.conf" || true
 SetOSVendorAndVersion

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -428,7 +428,7 @@ fi
 # Combine configuration files:
 Debug "Combining configuration files"
 # Use this file to manually override the OS detection:
-test -f "$CONFIG_DIR" && Error "Configuration directory $CONFIG_DIR is not a directory" || true
+test -d "$CONFIG_DIR" || Error "Configuration directory $CONFIG_DIR is not a directory"
 test -r "$CONFIG_DIR/os.conf" && Source "$CONFIG_DIR/os.conf" || true
 test -r "$CONFIG_DIR/$WORKFLOW.conf" && Source "$CONFIG_DIR/$WORKFLOW.conf" || true
 SetOSVendorAndVersion


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement** 

* Impact: **Low**

* Reference to related issue (URL): #1815 

* How was this pull request tested? via the CLI `sudo ./rear -D -c /etc/rear/local.conf mkrescue`

* Brief description of the changes in this pull request: added a test for CONFIG_DIR

