### PR TITLE
Add specific required programs to REQUIRED_PROGS (issue 1963)

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -1,12 +1,12 @@
 # Save the partition layout
-### This works on a per device basis.
-### The main function is extract_partitions
-### Temporary caching of data in $TMP_DIR/partitions
-### Temporary caching of parted data in $TMP_DIR/parted
+# This works on a per device basis.
+# The main function is extract_partitions
+# Temporary caching of data in $TMP_DIR/partitions
+# Temporary caching of parted data in $TMP_DIR/parted
 
-### Parted can output machine parseable information
+# Parted can output machine parseable information
 FEATURE_PARTED_MACHINEREADABLE=
-### Parted used to have slightly different naming
+# Parted used to have slightly different naming
 FEATURE_PARTED_OLDNAMING=
 
 parted_version=$( get_version parted -v )
@@ -324,5 +324,9 @@ Log "Saving disk partitions."
             fi
         fi
     done
-
 ) >> $DISKLAYOUT_FILE
+
+# parted is required in the recovery system if disklayout.conf contains at least one 'disk' or 'part' entry
+# cf. https://github.com/rear/rear/issues/1963
+egrep -q '^disk |^part ' $DISKLAYOUT_FILE && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" parted ) || true
+

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -326,7 +326,10 @@ Log "Saving disk partitions."
     done
 ) >> $DISKLAYOUT_FILE
 
-# parted is required in the recovery system if disklayout.conf contains at least one 'disk' or 'part' entry
+# parted and partprobe are required in the recovery system if disklayout.conf contains at least one 'disk' or 'part' entry
+# see the create_disk and create_partitions functions in layout/prepare/GNU/Linux/100_include_partition_code.sh
+# what program calls are written to diskrestore.sh and which programs will be run during "rear recover" in any case
+# e.g. mdadm is not called in any case and sfdisk is only used in case of BLOCKCLONE_STRICT_PARTITIONING
 # cf. https://github.com/rear/rear/issues/1963
-egrep -q '^disk |^part ' $DISKLAYOUT_FILE && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" parted ) || true
+egrep -q '^disk |^part ' $DISKLAYOUT_FILE && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" parted partprobe ) || true
 

--- a/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
@@ -91,4 +91,12 @@ if [ -e /proc/mdstat ] &&  grep -q blocks /proc/mdstat ; then
             extract_partitions "$device"
         done < <(mdadm --detail --scan --config=partitions)
     ) >> $DISKLAYOUT_FILE
+
+    # mdadm is required in the recovery system if disklayout.conf contains at least one 'raid' entry
+    # see the create_raid function in layout/prepare/GNU/Linux/120_include_raid_code.sh
+    # what program calls are written to diskrestore.sh
+    # cf. https://github.com/rear/rear/issues/1963
+    grep -q '^raid ' $DISKLAYOUT_FILE && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" mdadm ) || true
+
 fi
+

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -155,4 +155,11 @@ Log "Saving LVM layout."
 
 ) >> $DISKLAYOUT_FILE
 
+# lvm is required in the recovery system if disklayout.conf contains at least one 'lvmdev' or 'lvmgrp' or 'lvmvol' entry
+# see the create_lvmdev create_lvmgrp create_lvmvol functions in layout/prepare/GNU/Linux/110_include_lvm_code.sh
+# what program calls are written to diskrestore.sh
+# cf. https://github.com/rear/rear/issues/1963
+egrep -q '^lvmdev |^lvmgrp |^lvmvol ' $DISKLAYOUT_FILE && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" lvm ) || true
+
 # vim: set et ts=4 sw=4:
+

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -471,8 +471,9 @@ done
 required_mkfs_tools="$( echo $required_mkfs_tools | tr ' ' '\n' | sort -u | tr '\n' ' ' )"
 REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" $required_mkfs_tools )
 # mke2fs is also required in the recovery system if any 'mkfs.ext*' filesystem creating tool is required
