### PR TITLE
Do not patch $TARGET_FS_ROOT/etc/mtab if symbolic link.

### DIFF
--- a/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
+++ b/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
@@ -34,6 +34,13 @@ for file in 	[b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* \
 		[e]tc/security/pam_mount.conf.xml [b]oot/efi/*/*/grub.cfg
 	do
 
+	# $TARGET_FS_ROOT/etc/mtab is no longer regular file but symbolic link
+	# pointing to /proc/mounts resp /proc/self/mounts.
+	# We should not poke around /proc with `sed -i` for this reason we will
+	# check if $TARGET_FS_ROOT/etc/mtab is symbolic link and skip all further
+	# replacements.
+	[[ "$file" = "etc/mtab" && -L "$file" ]] && continue
+
 	#[[ -d "$file" ]] && continue # skip directory
 	[[ ! -f "$file" ]] && continue # skip directory and file not found
 	# sed -i bails on symlinks, so we follow the symlink and patch the result


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/pull/2047#issuecomment-464846777

* How was this pull request tested?
Full backup restore on Arch Linux with:
1. mtab as regular file
2. mtab as symbolic link

* Brief description of the changes in this pull request:
In the past when _/etc/mtab_ was a regular file it was desirable to update disk UUIDs inside file (along with _/etc/fstab_)
When _/etc/mtab_ become symbolic link pointing to _/proc/mtab_ resp _/proc/self/mtab_, we don't want to perform any replacements with `sed -i` (nor any other editor) because data are already up to date.