### PR TITLE
Fix SSH root login on the recovery system with some configurations

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/run-sshd
+++ b/usr/share/rear/skel/default/etc/scripts/run-sshd
@@ -13,8 +13,12 @@ if grep -q '^ssh:' /etc/inittab ; then
         ssh-keygen -q -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
         echo -e "\nSSH fingerprint: $( ssh-keygen -l -f /etc/ssh/ssh_host_rsa_key.pub )\n" >> /etc/issue
     fi
-    sed -i 's/^PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
-    sed -i 's/^ClientAliveInterval.*/ClientAliveInterval 0/' /etc/ssh/sshd_config
+    sed -i '
+        s/.*PermitRootLogin.*/#&/
+        $ a PermitRootLogin yes
+        s/.*ClientAliveInterval.*/#&/
+        $ a ClientAliveInterval 0
+    ' /etc/ssh/sshd_config
     mkdir -p /run/sshd
     # Avoid "Could not load host key: /etc/ssh/ssh_host_..._key" messages
     # that look confusing on the recovery system login screen


### PR DESCRIPTION
##### Pull Request Details:

* Supercedes: https://github.com/rear/rear/pull/2068

* Type: **Bug Fix**

* Impact: **High** (cannot log in via SSH on rescue system)

* Reference to related issue (URL):

* How was this pull request tested? On Ubuntu 18.04.2 LTS

* Brief description of the changes in this pull request:

On Ubuntu 18.04 with OpenSSH 7.6, /etc/ssh/sshd_config contains
commented-out lines for 'PermitRootLogin' and other options. This fix
makes sure that settings changed for ReaR will be real, not comments.