### PR TITLE
network: Record permanent mac address when device is enslaved in a bond, or else /etc/mac-addresses will record broken information

### DIFF
--- a/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
+++ b/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
@@ -854,7 +854,11 @@ function handle_physdev () {
 
     DebugPrint "$network_interface is a physical device"
 
-    mac="$( cat $sysfspath/address )" || BugError "Could not read a MAC address for '$network_interface'."
+    if [ -e $sysfspath/bonding_slave/perm_hwaddr ] ; then
+        mac="$( cat $sysfspath/bonding_slave/perm_hwaddr )"
+    else
+        mac="$( cat $sysfspath/address )" || BugError "Could not read a MAC address for '$network_interface'."
+    fi
     # Skip fake interfaces without MAC address
     [ "$mac" != "00:00:00:00:00:00" ] || return $rc_error
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**
* Impact: **Normal**

* How was this pull request tested? Unit tested + Recovery in migration mode

* Brief description of the changes in this pull request:

When a physical device is enslaved in a bond, its MAC address is modified to the first network interface's MAC address of the bond. This makes `/etc/mac-addresses` record an invalid information, e.g.:

**Broken**
~~~
eth1-bond0 52:54:00:31:e0:b9
eth2-bond0 52:54:00:31:e0:b9
eth0 52:54:00:a3:97:5b
~~~

**Expected**
~~~
eth1-bond0 52:54:00:31:e0:b9
eth2-bond0 52:54:00:86:ec:a8
eth0 52:54:00:a3:97:5b
~~~