### PR TITLE
Fix for #1974 - NBU (Netbackup) not working since ReaR 2.4

### DIFF
--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -57,7 +57,7 @@ Log "copy_as_is_executables = ${copy_as_is_executables[@]}"
 # add them to the LIBS list if they are not yet included in the copied files:
 Log "Adding required libraries of executables in all the copied files to LIBS"
 local required_library=""
-for required_library in $( RequiredSharedOjects "${copy_as_is_executables[@]}" ) ; do
+for required_library in $( RequiredSharedObjects "${copy_as_is_executables[@]}" ) ; do
     # Skip when the required library was already actually copied by 'tar' above.
     # grep for a full line (copy_as_is_filelist_file contains 1 file name per line)
     # to avoid that libraries get skipped when their library path is a substring

--- a/usr/share/rear/build/GNU/Linux/390_copy_binaries_libraries.sh
+++ b/usr/share/rear/build/GNU/Linux/390_copy_binaries_libraries.sh
@@ -62,16 +62,16 @@ Log "Binaries being copied: ${all_binaries[@]}"
 copy_binaries "$ROOTFS_DIR/bin" "${all_binaries[@]}"
 
 # Copy libraries:
-# It is crucial to also have all LIBS itself in all_libs because RequiredSharedOjects()
+# It is crucial to also have all LIBS itself in all_libs because RequiredSharedObjects()
 # outputs only those libraries that are required by a library but not the library itself
 # so that without all LIBS itself in all_libs those libraries in LIBS are missing that
 # are not needed by a binary in all_binaries (all_binaries were already copied above).
-# RequiredSharedOjects outputs the required shared objects on STDOUT.
+# RequiredSharedObjects outputs the required shared objects on STDOUT.
 # The output are absolute paths to the required shared objects.
 # The output can also be symbolic links (also as absolute paths).
 # In case of symbolic links only the link but not the link target is output.
 # Therefore for symbolic links also the link target gets copied below.
-local all_libs=( "${LIBS[@]}" $( RequiredSharedOjects "${all_binaries[@]}" "${LIBS[@]}" ) )
+local all_libs=( "${LIBS[@]}" $( RequiredSharedObjects "${all_binaries[@]}" "${LIBS[@]}" ) )
 
 Log "Libraries being copied: ${all_libs[@]}"
 local lib=""

--- a/usr/share/rear/build/OPALPBA/Linux-i386/391_list_executable_dependencies.sh
+++ b/usr/share/rear/build/OPALPBA/Linux-i386/391_list_executable_dependencies.sh
@@ -8,7 +8,7 @@ if is_true $KEEP_BUILD_DIR; then
     executable_dependencies_list="$TMP_DIR/executable-dependencies"
 
     for executable in "${executables[@]}"; do
-        dependents=( $(RequiredSharedOjects "$ROOTFS_DIR/$executable") )
+        dependents=( $(RequiredSharedObjects "$ROOTFS_DIR/$executable") )
         echo "$executable: ${dependents[*]}"
     done > "$executable_dependencies_list"
 

--- a/usr/share/rear/build/default/980_verify_rootfs.sh
+++ b/usr/share/rear/build/default/980_verify_rootfs.sh
@@ -54,6 +54,11 @@ if test "$BACKUP" = "SESAM" ; then
     # related libraries
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SESAM_LD_LIBRARY_PATH
 fi
+if test "$BACKUP" = "NBU" ; then
+    # Use a NBU-specific LD_LIBRARY_PATH to find NBU libraries
+    # see https://github.com/rear/rear/issues/1974
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$NBU_LD_LIBRARY_PATH
+fi
 # Actually test all binaries for 'not found' libraries.
 # Find all binaries and libraries also e.g. those that are copied via COPY_AS_IS into other paths:
 for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ); do

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1500,7 +1500,8 @@ OBDR_BLOCKSIZE=2048
 ##
 #
 COPY_AS_IS_NBU=( /usr/openv/bin/vnetd /usr/openv/bin/vopied /usr/openv/lib /usr/openv/netbackup /usr/openv/var/auth/[mn]*.txt )
