### PR TITLE
Suppress dispensable 'set -x' debug output unless called with '--debugscripts x'

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -108,6 +108,7 @@ readonly TARGET_FS_ROOT="/mnt/local"
 DEBUG=""
 DEBUGSCRIPTS=""
 DEBUGSCRIPTS_ARGUMENT="x"
+DISPENSABLE_OUTPUT_DEV="null"
 KEEP_BUILD_DIR=""
 KERNEL_VERSION=""
 RECOVERY_MODE=""
@@ -171,6 +172,7 @@ while true ; do
             DEBUG=1
             VERBOSE=1
             DEBUGSCRIPTS=1
+            DISPENSABLE_OUTPUT_DEV="stderr"
             if [[ "$2" == -* ]] ; then
                 # When the item that follows '--debugscripts' starts with a '-'
                 # it is considered to be the next option and not an argument for '--debugscripts':
@@ -253,12 +255,11 @@ fi
 # Exceptions here:
 # CONFIG_DIR because "rear recover" sets it in /etc/rear/rescue.conf in the recovery system
 # WORKFLOW because for the udev workflow WORKFLOW is set to the actual workflow
-# KERNEL_VERSION because if empty it is set when sourcing config files below
-# VERBOSE because there is a special "VERBOSE=1" setting below:
+# KERNEL_VERSION because if empty it is set when sourcing config files below:
 readonly ARGS
 readonly CONFIG_APPEND_FILES
-readonly DEBUG DEBUGSCRIPTS DEBUGSCRIPTS_ARGUMENT
-readonly SIMULATE STEPBYSTEP
+readonly DEBUG DEBUGSCRIPTS DEBUGSCRIPTS_ARGUMENT DISPENSABLE_OUTPUT_DEV
+readonly SIMULATE STEPBYSTEP VERBOSE
 
 # The udev workflow is a special case because it is only a wrapper workflow
 # that calls an actual workflow that is specified as $UDEV_WORKFLOW
@@ -540,7 +541,6 @@ if has_binary WORKFLOW_$WORKFLOW ; then
     WORKFLOW_$WORKFLOW "${ARGS[@]:-}"
     Log "Finished running $WORKFLOW workflow"
 else
