### PR TITLE
Include UDF support in rescue ISO when backup is stored on the ISO itself

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -580,10 +580,13 @@ ISO_MAX_SIZE=
 # ebiso (https://github.com/gozora/ebiso/) can be used as alternative
 # for mkisofs/genisoimage on UEFI bootable systems
 # to use ebiso, specify ISO_MKISOFS_BIN=<full_path_to_ebiso>/ebiso
-# in /etc/rear/local.conf or /etc/rear/site.conv
-# xorisofs is now used as the preferred method for generating the iso image
+# in /etc/rear/local.conf or /etc/rear/site.conf
+# xorrisofs is now used as the preferred method for generating the iso image
 # with mkisofs and genisoimage as second and third option
 ISO_MKISOFS_BIN="$( type -p xorrisofs || type -p mkisofs || type -p genisoimage )"
+
+# Additional options passed to the $ISO_MKISOFS_BIN binary
+ISO_MKISOFS_OPTS=""
 
 # Which files to include in the ISO image:
 ISO_FILES=()

--- a/usr/share/rear/output/ISO/Linux-i386/810_prepare_multiple_iso.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/810_prepare_multiple_iso.sh
@@ -66,7 +66,7 @@ for iso_number in $( seq -f '%02g' 1 $(( $number_of_ISOs - 1 )) ) ; do
     mkdir -p $TEMP_BACKUP_DIR
     mv $BACKUP_NAME $TEMP_BACKUP_DIR
     pushd $TEMP_ISO_DIR 1>/dev/null
-    if ! $ISO_MKISOFS_BIN $v -o "$ISO_OUTPUT_PATH" -R -J -volid "${ISO_VOLID}_$iso_number" -v -iso-level 3 . 1>/dev/null ; then
+    if ! $ISO_MKISOFS_BIN $v $ISO_MKISOFS_OPTS -o "$ISO_OUTPUT_PATH" -R -J -volid "${ISO_VOLID}_$iso_number" -v -iso-level 3 . 1>/dev/null ; then
         Error "Failed to create ISO image $ISO_NAME (with $ISO_MKISOFS_BIN)"
     fi
     popd 1>/dev/null
@@ -77,3 +77,4 @@ for iso_number in $( seq -f '%02g' 1 $(( $number_of_ISOs - 1 )) ) ; do
     RESULT_FILES=( "${RESULT_FILES[@]}" "$ISO_OUTPUT_PATH" )
 done
 
+# vim: set et ts=4 sw=4:

--- a/usr/share/rear/output/ISO/Linux-i386/820_create_iso_image.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/820_create_iso_image.sh
@@ -20,12 +20,13 @@ pushd $TMP_DIR/isofs >/dev/null
 if test "ebiso" = $( basename $ISO_MKISOFS_BIN ) ; then
     # ebiso currently works only with UEFI:
     if is_true $USING_UEFI_BOOTLOADER ; then
-        $ISO_MKISOFS_BIN -R -o $ISO_DIR/$ISO_PREFIX.iso -e boot/efiboot.img .
+        $ISO_MKISOFS_BIN $ISO_MKISOFS_OPTS -R -o $ISO_DIR/$ISO_PREFIX.iso -e boot/efiboot.img .
     else
         Error "$ISO_MKISOFS_BIN works only with UEFI"
     fi
 else
-    $ISO_MKISOFS_BIN $v -o "$ISO_DIR/$ISO_PREFIX.iso" -b isolinux/isolinux.bin -c isolinux/boot.cat \
+    $ISO_MKISOFS_BIN $v $ISO_MKISOFS_OPTS -o "$ISO_DIR/$ISO_PREFIX.iso" \
+        -b isolinux/isolinux.bin -c isolinux/boot.cat \
         -no-emul-boot -boot-load-size 4 -boot-info-table \
         -R -J -volid "$ISO_VOLID" $EFIBOOT -v -iso-level 3 .  >/dev/null
         ##-R -J -volid "$ISO_VOLID" $EFIBOOT  "${ISO_FILES[@]}"  >/dev/null
@@ -39,3 +40,4 @@ LogPrint "Wrote ISO image: $ISO_DIR/$ISO_PREFIX.iso ($iso_image_size)"
 # Add ISO image to result files
 RESULT_FILES=( "${RESULT_FILES[@]}" "$ISO_DIR/$ISO_PREFIX.iso" )
 
