### PR TITLE
630_run_efibootmgr.sh wrongly checks boot loader outside chroot

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/630_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/630_run_efibootmgr.sh
@@ -9,7 +9,7 @@ is_true $EFI_STUB && return 0
 
 # UEFI_BOOTLOADER empty or not a regular file means using BIOS cf. rescue/default/850_save_sysfs_uefi_vars.sh
 # Double quotes are mandatory here because 'test -f' without any (possibly empty) argument results true:
-test -f "$UEFI_BOOTLOADER" || return 0
+test -f "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" || return 0
 
 # Determine where the EFI System Partition (ESP) is mounted in the currently running recovery system:
 esp_mountpoint=$( df -P "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" | tail -1 | awk '{print $6}' )


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/2035#issuecomment-465602717

* How was this pull request tested?
Full backup restore on UEFI bootable RHEL 7.6

* Brief description of the changes in this pull request:
When system is set for UEFI boot, _finalize/Linux-i386/630_run_efibootmgr.sh_ script should create boot menu entry via `efibootmgr`. This however never happens because script is looking for $UEFI_BOOTLOADER outside chroot (_/mnt/local_) environment, where we unlikely find $UEFI_BOOTLOADER. This leads to messages like shown in https://github.com/rear/rear/issues/2035#issuecomment-465602717 (despite system might still boot without any problem).
This patch changes condition mentioned earlier and looks for $UEFI_BOOTLOADER inside of chrooted environment (_/mnt/local_).

