### PR TITLE
Fix for issue https://github.com/rear/rear/issues/1986

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/58-start-dhclient.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/58-start-dhclient.sh
@@ -23,16 +23,16 @@ sleep 5
 source /etc/scripts/dhcp-setup-functions.sh
 
 # Need to find the devices and their HWADDR (avoid local and virtual devices)
-for dev in `get_device_by_hwaddr` ; do
-        case $dev in
+for DEVICE in `get_device_by_hwaddr` ; do
+        case $DEVICE in
 		(lo|pan*|sit*|tun*|tap*|vboxnet*|vmnet*|virt*|vif*) continue ;; # skip all kind of internal devices
         esac
-        HWADDR=`get_hwaddr $dev`
+        HWADDR=`get_hwaddr $DEVICE`
 
 	if [ -n "$HWADDR" ]; then
 		HWADDR=$(echo $HWADDR | awk '{ print toupper($0) }')
+	    DEVICE=$(get_device_by_hwaddr $HWADDR)
 	fi
-	[ -z "$DEVICE" -a -n "$HWADDR" ] && DEVICE=$(get_device_by_hwaddr $HWADDR)
 	[ -z "$DEVICETYPE" ] && DEVICETYPE=$(echo ${DEVICE} | sed "s/[0-9]*$//")
 	[ -z "$REALDEVICE" -a -n "$PARENTDEVICE" ] && REALDEVICE=$PARENTDEVICE
 	[ -z "$REALDEVICE" ] && REALDEVICE=${DEVICE%%:*}


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):

https://github.com/rear/rear/issues/1986

* How was this pull request tested?

I created a new ISO file on a laptop that had multiple interfaces and the issue was resolved by this diff.

* Brief description of the changes in this pull request:

The DHCP client during recovery does not iterate correctly over all network interfaces that are found. It incorrectly takes the first found interface time and again. If the interface that is intended for recovery is not the first one then the automatic recovery will fail. The user can only work around the situation by running "dhclient" manually on the correct interface.
