### PR TITLE
Add new implementation to recreate all mounted Btrfs subvolumes

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/131_include_new_btrfs_subvolumes_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/131_include_new_btrfs_subvolumes_code.sh
@@ -1,0 +1,121 @@
+
+# New implementation for btrfs subvolume handling.
+
+# Enable this version only when explicitly configured to do so.
+[[ "$BTRFS_SETUP_IMPLEMENTATION" == "new" ]] || return 0
+
+# NOTE: This function intentionally overrides the identically named function 'btrfs_subvolumes_setup' from
+# '130_include_mount_subvolumes_code.sh'.
+
+btrfs_subvolumes_setup() {
+    # Invocation: btrfs_subvolumes_setup $device $top_level_mountpoint [...]
+    #
+    # This function
+    # (1) assumes that code present so far in $LAYOUT_FILE has
+    #     a) created a Btrfs file system on $device and
+    #     b) mounted its Btrfs top-level subvolume at $top_level_mountpoint,
+    # (2) interprets lines in $LAYOUT_FILE regarding Btrfs subvolumes for $device, and
+    # (3) appends shell code to the file $LAYOUT_CODE, which
+    #     a) recreates and
+    #     b) mounts
+    #     all Btrfs subvolumes for $device, which had been mounted on the original system.
+
+    local device="$1"  # disk device
+    local top_level_mountpoint="$2"  # the btrfs file system's top-level subvolume mount point
+
+    if test -z "$device" -o -z "$top_level_mountpoint"; then
+        StopIfError "btrfs_subvolumes_setup: missing required parameter: device='$device', top_level_mountpoint='$top_level_mountpoint'"
+    fi
+
+    Log "Begin btrfs_subvolumes_setup( $* ) - new implementation"
+
+    # Generate code to create all mounted non top-level subvolumes sorted
+    # - in subvolume path order,
+    # - discarding duplicate subvolume paths (to be mounted at multiple mount points):
+    local ignore_keyword ignore_device subvolume_mountpoint subvolume_mount_options subvolume_path ignore_rest
+    while read ignore_keyword ignore_device subvolume_mountpoint subvolume_mount_options subvolume_path ignore_rest; do
+        # Check parameters
+        if test -z "$subvolume_mountpoint" -o -z "$subvolume_mount_options" -o -z "$subvolume_path"; then
+            StopIfError "btrfsmountedsubvol entry for $device: missing required parameter: subvolume_mountpoint='$subvolume_mountpoint', subvolume_mount_options='$subvolume_mount_options', subvolume_path='$subvolume_path'"
+        fi
+
+        local relative_subvolume_path="${subvolume_path#/}"  # strip leading '/'
+        local relative_subvolume_parent_directory="$(dirname "$relative_subvolume_path")"
+
+        local target_top_level_mountpoint="$TARGET_FS_ROOT${top_level_mountpoint%/}"  # strip trailing '/'
+        local target_subvolume_parent_directory="$target_top_level_mountpoint/$relative_subvolume_parent_directory"
+        local target_subvolume_path="$target_top_level_mountpoint/$relative_subvolume_path"
+
+        # Create non top-level subvolume (the top-level subvolume will have '/' as its path and does already exist)
+        if [[ "$subvolume_path" != "/" ]]; then
+            info_message="Creating btrfs subvolume $subvolume_path for $device at $top_level_mountpoint"
+            Log "$info_message"
+            echo "# $info_message"
+            if [[ "$relative_subvolume_parent_directory" != "." ]]; then
+                echo "[[ -d '$target_subvolume_parent_directory' ]] || mkdir -p '$target_subvolume_parent_directory'"
+            fi
+            echo "btrfs subvolume create '$target_subvolume_path'"
+
+            # Mark the created subvolume as default subvolume fi necessary
+            if grep -q "^btrfsdefaultsubvol $device .* $subvolume_path\$" "$LAYOUT_FILE"; then
+                info_message="Setting default subvolume to $subvolume_path"
+                Log "$info_message"
+                echo "# $info_message"
+                echo "btrfs subvolume set-default '$target_subvolume_path'"
+            fi
+        fi
+
+        # Set a 'no copy on write' attribute if necessary
+        if grep -q "^btrfsnocopyonwrite $subvolume_path\$" "$LAYOUT_FILE"; then
+            info_message="Setting 'no copy on write' attribute for subvolume $subvolume_path"
+            Log "$info_message"
+            echo "# $info_message"
+            echo "chattr +C '$target_subvolume_path'"
+        fi
+    done < <( grep "^btrfsmountedsubvol $device " "$LAYOUT_FILE" | LC_COLLATE=C sort -k 5 -u )  >> "$LAYOUT_CODE"
+
+    # Generate code to mount subvolumes, sorted in mount-point order (top-down):
+    while read ignore_keyword ignore_device subvolume_mountpoint subvolume_mount_options subvolume_path ignore_rest; do
+        Log "Mounting subvolume $subvolume_path for $device at $subvolume_mountpoint"
+
+        # Strip 'subvolid=' and 'subvol=' from Btrfs mount options, as we'll add our own 'subvol=' option later.
+        # First add a comma at the end so that it is easier to remove a mount option at the end:
+        local subvolume_mount_options=${subvolume_mount_options/%/,}
+        # Remove all subvolid= and subvol= mount options (the extglob shell option is enabled in rear):
+        subvolume_mount_options=${subvolume_mount_options//subvolid=*([^,]),/}
+        subvolume_mount_options=${subvolume_mount_options//subvol=*([^,]),/}
+        # Remove all commas at the end:
+        subvolume_mount_options=${subvolume_mount_options/%,/}
+
+        local target_subvolume_mountpoint="$TARGET_FS_ROOT${subvolume_mountpoint%/}"  # strip trailing '/'
+        local mount_required=yes
+
+        if [[ "$subvolume_mountpoint" == "$top_level_mountpoint" ]]; then
+            if [[ "$subvolume_path" == "/" ]]; then
+                # The mount root for this Btrfs file system is the (initially mounted) top-level subvolume.
+                # There is nothing else to do for this subvolume.
+                mount_required=no
+            else
+                # If the mount root for this Btrfs file system is not the (initially mounted) top-level subvolume, we must
+                # unmount the top-level subvolume first before proceeding.
+                info_message="Unmounting the top-level subvolume for $device (it is about to be replaced by the mount root)"
+                Log "$info_message"
+                echo "# $info_message"
+                echo "umount '$target_subvolume_mountpoint'"
+            fi
+        fi
+
+        if [[ "$mount_required" == "yes" ]]; then
+            info_message="Mounting subvolume $subvolume_path at $subvolume_mountpoint for $device"
+            Log "$info_message"
+            echo "# $info_message"
+            if [[ "$subvolume_mountpoint" != "$top_level_mountpoint" ]]; then
+                echo "[[ -d '$target_subvolume_mountpoint' ]] || mkdir -p '$target_subvolume_mountpoint'"
+            fi
+            echo "mount -t btrfs -o '$subvolume_mount_options,subvol=$subvolume_path' '$device' '$target_subvolume_mountpoint'"
+        fi
+    done < <( grep "^btrfsmountedsubvol $device " "$LAYOUT_FILE" | LC_COLLATE=C sort -k 3 )  >> "$LAYOUT_CODE"
+
+    Log "End btrfs_subvolumes_setup( $* ) - new implementation"
+    true
+}


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High** (in specific Btrfs use cases, ReaR recover would fail)

* Reference to related issue (URL): https://github.com/rear/rear/issues/2067

* How was this pull request tested? On Ubuntu 18.04.2 LTS with different combinations of Btrfs file systems and subvolume hierarchies.

* Brief description of the changes in this pull request:

This PR aims to recreate all Btrfs file systems which have been mounted on the original system. It is a re-write of the original Btrfs subvolume code.

Although this code is simpler and focuses on mounted subvolumes only, its effects are intended to be entirely compatible with Btrfs scenarios addressed previously (e.g. using `snapper`). The assumptions are:
1. _All_ Btrfs subvolumes, which were actually mounted on the original system, are relevant for recovery and will finally be populated with backup data (or if not, at least their existence won't hurt).
2. Non-mounted subvolumes are not relevant for recovery at all.

Of course, we can only know for sure when people would actually try this on different systems. The code is not enabled by default, but must be activated by putting a line like this into the local configuration:
```
BTRFS_SETUP_IMPLEMENTATION="new"
```

Hope this helps.