### PR TITLE
Provide final power to the user for mkfs.xfs options if needed (issue 1998)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -452,6 +452,46 @@ AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE=2
 AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE=10
 
 ##
+# Creating XFS filesystems during "rear recover"
+#
+# MKFS_XFS_OPTIONS
+# MKFS_XFS_OPTIONS_...
+#
+# For details see the script
+# usr/share/rear/layout/prepare/GNU/Linux/130_include_filesystem_code.sh
+# and for some reasoning behind you may have a look at
+# https://github.com/rear/rear/pull/2005
+#
+# During "rear mkrescue/mkbackup" the script layout/save/GNU/Linux/230_filesystem_layout.sh
+# calls 'xfs_info' and stores its output in var/lib/rear/layout/xfs/XFS_DEVICE.xfs files
+# where XFS_DEVICE is the basename of the device where the XFS filesystem is (e.g. sda2).
+# By default during "rear recover" the XFS filesystem on that device gets recreated
+# with matching mkfs.xfs options according to the stored 'xfs_info' output so that
+# XFS filesystems should get recreated with same XFS filesystem options as before.
+#
+# In particular in MIGRATION_MODE when disk devices had changed it could be needed
+# to recreate XFS filesystems with different XFS filesystem options as before.
+# MKFS_XFS_OPTIONS specifies global mkfs.xfs options for recreating all XFS filesystems.
+# Device specific mkfs.xfs options can be specified for each XFS device via
+# MKFS_XFS_OPTIONS_XFS_DEVICE where XFS_DEVICE is the basename of the device
+# but only uppercase letters and digits to ensure a valid bash variable name.
+# For example for /dev/sda2 it would be MKFS_XFS_OPTIONS_SDA2 and
+# for /dev/mapper/ACME_1000-part3 it would be MKFS_XFS_OPTIONS_ACME1000PART3
+# Common global options can be specified first like MKFS_XFS_OPTIONS="global options"
+# and used via MKFS_XFS_OPTIONS_SDA2="$MKFS_XFS_OPTIONS additional options for sda2"
+# versus separated options as in MKFS_XFS_OPTIONS_SDB3="all options for sdb3".
+# To recreate XFS filesystems with the mkfs.xfs defaults (i.e. without mkfs.xfs options)
+# specify a space MKFS_XFS_OPTIONS=' ' or MKFS_XFS_OPTIONS_SDA2=' ' only for sda2.
+#
+# The by-default empty MKFS_XFS_OPTIONS results that the mkfs.xfs options are set
+# via the above described default according to the stored 'xfs_info' output.
+# MKFS_XFS_OPTIONS is set to a default value here only
+# if not already set so that the user can set it also via
+#   export MKFS_XFS_OPTIONS="..."
+# directly before he calls "rear recover":
+test "$MKFS_XFS_OPTIONS" || MKFS_XFS_OPTIONS=''
+
+##
 # Support for TCG Opal 2-compliant Self-Encrypting Disks
 # (see doc/user-guide/13-tcg-opal-support.adoc)
 #