-    VERBOSE=1
     LogPrintError "ERROR: The specified command '$WORKFLOW' does not exist!"
     EXIT_CODE=1
 fi

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -246,7 +246,12 @@ function trap () {
 # For actually intended user messages output to the original STDOUT
 # but only when the user launched 'rear -v' in verbose mode:
 function Print () {
-    test "$VERBOSE" && echo "${MESSAGE_PREFIX}$*" 1>&7 || true
+    # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV when $DISPENSABLE_OUTPUT_DEV is not 'null'.
+    # In debugscripts mode $DISPENSABLE_OUTPUT_DEV is 'stderr' (see usr/sbin/rear)
+    # and /dev/stderr is fd2 which is redirected to append to RUNTIME_LOGFILE (see usr/sbin/rear)
+    # so that 2>/dev/stderr would truncate RUNTIME_LOGFILE to zero size (see 'REDIRECTION' in "man bash")
+    # but 2>>/dev/stderr does not change things so that fd2 output is still appended to RUNTIME_LOGFILE:
+    { test "$VERBOSE" && echo "${MESSAGE_PREFIX}$*" 1>&7 || true ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
 }
 
 # For normal output messages that are intended for user dialogs.
@@ -256,13 +261,13 @@ function Print () {
 # but output to the original STDOUT without a MESSAGE_PREFIX because
 # MESSAGE_PREFIX is not helpful in normal user dialog output messages:
 function UserOutput () {
-    echo "$*" 1>&7 || true
+    { echo "$*" 1>&7 || true ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
 }
 
 # For actually intended user error messages output to the original STDERR
 # regardless whether or not the user launched 'rear' in verbose mode:
 function PrintError () {
-    echo "${MESSAGE_PREFIX}$*" 1>&8 || true
+    { echo "${MESSAGE_PREFIX}$*" 1>&8 || true ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
 }
 
 # For messages that should only appear in the log file output to the current STDERR
@@ -270,12 +275,15 @@ function PrintError () {
 function Log () {
     # Have a timestamp with nanoseconds precision in any case
     # so that any subsequent Log() calls get logged with precise timestamps:
-    local timestamp=$( date +"%Y-%m-%d %H:%M:%S.%N " )
-    if test $# -gt 0 ; then
-        echo "${MESSAGE_PREFIX}${timestamp}$*" || true
-    else
-        echo "${MESSAGE_PREFIX}${timestamp}$( cat )" || true
-    fi 1>&2
+    { local timestamp=$( date +"%Y-%m-%d %H:%M:%S.%N " )
+      local log_message=""
+      if test $# -gt 0 ; then
+          log_message="${MESSAGE_PREFIX}${timestamp}$*"
+      else
+          log_message="${MESSAGE_PREFIX}${timestamp}$( cat )"
+      fi
+    } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
+    echo "$log_message" 1>&2 || true
 }
 
 # For messages that should only appear in the log file when the user launched 'rear -d' in debug mode:
@@ -394,13 +402,14 @@ function Error () {
     # but also the outdated scripts with leading 2-digit number get sourced
     # see the SourceStage function in lib/framework-functions.sh
     # so that we grep for script files names with two or more leading numbers:
-    local last_sourced_script_log_entry=( $( grep -o ' Including .*/[0-9][0-9].*\.sh' $RUNTIME_LOGFILE | tail -n 1 ) )
-    # The last_sourced_script_log_entry contains: Including sub-path/to/script_file_name.sh
-    local last_sourced_script_sub_path="${last_sourced_script_log_entry[1]}"
-    local last_sourced_script_filename="$( basename $last_sourced_script_sub_path )"
-    # When it errors out in sbin/rear last_sourced_script_filename is empty which would result bad looking output
-    # cf. https://github.com/rear/rear/issues/1965#issuecomment-439437868
-    test "$last_sourced_script_filename" || last_sourced_script_filename="$SCRIPT_FILE"
+    { local last_sourced_script_log_entry=( $( grep -o ' Including .*/[0-9][0-9].*\.sh' $RUNTIME_LOGFILE | tail -n 1 ) )
+      # The last_sourced_script_log_entry contains: Including sub-path/to/script_file_name.sh
+      local last_sourced_script_sub_path="${last_sourced_script_log_entry[1]}"
+      local last_sourced_script_filename="$( basename $last_sourced_script_sub_path )"
+      # When it errors out in sbin/rear last_sourced_script_filename is empty which would result bad looking output
+      # cf. https://github.com/rear/rear/issues/1965#issuecomment-439437868
+      test "$last_sourced_script_filename" || last_sourced_script_filename="$SCRIPT_FILE"
+    } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
     # Do not log the error message right now but after the currenly last log messages were shown:
     PrintError "ERROR: $*"
     # Show some additional hopefully meaningful output on the user's terminal
@@ -433,25 +442,20 @@ function Error () {
     # Show at most the last 8 lines because too much before the actual error may cause more confusion than help.
     # Add two spaces indentation for better readability what those extracted log file lines are.
     # Some messages could be too long to be usefully shown on the user's terminal so that they are truncated after 200 bytes:
-    PrintError "$( sed -n -e "/Including .*$last_sourced_script_filename/,/+ [Bug]*Error /p" $RUNTIME_LOGFILE | grep -v '^+' | tail -n 8 | sed -e 's/^/  /' | cut -b-200 )"
+    { local last_sourced_script_log_messages="$( sed -n -e "/Including .*$last_sourced_script_filename/,/+ [Bug]*Error /p" $RUNTIME_LOGFILE | grep -v '^+' | tail -n 8 | sed -e 's/^/  /' | cut -b-200 )" ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
+    PrintError "$last_sourced_script_log_messages"
     Log "ERROR: $*"
     LogToSyslog "ERROR: $*"
-    # TODO: I <jsmeix@suse.de> wonder if the "has_binary caller" test is still needed nowadays
-    # because for me on SLE10 with bash-3.1-24 up to SLE12 with bash-4.2 'caller' is a shell builtin:
-    if has_binary caller ; then
-        # Print stack strace in reverse order to the current STDERR which is (usually) the log file:
-        (   echo "===== ${MESSAGE_PREFIX}Stack trace ====="
-            local c=0;
-            while caller $((c++)) ; do
-                # nothing to do
-                :
-            done | awk ' { l[NR]=$3":"$1" "$2 }
-                         END { for (i=NR; i>0;) print "Trace "NR-i": "l[i--] }
-                       '
-            echo "${MESSAGE_PREFIX}Message: $*"
-            echo "=== ${MESSAGE_PREFIX}End stack trace ==="
-        ) 1>&2
-    fi
+    # Print stack strace in reverse order to the current STDERR which is (usually) the log file:
+    ( echo "===== ${MESSAGE_PREFIX}Stack trace ====="
+      local c=0;
+      while caller $((c++)) ; do
+          :
+      done | awk ' { l[NR]=$3":"$1" "$2 }
+                   END { for (i=NR; i>0;) print "Trace "NR-i": "l[i--] }
+                 '
+      echo "=== ${MESSAGE_PREFIX}End stack trace ==="
+    ) 1>&2
     # Make sure Error exits the master process, even if called from child processes:
     kill -USR1 $MASTER_PID
 }
@@ -465,7 +469,7 @@ function StopIfError () {
 
 # Exit if there is a bug in ReaR:
 function BugError () {
-    local caller_source="$( CallerSource )"
+    { local caller_source="$( CallerSource )" ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
     Error "
 ====================
 BUG in $caller_source:

--- a/usr/share/rear/lib/array-functions.sh
+++ b/usr/share/rear/lib/array-functions.sh
@@ -2,14 +2,15 @@
 
 # return whether $1 equals one of the remaining arguments
 function IsInArray() {
-    local needle="$1"
-    test -z "$needle" && return 1
-    while shift ; do
-        # at the end $1 becomes an unbound variable (after all arguments were shifted)
-        # so that an empty default value is used to avoid 'set -eu' error exit
-        # and that empty default value cannot match because needle is non-empty:
-        test "$needle" == "${1:-}" && return 0
-    done
+    { local needle="$1"
+      test -z "$needle" && return 1
+      while shift ; do
+          # at the end $1 becomes an unbound variable (after all arguments were shifted)
+          # so that an empty default value is used to avoid 'set -eu' error exit
+          # and that empty default value cannot match because needle is non-empty:
+          test "$needle" == "${1:-}" && return 0
+      done
+    } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
     return 1
 }
 
@@ -17,13 +18,15 @@ function RmInArray() {
     # "$1" string to be removed in array "${2[@]}"
     # please note that the array elements are a bunch of words in this function
     # usage: BACKUP_RSYNC_OPTIONS=( $( RmInArray "--relative" "${BACKUP_RSYNC_OPTIONS[@]}" ) )
-    local needle="$1"
-    declare -a nArray  # we will build a new array
-    while shift ; do
-        if [[ "$needle" != "$1" ]] ; then
-            nArray=( ${nArray[@]} "$1" )
-        fi
-    done
+    { local needle="$1"
+      declare -a nArray  # we will build a new array
+      while shift ; do
+          if [[ "$needle" != "$1" ]] ; then
+              nArray=( ${nArray[@]} "$1" )
+          fi
+      done
+    } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
     # we return the array as a string
     echo "${nArray[@]}"
 }
+


### PR DESCRIPTION
Intent:
Improve readability of the ReaR log file by suppressing
particular `set -x` debug output that is usually of no interest
so that it gets easier for our users and for us to analyze an issue
by inspecting the log file when rear was called in debugscripts mode.

* Type: **Enhancement**

* Impact: **Low**

* How was this pull request tested?
By me on my openSUSE Leap 15.0 system

* Brief description of the changes in this pull request:

I think a noticeable part of the `set -x` debugscripts output
(that part is about 25% for my initial test, see below)
is usually of no interest and therefore dispensable by default.

This pull request is a proposal how we could suppress dispensable
debug output by default (in particular when rear is called with '-D')
unless rear is called with '--debugscripts x' where the full debugscripts
output is still there as it was before.

The basic idea is to suppress uninteresting output that goes to stderr
(in particular where `set -x` debugscripts output is usually of no interest)
by default via setting in usr/sbin/rear (i.e. this is no user config variable)
```
DISPENSABLE_OUTPUT_DEV="null"
```
and by using where applicable in the scripts code of the form
```
{ command_1
  command_2
  ...
  command_N
} 2>>/dev/$DISPENSABLE_OUTPUT_DEV
```
provided none of the commands outputs intentionally to stderr
(i.e. there is only `set -x` debugscripts output for the commands)
unless rear is called with '--debugscripts x' where in usr/sbin/rear
```
DISPENSABLE_OUTPUT_DEV="stderr"
```
is set which results in the above code
```
...
} 2>>/dev/stderr
```
and /dev/stderr is fd2 which is redirected to append to RUNTIME_LOGFILE
so that 2>>/dev/stderr does not change things and fd2 output is still
appended to RUNTIME_LOGFILE.

What happens in compacted form is with `2>>/dev/null`
```
# ( cat /dev/null >/tmp/mystderr ; exec 2>>/tmp/mystderr ; exec 1>&2 ; echo foo ; cat qqq ; echo bar ; cat QQQ 2>>/dev/null ; echo baz ) ; cat -n /tmp/mystderr
     1  foo
     2  cat: qqq: No such file or directory
     3  bar
     4  baz
```
versus with `2>>/dev/stderr`
```
# ( cat /dev/null >/tmp/mystderr ; exec 2>>/tmp/mystderr ; exec 1>&2 ; echo foo ; cat qqq ; echo bar ; cat QQQ 2>>/dev/stderr ; echo baz ) ; cat -n /tmp/mystderr
     1  foo
     2  cat: qqq: No such file or directory
     3  bar
     4  cat: QQQ: No such file or directory
     5  baz
```
FYI how things go wrong when `2>/dev/stderr` is used:
```
# ( cat /dev/null >/tmp/mystderr ; exec 2>>/tmp/mystderr ; exec 1>&2 ; echo foo ; cat qqq ; echo bar ; cat QQQ 2>/dev/stderr ; echo baz ) ; cat -n /tmp/mystderr
     1  cat: QQQ: No such file or directory
     2  baz
```
because `2>/file` truncates the file to zero size.

I tested `rear -D mkrescue` versus `rear --debugscripts x mkrescue`
and got 53807 `set -x` lines in the log file with suppressed dispensable debug output
versus 68862 `set -x` lines in the log file with full debugscripts output as it was before.

My initial suppressed dispensable debug output is primarily
the `set -x` debugscripts output for some outupt functions and
the `set -x` debugscripts output for IsInArray() and RmInArray().

@rear/contributors 
if you agree to the general idea behind and
if my implementation is not somehow broken by design
we could likely find more functions (or other code parts)
where the full `set -x` debug output is usually of no interest.