-# and tunefs is used to set tunable filesystem parameters on ext2/ext3/ext4:
-echo $required_mkfs_tools | grep -q 'mkfs.ext' && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" mke2fs tunefs )
+# and tune2fs or tune4fs is used to set tunable filesystem parameters on ext2/ext3/ext4
+# see above how $tunefs is set to tune2fs or tune4fs
+echo $required_mkfs_tools | grep -q 'mkfs.ext' && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" mke2fs $tunefs )
 # xfs_admin is also required in the recovery system if 'mkfs.xfs' is required:
 echo $required_mkfs_tools | grep -q 'mkfs.xfs' && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" xfs_admin )
 # reiserfstune is also required in the recovery system if 'mkfs.reiserfs' is required:

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -456,9 +456,11 @@ service docker status >/dev/null 2>&1 && docker_is_running="yes"
 # End writing output to DISKLAYOUT_FILE.
 
 # mkfs is required in the recovery system if disklayout.conf contains at least one 'fs' entry
+# see the create_fs function in layout/prepare/GNU/Linux/130_include_filesystem_code.sh
+# what program calls are written to diskrestore.sh
 # cf. https://github.com/rear/rear/issues/1963
 grep -q '^fs ' $DISKLAYOUT_FILE && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" mkfs )
-# other filesystem creating tools are required in the recovery system
+# Other filesystem creating tools are required in the recovery system
 # depending on which filesystem types entries exist in disklayout.conf
 # (see above supported_filesystems="ext2,ext3,ext4,vfat,xfs,reiserfs,btrfs"):
 required_mkfs_tools=""
@@ -468,8 +470,13 @@ done
 # Remove duplicates because in disklayout.conf there can be many entries with same filesystem type:
 required_mkfs_tools="$( echo $required_mkfs_tools | tr ' ' '\n' | sort -u | tr '\n' ' ' )"
 REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" $required_mkfs_tools )
-# mke2fs is also required in the recovery system if any 'mkfs.ext*' filesystem creating tool is required:
-echo $required_mkfs_tools | grep -q 'mkfs.ext' && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" mke2fs )
+# mke2fs is also required in the recovery system if any 'mkfs.ext*' filesystem creating tool is required
+# and tunefs is used to set tunable filesystem parameters on ext2/ext3/ext4:
+echo $required_mkfs_tools | grep -q 'mkfs.ext' && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" mke2fs tunefs )
+# xfs_admin is also required in the recovery system if 'mkfs.xfs' is required:
+echo $required_mkfs_tools | grep -q 'mkfs.xfs' && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" xfs_admin )
+# reiserfstune is also required in the recovery system if 'mkfs.reiserfs' is required:
+echo $required_mkfs_tools | grep -q 'mkfs.reiserfs' && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" reiserfstune )
 
 Log "End saving filesystem layout"
 

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -477,6 +477,9 @@ echo $required_mkfs_tools | grep -q 'mkfs.ext' && REQUIRED_PROGS=( "${REQUIRED_P
 echo $required_mkfs_tools | grep -q 'mkfs.xfs' && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" xfs_admin )
 # reiserfstune is also required in the recovery system if 'mkfs.reiserfs' is required:
 echo $required_mkfs_tools | grep -q 'mkfs.reiserfs' && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" reiserfstune )
+# btrfs is also required in the recovery system if 'mkfs.btrfs' is required
+# cf. what prepare/GNU/Linux/130_include_mount_subvolumes_code.sh writes to diskrestore.sh
+echo $required_mkfs_tools | grep -q 'mkfs.btrfs' && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" btrfs )
 
 Log "End saving filesystem layout"
 

--- a/usr/share/rear/layout/save/GNU/Linux/240_swaps_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/240_swaps_layout.sh
@@ -47,3 +47,10 @@ Log "Saving Swap information."
         echo "swap $filename uuid=$uuid label=$label"
     done < /proc/swaps
 ) >> $DISKLAYOUT_FILE
+
+# mkswap is required in the recovery system if disklayout.conf contains at least one 'swap' entry
+# see the create_swap function in layout/prepare/GNU/Linux/140_include_swap_code.sh
+# what program calls are written to diskrestore.sh
+# cf. https://github.com/rear/rear/issues/1963
+grep -q '^swap ' $DISKLAYOUT_FILE && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" mkswap ) || true
+

