### PR TITLE
Multipath optimizations

### DIFF
--- a/usr/share/rear/rescue/GNU/Linux/270_fc_transport_info.sh
+++ b/usr/share/rear/rescue/GNU/Linux/270_fc_transport_info.sh
@@ -1,3 +1,6 @@
+# don't collect this anymore, this can be very slow
+return 0
+
 # collect output from production SAN disks
 
 find /sys/class/fc_transport -follow -maxdepth 6 \( -name model -o -name vendor -o -name rev -name state -o -name model_name -o -name size -o -name node_name \) 2>/dev/null| egrep -v 'driver|rport|power|drivers|devices' | xargs grep '.' > $VAR_DIR/recovery/fc_transport.info  >&2


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **High**

* Reference to related issue (URL): #2020 

* How was this pull request tested? Tested by customer

* Brief description of the changes in this pull request:

When a system has many multipath devices (547 disks, 272 x 2 paths), creating the ReaR rescue takes several hours. This is due to:
- the `get_device_name()` function to scan all multipath devices multiple times without caching the information (legacy code, when kernel has no `/sys/block/<dev>/dm/name` node)
- the `get_device_name()` function to scan the multipath devices even if there is no need for that
- the collect of unused `/sys/class/fc_transport` information

With these optimizations, the ReaR rescue takes a few minutes only.