### PR TITLE
Udev before multipath

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -33,6 +33,12 @@ blacklist {
         fi
     fi
 
+    # it is recommended to reload udev in order to have /sys updated with information from all the device path before activating multipath. 
+    # This could avoid situation like https://github.com/rear/rear/issues/2016 and https://github.com/rear/rear/issues/2002
+    udevadm control --reload-rules
+    udevadm trigger
+
+    # multipath activation. 
     LogPrint "Activating multipath"
     list_mpath_device=1
     modprobe dm-multipath >&2 && LogPrint "multipath activated" || LogPrint "Failed to load dm-multipath module"

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -37,6 +37,8 @@ blacklist {
     # This could avoid situation like https://github.com/rear/rear/issues/2016 and https://github.com/rear/rear/issues/2002
     udevadm control --reload-rules
     udevadm trigger
+    # Wait for udev trigger to finish device detection/creation
+    udevadm settle
 
     # multipath activation. 
     LogPrint "Activating multipath"


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2016
https://github.com/rear/rear/issues/2002

* How was this pull request tested?
sles12sp3 / rhel 7 with disk migration and multipath

* Brief description of the changes in this pull request:

refresh udev with trigger before activating multipath

Ensure that all information from multipath devices are updated by udev
into /sys before activating multipath. This is one of the root cause
of issues rear#2002 and rear#2016