### PR TITLE
Fixed exit in usr/sbin/rear when getopt failed

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -118,11 +118,11 @@ WORKFLOW=""
 
 # Parse options
 help_note_text="Use '$PROGRAM --help' or 'man $PROGRAM' for more information."
-readonly OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVr:" -l "help,version,debugscripts:" -- "$@" )"
-if test $? -ne 0 ; then
+if ! OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVr:" -l "help,version,debugscripts:" -- "$@" )" ; then
     echo "$help_note_text"
     exit 1
 fi
+readonly OPTS
 eval set -- "$OPTS"
 while true ; do
     case "$1" in


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* How was this pull request tested?

By me on my openSUSE Leap 15.0 system.
Before:
```
# usr/sbin/rear -Q dump
rear: invalid option -- 'Q'
# Begin dumping out configuration and system information:
...
```
(i.e. the 'dump' workflow is run).
With the fix here:
```
# usr/sbin/rear -Q dump
rear: invalid option -- 'Q'
Use 'rear --help' or 'man rear' for more information.
```

* Brief description of the changes in this pull request:

In the code before in usr/sbin/rear
```
readonly OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVr:" -l "help,version,debugscripts:" -- "$@" )"
if test $? -ne 0 ; then
    echo "$help_note_text"
    exit 1
fi
```
the `$?` does not contain the `getopt` exit code
but the `readonly` return code which is always zero.
The new code
```
if ! OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVr:" -l "help,version,debugscripts:" -- "$@" )" ; then
    echo "$help_note_text"
    exit 1
fi
readonly OPTS
```
fixes that.
In general using `$?` is problematic, cf. the `StopIf...` functions 
https://github.com/rear/rear/pull/2013#discussion_r245909346
