### PR TITLE
fedora29 grub2-efi-x64-modules does not contain linuxefi module

### DIFF
--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -46,11 +46,11 @@ function build_bootx86_efi {
         Log "Did not find grub-mkimage (cannot build bootx86.efi)"
         return
     fi
-    if [[ -f /etc/slackware-version ]] || [[ -f /etc/fedora-release ]] ; then
-        # slackware grub doesn't have linuxefi module
-        $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs
-    else
-        $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs
-    fi
+    # as not all Linux distro's have the same kernel modules present we verify what we have (see also https://github.com/rear/rear/pull/2001)
+    grub_modules=""
+    for grub_module in part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs ; do
+        test "$( find /boot -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
+    done
+    $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" $grub_modules
     StopIfError "Error occurred during $gmkimage of BOOTX64.efi"
 }

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -46,7 +46,7 @@ function build_bootx86_efi {
         Log "Did not find grub-mkimage (cannot build bootx86.efi)"
         return
     fi
-    if [ -f /etc/slackware-version ] ; then
+    if [[ -f /etc/slackware-version ]] && [[ -f /etc/fedora-release ]] ; then
         # slackware grub doesn't have linuxefi module
         $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs
     else

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -46,7 +46,7 @@ function build_bootx86_efi {
         Log "Did not find grub-mkimage (cannot build bootx86.efi)"
         return
     fi
-    # as not all Linux distro's have the same kernel modules present we verify what we have (see also https://github.com/rear/rear/pull/2001)
+    # as not all Linux distro's have the same grub modules present we verify what we have (see also https://github.com/rear/rear/pull/2001)
     grub_modules=""
     for grub_module in part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs ; do
         test "$( find /boot -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -46,7 +46,7 @@ function build_bootx86_efi {
         Log "Did not find grub-mkimage (cannot build bootx86.efi)"
         return
     fi
-    if [[ -f /etc/slackware-version ]] && [[ -f /etc/fedora-release ]] ; then
+    if [[ -f /etc/slackware-version ]] || [[ -f /etc/fedora-release ]] ; then
         # slackware grub doesn't have linuxefi module
         $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" part_gpt part_msdos fat ext2 normal chain boot configfile linux multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs
     else


### PR DESCRIPTION
* Type: **Bug Fix** 

* Impact: **Low**

* Reference to related issue (URL): #1996 

* How was this pull request tested? not tested yet

* Brief description of the changes in this pull request: See https://github.com/rear/rear/issues/1996#issuecomment-445201012

