### PR TITLE
Fix for 'error:unrecognized number' when booting ISO on PPC

### DIFF
--- a/usr/share/rear/output/ISO/Linux-ppc64/310_create_grub2.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64/310_create_grub2.sh
@@ -16,7 +16,7 @@ cat >"$TMP_DIR/ppc/bootinfo.txt" <<EOF
 <chrp-boot>
 <description>Relax-and-Recover</description>
 <os-name>Linux</os-name>
-<boot-script>boot &device;:\boot\grub\powerpc.elf</boot-script>
+<boot-script>boot &device;:,\boot\grub\powerpc.elf</boot-script>
 </chrp-boot>
 EOF
 

--- a/usr/share/rear/output/ISO/Linux-ppc64le/300_create_grub2.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64le/300_create_grub2.sh
@@ -11,7 +11,7 @@ cat >"$TMP_DIR/ppc/bootinfo.txt" <<EOF
 <chrp-boot>
 <description>Relax-and-Recover</description>
 <os-name>Linux</os-name>
-<boot-script>boot &device;:\boot\grub\powerpc.elf</boot-script>
+<boot-script>boot &device;:,\boot\grub\powerpc.elf</boot-script>
 </chrp-boot>
 EOF
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): No issue created

* How was this pull request tested? Not tested, I don't have the hardware for now, please may someone with hardware test.

* Brief description of the changes in this pull request:

~~~
Issue is caused by incorrect, according to PAPR specification,
bootinfo entity parsing code in grub2.

In PAPR spec "B.4.1.6.1 Bootinfo Entities" partition and path
separator (,) is optional and if not present bootinfo may be
treated as directory and filename components unless it begins
with number:

  &device;:[&partition;][,]&directory;&filename;

If (,) is missing and directory begins with a hexadecimal number
GRUB2 treats this as partition number immediately followed by a
directory/filename.

Note that with (,) present in bootpath issue isn't in the case
as GRUB2 returns empty string for GRUB_PARSE_PARTITIONS. This
effectively meaning that GRUB2 code requires (,) as mandatory.

This is a GRUB2 bug, but until it is fixed, we can make the
message disappear by specifying a comma in bootinfo.txt.
~~~