-COPY_AS_IS_EXCLUDE_NBU=( "/usr/openv/netbackup/logs/*" "/usr/openv/netbackup/bin/bpjava*" "/usr/openv/netbackup/bin/xbp" )
+COPY_AS_IS_EXCLUDE_NBU=( "/usr/openv/netbackup/logs/*" "/usr/openv/netbackup/bin/bpjava*" /usr/openv/netbackup/bin/xbp /usr/openv/netbackup/bin/private /usr/openv/lib/java /usr/openv/lib/shared/vddk )
+NBU_LD_LIBRARY_PATH="/usr/openv/lib"
 PROGS_NBU=( )
 
 ##

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -327,7 +327,7 @@ function has_binary () {
         # Suppress success output via stdout which is crucial when has_binary is called
         # in other functions that provide their intended function results via stdout
         # to not pollute intended function results with intermixed has_binary stdout
-        # (e.g. the RequiredSharedOjects function) but keep failure output via stderr:
+        # (e.g. the RequiredSharedObjects function) but keep failure output via stderr:
         type $bin 1>/dev/null && return 0
     done
     return 1

--- a/usr/share/rear/lib/linux-functions.sh
+++ b/usr/share/rear/lib/linux-functions.sh
@@ -172,10 +172,11 @@ function RequiredSharedOjects () {
     #  2. Line: "        lib (mem-addr)"                 -> virtual library
     #  3. Line: "        lib => not found"               -> print error to stderr
     #  4. Line: "        lib => /path/to/lib (mem-addr)" -> print $3 '/path/to/lib'
-    #  5. Line: "        /path/to/lib (mem-addr)"        -> print $1 '/path/to/lib'
+    #  5. Line: "        /path/to/lib => /path/to/lib2 (mem-addr)" -> print $3 '/path/to/lib2'
+    #  6. Line: "        /path/to/lib (mem-addr)"        -> print $1 '/path/to/lib'
     ldd "$@" | awk ' /^\t.+ => not found/ { print "Shared object " $1 " not found" > "/dev/stderr" }
                      /^\t.+ => \// { print $3 }
-                     /^\t\// { print $1 } ' | sort -u
+                     /^\t\// && !/ => / { print $1 } ' | sort -u
 }
 
 # Provide a shell, with custom exit-prompt and history

--- a/usr/share/rear/lib/linux-functions.sh
+++ b/usr/share/rear/lib/linux-functions.sh
@@ -108,13 +108,13 @@ function FindStorageDrivers () {
 
 # Determine all required shared objects (shared/dynamic libraries)
 # for programs and/or shared objects (binaries) specified in $@.
-# RequiredSharedOjects outputs the required shared objects on STDOUT.
+# RequiredSharedObjects outputs the required shared objects on STDOUT.
 # The output are absolute paths to the required shared objects.
 # The output can also be symbolic links (also as absolute paths).
 # In case of symbolic links only the link but not the link target is output.
-function RequiredSharedOjects () {
-    has_binary ldd || Error "Cannot run RequiredSharedOjects() because there is no ldd binary"
-    Log "RequiredSharedOjects: Determining required shared objects"
+function RequiredSharedObjects () {
+    has_binary ldd || Error "Cannot run RequiredSharedObjects() because there is no ldd binary"
+    Log "RequiredSharedObjects: Determining required shared objects"
     # It uses 'ldd' to determine all required shared objects because 'ldd' outputs
     # also transitively required shared objects i.e. libraries needed by libraries,
     # e.g. for /usr/sbin/parted also the libraries needed by the libparted library:

--- a/usr/share/rear/prep/NBU/default/450_check_nbu_client_configured.sh
+++ b/usr/share/rear/prep/NBU/default/450_check_nbu_client_configured.sh
@@ -5,5 +5,6 @@
 Log "Running: /usr/openv/netbackup/bin/bplist command"
 LANG=C /usr/openv/netbackup/bin/bplist -l -s `date -d "-5 days" \
 	"+%m/%d/%Y"` / >/dev/null
-[ $? -gt 0 ] && LogPrint "WARNING: Netbackup bplist check failed with error code $?.
+rc=$?
+[ $rc -gt 0 ] && LogPrint "WARNING: Netbackup bplist check failed with error code ${rc}.
 See $RUNTIME_LOGFILE for more details."


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix** + **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): #1974 

* How was this pull request tested? **Tested by a Red Hat customer on rear-2.4.2**

* Brief description of the changes in this pull request:

With ReaR 2.4, a verification of the binaries included in the ISO is
performed. When using `COPY_AS_IS` with **NetBackup**, too many binaries were
included, causing the verification to fail or print error messages.

This fix defines a new `NBU_LD_LIBRARY_PATH` variable used during
verification and also excludes unused **NetBackup** binaries from the ISO.

Additionally, the `RequiredSharedObjects()` function has been fixed to not
list the left part of the ldd mapping when there is a right part: some
NetBackup libraries (e.g. `/usr/openv/lib/libbpfsmap.so`) were having a
mapping such as `/lib/ld64.so => /lib64/ld-linux-x86-64.so.2`, causing
the `RequiredSharedObjects()` function to print `/lib/ld64.so` which
doesn't resolve at all.
