### PR TITLE
For Slackware Linux:

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/610_install_lilo.sh
+++ b/usr/share/rear/finalize/Linux-i386/610_install_lilo.sh
@@ -1,0 +1,43 @@
+#  This script is meant for linux based systems using legacy LILO (Slackware)
+#
+
+# skip if another bootloader was installed
+if [[ -z "$NOBOOTLOADER" ]] ; then
+    return
+fi
+
+# For UEFI systems with lilo legacy with should use efibootmgr instead:
+is_true $USING_UEFI_BOOTLOADER && return
+
+# Only for lilo
+[[ "$BOOTLOADER" == "LILO" ]] || return 0 # only continue when bootloader is lilo based
+
+[[ $(type -p lilo) ]]
+StopIfError "Could not find lilo executable"
+
+
+LogPrint "Installing LILO boot loader"
+mount -t proc none $TARGET_FS_ROOT/proc
+#for virtual_filesystem in /dev /dev/pts /proc /sys ; do mount -B $virtual_filesystem $TARGET_FS_ROOT$virtual_filesystem ; done
+
+if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]]; then
+
+    [[ -r "$TARGET_FS_ROOT/etc/lilo.conf" ]]
+    LogIfError "Unable to find /etc/lilo.conf"
+
+    # Find the disks that need a new LILO
+    disks=$(grep '^disk \|^multipath ' $LAYOUT_FILE | cut -d' ' -f2)
+    [[ "$disks" ]]
+    StopIfError "Unable to find any disks"
+
+
+    chroot $TARGET_FS_ROOT /sbin/lilo -v >&2
+
+    if (( $? == 0 )); then
+        NOBOOTLOADER=
+    fi
+fi
+
+
+#for virtual_filesystem in /dev /dev/pts /proc /sys ; do umount $TARGET_FS_ROOT$virtual_filesystem ; done
+umount $TARGET_FS_ROOT/proc

--- a/usr/share/rear/finalize/Linux-i386/610_install_lilo.sh
+++ b/usr/share/rear/finalize/Linux-i386/610_install_lilo.sh
@@ -12,7 +12,7 @@ is_true $USING_UEFI_BOOTLOADER && return
 # Only for lilo
 [[ "$BOOTLOADER" == "LILO" ]] || return 0 # only continue when bootloader is lilo based
 
-[[ $(type -p lilo) ]]
+type -p $TARGET_FS_ROOT/sbin/lilo
 StopIfError "Could not find lilo executable"
 
 
@@ -27,8 +27,7 @@ if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]]; then
 
     # Find the disks that need a new LILO
     disks=$(grep '^disk \|^multipath ' $LAYOUT_FILE | cut -d' ' -f2)
-    [[ "$disks" ]]
-    StopIfError "Unable to find any disks"
+    [[ "$disks" ]] || Error "Unable to find any disks to install LILO on"
 
 
     chroot $TARGET_FS_ROOT /sbin/lilo -v >&2

--- a/usr/share/rear/lib/config-functions.sh
+++ b/usr/share/rear/lib/config-functions.sh
@@ -57,6 +57,11 @@ function SetOSVendorAndVersion () {
                 minornr=$( grep -o -E '[0-9]+' /etc/system-release | head -2 | tail -1 )
                 OS_VERSION="$majornr.$minornr"
             fi
+
+            if [[ -f /etc/slackware-version ]] ; then
+                OS_VENDOR=Slackware
+                OS_VERSION=$(cat /etc/slackware-version  | sed -r -e 's/slackware\s*//i')
+            fi
         fi
 
         # If OS_VENDOR is still generic then use as last resource 'lsb_release' to find out

--- a/usr/share/rear/pack/Linux-i386/300_copy_kernel.sh
+++ b/usr/share/rear/pack/Linux-i386/300_copy_kernel.sh
@@ -13,9 +13,13 @@ if [ ! -s "$KERNEL_FILE" ]; then
     # add slackware test on top to prevent error on get_kernel_version
     if [ -f /etc/slackware-version ]; then
         # check under /boot/efi/EFI/Slackware
-        [ -f "/boot/efi/EFI/Slackware/vmlinuz" ]
-        StopIfError "Could not find a matching kernel in /boot/efi/EFI/Slackware !"
-        KERNEL_FILE="/boot/efi/EFI/Slackware/vmlinuz"
+        if [ -f "/boot/efi/EFI/Slackware/vmlinuz" ]; then
+           KERNEL_FILE="/boot/efi/EFI/Slackware/vmlinuz"
+        elif [ -r "/boot/vmlinuz-$KERNEL_VERSION" ]; then
+            KERNEL_FILE="/boot/vmlinuz-$KERNEL_VERSION"
+        else 
+           Error "Could not find a matching kernel in /boot/efi/EFI/Slackware or /boot!"
+        fi
     elif [ -r "/boot/vmlinuz-$KERNEL_VERSION" ]; then
         KERNEL_FILE="/boot/vmlinuz-$KERNEL_VERSION"
     elif has_binary get_kernel_version; then


### PR DESCRIPTION
1. Added automatic OS vendor and version detection.
2. Added logic to search for kernel files in using default /boot/vmlinuz-`uname -r` pattern in the event that the standard ELILO kernel install paths come up empty.

Added legacy LILO bootloader support.

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?**
Enhancement

* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent**
Normal.

* Reference to related issue (URL):

* How was this pull request tested?
On a Slackware 14.2 OS, performed a full backup to and recover from a USB device. Was able to boot with coldstarted disk using basic LILO bootloader. Should not conflict with other bootloader types (GRUB and ELILO).

* Brief description of the changes in this pull request:
Updates to ease the backup/recover process of a Slackware OS using the legacy LILO bootloader. 
