### PR TITLE
add eno-fix.rules to the RULE_FILES array #2046

### DIFF
--- a/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
+++ b/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
@@ -6,7 +6,7 @@
 have_udev || return 0
 
 # we treat only these rules
-RULE_FILES=( $( echo /etc/udev/rules.d/*persistent*{names,net,cd}.rules /etc/udev/rules.d/*eno-fix.rules ) )
+RULE_FILES=( /etc/udev/rules.d/*persistent*{names,net,cd}.rules /etc/udev/rules.d/*eno-fix.rules )
 # the result looks like this on various systems:
 #   rear-centos4: ERROR
 #   rear-debian5: /etc/udev/rules.d/70-persistent-cd.rules

--- a/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
+++ b/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
@@ -6,7 +6,7 @@
 have_udev || return 0
 
 # we treat only these rules
-RULE_FILES=( $( echo /etc/udev/rules.d/*persistent*{names,net,cd}.rules ) )
+RULE_FILES=( $( echo /etc/udev/rules.d/*persistent*{names,net,cd}.rules /etc/udev/rules.d/*eno-fix.rules ) )
 # the result looks like this on various systems:
 #   rear-centos4: ERROR
 #   rear-debian5: /etc/udev/rules.d/70-persistent-cd.rules

--- a/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
+++ b/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
@@ -32,7 +32,6 @@ for rule in "${RULE_FILES[@]}" ; do
         # may have prevented the restore of one of these files
         [[ -f $TARGET_FS_ROOT/"$rule" ]] && cp $v $TARGET_FS_ROOT/"$rule" $TARGET_FS_ROOT/root/rear-"$rulefile".old >&2
         # copy the $rule from the rescue image to $TARGET_FS_ROOT/
-        cp $v "$rule" $TARGET_FS_ROOT/"$rule" >&2
-        StopIfError "Could not copy '$rule' -> '$TARGET_FS_ROOT/$rule'"
+        cp $v "$rule" $TARGET_FS_ROOT/"$rule" || LogPrintError "Failed to copy '$rule' -> '$TARGET_FS_ROOT/$rule'"
     fi
 done

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
@@ -12,7 +12,7 @@
 #
 
 # Get the rule files (though it should be only one):
-RULE_FILES=( /etc/udev/rules.d/*persistent*{names,net}.rules /etc/udev/rules.d/*eno-fix.rules )
+RULE_FILES=( /etc/udev/rules.d/*persistent*{names,net,cd}.rules /etc/udev/rules.d/*eno-fix.rules )
 ORIG_MACS_FILE=/etc/mac-addresses
 MAC_MAPPING_FILE=/etc/rear/mappings/mac
 MANUAL_MAC_MAPPING=

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
@@ -12,7 +12,7 @@
 #
 
 # Get the rule files (though it should be only one):
-RULE_FILES=( /etc/udev/rules.d/*persistent*{names,net}.rules )
+RULE_FILES=( /etc/udev/rules.d/*persistent*{names,net}.rules /etc/udev/rules.d/*eno-fix.rules )
 ORIG_MACS_FILE=/etc/mac-addresses
 MAC_MAPPING_FILE=/etc/rear/mappings/mac
 MANUAL_MAC_MAPPING=


### PR DESCRIPTION
Signed-off-by: Gratien D'haese <gratien.dhaese@gmail.com>

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): #2046 

* How was this pull request tested? at the customer site with success

* Brief description of the changes in this pull request: See #2046 for the full problem description.

> What we found is that Red Hat Enterprise Linux 7 virtual guests using the vmxnet3 driver on VMware hypervisors have names such as eno16780032 instead of an expected name such as ens192 (scheme 2). Unfortunately, this can lead to not only inconsistent network device names but sometimes network loss when the virtual guest machine or the hypervisor was rebooted.

