### PR TITLE
to avoid confusing in mkrescue run we do not print using archive #1363

### DIFF
--- a/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
+++ b/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
@@ -3,6 +3,10 @@
 
 # FIXME: backuparchive is no local variable (regardless that it is lowercased)
 
+# To avoid logging of 'Using backup archive' on the screen and in the log file
+# during a mkrescue run we add the following - #1363
+[[ "$WORKFLOW" = "mkrescue" ]] && return
+
 # If TAPE_DEVICE is specified, use that:
 if test "$TAPE_DEVICE" ; then
     backuparchive="$TAPE_DEVICE"


### PR DESCRIPTION
Signed-off-by: Gratien D'haese <gratien.dhaese@gmail.com>

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): #1363 

* How was this pull request tested? at the customer side

* Brief description of the changes in this pull request: when the WORKFLOW=mkrescue we immediately return from script `prep/NETFS/default/070_set_backup_archive.sh`

