### PR TITLE
Fix broken 'make pacman'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,10 +216,10 @@ pacman: dist
 	rm -rf $(BUILD_DIR)
 	mkdir -p $(BUILD_DIR)
 	cp packaging/arch/PKGBUILD.local $(BUILD_DIR)/PKGBUILD
-	cp $(name)-$(distversion).tar.gz $(BUILD_DIR)/
+	cp dist/$(name)-$(distversion).tar.gz $(BUILD_DIR)/
 	cd $(BUILD_DIR) ; sed -i -e 's/VERSION/$(date)/' \
 		-e 's/SOURCE/$(name)-$(distversion).tar.gz/' \
-		-e 's/MD5SUM/$(shell md5sum $(name)-$(distversion).tar.gz | cut -d' ' -f1)/' \
+		-e 's/MD5SUM/$(shell md5sum dist/$(name)-$(distversion).tar.gz | cut -d' ' -f1)/' \
 		PKGBUILD ; makepkg -c
 	cp $(BUILD_DIR)/*.pkg.* .
 	rm -rf $(BUILD_DIR)

--- a/packaging/arch/PKGBUILD.local
+++ b/packaging/arch/PKGBUILD.local
@@ -19,6 +19,7 @@ md5sums=(MD5SUM)
 package() {
   cd $srcdir/rear-*/
   make DESTDIR="${pkgdir}/" install
+  mv ${pkgdir}/usr/sbin ${pkgdir}/usr/bin
 }
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**
* Impact: **Low**
* Reference to related issue (URL):

* How was this pull request tested?
I built and installed rear on my own Arch system using these 2 patches.

* Brief description of the changes in this pull request:
First change modifies the makefile to refer to dist/$(name)-$(distversion).tar.gz instead of $(name)-$(distversion).tar.gz.
Second change renames /usr/sbin to /usr/bin before assembly of Pacman package.
