### PR TITLE
properly handle module-less kernels (fixes #1941)

### DIFF
--- a/usr/share/rear/lib/linux-functions.sh
+++ b/usr/share/rear/lib/linux-functions.sh
@@ -82,6 +82,14 @@ function my_udevinfo () {
 # optionally $1 specifies the directory where to search for
 # drivers files
 function FindStorageDrivers () {
+    # The special user setting MODULES=( 'no_modules' ) enforces that
+    # no kernel modules get included in the rescue/recovery system
+    # regardless of what modules are currently loaded.
+    # Test the first MODULES array element because other scripts
+    # in particular rescue/GNU/Linux/240_kernel_modules.sh
+    # already appended other modules to the MODULES array:
+    test "no_modules" = "$MODULES" && return
+
     if (( ${#STORAGE_DRIVERS[@]} == 0 )) ; then
         if ! grep -E 'kernel/drivers/(block|firewire|ide|ata|md|message|scsi|usb/storage)' /lib/modules/$KERNEL_VERSION/modules.builtin ; then
             Error "FindStorageDrivers called but STORAGE_DRIVERS is empty and no builtin storage modules found"


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/1941

* How was this pull request tested?
Patch has been tested on a system with a kernel without module support.

* Brief description of the changes in this pull request:
Permits ReaR to work on systems which do not support kernel modules. It still requires setting `MODULES=( 'no_modules' )`in the config.
