### PR TITLE
Error out when we cannot make a bootable EFI image of GRUB2 (issue 1193)

### DIFF
--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -62,7 +62,8 @@ function build_bootx86_efi {
     for grub_module in part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs ; do
         test "$( find /boot -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
     done
-    $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" $grub_modules && return 0
-    Error "Failed to make bootable EFI image of GRUB2 (error during $gmkimage of BOOTX64.efi)"
+    if ! $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" $grub_modules ; then
+        Error "Failed to make bootable EFI image of GRUB2 (error during $gmkimage of BOOTX64.efi)"
+    fi
 }
 

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -37,20 +37,32 @@ function trim {
 }
 
 function build_bootx86_efi {
-    local gmkimage
-    if has_binary grub-mkimage; then
+    local gmkimage=""
+    if has_binary grub-mkimage ; then
         gmkimage=grub-mkimage
-    elif has_binary grub2-mkimage; then
+    elif has_binary grub2-mkimage ; then
+        # At least SUSE systems use 'grub2' prefixed names for GRUB2 programs:
         gmkimage=grub2-mkimage
     else
-        Log "Did not find grub-mkimage (cannot build bootx86.efi)"
-        return
+        # This build_bootx86_efi function is only called in output/ISO/Linux-i386/250_populate_efibootimg.sh
+        # which runs only if UEFI is used so that we simply error out here if we cannot make a bootable EFI image of GRUB2
+        # (normally a function should not exit out but return to its caller with a non-zero return code):
+        Error "Cannot make bootable EFI image of GRUB2 (neither grub-mkimage nor grub2-mkimage found)"
     fi
-    # as not all Linux distro's have the same grub modules present we verify what we have (see also https://github.com/rear/rear/pull/2001)
-    grub_modules=""
+    # grub-mkimage needs /usr/lib/grub/x86_64-efi/moddep.lst (cf. https://github.com/rear/rear/issues/1193)
+    # and at least on SUSE systems grub2-mkimage needs /usr/lib/grub2/x86_64-efi/moddep.lst (in 'grub2' directory)
+    # so that we error out if grub-mkimage or grub2-mkimage would fail when its moddep.lst is missing.
+    # Careful: usr/sbin/rear sets nullglob so that /usr/lib/grub*/x86_64-efi/moddep.lst gets empty if nothing matches
+    # and 'test -f' succeeds with empty argument so that we cannot use 'test -f /usr/lib/grub*/x86_64-efi/moddep.lst'
+    # also 'test -n' succeeds with empty argument but (fortunately/intentionally?) plain 'test' fails with empty argument:
+    test /usr/lib/grub*/x86_64-efi/moddep.lst || Error "$gmkimage would not make bootable EFI image of GRUB2 (no /usr/lib/grub*/x86_64-efi/moddep.lst file)"
+    # As not all Linux distros have the same GRUB2 modules present we verify what we have (see also https://github.com/rear/rear/pull/2001)
+    local grub_module=""
+    local grub_modules=""
     for grub_module in part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs ; do
         test "$( find /boot -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
     done
-    $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" $grub_modules
-    StopIfError "Error occurred during $gmkimage of BOOTX64.efi"
+    $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" $grub_modules && return 0
+    Error "Failed to make bootable EFI image of GRUB2 (error during $gmkimage of BOOTX64.efi)"
 }
+


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1193

* How was this pull request tested?
On my openSUSE Leap 15.0 system with UEFI boot:

Without /usr/lib/grub2/x86_64-efi/moddep.lst (excerpts):
<pre>
# mv /usr/lib/grub2/x86_64-efi/moddep.lst /usr/lib/grub2/x86_64-efi/moddep.lst.away

