### PR TITLE
Fix for commit f9e53a33

### DIFF
--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -60,7 +60,7 @@ function build_bootx86_efi {
     local grub_module=""
     local grub_modules=""
     for grub_module in part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs ; do
-        test "$( find /boot -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
+        test "$( find /boot /usr/lib/grub* -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
     done
     if ! $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" $grub_modules ; then
         Error "Failed to make bootable EFI image of GRUB2 (error during $gmkimage of BOOTX64.efi)"


### PR DESCRIPTION
##### Pull Request Details:

* Type: Bug Fix

* Impact: **High**

* Reference to related issue (URL): https://github.com/rear/rear/commit/f9e53a331c226fa305145866492bb978a1e66a2a

* How was this pull request tested?
Created and UEFI booted ReaR recovery system on RHEL 7.6, SLES12 SP2 and Fedora29

* Brief description of the changes in this pull request:
It looks like https://github.com/rear/rear/commit/f9e53a331c226fa305145866492bb978a1e66a2a introduced a regression for Linux distributions that ships Grub2 EFI modules (grub2-efi-x64-modules) only in _/usr/lib/grub*/x86_64-efi_ but does not copy them to _/boot_ when installed (observed on RHEL7.6 and Fedora29 so far, but there might be more ...).
Missing modules in _/boot_ combined with code from https://github.com/rear/rear/commit/f9e53a331c226fa305145866492bb978a1e66a2a 
```
test "$( find /boot -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
```
are causing that resulting boot loader _BOOTX64.efi_ is silently missing all the important modules because `grub-mkimage` is executed without any module as follows:
```
++ grub2-mkimage -v -O x86_64-efi -c /tmp/rear.XqviherDVAkuSdo/tmp/mnt/EFI/BOOT/embedded_grub.cfg -o /tmp/rear.XqviherDVAkuSdo/tmp/mnt/EFI/BOOT/BOOTX64.efi -p /EFI/BOOT
```
where command should look something like:
```
++ grub2-mkimage -v -O x86_64-efi -c /tmp/rear.0al2HwSlvQ5XsiC/tmp/mnt/EFI/BOOT/embedded_grub.cfg -o /tmp/rear.0al2HwSlvQ5XsiC/tmp/mnt/EFI/BOOT/BOOTX64.efi -p /EFI/BOOT part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs
```

ReaR rescue system is created, but after boot attempt following message appear:
![screenshot from 2019-02-11 20-24-01](https://user-images.githubusercontent.com/12116358/52587767-0f878a80-2e3b-11e9-9f23-27f3243d36c8.png)

This was originally proposed by @jsmeix in https://github.com/rear/rear/pull/2001#issuecomment-446536035 but somehow fall into oblivion.

V.