--- a/usr/share/rear/layout/save/GNU/Linux/250_drbd_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/250_drbd_layout.sh
@@ -14,3 +14,10 @@ if [ -e /proc/drbd ] ; then
         done
     done
 fi
+
+# drbdadm is required in the recovery system if disklayout.conf contains at least one 'drbd' entry
+# see the create_drbd function in layout/prepare/GNU/Linux/150_include_drbd_code.sh
+# what program calls are written to diskrestore.sh
+# cf. https://github.com/rear/rear/issues/1963
+grep -q '^drbd ' $DISKLAYOUT_FILE && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" drbdadm ) || true
+

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -44,3 +44,10 @@ while read target_name junk ; do
 
     echo "crypt /dev/mapper/$target_name $source_device cipher=$cipher-$mode key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE
 done < <( dmsetup ls --target crypt )
+
+# cryptsetup is required in the recovery system if disklayout.conf contains at least one 'crypt' entry
+# see the create_crypt function in layout/prepare/GNU/Linux/160_include_luks_code.sh
+# what program calls are written to diskrestore.sh
+# cf. https://github.com/rear/rear/issues/1963
+grep -q '^crypt ' $DISKLAYOUT_FILE && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" cryptsetup ) || true
+

--- a/usr/share/rear/layout/save/GNU/Linux/280_multipath_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/280_multipath_layout.sh
@@ -29,7 +29,10 @@ while read dm_name junk ; do
 done < <( dmsetup ls --target multipath )
 
 if grep -q ^multipath $DISKLAYOUT_FILE ; then
-    PROGS=( "${PROGS[@]}" multipath kpartx multipathd )
+    # See REQUIRED_PROGS below regarding what is actually required.
+    # TODO: It seems this code here is a duplicate of what is done in prep/GNU/Linux/240_include_multipath_tools.sh
+    # but (in contrast to here) the actual code in 240_include_multipath_tools.sh is only run if BOOT_OVER_SAN is true:
+    PROGS=( "${PROGS[@]}" multipath kpartx multipathd mpathconf )
     COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/multipath.conf /etc/multipath/* /lib*/multipath )
 
     # depending to the linux distro and arch, libaio can be located in different dir. (ex: /lib/powerpc64le-linux-gnu)
@@ -38,3 +41,10 @@ if grep -q ^multipath $DISKLAYOUT_FILE ; then
     done
     LIBS=( "${LIBS[@]}" $libaio2add )
 fi
+
+# multipath is required in the recovery system if disklayout.conf contains at least one 'multipath' entry
+# see layout/prepare/GNU/Linux/210_load_multipath.sh which programs will be run during "rear recover" in any case
+# e.g. mpathconf is not called in any case and multipathd is only used when $list_mpath_device is true
+# cf. https://github.com/rear/rear/issues/1963
+grep -q '^multipath ' $DISKLAYOUT_FILE && REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" multipath ) || true
+


### PR DESCRIPTION
* Type: **Bug Fix** / **Enhancement**

* Impact: **High**
Basically no impact on usual systems where all those tools are installed
but high impact on systems where such tools are missing because
when specific required programs are missing on a system
better safe than sorry and error out during "rear mkrescue/mkbackup"
than "successfully" provide the user a recovery system that is useless.

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1963

* How was this pull request tested?
By me on my system with an ext4 root filesystem as in
https://github.com/rear/rear/issues/1963#issue-380602044

* Brief description of the changes in this pull request:

Currently this is only a first step where I only added specific
required `parted` and `mkfs.*` programs to REQUIRED_PROGS
in layout/save/GNU/Linux/200_partition_layout.sh
and layout/save/GNU/Linux/230_filesystem_layout.sh
depending on what there actually is in disklayout.conf

Further commits here will add more specific required programs
in the 'layout/save' scripts as far as I can with reasonable effort
(I am not an expert in all those various kind of storage stuff
so that I cannot imagine what specific programs are required
to recreate all those various kind of storage objects).
