### PR TITLE
skip patching absolute symlinks during finalize stage (related to issue 1338)

### DIFF
--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
@@ -18,7 +18,7 @@ pushd $TARGET_FS_ROOT >&2
 
 # Save the original restored files because in general any user data is sacrosanct,
 # cf. how BACKUP_RESTORE_MOVE_AWAY is implemented in restore/default/990_move_away_restored_files.sh
-save_original_file_dir="$VAR_DIR/saved_original_files/"
+local save_original_file_dir="$VAR_DIR/saved_original_files/"
 # Strip leading '/' to get a relative path that is needed inside the recovery system:
 save_original_file_dir="${save_original_file_dir#/}"
 # Create the save_original_file_dir with mode 0700 (rwx------)
@@ -27,52 +27,74 @@ save_original_file_dir="${save_original_file_dir#/}"
 mkdir -p -m 0700 $save_original_file_dir
 LogPrint "The original restored files get saved in $save_original_file_dir (in $TARGET_FS_ROOT)"
 
-# The funny [] around the first letter make sure that shopt -s nullglob removes this file from the list if it does not exist.
-# Files without a [] are mandatory, like fstab:
-for file in [b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* [b]oot/grub/{grub.conf,menu.lst,device.map} \
-            [b]oot/grub2/{grub.conf,grub.cfg,menu.lst,device.map} \
-            [e]tc/sysconfig/grub [e]tc/sysconfig/bootloader \
-            [e]tc/lilo.conf \
-            [e]tc/yaboot.conf \
-            [e]tc/mtab [e]tc/fstab \
-            [e]tc/mtools.conf \
-            [e]tc/smartd.conf [e]tc/sysconfig/smartmontools \
-            [e]tc/sysconfig/rawdevices \
-            [e]tc/security/pam_mount.conf.xml [b]oot/efi/*/*/grub.cfg
-    do
-        # Skip directory or file not found:
-        test -f "$file" || continue
-        # sed -i bails on symlinks, so we follow the symlink and patch the result
-        # absolute links are rebased on $TARGET_FS_ROOT (/etc/fstab => $TARGET_FS_ROOT/etc/fstab)
-        # on dead links we warn and skip them
-        if test -L "$file" ; then
-            linkdest="$( readlink -m "$file" | sed -e "s#^/#$TARGET_FS_ROOT/#" )"
-            if test -f "$linkdest" ; then
-                LogPrint "Using symlink '$file' destination '$linkdest'"
-                file="$linkdest"
-            else
-                LogPrint "Skipping dead symlink '$file'"
+local symlink_target=""
+local restored_file=""
+# the funny [] around the first letter make sure that shopt -s nullglob removes this file from the list if it does not exist
+# the files without a [] are mandatory, like fstab FIXME: but below there is [e]tc/fstab not etc/fstab - why?
+
+for restored_file in [b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* [b]oot/grub/{grub.conf,menu.lst,device.map} \
+                     [b]oot/grub2/{grub.conf,grub.cfg,menu.lst,device.map} \
+                     [e]tc/sysconfig/grub [e]tc/sysconfig/bootloader \
+                     [e]tc/lilo.conf \
+                     [e]tc/yaboot.conf \
+                     [e]tc/mtab [e]tc/fstab \
+                     [e]tc/mtools.conf \
+                     [e]tc/smartd.conf [e]tc/sysconfig/smartmontools \
+                     [e]tc/sysconfig/rawdevices \
+                     [e]tc/security/pam_mount.conf.xml [b]oot/efi/*/*/grub.cfg
+do
+    # Silently skip directories and file not found:
+    test -f "$restored_file" || continue
+    # 'sed -i' bails out on symlinks, so we follow the symlink and patch the symlink target
+    # on dead links we inform the user and skip them
+    # TODO: We should do this inside 'chroot $TARGET_FS_ROOT' so that absolute symlinks will work correctly
+    # cf. https://github.com/rear/rear/issues/1338
+    if test -L "$restored_file" ; then
+        if symlink_target="$( readlink -f "$restored_file" )" ; then
+            # symlink_target is an absolute path in the recovery system
+            # e.g. the symlink target of etc/mtab is /mnt/local/proc/12345/mounts
+            # because we use only 'pushd $TARGET_FS_ROOT' but not 'chroot $TARGET_FS_ROOT'.
+            # If the symlink target does not start with /mnt/local/ (i.e. if it does not start with $TARGET_FS_ROOT)
+            # it is an absolute symlink (e.g. inside $TARGET_FS_ROOT a symlink points to /absolute/path/file)
+            # and the target of an absolute symlink is not within the recreated system but in the recovery system
+            # where it does not make sense to patch files, cf. https://github.com/rear/rear/issues/1338
+            # so that we skip patching symlink targets that are not within the recreated system:
+            if ! echo $symlink_target | grep -q "^$TARGET_FS_ROOT/" ; then
+                LogPrint "Skip patching symlink $restored_file target $symlink_target not within $TARGET_FS_ROOT"
                 continue
             fi
-        fi
-        # Skip empty files:
-        test -s "$file" || continue
-        # Save the original file:
-        # Clean up already existing stuff in save_original_file_dir
-        # that would be (partially) overwritten by the current copy
-        # (such stuff is considered as outdated leftover e.g. from a previous recovery)
-        # but keep already existing stuff in the save_original_file_dir because
-        # any user data is sacrosanct (also outdated stuff from a previous recovery):
-        rm -rf "$save_original_file_dir/$file"
-        # Copy the original file with its directory path:
-        cp -a --parents "$file" $save_original_file_dir
-        # Inform the user but do not error out here at this late state of "rear recover"
-        # when it failed to apply the layout mappings to one particular restored file:
-        if apply_layout_mappings "$file" ; then
-            LogPrint "Applied disk layout mappings to restored '$file' (in $TARGET_FS_ROOT)"
+            # If the symlink target contains /proc/ /sys/ /dev/ or /run/ we skip it because then
+            # the symlink target is considered to not be a restored file that needs to be patched
+            # cf. https://github.com/rear/rear/pull/2047#issuecomment-464846777
+            if echo $symlink_target | egrep -q '/proc/|/sys/|/dev/|/run/' ; then
+                LogPrint "Skip patching symlink $restored_file target $symlink_target on /proc/ /sys/ /dev/ or /run/"
+                continue
+            fi
+            LogPrint "Patching symlink $restored_file target $symlink_target"
+            restored_file="$symlink_target"
         else
-            LogPrintError "Failed to apply disk layout mappings to restored '$file' (in $TARGET_FS_ROOT)"
+            LogPrint "Skip patching dead symlink $restored_file"
+            continue
         fi
+    fi
+    # Silently skip empty files:
+    test -s "$restored_file" || continue
+    # Save the original file:
+    # Clean up already existing stuff in save_original_file_dir
+    # that would be (partially) overwritten by the current copy
+    # (such stuff is considered as outdated leftover e.g. from a previous recovery)
+    # but keep already existing stuff in the save_original_file_dir because
+    # any user data is sacrosanct (also outdated stuff from a previous recovery):
+    rm -rf "$save_original_file_dir/$restored_file"
+    # Copy the original file with its directory path:
+    cp $v -a --parents "$restored_file" $save_original_file_dir
+    # Inform the user but do not error out here at this late state of "rear recover"
+    # when it failed to apply the layout mappings to one particular restored file:
+    if apply_layout_mappings "$restored_file" ; then
+        LogPrint "Applied disk layout mappings to restored '$restored_file' (in $TARGET_FS_ROOT)"
+    else
+        LogPrintError "Failed to apply disk layout mappings to restored '$restored_file' (in $TARGET_FS_ROOT)"
+    fi
 done
 
 popd >&2

--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_lun_wwid.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_lun_wwid.sh
@@ -3,48 +3,68 @@
 # skip if no mappings
 test -s "$LUN_WWID_MAP" || return 0
 
+# FIXME: What the heck does that "TAG-15-migrate-wwid" mean?
 Log "TAG-15-migrate-wwid: $LUN_WWID_MAP"
 
-# create the SED_SCRIPT
-SED_SCRIPT=""
+# create the sed script
+local sed_script=""
+local old_wwid new_wwid device
 while read old_wwid new_wwid device ; do
-        SED_SCRIPT="$SED_SCRIPT;/${old_wwid}/s/${old_wwid}/${new_wwid}/g"
-done < <(sort -u $LUN_WWID_MAP)
-
+    sed_script="$sed_script;/${old_wwid}/s/${old_wwid}/${new_wwid}/g"
+done < <( sort -u $LUN_WWID_MAP )
 # debug line:
-Log "$SED_SCRIPT"
+Debug "$sed_script"
 
 # Careful in case of 'return' after 'pushd' (must call the matching 'popd' before 'return'):
 pushd $TARGET_FS_ROOT >&2
 
 # now run sed
+LogPrint "Migrating LUN WWIDs in certain restored files in $TARGET_FS_ROOT to current WWIDs ..."
 
+local symlink_target=""
+local restored_file=""
 # the funny [] around the first letter make sure that shopt -s nullglob removes this file from the list if it does not exist
-# the files without a [] are mandatory, like fstab
-for file in [e]tc/elilo.conf \
-            [e]tc/fstab
-        do
-
-        #[[ -d "$file" ]] && continue # skip directory
-        [[ ! -f "$file" ]] && continue # skip directory and file not found
-        # sed -i bails on symlinks, so we follow the symlink and patch the result
-        # on dead links we warn and skip them
-        # TODO: maybe we must put this into a chroot so that absolute symlinks will work correctly
-	    if test -L "$file" ; then
-            if linkdest="$(readlink -f "$file")" ; then
-                # if link destination is residing on /proc we skip it silently
-			    echo $linkdest | grep -q "^/proc" && continue
-			    LogPrint "Patching '$linkdest' instead of '$file'"
-			    file="$linkdest"
-		    else
-                LogPrint "Not patching dead link '$file'"
-			    continue
-			fi
+# the files without a [] are mandatory, like fstab FIXME: but below there is [e]tc/fstab not etc/fstab - why?
+for restored_file in [e]tc/elilo.conf \
+                     [e]tc/fstab
+do
+    # Silently skip directories and file not found:
+    test -f "$restored_file" || continue
+    # 'sed -i' bails out on symlinks, so we follow the symlink and patch the symlink target
+    # on dead links we inform the user and skip them
+    # TODO: We should do this inside 'chroot $TARGET_FS_ROOT' so that absolute symlinks will work correctly
+    # cf. https://github.com/rear/rear/issues/1338
+    if test -L "$restored_file" ; then
+        if symlink_target="$( readlink -f "$restored_file" )" ; then
+            # symlink_target is an absolute path in the recovery system
+            # e.g. the symlink target of etc/mtab is /mnt/local/proc/12345/mounts
+            # because we use only 'pushd $TARGET_FS_ROOT' but not 'chroot $TARGET_FS_ROOT'.
+            # If the symlink target does not start with /mnt/local/ (i.e. if it does not start with $TARGET_FS_ROOT)
+            # it is an absolute symlink (i.e. inside $TARGET_FS_ROOT a symlink points to /absolute/path/file)
+            # and the target of an absolute symlink is not within the recreated system but in the recovery system
+            # where it does not make sense to patch files, cf. https://github.com/rear/rear/issues/1338
+            # so that we skip patching symlink targets that are not within the recreated system:
+            if ! echo $symlink_target | grep -q "^$TARGET_FS_ROOT/" ; then
+                LogPrint "Skip patching symlink $restored_file target $symlink_target not within $TARGET_FS_ROOT"
+                continue
+            fi
+            # If the symlink target contains /proc/ /sys/ /dev/ or /run/ we skip it because then
+            # the symlink target is considered to not be a restored file that needs to be patched
+            # cf. https://github.com/rear/rear/pull/2047#issuecomment-464846777
+            if echo $symlink_target | egrep -q '/proc/|/sys/|/dev/|/run/' ; then
+                LogPrint "Skip patching symlink $restored_file target $symlink_target on /proc/ /sys/ /dev/ or /run/"
+                continue
+            fi
+            LogPrint "Patching symlink $restored_file target $symlink_target"
+            restored_file="$symlink_target"
+        else
+            LogPrint "Skip patching dead symlink $restored_file"
+            continue
         fi
-
-        LogPrint "Patching file '$file'"
-        sed -i "$SED_SCRIPT" "$file"
-        StopIfError "Patching '$file' with sed failed."
+    fi
+    LogPrint "Patching LUN WWIDs in $restored_file to current WWIDs"
+    # Do not error out at this late state of "rear recover" (after the backup was restored) but inform the user:
+    sed -i "$sed_script" "$restored_file" || LogPrintError "Migrating LUN WWIDs in $restored_file to current WWIDs failed"
 done
 
 popd >&2

--- a/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
+++ b/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
@@ -47,6 +47,15 @@ do
             # symlink_target is an absolute path in the recovery system
             # e.g. the symlink target of etc/mtab is /mnt/local/proc/12345/mounts
             # because we use only 'pushd $TARGET_FS_ROOT' but not 'chroot $TARGET_FS_ROOT'.
+            # If the symlink target does not start with /mnt/local/ (i.e. if it does not start with $TARGET_FS_ROOT)
+            # it is an absolute symlink (i.e. inside $TARGET_FS_ROOT a symlink points to /absolute/path/file)
+            # and the target of an absolute symlink is not within the recreated system but in the recovery system
+            # where it does not make sense to patch files, cf. https://github.com/rear/rear/issues/1338
+            # so that we skip patching symlink targets that are not within the recreated system:
+            if ! echo $symlink_target | grep -q "^$TARGET_FS_ROOT/" ; then
+                LogPrint "Skip patching symlink $restored_file target $symlink_target not within $TARGET_FS_ROOT"
+                continue
+            fi
             # If the symlink target contains /proc/ /sys/ /dev/ or /run/ we skip it because then
             # the symlink target is considered to not be a restored file that needs to be patched
             # cf. https://github.com/rear/rear/pull/2047#issuecomment-464846777

--- a/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
+++ b/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
@@ -25,13 +25,20 @@ RULE_FILES=( /etc/udev/rules.d/*persistent*{names,net,cd}.rules /etc/udev/rules.
 # and, if they differ, copy the version from the rescue system into the recovered system, of course
 # preserving a backup in /root/rear-*.old
 for rule in "${RULE_FILES[@]}" ; do
-    rulefile="$(basename "$rule")"
-    if test -s "$rule" && ! diff -q "$rule" $TARGET_FS_ROOT/"$rule" >/dev/null ; then
-        LogPrint "Updating udev configuration ($rulefile)"
-        # test for file $TARGET_FS_ROOT/"$rule" as BACKUP_RESTORE_MOVE_AWAY_FILES variable
-        # may have prevented the restore of one of these files
-        [[ -f $TARGET_FS_ROOT/"$rule" ]] && cp $v $TARGET_FS_ROOT/"$rule" $TARGET_FS_ROOT/root/rear-"$rulefile".old >&2
-        # copy the $rule from the rescue image to $TARGET_FS_ROOT/
-        cp $v "$rule" $TARGET_FS_ROOT/"$rule" || LogPrintError "Failed to copy '$rule' -> '$TARGET_FS_ROOT/$rule'"
-    fi
+    rulefile="$( basename "$rule" )"
+    # Skip if the one in the rescue system does not exists or is empty:
+    test -s "$rule" || continue
+    # Skip if the one in the rescue system is the same as the one from the restores backup:
+    cmp -s "$rule" $TARGET_FS_ROOT/"$rule" && continue
+    # Test for file $TARGET_FS_ROOT/$rule as BACKUP_RESTORE_MOVE_AWAY_FILES variable
+    # may have prevented the restore of one of these files:
+    test -f "$TARGET_FS_ROOT/$rule" && cp $v "$TARGET_FS_ROOT/$rule" $TARGET_FS_ROOT/root/rear-"$rulefile".old
+    # Copy the rule from the rescue system to TARGET_FS_ROOT even if it did not exist in TARGET_FS_ROOT.
+    # FIXME: It does not look right to test for $TARGET_FS_ROOT/$rule before making a backup in /root/rear-*.old
+    # but to copy it from the rescue system into TARGET_FS_ROOT in any case even if it did not exist before
+    # (why do we put files into the target system that were not restored from the backup?)
+    # or when BACKUP_RESTORE_MOVE_AWAY_FILES has explicitly moved it away:
+    LogPrint "Updating udev rule '$rulefile' with the one from the Relax-and-Recover rescue system"
+    cp $v "$rule" "$TARGET_FS_ROOT/$rule" || LogPrintError "Failed to copy '$rule' to '$TARGET_FS_ROOT/$rule'"
 done
+

--- a/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
+++ b/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
@@ -20,25 +20,28 @@ RULE_FILES=( /etc/udev/rules.d/*persistent*{names,net,cd}.rules /etc/udev/rules.
 #    rear-sles11: /etc/udev/rules.d/70-persistent-cd.rules
 #    rear-sles11: /etc/udev/rules.d/70-persistent-net.rules
 #     rear-sles9: ERROR
+# SLES12-SP4 and openSUSE Leap 15.0: /etc/udev/rules.d/70-persistent-net.rules
 
-# for each rule file compare the version in the rescue system with the version in the restores backup
+# For each rule file compare the version in the rescue system with the version in the restored backup
 # and, if they differ, copy the version from the rescue system into the recovered system, of course
 # preserving a backup in /root/rear-*.old
 for rule in "${RULE_FILES[@]}" ; do
-    rulefile="$( basename "$rule" )"
+    # Skip if there was no such udev rule file restored from the backup
+    # because we must not put files into the recreated system that have not been there
+    # in particular no udev rule files because wrong udev rules can cause severe issues.
+    # E.g. nowadays /etc/udev/rules.d/70-persistent-net.rules is created and maintained
+    # by systemd/udev (see https://github.com/rear/rear/issues/770) so that we must not
+    # mess around with systemd/udev by creating udev rules in the recreated system:
+    test -f "$TARGET_FS_ROOT/$rule" || continue
     # Skip if the one in the rescue system does not exists or is empty:
     test -s "$rule" || continue
-    # Skip if the one in the rescue system is the same as the one from the restores backup:
-    cmp -s "$rule" $TARGET_FS_ROOT/"$rule" && continue
-    # Test for file $TARGET_FS_ROOT/$rule as BACKUP_RESTORE_MOVE_AWAY_FILES variable
-    # may have prevented the restore of one of these files:
-    test -f "$TARGET_FS_ROOT/$rule" && cp $v "$TARGET_FS_ROOT/$rule" $TARGET_FS_ROOT/root/rear-"$rulefile".old
-    # Copy the rule from the rescue system to TARGET_FS_ROOT even if it did not exist in TARGET_FS_ROOT.
-    # FIXME: It does not look right to test for $TARGET_FS_ROOT/$rule before making a backup in /root/rear-*.old
-    # but to copy it from the rescue system into TARGET_FS_ROOT in any case even if it did not exist before
-    # (why do we put files into the target system that were not restored from the backup?)
-    # or when BACKUP_RESTORE_MOVE_AWAY_FILES has explicitly moved it away:
-    LogPrint "Updating udev rule '$rulefile' with the one from the Relax-and-Recover rescue system"
+    # Skip if the one in the rescue system is the same as the one from the restored backup:
+    cmp -s "$rule" "$TARGET_FS_ROOT/$rule" && continue
+    # Save the one that was restored from the backup:
+    rulefile="$( basename "$rule" )"
+    cp $v "$TARGET_FS_ROOT/$rule" $TARGET_FS_ROOT/root/rear-"$rulefile".old
+    # Overwrite the one that was restored from the backup with the one from the rescue system:
+    LogPrint "Replacing restored udev rule '$TARGET_FS_ROOT/$rule' with the one from the ReaR rescue system"
     cp $v "$rule" "$TARGET_FS_ROOT/$rule" || LogPrintError "Failed to copy '$rule' to '$TARGET_FS_ROOT/$rule'"
 done
 

--- a/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
+++ b/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
@@ -1,5 +1,5 @@
 # rewrite all the network configuration files (currently Redhat/Suse/Debian/Ubuntu)
-# accoring to the mapping files
+# according to the mapping files
 
 # because the bash option nullglob is set in rear (see usr/sbin/rear)
 # PATCH_FILES is empty if nothing matches $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-* $TARGET_FS_ROOT/etc/network/inter[f]aces or $TARGET_FS_ROOT/etc/network/interfaces.d/*
@@ -9,26 +9,36 @@ PATCH_FILES=( $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-* $TARGET_FS_ROOT/etc/networ
 # skip if no network configuration files are found
 test $PATCH_FILES || return 0
 
-# strip all comments and empty lines from the mapping files and copy
-# the results to a temporary directory
-mkdir -p $TMP_DIR/mappings
-StopIfError "Could not create $TMP_DIR/mappings"
+# Strip all comments and empty lines from the mapping files and copy the results to a temporary directory.
+# Do not error out at this late state of "rear recover" (after the backup was restored) but inform the user:
+if ! mkdir $v -p $TMP_DIR/mappings ; then
+    LogPrintError "Cannot migrate network configuration files according to the mapping files (could not create $TMP_DIR/mappings)"
+fi
 for mapping_file in mac ip_addresses routes ; do
     read_and_strip_file $CONFIG_DIR/mappings/$mapping_file > $TMP_DIR/mappings/$mapping_file
 done
 
+LogPrint "Migrating network configuration files according to the mapping files ..."
+
+# TODO:
+# All finalize scripts that patch restored files within TARGET_FS_ROOTshould do the same symlink handling which means:
+# 1. Skip patching symlink targets that are not within TARGET_FS_ROOT (i.e. when it is an absolute symlink)
+# 2. Skip patching if the symlink target contains /proc/ /sys/ /dev/ or /run/
+# 3. Skip patching dead symlinks
+# See the symlink handling code in finalize/GNU/Linux/280_migrate_uuid_tags.sh and other such files,
+# cf. https://github.com/rear/rear/pull/2055 and https://github.com/rear/rear/issues/1338
 
 # rewrite the changed mac addresses if a valid mapping exists
 if test -s $TMP_DIR/mappings/mac ; then
 
     # create sed script
-    SED_SCRIPT=""
+    sed_script=""
     while read old_mac new_mac dev ; do
-        SED_SCRIPT="$SED_SCRIPT;s/$old_mac/$new_mac/g"
+        sed_script="$sed_script;s/$old_mac/$new_mac/g"
         # get device name from mac in case of inet renaming
         new_dev=$( get_device_by_hwaddr "$new_mac" )
         if test "$new_dev" != "$old_dev" ; then
-            SED_SCRIPT="$SED_SCRIPT;s/$dev/$new_dev/g"
+            sed_script="$sed_script;s/$dev/$new_dev/g"
         fi
     done < <( read_and_strip_file $CONFIG_DIR/mappings/mac | sed -e 'p;y/abcdef/ABCDEF/' )
     #                                              ^^^^^^^
@@ -37,13 +47,15 @@ if test -s $TMP_DIR/mappings/mac ; then
     #       the MAC adresses in upper case and since I don't want to mess with this I treat it as
     #       separate things and do the replacement case-sensitive
 
-    Log "SED_SCRIPT: '$SED_SCRIPT'"
-    sed -i -e "$SED_SCRIPT" "${PATCH_FILES[@]}"
-    LogPrintIfError "WARNING! There was an error patching the network configuration files!"
+    Debug "sed_script: '$sed_script'"
+
+    for patch_file in "${PATCH_FILES[@]}" ; do
+        sed -i -e "$sed_script" "$patch_file" || LogPrintError "Migrating network configuration in $patch_file failed"
+    done
 
     # rename files
     for file in "${PATCH_FILES[@]}"; do
-        new_file="$(sed -e "$SED_SCRIPT" <<<"$file")"
+        new_file="$(sed -e "$sed_script" <<<"$file")"
         if test "$new_file" -a "$new_file" != "$file" ; then
             mv $v "$file" "$new_file" >&2
         fi
@@ -81,26 +93,24 @@ if test -s $TMP_DIR/mappings/ip_addresses ; then
         # Fedora/Suse Family
         for network_file in $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-*${new_mac}* $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-*${dev}*; do
             # TODO: what if NETMASK keyword is not defined? Should be keep new_ip then??
-            SED_SCRIPT="s#^IPADDR=.*#IPADDR='${nip}'#g;s#^NETMASK=.*#NETMASK='${nmask}'#g;s#^NETWORK=.*#NETWORK=''#g;s#^BROADCAST=.*#BROADCAST=''#g;s#^BOOTPROTO=.*#BOOTPROTO='static'#g;s#STARTMODE='[mo].*#STARTMODE='auto'#g;/^IPADDR_/d;/^LABEL_/d;/^NETMASK_/d"
-            Log "SED_SCRIPT: '$SED_SCRIPT'"
+            sed_script="s#^IPADDR=.*#IPADDR='${nip}'#g;s#^NETMASK=.*#NETMASK='${nmask}'#g;s#^NETWORK=.*#NETWORK=''#g;s#^BROADCAST=.*#BROADCAST=''#g;s#^BOOTPROTO=.*#BOOTPROTO='static'#g;s#STARTMODE='[mo].*#STARTMODE='auto'#g;/^IPADDR_/d;/^LABEL_/d;/^NETMASK_/d"
+            Debug "sed_script: '$sed_script'"
             LogPrint "Patching file ${network_file##*/}"
-            sed -i -e "$SED_SCRIPT" "$network_file"
-            LogPrintIfError "WARNING! There was an error patching the network configuration files!"
+            sed -i -e "$sed_script" "$network_file" || LogPrintError "Migrating network configuration in $network_file failed"
         done
 
         #Debian / ubuntu Family (with network interfaces configuration files)
         for network_file in $TARGET_FS_ROOT/etc/network/inter[f]aces $TARGET_FS_ROOT/etc/network/interfaces.d/* ; do
             new_dev=$( get_device_by_hwaddr "$new_mac" )
-            SED_SCRIPT="\
+            sed_script="\
                 /iface $new_dev/ s/;address [0-9.]*;/;address ${nip};/g ;\
                 /iface $new_dev/ s/;netmask [0-9.]*;/;netmask ${nmask};/g"
-            Log "SED_SCRIPT: '$SED_SCRIPT'"
+            Debug "sed_script: '$sed_script'"
 
             tmp_network_file="$TMP_DIR/${network_file##*/}"
             linearize_interfaces_file "$network_file" > "$tmp_network_file"
 
-            sed -i -e "$SED_SCRIPT" "$tmp_network_file"
-            LogPrintIfError "WARNING! There was an error patching the network configuration files!"
+            sed -i -e "$sed_script" "$tmp_network_file" || LogPrintError "Migrating network configuration for $network_file in $tmp_network_file failed"
 
             rebuild_interfaces_file_from_linearized "$tmp_network_file" > "$network_file"
         done
@@ -116,30 +126,30 @@ if test -s $TMP_DIR/mappings/routes ; then
         if [[ "$destination" = "default" ]]; then
             # Fedora/Suse Family
             for network_file in $TARGET_FS_ROOT/etc/sysconfig/*/ifcfg-*${device}* $TARGET_FS_ROOT/etc/sysconfig/network ; do
-                SED_SCRIPT="s#^GATEWAY=.*#GATEWAY='$gateway'#g;s#^GATEWAYDEV=.*#GATEWAYDEV='$device'#g"
-                Log "SED_SCRIPT: '$SED_SCRIPT'"
-                sed -i -e "$SED_SCRIPT" "$network_file"
-                LogPrintIfError "WARNING! There was an error patching the network configuration files!"
+                sed_script="s#^GATEWAY=.*#GATEWAY='$gateway'#g;s#^GATEWAYDEV=.*#GATEWAYDEV='$device'#g"
+                Debug "sed_script: '$sed_script'"
+                sed -i -e "$sed_script" "$network_file" || LogPrintError "Migrating network configuration in $network_file failed"
             done
 
             #Debian / ubuntu Family (with network interfaces configuration files)
             for network_file in $TARGET_FS_ROOT/etc/network/inter[f]aces $TARGET_FS_ROOT/etc/network/interfaces.d/* ; do
                 new_dev=$( get_device_by_hwaddr "$new_mac" )
-                SED_SCRIPT="/iface $new_dev/ s/;gateway [0-9.]*;/;gateway $gateway;/g"
+                sed_script="/iface $new_dev/ s/;gateway [0-9.]*;/;gateway $gateway;/g"
+                Debug "sed_script: '$sed_script'"
 
                 tmp_network_file="$TMP_DIR/${network_file##*/}"
                 linearize_interfaces_file "$network_file" > "$tmp_network_file"
 