+# vim: set et ts=4 sw=4:

--- a/usr/share/rear/output/ISO/Linux-ia64/800_create_isofs.sh
+++ b/usr/share/rear/output/ISO/Linux-ia64/800_create_isofs.sh
@@ -24,8 +24,9 @@ mv -f $v $TMP_DIR/boot.img "$TMP_DIR/isofs/boot" >&2
 # Careful in case of 'return' after 'pushd' (must call the matching 'popd' before 'return'):
 pushd $TMP_DIR/isofs >&2 # so that relative paths will work
 
-$ISO_MKISOFS_BIN $v -o "$ISO_DIR/$ISO_PREFIX.iso" -b boot/boot.img -c boot/boot.catalog \
-	-no-emul-boot -R -T -J -volid "$ISO_VOLID" -v . >/dev/null
+$ISO_MKISOFS_BIN $v $ISO_MKISOFS_OPTS -o "$ISO_DIR/$ISO_PREFIX.iso" \
+    -b boot/boot.img -c boot/boot.catalog \
+    -no-emul-boot -R -T -J -volid "$ISO_VOLID" -v . >/dev/null
 StopIfError "Could not create ISO image"
 
 iso_image_size=( $(du -h "$ISO_DIR/$ISO_PREFIX.iso") )
@@ -36,3 +37,4 @@ RESULT_FILES=( "${RESULT_FILES[@]}" "$ISO_DIR/$ISO_PREFIX.iso" )
 
 popd >&2
 
+# vim: set et ts=4 sw=4:

--- a/usr/share/rear/output/ISO/Linux-ppc64le/820_create_iso_image.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64le/820_create_iso_image.sh
@@ -17,7 +17,9 @@ else
     chrp_boot_option="-chrp-boot"
 fi
 
-$ISO_MKISOFS_BIN $v -o "$ISO_DIR/$ISO_PREFIX.iso" -U $chrp_boot_option -R -J -volid "$ISO_VOLID" -v -graft-points "${ISO_FILES[@]}" >&2
+$ISO_MKISOFS_BIN $v $ISO_MKISOFS_OPTS -o "$ISO_DIR/$ISO_PREFIX.iso" \
+    -U $chrp_boot_option -R -J -volid "$ISO_VOLID" -v -graft-points \
+    "${ISO_FILES[@]}" >&2
 
 StopIfError "Could not create ISO image (with $ISO_MKISOFS_BIN)"
 popd >&2
@@ -27,3 +29,5 @@ LogPrint "Wrote ISO image: $ISO_DIR/$ISO_PREFIX.iso ($iso_image_size)"
 
 # Add ISO image to result files
 RESULT_FILES=( "${RESULT_FILES[@]}" "$ISO_DIR/$ISO_PREFIX.iso" )
+
+# vim: set et ts=4 sw=4:

--- a/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
+++ b/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
@@ -5,4 +5,13 @@
 [ -x "$ISO_MKISOFS_BIN" ]
 StopIfError "Could not find 'mkisofs' compatible program. Please install 'mkisofs', 'genisoimage' or 'ebiso' into your path or manually set ISO_MKISOFS_BIN [$ISO_MKISOFS_BIN]"
 
+# We also include 'udf' module which is required if backup archive is >= 4GiB
+# and mkisofs/genisoimage is used.
+if $ISO_MKISOFS_BIN --help 2>&1 >/dev/null | grep -qw -- -allow-limited-size ; then
+    MODULES+=( udf )
+    ISO_MKISOFS_OPTS+=" -allow-limited-size"
+fi
+
 Log "Using '$ISO_MKISOFS_BIN' to create ISO images"
+
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* How was this pull request tested?

Tested on x86_64 with xorrisofs (no change) and mkisofs:
- no change when backup is not embedded
- **udf** included + mkisofs option when backup is embedded

* Brief description of the changes in this pull request:

When using **BACKUP_URL=iso:///backup** and ISO generator is **mkisofs** or **genisoimage**, include the **udf** module and enable creating an hybrid **iso9660/udf** DVD.
This is necessary if the backup archive is >= 4GiB, otherwise the following error occurs:
~~~
File ./backup/backup.tar.gz is larger than 4GiB-1.
-allow-limited-size was not specified. There is no way do represent this file size. Aborting.
~~~

*xorrisoifs* doesn't require this.
