### PR TITLE
Have MODULES all_modules by default plus needed adaptions for that

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -208,38 +208,6 @@ ${LIBS[@]:-}
 /usr/lib*/libnssdbm3.so*
 )
 
-MODULES=(
-${MODULES[@]:-}
-vfat
-nls_iso8859_1
-nls_utf8
-nls_cp437
-af_packet
-unix
-nfs
-nfsv4
-nfsv3
-lockd
-sunrpc
-cifs
-usbcore
-usb_storage
-usbhid
-sr_mod
-ide_cd
-cdrom
-uhci_hcd
-ehci_hcd
-xhci_hcd
-ohci_hcd
-zlib
-zlib-inflate
-zlib-deflate
-libcrc32c
-crc32c
-crc32c-intel
-)
-
 COPY_AS_IS=( ${COPY_AS_IS[@]:-} /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/termcap /etc/terminfo /lib*/terminfo /usr/share/terminfo /etc/netconfig /etc/mke2fs.conf /etc/*-release /etc/localtime /etc/magic /usr/share/misc/magic /etc/dracut.conf /etc/dracut.conf.d /usr/lib/dracut /sbin/modprobe.ksplice-orig /etc/sysctl.conf /etc/sysctl.d /etc/e2fsck.conf )
 # Required by curl with https:
 # There are stored the distribution provided certificates

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1082,45 +1082,56 @@ wc
 LIBS=()
 
 # Kernel modules to include in the rescue/recovery system:
-# The by default empty MODULES=() means that the currently loaded
-# kernel modules get included in the rescue/recovery system
+# The default MODULES=( 'all_modules' ) results that
+# all files in the /lib/modules/$KERNEL_VERSION directory
+# get included in the recovery system. Usually this is
+# required when migrating to different hardware to ensure
+# that all possibly needed kernel drivers for the new hardware
+# are available in the recovery system. It is also required
+# to have the recovery system better prepared for somewhat
+# "unusual use cases" where this or that additional kernel module
+# is needed (see https://github.com/rear/rear/issues/1202),
+# e.g. to ensure a USB keyboard is usable in the recovery system
+# (see https://github.com/rear/rear/issues/1870)
+# or to ensure data on external medium (e.g. iso9660) can be read
+# (see https://github.com/rear/rear/issues/1202).
+# Furthermore this is helpful to be on the safe side against possibly
+# missing other (dependant) kernel modules that are not automatically
+# found (see https://github.com/rear/rear/issues/1355).
+# The drawback of MODULES=( 'all_modules' ) is that it makes the
+# recovery system (and its ISO image) somewhat bigger,
+# see https://github.com/rear/rear/issues/2041 for some numbers.
+# To get the recovery system smaller by leaving out kernel modules
+# the following settings can be specified:
+# An empty MODULES=() setting means that the currently loaded
+# kernel modules get included in the recovery system
 # (so that recovery should work on same replacement hardware)
+# plus some kernel modules that should always be included
+# (see build/GNU/Linux/400_copy_modules.sh)
 # plus kernel modules for certain kernel drivers like
 # storage drivers, network drivers, crypto drivers,
 # virtualization drivers, and some extra drivers
 # (see rescue/GNU/Linux/230_storage_and_network_modules.sh
 # and rescue/GNU/Linux/240_kernel_modules.sh). Usually this
 # works reasonably well but no automatism works in any case
-# so that more explicit user settings are possible:
-# Via MODULES=( "${MODULES[@]}" 'moduleX' 'moduleY' )
-# additional kernel modules can be specified to be included
-# in the rescue/recovery system in addition to the default ones.
-# In this case other required kernel modules are usually also
+# so that more explicit user settings are possible via
+# MODULES=( 'moduleX' 'moduleY' ) where additional kernel modules
+# can be specified to be included in the recovery system
+# in addition to the ones via an empty MODULES=() setting.
+# Normally other required kernel modules are usually also
 # automatically included but this may not work in any case
 # (see https://github.com/rear/rear/issues/1355).
-# The special user setting MODULES=( 'all_modules' ) enforces that
-# all files in the /lib/modules/$KERNEL_VERSION directory
-# get included in the rescue/recovery system. Usually this is
-# required when migrating to different hardware to ensure
-# that all possibly needed kernel drivers for the new hardware
-# are available in the rescue/recovery system. It is also required
-# to have the rescue/recovery system better prepared for somewhat
-# "unusual use cases" where this or that additional kernel module
-# might be needed (see https://github.com/rear/rear/issues/1202).
-# Furthermore this is helpful to be on the safe side against possibly
-# missing other (dependant) kernel modules that are not automatically
-# found (cf. above https://github.com/rear/rear/issues/1355).
-# The special user setting MODULES=( 'loaded_modules' ) enforces that
+# The setting MODULES=( 'loaded_modules' ) results that
 # only those kernel modules that are currently loaded
-# get included in the rescue/recovery system. This results a smaller
-# rescue/recovery system but on the other hand it means that recovery
-# will only work on same replacement hardware.
-# The special user setting MODULES=( 'no_modules' ) enforces that
-# no kernel modules get included in the rescue/recovery system
+# get included in the recovery system. This results a noticeable
+# smaller recovery system but on the other hand it means that
+# recovery will only work on same replacement hardware.
+# The very special setting MODULES=( 'no_modules' ) enforces that
+# no kernel modules at all get included in the recovery system
 # regardless of what modules are currently loaded. Usually this
-# means that the rescue/recovery system will not work - unless
+# means that the recovery system will not work - unless
 # you have all needed kernel drivers compiled into your kernel.
-MODULES=()
+MODULES=( 'all_modules' )
 #
 # Enforce to load these modules in the given order in the rescue/recovery system.
 # We also load modules listed in /etc/modules. The order is 1) /etc/modules and


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

Hopefully low impact because this change should only
make things work better by default in the recovery system
without really bad side effects.
The somewhat bigger default recovery system should
not be a really bad side effect.

There is one backward incompatible change:
Before the user had to specify in local.conf
```
MODULES=( "${MODULES[@]}" 'moduleX' 'moduleY' )
```
to get additional kernel modules included
but now the user must specify
```
MODULES=( 'moduleX' 'moduleY' )
```
for that because with `"${MODULES[@]}"`
the default value `all_modules` would be kept
which triggers to get all modules included.

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2041

* How was this pull request tested?

By me on my openSUSE Leap 15.0 system with
```
MODULES=( 'all_modules' )
MODULES=( 'loaded_modules' )
MODULES=( 'no_modules' )
MODULES=( 'hwpoison-inject' 'trusted' )
MODULES=()
```
and to me things look o.k.

* Brief description of the changes in this pull request:

Now there is in default.conf
```
MODULES=( 'all_modules' )
```
which results that some additional adaptions were needed
in build/GNU/Linux/400_copy_modules.sh and conf/GNU/Linux.conf
because now the default value is no longer empty.
