### PR TITLE
Update 470_safe_filesystems.sh for NSR

### DIFF
--- a/usr/share/rear/rescue/NSR/default/470_safe_filesystems.sh
+++ b/usr/share/rear/rescue/NSR/default/470_safe_filesystems.sh
@@ -1,10 +1,5 @@
 # 470_safe_filesystems.sh
 #
-# In case NSR_CLIENT_MODE is enabled return else continue ...
-if is_true "$NSR_CLIENT_MODE"; then
-    return
-fi
-
 savefs -p -s $NSRSERVER 2>&1 | awk -F '(=|,)' '/path/ { printf ("%s ", $2) }' > $VAR_DIR/recovery/nsr_paths
 [[ ! -s $VAR_DIR/recovery/nsr_paths ]] && Error "The savefs command could not retrieve the \"save sets\" from this client"
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Improvement/Others?**

* Impact: **Low** 

* Reference to related issue (URL): None.

* How was this pull request tested? On a HP DL360 G9 / RHEL7.4

* Brief description of the changes in this pull request:
During the time working with the EMC Networker recovery I determined it is of additional use to not skip the retrieval of the filesystems in NSR_CLIENT_MODE I introduced with f09c3d3. It does not harm to do so since gathering this information is "read-only" for the client. 
Due to saving the save sets filesystem information in $VAR_DIR/recovery/nsr_paths within the recovery image one is able to retrieve/read this stored information during a recovery process i.e. for advising the EMC networker server team to recover the appropriate filesystem(-structure) from the backups beeing made.
