### PR TITLE
Issue #1975 - Missing libraries in Rescue ISO causing executables to fail

### DIFF
--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -59,7 +59,7 @@ Log "Adding required libraries of executables in all the copied files to LIBS"
 local required_library=""
 for required_library in $( RequiredSharedOjects "${copy_as_is_executables[@]}" ) ; do
     # Skip when the required library was already actually copied by 'tar' above:
-    grep -q "$required_library" $copy_as_is_filelist_file && continue
+    grep -q "^${required_library}\$" $copy_as_is_filelist_file && continue
     # Skip when the required library is already in LIBS:
     IsInArray "$required_library" "${LIBS[@]}" && continue
     Log "Adding required library '$required_library' to LIBS"


### PR DESCRIPTION
When including files in the ISO using COPY_AS_IS functionality and some of these are libraries with same name as standard system libraries, the standard system libraries are not included if an executable included through COPY_AS_IS requires a library.
This does not happen for executables specified through PROG.

Example: copy /lib64/libglib-2.0.so.0 into /non-standard-dir/lib64/ and include /non-standard-dir/lib64 in the ISO (COPY_AS_IS+=( /non-standard-dir/lib64 ))

- /usr/lib/udev/rename_device which is also included as COPY_AS_IS (in /usr/share/rear/rescue/GNU/Linux/250_udev.sh) requires /lib64/libglib-2.0.so.0 but /lib64/libglib-2.0.so.0 is not included, only /non-standard-dir/lib64/libglib-2.0.so.0 will be
- /usr/lib/udev/rename_device will not be usable in rescue due to missing library

If we now add /usr/lib/udev/rename_device to PROG (PROG+=( /usr/lib/udev/rename_device )), the library /lib64/libglib-2.0.so.0 will be included because of code in /usr/share/rear/build/GNU/Linux/390_copy_binaries_libraries.sh, so there will be no issue in that case.

The root cause of the issue is due to the grep line being used:

  grep -q "$required_library" $copy_as_is_filelist_file && continue

Because $required_library is "/lib64/libglib-2.0.so.0" and file $copy_as_is_filelist_file contains "/non-standard-dir/lib64/libglib-2.0.so.0", this will be a match, whereas it should not.

The fix consists in modifying the grep line to match a full line instead (file $copy_as_is_filelist_file contains 1 file name per line).