### PR TITLE
Allow non-interactive rsync authentication

### DIFF
--- a/usr/share/rear/output/RSYNC/default/200_make_prefix_dir.sh
+++ b/usr/share/rear/output/RSYNC/default/200_make_prefix_dir.sh
@@ -15,7 +15,7 @@ case $RSYNC_PROTO in
 		;;
 
 	(rsync)
-		$BACKUP_PROG -a $v -r "${TMP_DIR}/rsync/${RSYNC_PREFIX}" "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/" >/dev/null
+		$BACKUP_PROG -a $v -r "${TMP_DIR}/rsync/${RSYNC_PREFIX}" ${RSYNC_OPTIONS} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/" >/dev/null
 		StopIfError "Could not create '${RSYNC_PATH}/${RSYNC_PREFIX}' on remote ${RSYNC_HOST}"
 		;;
 

--- a/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
+++ b/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
@@ -27,9 +27,9 @@ case $RSYNC_PROTO in
     StopIfError "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
     ;;
 
-(rsync)
-    Log "$BACKUP_PROG -a ${TMP_DIR}/rsync/${RSYNC_PREFIX}/ ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/"
-    $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null
+    (rsync)
+    Log "$BACKUP_PROG -a ${TMP_DIR}/rsync/${RSYNC_PREFIX}/ ${RSYNC_OPTIONS} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/"
+    $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" ${RSYNC_OPTIONS} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null
     StopIfError "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
     ;;
 

--- a/usr/share/rear/prep/RSYNC/default/100_check_rsync.sh
+++ b/usr/share/rear/prep/RSYNC/default/100_check_rsync.sh
@@ -89,8 +89,8 @@ fi
 case "$RSYNC_PROTO" in
 
     (rsync)
-        Log "Test: $BACKUP_PROG ${RSYNC_PROTO}://${RSYNC_HOST}:${RSYNC_PORT}/"
-        $BACKUP_PROG ${RSYNC_PROTO}://${RSYNC_HOST}:${RSYNC_PORT}/ >/dev/null
+        Log "Test: $BACKUP_PROG ${RSYNC_OPTIONS} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/"
+        $BACKUP_PROG ${RSYNC_OPTIONS} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/ >/dev/null
         StopIfError "Rsync daemon not running on $RSYNC_HOST"
         ;;
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): No issue existing

* How was this pull request tested?: at my installation:

`
Source system: Fedora release 28
ReaR Version: rear-2.4-1.fc28.x86_64

Remote system: QNAP TS-253A (Version QTS 4.3.4 (20180830))
`

* Brief description of the changes in this pull request:

I've added the correct variables to allow non-interactive authentication using rsync protocol. Now, one can use RSYNC_OPTIONS to authenticate using the "--password-file=/full/path/to/file" rsync's option.

I already fixed the missing username when rsync protocol at checking stage.
