### PR TITLE
OPALPBA output fix: Do not include any PBA into another PBA

### DIFF
--- a/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
+++ b/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
@@ -28,6 +28,10 @@ COPY_AS_IS+=( /etc/alternatives /usr/lib/x86_64-linux-gnu/plymouth /usr/share/pl
 # Redirect output
 [[ -n "$OPAL_PBA_OUTPUT_URL" ]] || Error "The OPAL_PBA_OUTPUT_URL configuration variable must be set."
 OUTPUT_URL="$OPAL_PBA_OUTPUT_URL"
+if [[ "$(url_scheme "$OPAL_PBA_OUTPUT_URL")" == "file" ]]; then
+    # Do not include any PBA into another PBA
+    COPY_AS_IS_EXCLUDE+=( "$(url_path "$OPAL_PBA_OUTPUT_URL")" )
+fi
 
 # Configure raw disk output
 RAWDISK_IMAGE_NAME="TCG-Opal-PBA-$HOSTNAME"


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low** (excessive PBA size)

* Reference to related issue (URL):

* How was this pull request tested? On Ubuntu 18.04.2 LTS

* Brief description of the changes in this pull request:

A TCG Opal pre-boot authentication (PBA) system is a minimal operating system constructed by ReaR to unlock self-encrpyting disks before the regular OS takes over. Before this PR, it could happen that a previously created PBA was included in a subsequently created PBA, causing it to be unnecessarily large.