### PR TITLE
Add possibility to fine tune some of Borg output

### DIFF
--- a/usr/share/rear/backup/BORG/default/500_make_backup.sh
+++ b/usr/share/rear/backup/BORG/default/500_make_backup.sh
@@ -17,14 +17,16 @@ for i in $(cat $TMP_DIR/backup-include.txt); do
 done
 
 # Only in ReaR verbose mode also show borg progress output and stats
-local borg_progress=''
-test "$verbose" && borg_progress='--progress --stats'
+local borg_additional_options=''
+
+is_true $BORGBACKUP_SHOW_PROGRESS && borg_additional_options+='--progress '
+is_true $BORGBACKUP_SHOW_STATS && borg_additional_options+='--stats '
 
 # Start actual Borg backup.
 Log "Creating archive ${BORGBACKUP_ARCHIVE_PREFIX}_$BORGBACKUP_SUFFIX \
 in repository $BORGBACKUP_REPO"
 
-borg create --one-file-system $borg_progress $verbose \
+borg create --one-file-system $borg_additional_options $verbose \
 $BORGBACKUP_OPT_COMPRESSION $BORGBACKUP_OPT_REMOTE_PATH \
 $BORGBACKUP_OPT_UMASK --exclude-from $TMP_DIR/backup-exclude.txt \
 ${borg_dst_dev}${BORGBACKUP_REPO}::\

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1660,6 +1660,15 @@ BORGBACKUP_PRUNE_MONTHLY=
 BORGBACKUP_PRUNE_YEARLY=
 # Borg default ssh port
 BORGBACKUP_PORT=22
+# Should be progress from Borg displayed as backup runs? 
+# (Progress data will not be stored in ReaR log.)
+BORGBACKUP_SHOW_PROGRESS="no"
+# Should be final Borg stats displayed after backup is over ?
+# (Borg final stats will not be stored into ReaR log.)
+# If there is a need to store additional data into log file, `tee' can be used for this purpose.
+# For more information on how additional output can be stored check:
+# https://github.com/rear/rear/issues/2007#issuecomment-448618562
+BORGBACKUP_SHOW_STATS="no"
 #
 # Environment variables
 # Borg is using couple of environment variables which can influence its behavior.
@@ -1674,7 +1683,7 @@ BORGBACKUP_PORT=22
 # ...
 #
 # For full list and description see:
-# https://borgbackup.readthedocs.io/en/stable/usage.html#environment-variables
+# https://borgbackup.readthedocs.io/en/stable/usage/general.html#environment-variables
 
 ##
 # BACKUP=BLOCKCLONE


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low** 

* Reference to related issue (URL): https://github.com/rear/rear/issues/2007

* How was this pull request tested?
Checked output of `rear mkbackuponly` on Fedora 26

* Brief description of the changes in this pull request:
Add possibility for user to specify whether or not show Borg stats at the end of backup session.
Add possibility for user to specify whether or not show Borg backup session progress.
Corrected URL to Borg backup environment variables documentation.