-                sed -i -e "$SED_SCRIPT" "$tmp_network_file"
-                LogPrintIfError "WARNING! There was an error patching the network configuration files!"
+                sed -i -e "$sed_script" "$tmp_network_file" || LogPrintError "Migrating network configuration for $network_file in $tmp_network_file failed"
 
                 rebuild_interfaces_file_from_linearized "$tmp_network_file" > "$network_file"
             done
         else
             # static-routes or route-<device> settings?
             for network_file in $TARGET_FS_ROOT/etc/sysconfig/*/route-*${device}* $TARGET_FS_ROOT/etc/sysconfig/static-routes ; do
-                LogPrint "WARNING! Change entries in $network_file manually please!"
+                LogPrint "Cannot migrate network configuration in $network_file - you need to do that manually"
             done
         fi
     done
 fi
+

--- a/usr/share/rear/finalize/default/520_confirm_finalize.sh
+++ b/usr/share/rear/finalize/default/520_confirm_finalize.sh
@@ -1,16 +1,22 @@
 #
 # In migration mode let the user confirm that
 # the up to that point recreated system
-# (i.e. recreated disk layout plus restored backup)
-# is ready to run the finalize stage
-# (i.e. to recreate the initrd and to reinstall the bootloader).
+# (i.e. recreated disk layout plus restored backup plus
+#  migrated certain restored files by 'finalize' scripts
+#  that were run before this user confirmation dialog appears)
+# is ready to recreate the initrd and to reinstall the bootloader
+# or let the user adapt his restored config files as he needs it
+# cf. https://github.com/rear/rear/pull/2055#issuecomment-468193571
 # For example in case of a changed disk layout certain config files
-# that were restored from the backup could contain outdated content
-# which may need manual adaptions before the initrd gets recreated
-# and the bootloader gets reinstalled.
+# that were restored from the backup could contain outdated or false content
+# which may need manual adaptions (in addition to what 'finalize' scripts did
+# that were run before or to correct what those scripts may have falsely done)
+# before the initrd gets recreated and the bootloader gets reinstalled.
 # In particular in case of a changed disk layout the restored etc/fstab
-# is usually outdated and needs to be manually adapted to get
-# the recreated system ready to run the scripts of the finalize stage.
+# is usually outdated and may need to be manually adapted to get
+# the recreated system ready to run the subsequent 'finalize' scripts
+# that recreate the initrd and reinstall the bootloader
+# via 'chroot' from within the recreated system.
 #
 
 # Skip if not in migration mode:
@@ -25,7 +31,7 @@ choices[1]="Edit restored etc/fstab ($restored_fstab)"
 choices[2]="View restored etc/fstab ($restored_fstab)"
 choices[3]="Use Relax-and-Recover shell and return back to here"
 choices[4]="Abort '$rear_workflow'"
-prompt="Confirm restored config files or edit them"
+prompt="Confirm restored config files are OK or adapt them as needed"
 choice=""
 wilful_input=""
 # When USER_INPUT_RESTORED_FILES_CONFIRMATION has any 'true' value be liberal in what you accept and


### PR DESCRIPTION
* Type: **Bug Fix** **Enhancement** **Cleanup**

* Impact: **Normal**

* Reference to related issue (URL):
skip patching absolute symlinks during finalize stage
is only a first step towards actually fixing
https://github.com/rear/rear/issues/1338

* How was this pull request tested?
Not yet tested and not yet complete - some more commits are needed...

* Brief description of the changes in this pull request:

All finalize scripts that patch restored files within TARGET_FS_ROOT
should do the same symlink handling which means

1. Skip patching symlink targets that are not within TARGET_FS_ROOT
(i.e. when it is an absolute symlink)

2. Skip patching if the symlink target contains /proc/ /sys/ /dev/ or /run/

3. Skip patching dead symlinks

Skip patching symlink targets that are not within TARGET_FS_ROOT
does not actually fix https://github.com/rear/rear/issues/1338
but at least it should avoid patching wrong files
so that for now this pull request before the ReaR 2.5 release
is meant only as a first step towards actually fixing
https://github.com/rear/rear/issues/1338
