### PR TITLE
Automatically exclude $BUILD_DIR from the backup

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -520,6 +520,10 @@ Build date: $( date -R )
 if test "$WORKFLOW" != "help" ; then
     # Create temporary work area and register removal exit task:
     BUILD_DIR="$( mktemp -d -t rear.XXXXXXXXXXXXXXX || Error "Could not create build area '$BUILD_DIR'" )"
+    # Since 'mktemp' doesn't always return a path under /tmp, the build
+    # directory has always to be excluded for safety
+    BACKUP_PROG_EXCLUDE+=( "$BUILD_DIR" )
+
     QuietAddExitTask cleanup_build_area_and_end_program
     Log "Using build area '$BUILD_DIR'"
     ROOTFS_DIR=$BUILD_DIR/rootfs
@@ -575,3 +579,5 @@ if test "$WORKFLOW" != "help" ; then
 fi
 
 exit $EXIT_CODE
+
+# vim: set et ts=4 sw=4:

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -47,7 +47,9 @@
 # is set in the environment where /usr/sbin/rear is called.
 # To have a specific working area directory prefix for Relax-and-Recover
 # specify in /etc/rear/local.conf something like
+#
 #   export TMPDIR="/prefix/for/rear/working/directory"
+#
 # where /prefix/for/rear/working/directory must already exist.
 # This is useful for example when there is not sufficient free space
 # in /tmp or $TMPDIR for the ISO image or even the backup archive.


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* How was this pull request tested?

    - Tested without `export TMPDIR=xxx` variable
    - Tested with `export TMPDIR=xxx` variable

* Brief description of the changes in this pull request:

Usually **$BUILD_DIR** hosted on `/tmp` and hence automatically excluded from the backup.
When specifying **$TMPDIR**, **$BUILD_DIR** was not excluded from the backup.