### PR TITLE
Debian packaging: downgrade syslinux from Depends to Suggests

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 9)
 Package: rear
 Architecture: i386 ia64 amd64 ppc64el
 Provides: rear
-Depends: syslinux[!ppc64el], syslinux-common[!ppc64el], ethtool, ${shlibs:Depends}, lsb-release, iputils-ping, dosfstools, binutils, parted, openssl, gawk, attr, bc, ${misc:Depends}
-Suggests: nfs-client, portmap, xorriso, isolinux, gdisk, syslinux-efi[!ppc64el], iproute, iproute2
+Depends: ethtool, ${shlibs:Depends}, lsb-release, iputils-ping, dosfstools, binutils, parted, openssl, gawk, attr, bc, ${misc:Depends}
+Suggests: nfs-client, portmap, xorriso, isolinux, gdisk, syslinux[!ppc64el], syslinux-common[!ppc64el], syslinux-efi[!ppc64el], iproute, iproute2
 Description: Relax-and-Recover is a bare metal disaster recovery and system
  migration framework. See http://relax-and-recover.org/ for all the details.


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested? On Ubuntu 18.04.2 LTS

* Brief description of the changes in this pull request:

ReaR works in configurations not using syslinux, so `Depends` is too strong. Additionally, not using syslinux is not unusual per se, so `Recommends` would still be too strong. Per Debian Policy [7.2. Binary Dependencies](https://www.debian.org/doc/debian-policy/ch-relationships.html#binary-dependencies-depends-recommends-suggests-enhances-pre-depends), `Suggests` would be the right level here.