--- a/usr/share/rear/layout/prepare/GNU/Linux/130_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/130_include_filesystem_code.sh
@@ -143,35 +143,44 @@ function create_fs () {
             # unless the user has explicitly specified XFS filesystem options:
             local xfs_opts
             local xfs_device_basename="$( basename $device )"
-            # Only uppercase letters and digits are used to ensure mkfs_xfs_device_options_variable_name is a valid bash variable name
+            local xfs_info_filename="$LAYOUT_XFS_OPT_DIR/$xfs_device_basename.xfs"
+            # Only uppercase letters and digits are used to ensure mkfs_xfs_options_variable_name is a valid bash variable name
             # even in case of complicated device nodes e.g. things like /dev/mapper/SIBM_2810XIV_78033E7012F-part3 
             # cf. current_orig_device_basename_alnum_uppercase in layout/prepare/default/300_map_disks.sh
             local xfs_device_basename_alnum_uppercase="$( echo $xfs_device_basename | tr -d -c '[:alnum:]' | tr '[:lower:]' '[:upper:]' )"
             # cf. predefined_input_variable_name in the function UserInput in lib/_input-output-functions.sh
-            local mkfs_xfs_device_options_variable_name="MKFS_XFS_OPTIONS_$xfs_device_basename_alnum_uppercase"
+            local mkfs_xfs_options_variable_name="MKFS_XFS_OPTIONS_$xfs_device_basename_alnum_uppercase"
             # Set which options to use for mkfs.xfs:
-            if test "${!mkfs_xfs_device_options_variable_name:-}" ; then
+            if test "${!mkfs_xfs_options_variable_name:-}" ; then
                 # When the user has specified device specific options for mkfs.xfs e.g. in MKFS_XFS_OPTIONS_SDA2 use that:
-                Log "Using device specific options for mkfs.xfs as specified in $mkfs_xfs_device_options_variable_name"
-                xfs_opts="${!mkfs_xfs_device_options_variable_name:-}"
+                if test -s $xfs_info_filename ; then
+                    LogPrint "Overriding $xfs_device_basename mkfs.xfs options in $xfs_info_filename with those in $mkfs_xfs_options_variable_name"
+                else
+                    Log "Using $xfs_device_basename mkfs.xfs options in $mkfs_xfs_options_variable_name"
+                fi
+                xfs_opts="${!mkfs_xfs_options_variable_name:-}"
             else
                 if test "$MKFS_XFS_OPTIONS" ; then
                     # When the user has specified global options for mkfs.xfs in MKFS_XFS_OPTIONS use that:
-                    Log "Using global options for mkfs.xfs as specified in MKFS_XFS_OPTIONS"
+                    if test -s $xfs_info_filename ; then
+                        LogPrint "Overriding $xfs_device_basename mkfs.xfs options in $xfs_info_filename with those in MKFS_XFS_OPTIONS"
+                    else
+                        Log "Using $xfs_device_basename mkfs.xfs options in MKFS_XFS_OPTIONS"
+                    fi
                     xfs_opts="$MKFS_XFS_OPTIONS"
                 else
                     # When the user has not specified any options for mkfs.xfs
                     # recreate the XFS filesystem on that particular device as it originally was
                     # cf. https://github.com/rear/rear/issues/1998#issuecomment-445149675
                     # The function xfs_parse in lib/filesystems-functions.sh falls back to mkfs.xfs defaults
-                    # when there is no file $LAYOUT_XFS_OPT_DIR/$xfs_device_basename.xfs where the
+                    # (i.e. xfs_parse outputs nothing) when there is no $xfs_info_filename file where the
                     # XFS filesystem options of that particular device on the original system were saved:
-                    Log "Using device specific options for mkfs.xfs from $LAYOUT_XFS_OPT_DIR/$xfs_device_basename.xfs"
-                    xfs_opts=$( xfs_parse $LAYOUT_XFS_OPT_DIR/$xfs_device_basename.xfs )
+                    Log "Parsing $xfs_device_basename mkfs.xfs options from $xfs_info_filename"
+                    xfs_opts="$( xfs_parse $xfs_info_filename )"
                 fi
             fi
             # In case of fallback to mkfs.xfs defaults xfs_opts is empty:
-            test "$xfs_opts" && Log "Using mkfs.xfs options: $xfs_opts" || Log "Using mkfs.xfs defaults"
+            contains_visible_char "$xfs_opts" && Log "Using $xfs_device_basename mkfs.xfs options: $xfs_opts" || LogPrint "Using $xfs_device_basename mkfs.xfs defaults"
             # Decide if mkfs.xfs or xfs_admin will set uuid.
             # Uuid set by xfs_admin will set incompatible flag on systems with
             # enabled CRC. This might cause ReaR failure during grub installation.
@@ -187,7 +196,6 @@ function create_fs () {
                   echo "fi"
                 ) >> "$LAYOUT_CODE"
             else
-                # Actually create the filesystem
                 echo "mkfs.xfs -f $xfs_opts $device >&2" >> "$LAYOUT_CODE"
             fi
 


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **High**
Usually this is not needed but if the worst comes to the worst
an easy way to specify mkfs.xfs options it is likely highly appreciated.

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1998

* How was this pull request tested?
Currently it is not at all tested by me.
Currently it is meant so that @gozora can have a first look, cf.
https://github.com/rear/rear/issues/1998#issuecomment-447325672

* Brief description of the changes in this pull request:
Via the new optional global MKFS_XFS_OPTIONS config variable
the user can specify mkfs.xfs options for all mkfs.xfs calls
and/or via optional device specific config variables like
MKFS_XFS_OPTIONS_SDA2
the user can specify mkfs.xfs options only for the mkfs.xfs call
for that dvice (e.g. for /dev/sda2 via MKFS_XFS_OPTIONS_SDA2)
where device specific config variables take precedence over
a global MKFS_XFS_OPTIONS config variable which
takes precedence over the not changed default behaviour
where device specific options for the mkfs.xfs calls are set via
`xfs_parse $LAYOUT_XFS_OPT_DIR/$xfs_device_basename.xfs`
