### PR TITLE
network: Automatically map device to its new name when device is found on the system with same MAC address but different name

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
@@ -30,14 +30,38 @@ ORIGINAL_DEVICES=()
 while read orig_dev orig_mac junk ; do
     ORIGINAL_DEVICES=( "${ORIGINAL_DEVICES[@]}" "$orig_dev")
     ORIGINAL_MACS=( "${ORIGINAL_MACS[@]}" "$orig_mac" )
-    # Continue with the next original MAC address if it is found on the current system:
-    ip link show | grep -q "$orig_mac" && continue
-    MIGRATE_DEVNAMES=( "${MIGRATE_DEVNAMES[@]}" "$orig_dev" )
-    MIGRATE_MACS=( "${MIGRATE_MACS[@]}" "$orig_mac" )
+    # Continue with the next original MAC address if it is found on the current
+    # system, otherwise we consider it needs migration:
+    new_dev=$( get_device_by_hwaddr "$orig_mac" )
+    if [ -n "$new_dev" ] ; then
+        [ "$new_dev" = "$orig_dev" ] && continue
+        # The device was found but has been renamed (it was customized in
+        # source system).
+        # Create a temporary mac mapping, we don't want finalize() to update
+        # the ifcfg-* files!
+        echo "$orig_mac $orig_mac $orig_dev" >> /tmp/mac
+    else
+        MIGRATE_MACS+=( "$orig_mac" )
+    fi
 done < $ORIG_MACS_FILE
 
-# Skip this process if all MACs and network interfacs (devices) are accounted for:
-test ${#MIGRATE_MACS[@]} -eq 0 && test ${#MIGRATE_DEVNAMES[@]} -eq 0 && return 0
+
+if [ ${#MIGRATE_MACS[@]} -ne 0 ] ; then
+    # If some MACs were not found (MIGRATE_MACS not empty) then, we need a migration
+    :
+elif [ -s /tmp/mac ] ; then
+    # Else, if some devices were renamed, we also need a migration, but it will
+    # be automatic thanks to the /tmp/mac mapping file
+
+    # We do not need the $MAC_MAPPING_FILE file from the user, just overwrite it
+    # Later, we will remove that file to not have finalize() modify the ifcfg-*
+    # files.
+    mkdir -p $(dirname $MAC_MAPPING_FILE)
+    cp /tmp/mac $MAC_MAPPING_FILE
+else
+    # Skip this process if all MACs and network interfaces (devices) are accounted for
+    return 0
+fi
 
 # Find the MAC addresses that are now available.
 # This is an array with values of the form "$dev $mac $driver"
@@ -74,7 +98,7 @@ done
 # so that it is shown to the user what MAC address mappings will be done:
 if read_and_strip_file $MAC_MAPPING_FILE ; then
     while read orig_dev orig_mac junk ; do
-        read_and_strip_file $MAC_MAPPING_FILE | grep -q "$orig_mac" && MANUAL_MAC_MAPPING=true
+        read_and_strip_file $MAC_MAPPING_FILE | grep -qw "^$orig_mac" && MANUAL_MAC_MAPPING=true
     done < $ORIG_MACS_FILE
 fi
 
@@ -237,7 +261,7 @@ if is_true $reload_udev ; then
     echo -n "Reloading udev ... "
     # Force udev to reload rules (as they were just changed)
     # Failback to "udevadm control --reload" in case of problem (as specify in udevadm manpage in SLES12)
-    # If nothing work, then wait 1 seconf delay. It should let the time for udev to detect changes in the rules files.
+    # If nothing work, then wait 1 second delay. It should let the time for udev to detect changes in the rules files.
     udevadm control --reload-rules || udevadm control --reload || sleep 1
     my_udevtrigger
     sleep 1
@@ -252,5 +276,11 @@ if is_true $reload_udev ; then
 fi
 
 # A later script in finalize/* will also go over the MAC mappings file and
-# apply them to the files in the recovered system.
+# apply them to the files in the recovered system, unless we did the mapping
+# automatically, which means some device has been renamed and will probably
+# gets its name back upon reboot.
+if [ -s /tmp/mac ] ; then
+    rm $MAC_MAPPING_FILE /tmp/mac
+fi
 
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* How was this pull request tested? Tested on RHEL7

* Brief description of the changes in this pull request:

Prior to this change, when a network interface had a custom name set instead of `ethX`, the network configuration was not applied. Typical usage is the `ifcfg` file sets up a `DEVICE` name and `HWADDR` mapping.

The new code fixes this issue by running the network interface migration code in an unattended manner.

Example (tested on a RHEL 7 box):
~~~
/etc/sysconfig/network-scripts/ifcfg-first:
TYPE="Ethernet"
BOOTPROTO="dhcp"
DEFROUTE="yes"
IPV6INIT="no"
DEVICE="first"
HWADDR="52:54:00:eb:6c:bf"
ONBOOT="yes"
~~~

/etc/rear/site.conf:
~~~
USE_STATIC_NETWORKING=y
~~~

Prior to this change:
- no network configured

With this code:
- network is configured, interface `first` is mapped onto `eth0` temporarily
- after recovery and reboot, the network interface `first` will be restored
