### PR TITLE
Improve rear dump output to clearly distinguish array elements

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -234,7 +234,7 @@ ARGS=( "$@" )
 
 # The following workflows are always verbose:
 case "$WORKFLOW" in
-    (validate|dump|shell|recover)
+    (validate|shell|recover)
         VERBOSE=1
         ;;
 esac

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -246,7 +246,7 @@ function trap () {
 # For actually intended user messages output to the original STDOUT
 # but only when the user launched 'rear -v' in verbose mode:
 function Print () {
-    test "$VERBOSE" && echo -e "${MESSAGE_PREFIX}$*" 1>&7 || true
+    test "$VERBOSE" && echo "${MESSAGE_PREFIX}$*" 1>&7 || true
 }
 
 # For normal output messages that are intended for user dialogs.
@@ -256,13 +256,13 @@ function Print () {
 # but output to the original STDOUT without a MESSAGE_PREFIX because
 # MESSAGE_PREFIX is not helpful in normal user dialog output messages:
 function UserOutput () {
-    echo -e "$*" 1>&7 || true
+    echo "$*" 1>&7 || true
 }
 
 # For actually intended user error messages output to the original STDERR
 # regardless whether or not the user launched 'rear' in verbose mode:
 function PrintError () {
-    echo -e "${MESSAGE_PREFIX}$*" 1>&8 || true
+    echo "${MESSAGE_PREFIX}$*" 1>&8 || true
 }
 
 # For messages that should only appear in the log file output to the current STDERR

--- a/usr/share/rear/lib/dump-workflow.sh
+++ b/usr/share/rear/lib/dump-workflow.sh
@@ -63,9 +63,9 @@ WORKFLOW_dump () {
 
     LogUserOutput "# Backup with $BACKUP:"
     # Output all $BACKUP_* config variable values e.g. for BACKUP=NETFS as something like
-    #   NETFS_CONFIG_STRING='string of words'
+    #   NETFS_CONFIG_STRING="string of words"
     # or when it is an array variable than as
-    #   NETFS_CONFIG_ARRAY='first element' 'second element' ...
+    #   NETFS_CONFIG_ARRAY=("first element" "second element" ... )
     for variable_name in $( eval echo '${!'"$BACKUP"'_*}' ) ; do
         # The command substitution for the list of items in the above 'for' loop evaluates
         # to all $BACKUP_* config variable names e.g. for BACKUP=NETFS to something like:
@@ -74,9 +74,9 @@ WORKFLOW_dump () {
         output_variable_assignment $variable_name
     done
     # Output all BACKUP_* config variable values e.g. as something like
-    #   BACKUP_CONFIG_STRING='string of words'
+    #   BACKUP_CONFIG_STRING="string of words"
     # or when it is an array variable than as
-    #   BACKUP_CONFIG_ARRAY='first element' 'second element' ...
+    #   BACKUP_CONFIG_ARRAY=("first element" "second element" ... )
     for variable_name in $( eval echo '${!BACKUP_*}' ) ; do
         case $variable_name in
 	    (BACKUP_PROG*)
@@ -90,9 +90,9 @@ WORKFLOW_dump () {
         (NETFS)
             LogUserOutput "# Backup program is '$BACKUP_PROG':"
             # Output all BACKUP_PROG_* config variable values e.g. as something like
-            #   BACKUP_PROG_STRING='string of words'
+            #   BACKUP_PROG_STRING="string of words"
             # or when it is an array variable than as
-            #   BACKUP_PROG_ARRAY='first element' 'second element' ...
+            #   BACKUP_PROG_ARRAY=("first element" "second element" ... )
             for variable_name in $( eval echo '${!BACKUP_PROG_*}' ) ; do
                 output_variable_assignment $variable_name
             done
@@ -101,13 +101,13 @@ WORKFLOW_dump () {
 
     LogUserOutput "# Output to $OUTPUT:"
     # Output all $OUTPUT_* config variable values e.g. for OUTPUT=ISO as something like
-    #   ISO_CONFIG_STRING='string of words'
+    #   ISO_CONFIG_STRING="string of words"
     # or when it is an array variable than as
-    #   ISO_CONFIG_ARRAY='first element' 'second element' ...
+    #   ISO_CONFIG_ARRAY=("first element" "second element" ... )
     # and output all OUTPUT_* config variable values e.g. as something like
-    #   OUTPUT_CONFIG_STRING='string of words'
+    #   OUTPUT_CONFIG_STRING="string of words"
     # or when it is an array variable than as
-    #   OUTPUT_CONFIG_ARRAY='first element' 'second element' ...
+    #   OUTPUT_CONFIG_ARRAY=("first element" "second element" ... )
     # and finally output the RESULT_MAILTO config variable value:
     for variable_name in $( eval echo '${!'"$OUTPUT"'_*}' '${!OUTPUT_*}' ) RESULT_MAILTO ; do
         output_variable_assignment $variable_name
@@ -116,21 +116,23 @@ WORKFLOW_dump () {
     LogUserOutput "# Validation status:"
     validation_file="$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt"
     LogUserOutput "  # $validation_file : $( test -s $validation_file && echo OK || echo missing/empty )"
-    if test -s "$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt" ; then
+    if test -s "$validation_file" ; then
         LogUserOutput "  # Your system is validated with the following details:"
         while read -r ; do
             LogUserOutput "  # $REPLY"
-        done <"$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt"
+        done <"$validation_file"
     else
         LogUserOutput "  # Your system is not yet validated. Please carefully check all functions"
         LogUserOutput "  # and create a validation record with '$PROGRAM validate'. This will help others"
         LogUserOutput "  # to know about the validation status of $PRODUCT on this system."
-        # If the master OS is validated print out a suitable hint
-        if test -s "$SHARE_DIR/lib/validated/$OS_MASTER_VENDOR_VERSION_ARCH.txt" ; then
+        # Show a hint when there is no OS_VENDOR_VERSION_ARCH.txt but OS_MASTER_VENDOR_VERSION_ARCH.txt exists:
+        validation_file="$SHARE_DIR/lib/validated/$OS_MASTER_VENDOR_VERSION_ARCH.txt"
+        if test -s "$validation_file" ; then
+            LogUserOutput "  # $validation_file : OK"
             LogUserOutput "  # Your system is derived from $OS_MASTER_VENDOR_VERSION which is validated:"
             while read -r ; do
                 LogUserOutput "  # $REPLY"
-            done <"$SHARE_DIR/lib/validated/$OS_MASTER_VENDOR_VERSION_ARCH.txt"
+            done <"$validation_file"
         fi
     fi
 

--- a/usr/share/rear/lib/dump-workflow.sh
+++ b/usr/share/rear/lib/dump-workflow.sh
@@ -10,86 +10,137 @@ WORKFLOW_dump_DESCRIPTION="dump configuration and system information"
 WORKFLOWS=( ${WORKFLOWS[@]} dump )
 WORKFLOW_dump () {
 
-        # Do nothing in simulation mode, cf. https://github.com/rear/rear/issues/1939
-        if is_true "$SIMULATE" ; then
-            LogPrint "${BASH_SOURCE[0]} dumps configuration and system information"
-            return 0
+    # The dump workflow is always verbose (see usr/sbin/rear).
+
+    # Do nothing in simulation mode, cf. https://github.com/rear/rear/issues/1939
+    if is_true "$SIMULATE" ; then
+        LogPrint "${BASH_SOURCE[0]} dumps configuration and system information"
+        return 0
+    fi
+
+    LogPrint "Dumping out configuration and system information"
+
+    if [ "$ARCH" != "$REAL_ARCH" ] ; then
+        LogPrint "This is a '$REAL_ARCH' system, compatible with '$ARCH'."
+    fi
+
+    LogPrint "System definition:"
+    for var in "ARCH" "OS" \
+               "OS_MASTER_VENDOR" "OS_MASTER_VERSION" "OS_MASTER_VENDOR_ARCH" "OS_MASTER_VENDOR_VERSION" "OS_MASTER_VENDOR_VERSION_ARCH" \
+               "OS_VENDOR" "OS_VERSION" "OS_VENDOR_ARCH" "OS_VENDOR_VERSION" "OS_VENDOR_VERSION_ARCH" ; do
+        LogPrint "$( printf "%40s = %s" "$var" "${!var}" )"
+    done
+
+    LogPrint "Configuration tree:"
+    for config in "$ARCH" "$OS" \
+                  "$OS_MASTER_VENDOR" "$OS_MASTER_VENDOR_ARCH" "$OS_MASTER_VENDOR_VERSION" "$OS_MASTER_VENDOR_VERSION_ARCH" \
+                  "$OS_VENDOR" "$OS_VENDOR_ARCH" "$OS_VENDOR_VERSION" "$OS_VENDOR_VERSION_ARCH" ; do
+        if [ "$config" ] ; then
+            LogPrint "$( printf "%40s : %s" "$config".conf "$( test -s $SHARE_DIR/conf/"$config".conf && echo OK || echo missing/empty )" )"
         fi
+    done
+    for config in site local ; do
+        LogPrint "$( printf "%40s : %s" "$config".conf "$( test -s $CONFIG_DIR/"$config".conf && echo OK || echo missing/empty )" )"
+    done
 
-	LogPrint "Dumping out configuration and system information"
+    LogPrint "Backup with $BACKUP:"
+    # Output all $BACKUP_* config variable values e.g. for BACKUP=NETFS as something like
+    #   NETFS_CONFIG_STRING = 'string of words'
+    # or when it is an array variable than as
+    #   NETFS_CONFIG_ARRAY = 'first element' 'second element' ...
+    for variable_name in $( eval echo '${!'"$BACKUP"'_*}' ) ; do
+        # The command substitution for the list of items in the above 'for' loop evaluates
+        # to all $BACKUP_* config variable names e.g. for BACKUP=NETFS to something like:
+        #   ++ eval echo '${!NETFS_*}'
+        #   +++ echo NETFS_CONFIG_STRING NETFS_CONFIG_ARRAY ...
+        variable_values="$( eval 'for array_element in "${'"$variable_name"'[@]:-}" ; do echo -n "'"'"'$array_element'"'"' " ; done' )"
+        # Using an empty default value ( via "${ARRAY[@]:-}" ) in the above 'for' loop is needed for empty array variables because
+        # otherwise the 'for' loop would not be run at all for empty arrays like ARRAY=( ) which would result variable_values=
+        # instead of the intended variable_values="'' " that is output as ARRAY = '' to explicitly show an empty '' value.
+        # Welcome to the quoting hell in the command substitution for the variable_values assignment above:
+        # cf. "How to escape single quotes within single quoted strings?" at
+        # https://stackoverflow.com/questions/1250079/how-to-escape-single-quotes-within-single-quoted-strings
+        # that reads (excerpts and a bit changed here):
+        #   To use single quotes in the outermost layer ... you can glue both kinds of quotation.
+        #   Example:
+        #     eval ' ... '"'"' ... '"'"' ... '
+        #   Explanation of how '"'"' is interpreted as just ' :
+        #   1. ' end first quotation which uses single quotes
+        #   2. " start second quotation using double-quotes
+        #   3. ' quoted character
+        #   4. " end second quotation using double-quotes
+        #   5. ' start third quotation using single quotes
+        # If you do not place any whitespaces between (1) and (2) or between (4) and (5)
+        # the shell will interpret that string as a one long word.
+        LogPrint "$( printf "%40s = %s" "$variable_name" "$variable_values" )"
+    done
+    # Output all BACKUP_* config variable values e.g. as something like
+    #   BACKUP_CONFIG_STRING = 'string of words'
+    # or when it is an array variable than as
+    #   BACKUP_CONFIG_ARRAY = 'first element' 'second element' ...
+    for variable_name in $( eval echo '${!BACKUP_*}' ) ; do
+        case $variable_name in
+	    (BACKUP_PROG*)
+                ;;
+            (*)
+                # LogPrint "$( printf "%40s = %s" "$opt" "$(eval 'echo "${'"$opt"'[@]}"')" )"
+                variable_values="$( eval 'for array_element in "${'"$variable_name"'[@]:-}" ; do echo -n "'"'"'$array_element'"'"' " ; done' )"
+                LogPrint "$( printf "%40s = %s" "$variable_name" "$variable_values" )"
+                ;;
+        esac
+    done
+    case "$BACKUP" in
+        (NETFS)
+            LogPrint "Backup program is '$BACKUP_PROG':"
+            # Output all BACKUP_PROG_* config variable values e.g. as something like
+            #   BACKUP_PROG_STRING = 'string of words'
+            # or when it is an array variable than as
+            #   BACKUP_PROG_ARRAY = 'first element' 'second element' ...
+            for variable_name in $( eval echo '${!BACKUP_PROG_*}' ) ; do
+                # LogPrint "$( printf "%40s = %s" "$opt" "$(eval 'echo "${'"$opt"'[@]}"')" )"
+                variable_values="$( eval 'for array_element in "${'"$variable_name"'[@]:-}" ; do echo -n "'"'"'$array_element'"'"' " ; done' )"
+                LogPrint "$( printf "%40s = %s" "$variable_name" "$variable_values" )"
+            done
+        ;;
+    esac
 
-	if [ "$ARCH" != "$REAL_ARCH" ] ; then
-		LogPrint "This is a '$REAL_ARCH' system, compatible with '$ARCH'."
-	fi
+    LogPrint "Output to $OUTPUT:"
+    # Output all $OUTPUT_* config variable values e.g. for OUTPUT=ISO as something like
+    #   ISO_CONFIG_STRING = 'string of words'
+    # or when it is an array variable than as
+    #   ISO_CONFIG_ARRAY = 'first element' 'second element' ...
+    # and output all OUTPUT_* config variable values e.g. as something like
+    #   OUTPUT_CONFIG_STRING = 'string of words'
+    # or when it is an array variable than as
+    #   OUTPUT_CONFIG_ARRAY = 'first element' 'second element' ...
+    # and finally output the RESULT_MAILTO config variable value:
+    for variable_name in $( eval echo '${!'"$OUTPUT"'_*}' '${!OUTPUT_*}' ) RESULT_MAILTO ; do
+        # LogPrint "$( printf "%40s = %s" "$opt" "$(eval 'echo "${'"$opt"'[@]}"')" )"
+        variable_values="$( eval 'for array_element in "${'"$variable_name"'[@]:-}" ; do echo -n "'"'"'$array_element'"'"' " ; done' )"
+        LogPrint "$( printf "%40s = %s" "$variable_name" "$variable_values" )"
+    done
 
-	LogPrint "System definition:"
-	for var in "ARCH" "OS" \
-		"OS_MASTER_VENDOR" "OS_MASTER_VERSION" "OS_MASTER_VENDOR_ARCH" "OS_MASTER_VENDOR_VERSION" "OS_MASTER_VENDOR_VERSION_ARCH" \
-		"OS_VENDOR" "OS_VERSION" "OS_VENDOR_ARCH" "OS_VENDOR_VERSION" "OS_VENDOR_VERSION_ARCH"; do
-		LogPrint "$( printf "%40s = %s" "$var" "${!var}" )"
-	done
+    Print ""
 
-	LogPrint "Configuration tree:"
-	for config in "$ARCH" "$OS" \
-		"$OS_MASTER_VENDOR" "$OS_MASTER_VENDOR_ARCH" "$OS_MASTER_VENDOR_VERSION" "$OS_MASTER_VENDOR_VERSION_ARCH" \
-		"$OS_VENDOR" "$OS_VENDOR_ARCH" "$OS_VENDOR_VERSION" "$OS_VENDOR_VERSION_ARCH"; do
-		if [ "$config" ] ; then
-			LogPrint "$( printf "%40s : %s" "$config".conf "$(
-									test -s $SHARE_DIR/conf/"$config".conf && echo OK || echo missing/empty
-									)" )"
-		fi
-	done
-	for config in site local ; do
-		LogPrint "$( printf "%40s : %s" "$config".conf "$(
-								test -s $CONFIG_DIR/"$config".conf && echo OK || echo missing/empty
-								)" )"
-	done
-
-	LogPrint "Backup with $BACKUP"
-	for opt in $(eval echo '${!'"$BACKUP"'_*}') ; do
-		LogPrint "$( printf "%40s = %s" "$opt" "$(eval 'echo "${'"$opt"'[@]}"')" )"
-	done
-	for opt in $(eval echo '${!BACKUP_*}') ; do
-		case $opt in
-			BACKUP_PROG*) ;;
-			*) LogPrint "$( printf "%40s = %s" "$opt" "$(eval 'echo "${'"$opt"'[@]}"')" )" ;;
-		esac
-	done
-
-	case "$BACKUP" in
-		NETFS)
-		LogPrint "Backup program is '$BACKUP_PROG':"
-		for opt in $(eval echo '${!BACKUP_PROG*}') ; do
-			LogPrint "$( printf "%40s = %s" "$opt" "$(eval 'echo "${'"$opt"'[@]}"')" )"
-		done
-		;;
-	esac
-
-	LogPrint "Output to $OUTPUT"
-	for opt in $(eval echo '${!'"$OUTPUT"'_*}' '${!OUTPUT_*}') RESULT_MAILTO ; do
-		LogPrint "$( printf "%40s = %s" "$opt" "$(eval 'echo "${'"$opt"'[@]}"')" )"
-	done
-
-	Print ""
-
-	UserOutput "$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt"
-	if test -s "$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt" ; then
-		LogPrint "Your system is validated with the following details:"
-		while read -r ; do
-			LogPrint "$REPLY"
-		done <"$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt"
-	else
-		LogPrint "Your system is not yet validated. Please carefully check all functions"
-		LogPrint "and create a validation record with '$PROGRAM validate'. This will help others"
-		LogPrint "to know about the validation status of $PRODUCT on this system."
-		# if the master OS is validated print out a suitable hint
-		if test -s "$SHARE_DIR/lib/validated/$OS_MASTER_VENDOR_VERSION_ARCH.txt" ; then
-			LogPrint ""
-			LogPrint "Your system is derived from $OS_MASTER_VENDOR_VERSION which is validated:"
-			while read -r ; do
-				LogPrint "$REPLY"
-			done <"$SHARE_DIR/lib/validated/$OS_MASTER_VENDOR_VERSION_ARCH.txt"
-		fi
-	fi
+    UserOutput "$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt"
+    if test -s "$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt" ; then
+        LogPrint "Your system is validated with the following details:"
+        while read -r ; do
+            LogPrint "$REPLY"
+        done <"$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt"
+    else
+        LogPrint "Your system is not yet validated. Please carefully check all functions"
+        LogPrint "and create a validation record with '$PROGRAM validate'. This will help others"
+        LogPrint "to know about the validation status of $PRODUCT on this system."
+        # if the master OS is validated print out a suitable hint
+        if test -s "$SHARE_DIR/lib/validated/$OS_MASTER_VENDOR_VERSION_ARCH.txt" ; then
+            LogPrint ""
+            LogPrint "Your system is derived from $OS_MASTER_VENDOR_VERSION which is validated:"
+            while read -r ; do
+                LogPrint "$REPLY"
+            done <"$SHARE_DIR/lib/validated/$OS_MASTER_VENDOR_VERSION_ARCH.txt"
+        fi
+    fi
 
 }
+

--- a/usr/share/rear/lib/dump-workflow.sh
+++ b/usr/share/rear/lib/dump-workflow.sh
@@ -115,7 +115,7 @@ WORKFLOW_dump () {
 
     LogUserOutput "# Validation status:"
     validation_file="$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt"
-    Print "  $validation_file : $( test -s $validation_file && echo OK || echo missing/empty )"
+    LogUserOutput "  # $validation_file : $( test -s $validation_file && echo OK || echo missing/empty )"
     if test -s "$SHARE_DIR/lib/validated/$OS_VENDOR_VERSION_ARCH.txt" ; then
         LogUserOutput "  # Your system is validated with the following details:"
         while read -r ; do


### PR DESCRIPTION
* Type: **Minor Bug Fix** **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2011#issuecomment-453085678

* How was this pull request tested?
By me on my openSUSE Leap 15.0 system.

* Brief description of the changes in this pull request:

Now `rear dump` shows array variable elements separated by `'` characters as
```
    ARRAY_VARIABLE_NAME = 'first element' 'second element'
```
for example with `BACKUP_RSYNC_OPTIONS=( this that 'something else' )`
(excerpts):
```
# usr/sbin/rear dump
...
    BACKUP_RSYNC_OPTIONS = 'this' 'that' 'something else' 
...
    BACKUP_PROG_EXCLUDE = '/tmp/*' '/dev/shm/*' '/root/rear.github.master/var/lib/rear/output/*' '/nfs/*' '/tmp/rear.Prkdrs6sR9pybOv' 
```

Before it would have been e.g.
```
    BACKUP_RSYNC_OPTIONS = this that something else
```
where it is not clear that actually `something else` is one array element.

I also cleaned up the indentation in lib/dump-workflow.sh to N*4 spaces.
