### PR TITLE
check for carriage return in {local|site|rescue}.conf files

### DIFF
--- a/etc/rear/local.conf
+++ b/etc/rear/local.conf
@@ -7,4 +7,3 @@
 # through packages and other automated means we recommend creating a new
 # file named site.conf next to this file and to leave the local.conf as it is. 
 # Our packages will never ship with a site.conf.
-BACKUP=NETFS

--- a/etc/rear/local.conf
+++ b/etc/rear/local.conf
@@ -7,3 +7,4 @@
 # through packages and other automated means we recommend creating a new
 # file named site.conf next to this file and to leave the local.conf as it is. 
 # Our packages will never ship with a site.conf.
+BACKUP=NETFS

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -440,7 +440,11 @@ for config in "$ARCH" "$OS" \
 done
 # User configuration files, last thing is to overwrite variables if we are in the rescue system:
 for config in site local rescue ; do
-    test -r "$CONFIG_DIR/$config.conf" && Source "$CONFIG_DIR/$config.conf" || true
+    if test -r "$CONFIG_DIR/$config.conf" ; then
+        # Delete all characters except '\r' and error out if the resulting string is not empty:
+        test "$( tr -d -c '\r' < $CONFIG_DIR/$config.conf )" && Error "Carriage return character in $CONFIG_DIR/$config.conf (perhaps DOS or Mac format)"
+        Source "$CONFIG_DIR/$config.conf" || true
+    fi
 done
 # Finally source additional configuration files if specified on the command line:
 if test "$CONFIG_APPEND_FILES" ; then


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): #1965 

* How was this pull request tested? locally
````
$ sudo usr/sbin/rear -v mkrescue
Relax-and-Recover 2.4 / Git
Running rear mkrescue (PID 15205)
Using log file: /projects/rear/myforks/rear/var/log/rear/rear-okido.log
ERROR: Carriage return character in /projects/rear/myforks/rear/etc/rear/local.conf (perhaps DOS or Mac format)
````

* Brief description of the changes in this pull request: If configuration files contain hidden carriage returns this often runs into an error (which is sometimes not obvious to understand where the issue came from). With this patch we will bail out and tell the user to fix his config file

