### PR TITLE
Add /etc/ca-certificates directory to ReaR recovery system for Arch Linux

### DIFF
--- a/usr/share/rear/conf/Arch/i386.conf
+++ b/usr/share/rear/conf/Arch/i386.conf
@@ -1,0 +1,1 @@
+COPY_AS_IS=( "${COPY_AS_IS[@]}" '/etc/ca-certificates/*' )

--- a/usr/share/rear/conf/Arch/i386.conf
+++ b/usr/share/rear/conf/Arch/i386.conf
@@ -1,1 +1,0 @@
-COPY_AS_IS=( "${COPY_AS_IS[@]}" '/etc/ca-certificates/*' )

--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -246,7 +246,9 @@ COPY_AS_IS=( ${COPY_AS_IS[@]:-} /dev /etc/inputr[c] /etc/protocols /etc/services
 # Usually the public verified certs, and not private keys.
 # The private keys are stored in /etc/ssl/private (not copied)
 # Private keys in /etc/pki/* are excluded (see below).
-COPY_AS_IS=( "${COPY_AS_IS[@]}" '/etc/ssl/certs/*' '/etc/pki/*' '/usr/lib/ssl/*' '/usr/share/ca-certificates/*' )
+# For more information on why brackets and quotes are not used, check https://github.com/rear/rear/pull/1971
+COPY_AS_IS=( "${COPY_AS_IS[@]}" /etc/ssl/[c]erts /etc/[p]ki /usr/lib/[s]sl /usr/share/[c]a-certificates  /etc/[c]a-certificates )
+
 # exclude /dev/shm/*, due to the way we use tar the leading / should be omitted
 COPY_AS_IS_EXCLUDE=( ${COPY_AS_IS_EXCLUDE[@]:-} dev/shm/\* )
 # Exclude private keys: /etc/pki/tls/private /etc/pki/CA/private /etc/pki/nssdb/key*.db and /usr/lib/ssl/private (cf. above):


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): N/A

* How was this pull request tested?
By running `rear mkrescue` on Arch Linux.

* Brief description of the changes in this pull request:

On current Arch (rolling release), SSL certificates are symlinked from /etc/ssl/certs to /etc/ca-certificates/extracted/cadir.
This is causing ReaR to complaint about broken symlinks when running `rear mkrescue/mkbackup`:

```
Broken symlink './etc/ssl/certs/QuoVadis_Root_CA_1_G3.pem' in recovery system because 'readlink' cannot determine its link target
Broken symlink './etc/ssl/certs/1e09d511.0' in recovery system because 'readlink' cannot determine its link target
Broken symlink './etc/ssl/certs/Staat_der_Nederlanden_Root_CA_-_G2.pem' in recovery system because 'readlink' cannot determine its link target
...
```
