### PR TITLE
RAWDISK output: improve device partition detection (e.g. Ubuntu 18.04)

### DIFF
--- a/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
@@ -63,7 +63,8 @@ gdisk -l "$disk_image" >&2
 ### Create block devices representing the raw disk image
 
 local disk_device  # separate 'local' statement to avoid losing $(...) exit status - cf. https://stackoverflow.com/a/10397996
-disk_device="$(losetup --show --find "$disk_image")"
+# Set up the loop device, trying the '--partscan' option first (introduced in util-linux v2.21)
+disk_device="$(losetup --show --find "$disk_image" --partscan || losetup --show --find "$disk_image")"
 StopIfError "Could not create loop device on $disk_image"
 AddExitTask "losetup -d $disk_device >&2"
 

--- a/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
@@ -64,6 +64,8 @@ gdisk -l "$disk_image" >&2
 
 local disk_device  # separate 'local' statement to avoid losing $(...) exit status - cf. https://stackoverflow.com/a/10397996
 # Set up the loop device, trying the '--partscan' option first (introduced in util-linux v2.21)
+# Trying '--partscan' here first avoids a situation where all of the methods below fail to make the kernel recognize
+# partitions on the loop device (cf. https://github.com/rear/rear/pull/2071).
 disk_device="$(losetup --show --find "$disk_image" --partscan || losetup --show --find "$disk_image")"
 StopIfError "Could not create loop device on $disk_image"
 AddExitTask "losetup -d $disk_device >&2"


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal** (creating RAWDISK output fails with "no space left on device")

* Reference to related issue (URL):

* How was this pull request tested? On Ubuntu 18.04.2 LTS

* Brief description of the changes in this pull request:

On Ubuntu 18.04, it has been observed that after creating a loop device
and creating a properly sized VFAT file system >250 MB on it, after
mounting the file system size was actually just 30 MB. Reason: The
partition detection did not pick up the correct partition sizes of the
associated image file. This change uses losetup's --partscan option
(supported by util-linux v2.21 and above) to offer one additional
opportunity to detect partitions. If the option is not available, a
traditional losetup call will be used as a fallback.