### PR TITLE
Support simulation mode for dump and help workflows plus better help workflow

### DIFF
--- a/usr/share/rear/init/default/050_check_rear_recover_mode.sh
+++ b/usr/share/rear/init/default/050_check_rear_recover_mode.sh
@@ -1,12 +1,14 @@
 # In the ReaR rescue/recovery system the only possible workflows are
 # - 'recover' and its partial workflows 'layoutonly' 'restoreonly' 'finalizeonly'
 # - 'opaladmin'
+# - 'help'
 # cf. https://github.com/rear/rear/issues/987
 # and https://github.com/rear/rear/issues/1088
+# and https://github.com/rear/rear/issues/1901
 # In the ReaR rescue/recovery system /etc/rear-release is unique (it does not exist otherwise):
 test -f /etc/rear-release || return 0
 case "$WORKFLOW" in
-    (recover|layoutonly|restoreonly|finalizeonly|opaladmin)
+    (recover|layoutonly|restoreonly|finalizeonly|opaladmin|help)
         LogPrint "Running workflow $WORKFLOW within the ReaR rescue/recovery system"
         ;;
     (*)

--- a/usr/share/rear/lib/dump-workflow.sh
+++ b/usr/share/rear/lib/dump-workflow.sh
@@ -9,6 +9,13 @@ LOCKLESS_WORKFLOWS=( ${LOCKLESS_WORKFLOWS[@]} dump )
 WORKFLOW_dump_DESCRIPTION="dump configuration and system information"
 WORKFLOWS=( ${WORKFLOWS[@]} dump )
 WORKFLOW_dump () {
+
+        # Do nothing in simulation mode, cf. https://github.com/rear/rear/issues/1939
+        if is_true "$SIMULATE" ; then
+            LogPrint "${BASH_SOURCE[0]} dumps configuration and system information"
+            return 0
+        fi
+
 	LogPrint "Dumping out configuration and system information"
 
 	if [ "$ARCH" != "$REAL_ARCH" ] ; then

--- a/usr/share/rear/lib/finalizeonly-workflow.sh
+++ b/usr/share/rear/lib/finalizeonly-workflow.sh
@@ -13,6 +13,11 @@ WORKFLOWS=( ${WORKFLOWS[@]} finalizeonly )
 # The finalizeonly workflow does currently not yet work,
 # see https://github.com/rear/rear/pull/1091#issuecomment-263621714
 function WORKFLOW_finalizeonly () {
+    # Do nothing in simulation mode, cf. https://github.com/rear/rear/issues/1939
+    if is_true "$SIMULATE" ; then
+        LogPrint "${BASH_SOURCE[0]} only finalizes the recovery (does not yet work)"
+        return 0
+    fi
     Error "The finalizeonly workflow does not yet work: Aborting in ${BASH_SOURCE[0]}"
     SourceStage "setup"
     SourceStage "verify"

--- a/usr/share/rear/lib/opaladmin-workflow.sh
+++ b/usr/share/rear/lib/opaladmin-workflow.sh
@@ -41,6 +41,12 @@ function opaladmin_help() {
 function WORKFLOW_opaladmin() {
     # ReaR command 'opaladmin'
 
+    # Do nothing in simulation mode, cf. https://github.com/rear/rear/issues/1939
+    if is_true "$SIMULATE" ; then
+        LogPrint "${BASH_SOURCE[0]} administrates TCG Opal 2-compliant self-encrypting disks"
+        return 0
+    fi
+
     [[ -n "$DEBUGSCRIPTS" ]] && set -$DEBUGSCRIPTS_ARGUMENT
 
     Log "Command line options of the opaladmin workflow: $*"

--- a/usr/share/rear/lib/udev-workflow.sh
+++ b/usr/share/rear/lib/udev-workflow.sh
@@ -10,6 +10,13 @@ if [[ "$VERBOSE" ]]; then
 fi
 WORKFLOWS=( ${WORKFLOWS[@]} udev )
 WORKFLOW_udev () {
+
+    # Do nothing in simulation mode, cf. https://github.com/rear/rear/issues/1939
+    if is_true "$SIMULATE" ; then
+        LogPrint "${BASH_SOURCE[0]} is a udev handler; triggered by udev rule"
+        return 0
+    fi
+
     # If no udev workflow has been defined, exit cleanly
     if [[ -z "$UDEV_WORKFLOW" ]]; then
         Log "Variable UDEV_WORKFLOW not set, skipping udev workflow."


### PR DESCRIPTION
* Type: **Bug Fix** **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1901
https://github.com/rear/rear/issues/1939

* How was this pull request tested?
By me on my openSUSE Leap 15.0 system.
The behaviour in the recovery system was simulated and tested via
<pre>
# touch /etc/rear-release

# usr/sbin/rear help

# usr/sbin/rear -v help

# usr/sbin/rear -s help

# rm /etc/rear-release
</pre>

* Brief description of the changes in this pull request:
Now `rear -s dump` and `rear -s help` work and
the help workflow is supported in the running recovery system.
