### PR TITLE
network: Record permanent mac address when device is enslaved in a Team, or else /etc/mac-addresses will record broken information

### DIFF
--- a/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
+++ b/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
@@ -862,7 +862,7 @@ function handle_physdev () {
     local mac=""
 
     if has_binary ethtool ; then
-        mac="$( ethtool -P $network_interface 2>/dev/null | awk '{ print $3 }' )"
+        mac="$( ethtool -P $network_interface 2>/dev/null | awk '{ print $NF }' )"
     fi
     if [ -z "$mac" ] ; then
         if [ -e $sysfspath/bonding_slave/perm_hwaddr ] ; then

--- a/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
+++ b/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
@@ -562,7 +562,12 @@ function handle_team () {
     local network_interface=$1
     local sysfspath=/sys/class/net/$network_interface
 
-    if [ "$( ethtool -i $network_interface | awk '$1 == "driver:" { print $2 }' )" != "team" ] ; then
+    if has_binary ethtool ; then
+        if [ "$( ethtool -i $network_interface | awk '$1 == "driver:" { print $2 }' )" != "team" ] ; then
+            return $rc_error
+        fi
+    else
+        LogPrintError "Couldn't determine if network interface '$network_interface' is a Team, skipping."
         return $rc_error
     fi
 
@@ -854,10 +859,17 @@ function handle_physdev () {
 
     DebugPrint "$network_interface is a physical device"
 
-    if [ -e $sysfspath/bonding_slave/perm_hwaddr ] ; then
-        mac="$( cat $sysfspath/bonding_slave/perm_hwaddr )"
-    else
-        mac="$( cat $sysfspath/address )" || BugError "Could not read a MAC address for '$network_interface'."
+    local mac=""
+
+    if has_binary ethtool ; then
+        mac="$( ethtool -P $network_interface 2>/dev/null | awk '{ print $3 }' )"
+    fi
+    if [ -z "$mac" ] ; then
+        if [ -e $sysfspath/bonding_slave/perm_hwaddr ] ; then
+            mac="$( cat $sysfspath/bonding_slave/perm_hwaddr )"
+        else
+            mac="$( cat $sysfspath/address )" || BugError "Could not read a MAC address for '$network_interface'."
+        fi
     fi
     # Skip fake interfaces without MAC address
     [ "$mac" != "00:00:00:00:00:00" ] || return $rc_error


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): See PR https://github.com/rear/rear/pull/1954

* How was this pull request tested? Tested on RHEL7 with a Team on eth0 and eth1

* Brief description of the changes in this pull request:

Use "ethtool -P" as the preferred method to retrieve the MAC address.
Otherwise fall back to other methods, which may lead to some invalid MAC address when using Teams.