# usr/sbin/rear -D mkrescue
...
Using UEFI Boot Loader for Linux (USING_UEFI_BOOTLOADER=1)
...
Trying to find what to use as UEFI bootloader...
Trying to find a 'well known file' to be used as UEFI bootloader...
Using '/boot/efi/EFI/opensuse/grubx64.efi' as UEFI bootloader file
...
Created initrd.cgz with gzip default compression (69492491 bytes) in 9 seconds
ERROR: grub2-mkimage would not make bootable EFI image of GRUB2 (no /usr/lib/grub*/x86_64-efi/moddep.lst file)
Some latest log messages since the last called script 250_populate_efibootimg.sh:
  2019-01-07 14:56:06.723473419 Entering debugscripts mode via 'set -x'.
  mkdir: created directory '/tmp/rear.VgRH5w8InHHhFjJ/tmp/mnt'
  mkdir: created directory '/tmp/rear.VgRH5w8InHHhFjJ/tmp/mnt/EFI'
  mkdir: created directory '/tmp/rear.VgRH5w8InHHhFjJ/tmp/mnt/EFI/BOOT'
  mkdir: created directory '/tmp/rear.VgRH5w8InHHhFjJ/tmp/mnt/EFI/BOOT/fonts'
  mkdir: created directory '/tmp/rear.VgRH5w8InHHhFjJ/tmp/mnt/EFI/BOOT/locale'
  '/boot/efi/EFI/opensuse/grubx64.efi' -> '/tmp/rear.VgRH5w8InHHhFjJ/tmp/mnt/EFI/BOOT/BOOTX64.efi'
  /root/rear.github.master/usr/share/rear/lib/_input-output-functions.sh: line 331: type: grub-mkimage: not found
Aborting due to an error, check /root/rear.github.master/var/log/rear/rear-g243.log for details
Exiting rear mkrescue (PID 10957) and its descendant processes
Running exit tasks
You should also rm -Rf /tmp/rear.VgRH5w8InHHhFjJ
Terminated
</pre>

With /usr/lib/grub2/x86_64-efi/moddep.lst (excerpts):
<pre>
# mv /usr/lib/grub2/x86_64-efi/moddep.lst.away /usr/lib/grub2/x86_64-efi/moddep.lst

# usr/sbin/rear -D mkrescue
...
Using UEFI Boot Loader for Linux (USING_UEFI_BOOTLOADER=1)
...
Trying to find what to use as UEFI bootloader...
Trying to find a 'well known file' to be used as UEFI bootloader...
Using '/boot/efi/EFI/opensuse/grubx64.efi' as UEFI bootloader file
...
Created initrd.cgz with gzip default compression (69492853 bytes) in 9 seconds
Making ISO image
Wrote ISO image: /root/rear.github.master/var/lib/rear/output/rear-g243.iso (113M)
Copying resulting files to nfs location
Saving /root/rear.github.master/var/log/rear/rear-g243.log as rear-g243.log to nfs location
Copying result files '/root/rear.github.master/var/lib/rear/output/rear-g243.iso /tmp/rear.4s0ZKWq4YxvVB6x/tmp/VERSION /tmp/rear.4s0ZKWq4YxvVB6x/tmp/README /tmp/rear.4s0ZKWq4YxvVB6x/tmp/rear-g243.log' to /tmp/rear.4s0ZKWq4YxvVB6x/outputfs/g243 at nfs location
Exiting rear mkrescue (PID 25791) and its descendant processes
Running exit tasks
You should also rm -Rf /tmp/rear.4s0ZKWq4YxvVB6x
</pre>

* Brief description of the changes in this pull request:

Now it errors out directly in the 'build_bootx86_efi' function if
1. neither `grub-mkimage` nor `grub2-mkimage` is found
2. no `/usr/lib/grub*/x86_64-efi/moddep.lst` file is found
3. grub-mkimage or grub2-mkimage results non-zero exit code

The `build_bootx86_efi` function is only called in
output/ISO/Linux-i386/250_populate_efibootimg.sh
which runs only if UEFI is used so that we simply error out
in that function if we cannot make a bootable EFI image of GRUB2.
Normally a function should not exit out but return to its caller with
various appropriate non-zero return codes depending on each error.
