### PR TITLE
Enable creation of non consecutive partitions

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
@@ -4,7 +4,10 @@
 # see https://github.com/rear/rear/issues/1933#issuecomment-430207057
 has_binary parted || Error "Cannot find 'parted' command"
 
-# Test for features of parted.
+#
+# TODO: clean up that old code when parted doesn't support any unit.
+# It's there since ages!
+#
 
 # True if parted accepts values in units other than mebibytes.
 FEATURE_PARTED_ANYUNIT=

--- a/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
@@ -62,6 +62,7 @@ fi
 Log "Erasing MBR of disk $disk"
 dd if=/dev/zero of=$disk bs=512 count=1
 sync
+
 EOF
 
     create_partitions "$disk" "$label"
@@ -70,6 +71,10 @@ EOF
 # Make sure device nodes are visible (eg. in RHEL4)
 my_udevtrigger
 my_udevsettle
+
+# Clean up transient partitions are resize shrinked ones
+delete_dummy_partitions_and_resize_real_ones
+
 EOF
 }
 
@@ -111,10 +116,7 @@ create_partitions() {
     # so that $label is not empty but still set to 'gpt_sync_mbr' here.
 
     cat >> "$LAYOUT_CODE" <<EOF
-LogPrint "Creating partitions for disk $device ($label)"
-my_udevsettle
-parted -s $device mklabel $label >&2
-my_udevsettle
+create_disk_label $device $label
 EOF
 
     # There are certrain conditions below that test for AUTORESIZE_PARTITIONS
@@ -144,13 +146,32 @@ EOF
         fi
     fi
 
-    local start end start_mb end_mb
+    local start end start_mb end_mb number last_number
     # let start=32768 # start after one cylinder 63*512 + multiple of 4k = 64*512
     let start=2097152 # start after cylinder 4096*512 (for grub2 - see issue #492)
     let end=0
+    let last_number=0
 
     local flags partition
     while read part disk size pstart name flags partition junk; do
+
+        # Get the partition number from the name
+        number=$( get_partition_number "$partition" )
+
+        # Because parted creates partitions starting at number 1 consecutively,
+        # we expect the partition numbers to be increasing. Failing to do so
+        # will make the parted command setting the file system type die in
+        # error.
+
+        if [[ $number -lt $last_number ]] ; then
+            # Admin probably reordered entries in disklayout.conf, die
+            Error "Device '$disk': partitions are not defined in expected order (partitions must be specified in ascending number)"
+        elif [[ $number -eq $last_number ]] ; then
+            Error "Device '$disk': partition with number $number is already defined"
+        elif [[ $( mathlib_calculate "$number - $last_number" ) -gt 1 ]] && [[ -z "$FEATURE_PARTED_ANYUNIT" ]] ; then 
+            Error "Device '$disk': there are gaps between partitions, this is not supported"
+        fi
+        let last_number=$number
 
         # In layout/save/GNU/Linux/200_partition_layout.sh
         # in particular a GPT partition name that can contain spaces
@@ -196,24 +217,10 @@ EOF
 
         if [[ "$FEATURE_PARTED_ANYUNIT" ]] ; then
             if [[ "$end" ]] ; then
-                end=$( mathlib_calculate "$end - 1" )B
-            else
-                # FIXME: I <jsmeix@suse.de> think one cannot silently set the end of a partition to 100%
-                # if there is no partition end value, I think in this case "rear recover" should error out:
-                end="100%"
+                end=$( mathlib_calculate "$end - 1" )
             fi
-            # The duplicated quoting "'$name'" is there because
-            # parted's internal parser needs single quotes for values with blanks.
-            # In particular a GPT partition name that can contain spaces
-            # like 'EFI System Partition' cf. https://github.com/rear/rear/issues/1563
-            # so that when calling parted on command line it must be done like
-            #    parted -s /dev/sdb unit MiB mkpart "'partition name'" 12 34
-            # where the outer quoting "..." is for bash so that
-            # the inner quoting '...' is preserved for parted's internal parser:
             cat >> "$LAYOUT_CODE" <<EOF
-my_udevsettle
-parted -s $device mkpart "'$name'" ${start}B $end >&2
-my_udevsettle
+create_disk_partition "$device" "$name" $number $start $end
 EOF
         else
             ### Old versions of parted accept only sizes in megabytes...
@@ -271,9 +278,6 @@ EOF
         if is_true "$autoresize_partitions" ; then
             start=$(( $start + 4096 - ( $start % 4096 ) ))
         fi
-
-        # Get the partition number from the name
-        local number=$( get_partition_number "$partition" )
 
         local flags="$( echo $flags | tr ',' ' ' )"
         local flag
@@ -354,3 +358,4 @@ EOF
     ) >> "$LAYOUT_CODE"
 }
 
+# vim: set et ts=4 sw=4:

--- a/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
@@ -43,6 +43,11 @@ create_disk() {
     StopIfError "Disk $disk has size $disk_size, unable to continue."
 
     cat >> "$LAYOUT_CODE" <<EOF
+
+#
+# Code handling disk '$disk'
+#
+
 Log "Stop mdadm"
 if grep -q md /proc/mdstat &>/dev/null; then
     mdadm --stop -s >&2 || echo "stop mdadm failed"
@@ -72,8 +77,12 @@ EOF
 my_udevtrigger
 my_udevsettle
 
-# Clean up transient partitions are resize shrinked ones
+# Clean up transient partitions and resize shrinked ones
 delete_dummy_partitions_and_resize_real_ones
+
+#
+# End of code handling disk '$disk'
+#
 
 EOF
 }

--- a/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
@@ -8,19 +8,13 @@ has_binary parted || Error "Cannot find 'parted' command"
 
 # True if parted accepts values in units other than mebibytes.
 FEATURE_PARTED_ANYUNIT=
-# True if parted can align partitions.
-FEATURE_PARTED_ALIGNMENT=
 
 # Test by using the parted version numbers...
 parted_version=$( get_version parted -v )
 
 test "$parted_version" || BugError "Function get_version could not detect parted version"
 
-if version_newer "$parted_version" 2.0 ; then
-    # All features supported
-    FEATURE_PARTED_ANYUNIT="y"
-    FEATURE_PARTED_ALIGNMENT="y"
-elif version_newer "$parted_version" 1.6.23 ; then
+if version_newer "$parted_version" 1.6.23 ; then
     FEATURE_PARTED_ANYUNIT="y"
 fi
 

--- a/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
+++ b/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
@@ -10,6 +10,15 @@
 #   Error: Partition doesn't exist
 # cf. https://github.com/rear/rear/issues/1681
 #
+# THIS LIMITATION APPLIES TO parted NOT BEING ABLE TO SPECIFY PARTITIONS IN
+# BYTES ONLY.
+#
+
+# Test by using the parted version numbers...
+parted_version=$( get_version parted -v )
+
+test "$parted_version" || BugError "Function get_version could not detect parted version"
+version_newer "$parted_version" 2.0 && return 0
 
 LogPrint "Verifying that the entries in $DISKLAYOUT_FILE are correct ..."
 local keyword dummy junk
@@ -209,3 +218,4 @@ is_true "$non_consecutive_partitions" && Error "There are non consecutive partit
 # Finish this script successfully in the normal case (i.e. when both 'is_true' above result non zero return code):
 true
 
+# vim: set et ts=4 sw=4:

--- a/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
+++ b/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
@@ -203,20 +203,19 @@ for error_message in "${broken_part_errors[@]}" ; do
 done
 
 #
-# Non consecutive partitions are now supported, unless parted < 2.0
+# Non consecutive partitions are supported unless parted tells otherwise
 #
-local parted_version=$( get_version parted -v )
-test "$parted_version" || BugError "Function get_version could not detect parted version"
-if ! version_newer "$parted_version" 2.0 ; then
+if is_false $FEATURE_PARTED_RESIZEPART && is_false $FEATURE_PARTED_RESIZE ; then
     for error_message in "${non_consecutive_part_errors[@]}" ; do
         contains_visible_char "$error_message" || continue
         LogPrintError "$error_message"
         non_consecutive_partitions="yes"
     done
-    is_true "$non_consecutive_partitions" && Error "There are non consecutive partitions ('rear recover' would fail)"
 fi
 
 is_true "$disklayout_file_is_broken" && BugError "Entries in $DISKLAYOUT_FILE are broken ('rear recover' would fail)"
+
+is_true "$non_consecutive_partitions" && Error "There are non consecutive partitions ('rear recover' would fail)"
 
 # Finish this script successfully in the normal case (i.e. when both 'is_true' above result non zero return code):
 true

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -1170,7 +1170,7 @@ create_disk_partition() {
             local partname="dummy$i"
             [[ "$disk_label" != "msdos" ]] || partname="primary"
             dummy_partitions_to_delete+=( $i )
-            LogPrint "Disk '$disk': creating partition number $i with name '$partname' (will be deleted later)"
+            LogPrint "Disk '$disk': creating dummy partition number $i with name '$partname' (will be deleted later)"
             parted -s -m $disk mkpart "$partname" "${endB}B" "${endB}B"
             my_udevsettle
             let endB-=$logical_sector_size

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -992,4 +992,180 @@ function apply_layout_mappings() {
     is_true $apply_layout_mappings_succeeded && return 0 || return 1
 }
 
+# Keeps track of last partition created for a specific disk
+# Associative array indexed by disk
+# e.g. last_partition_number[/dev/sda]=1
+declare -A last_partition_number=()
+
+# Keeps track of dummy partitions created and to be removed (due to parted limitation)
+# Associative array indexed by disk and containing a list of partition numbers
+# e.g. dummy_partitions_to_delete[/dev/sda]=" 1 2 4 5"
+declare -A dummy_partitions_to_delete=()
+
+# Keeps track of partitions to resize to original size
+# Associative array indexed by disk and containing a list of partition "number:end_in_bytes"
+# e.g. partitions_to_resize[/dev/sda]="3:2096127 6:8388607"
+declare -A partitions_to_resize=()
+
+# Keeps track of the label of a specific disk
+# Associative array indexed by disk
+# e.g. disk_label[/dev/sda]="gpt"
+declare -A disk_label=()
+
+create_disk_label() {
+    local disk="$1" label="$2"
+
+    LogPrint "Disk '$disk': creating '$label' partition table"
+    parted -s $disk mklabel $label >&2
+    my_udevsettle
+    disk_label[$disk]="$label"
+}
+
+create_disk_partition() {
+    local disk="$1" name="$2" number=$3 startB=$4 endB=$5
+
+    #
+    # FIXME? This code assumes that "parted" is capable of handling sizes in
+    # Bytes. parted supports partitions in Bytes since ages.
+    #
+
+    # The duplicated quoting "'$name'" is there because
+    # parted's internal parser needs single quotes for values with blanks.
+    # In particular a GPT partition name that can contain spaces
+    # like 'EFI System Partition' cf. https://github.com/rear/rear/issues/1563
+    # so that when calling parted on command line it must be done like
+    #    parted -s /dev/sdb unit MiB mkpart "'partition name'" 12 34
+    # where the outer quoting "..." is for bash so that
+    # the inner quoting '...' is preserved for parted's internal parser:
+    [ ${disk_label[$disk]} == "msdos" ] || name="'$name'"
+
+    [[ "${last_partition_number[$disk]}" ]] || last_partition_number[$disk]=0
+
+    if [[ $number -le ${last_partition_number[$disk]} ]] ; then
+        Error "Disk '$disk': trying to create partition number $number but last created partition was number ${last_partition_number[$disk]}"
+    fi
+
+    if [[ $(( $number - ${last_partition_number[$disk]} - 1 )) -eq 0 ]] ; then
+        LogPrint "Disk '$disk': creating partition number $number with name '$name'"
+        # FIXME: I <jsmeix@suse.de> think one cannot silently set the end of a partition to 100%
+        # if there is no partition end value, I think in this case "rear recover" should error out:
+        if [[ ! $endB ]] ; then
+            parted -s $disk mkpart "$name" "${startB}B" 100% >&2
+        else
+            parted -s $disk mkpart "$name" "${startB}B" "${endB}B" >&2
+        fi
+        my_udevsettle
+        last_partition_number[$disk]=$number
+        return 0
+    fi
+
+    # "parted" is only capable of creating partitions consecutively. Since
+    # there is a gap between the previous partition and this partition, dummy
+    # partitions must be created, and later will be removed once disks are
+    # fully partitioned (this is done in
+    # delete_dummy_partitions_and_resize_real_ones()).
+    #
+    # Once the dummy partitions are removed, the real partition needs to be
+    # resized to original size.
+    # Unfortunately, "parted" is only capable of resizing a partition toward
+    # its end, not the beginning, so the only way to create dummy partitions
+    # appropriately is to use some space at the end of the real partition.
+    #
+    # Example: the GPT disk contains only 1 partition numbered 3 named PART
+    #
+    # # parted -m -s /dev/sda unit B print
+    # /dev/sda:21474836480B:scsi:512:512:gpt:QEMU QEMU HARDDISK:;
+    # 3:1048576B:2097151B:1048576B::PART:;
+    #
+    # We need to create these partitions to recreate the exact same partitions:
+    #
+    # # parted -m -s /dev/sda unit B print
+    # /dev/sda:21474836480B:scsi:512:512:gpt:QEMU QEMU HARDDISK:;
+    # 3:1048576B:2096127B:1047552B::PART:;
+    # 2:2096128B:2096639B:512B::dummy2:;
+    # 1:2096640B:2097151B:512B::dummy1:;
+    #
+    # Then delete dummy partition 1 and 2 and resize 3 to its original end.
+    #
+    # For 'msdos' disks, only non-logical partitions are affected.
+
+    if [[ ! $endB ]] ; then
+        # We need to compute '$endB' based on disk size. To do so, create a
+        # partition then get its end
+        LogPrint "Disk '$disk': creating a temporary partition to find out the end of the disk"
+        parted -s -m $disk mkpart "$name" ${startB}B 100% >&2
+        local num
+        read num endB <<< $( parted -s -m $disk unit B print | tail -1 | awk -F ':' '{ print $1, $3 }' | sed 's/\([0-9]*\)B$/\1/' )
+        LogPrint "Disk '$disk': last allocatable byte on disk is '$endB'"
+        LogPrint "Disk '$disk': deleting the temporary partition number $num"
+        parted -s -m $disk rm $num >&2
+    fi
+
+    [[ "${partitions_to_resize[$disk]}" ]] || partitions_to_resize[$disk]=""
+    partitions_to_resize[$disk]+=" $number:$endB"
+
+    local -i logical_sector_size=$( parted -m -s $disk unit B print | awk -F ':' "\$1 == \"$disk\" { print \$4 }" )
+
+    [[ "${dummy_partitions_to_delete[$disk]}" ]] || dummy_partitions_to_delete[$disk]=""
+
+    if [[ ${disk_label[$disk]} != "msdos" ]] || [[ "$name" != "logical" ]] ; then
+        local -i i=${last_partition_number[$disk]}+1
+        while [[ $i -lt $number ]] ; do
+            local partname="dummy$i"
+            [[ ${disk_label[$disk]} != "msdos" ]] || partname="primary"
+            dummy_partitions_to_delete[$disk]+=" $i"
+            LogPrint "Disk '$disk': creating partition number $i with name '$partname' (will be deleted later)"
+            parted -s -m $disk mkpart "$partname" "${endB}B" "${endB}B" >&2
+            my_udevsettle
+            let endB-=$logical_sector_size
+            if [[ $endB -lt $startB ]] ; then
+                # Not enough space left for real partition: this happens if the
+                # partition to create is very small and we cannot create dummy
+                # temporary partitions!
+                # e.g. Partition table starts at partition number 2 and partition 2
+                # has only 1 cylinder
+                Error "Disk '$disk': Cannot create partition number $number, the partition is too small to create dummy partitions to work around parted's limitation (parted can only create consecutive partitions)"
+            fi
+            let i++
+        done
+    fi
+
+    LogPrint "Disk '$disk': creating partition number $number with name '$name'"
+    parted -s $disk mkpart "$name" "${startB}B" "${endB}B" >&2
+    my_udevsettle
+
+    last_partition_number[$disk]=$number
+}
+
+delete_dummy_partitions_and_resize_real_ones() {
+    [[ ${#dummy_partitions_to_delete[@]} -gt 0 ]] || return 0
+
+    # Delete dummy partitions
+    local -a disks=(${!dummy_partitions_to_delete[@]})
+    local disk
+    local -i num
+    for disk in ${disks[@]} ; do
+        for num in ${dummy_partitions_to_delete[$disk]} ; do
+            LogPrint "Disk '$disk': deleting dummy partition number $num"
+            parted -s -m $disk rm $num >&2
+        done
+        unset "dummy_partitions_to_delete[$disk]"
+    done
+    my_udevsettle
+
+    # Resize previously shrinked partitions (to make place for dummy
+    # partitions) to expected size
+    local num_end
+    local -i endB
+    for disk in ${disks[@]} ; do
+        for num_end in ${partitions_to_resize[$disk]} ; do
+            read num endB <<< $( awk -F ':' '{ print $1, $2 }' <<< "$num_end" )
+            LogPrint "Disk '$disk': resizing partition number $num to original size"
+            parted -s -m $disk resizepart $num "${endB}B" >&2
+        done
+        unset "partitions_to_resize[$disk]"
+    done
+    my_udevsettle
+}
+
 # vim: set et ts=4 sw=4:


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**
* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1681
https://github.com/rear/rear/issues/1771

* How was this pull request tested?

Tested with 4 disks:
- Disk 1: GPT with consecutive partitions
- Disk 2: MSDOS with consecutive partitions
- Disk 3: GPT with non-consecutive partitions (1, 3, 4, 6)
- Disk 4: MSDOS with non-consecutive partitions (1, 3 (extended), 5 (logical), 6 (logical))

* Brief description of the changes in this pull request:

`parted` is not capable of creating non-consecutive partitions. To still  be able to do so, the trick consists in creating dummy partitions to fill the gaps between partition numbers.
Allocation of these dummy partitions is done from the end of the target partition, because `parted` is not capable of resizing a partition from the beginning.

Example (see also in `/usr/share/rear/lib/layout-functions.sh`, `create_disk_partition()` function):

~~~
The GPT disk contains only 1 partition numbered 3 named PART

# parted -m -s /dev/sda unit B print
/dev/sda:21474836480B:scsi:512:512:gpt:QEMU QEMU HARDDISK:;
3:1048576B:2097151B:1048576B::PART:;

We need to create these partitions to recreate the exact same partitions:

# parted -m -s /dev/sda unit B print
/dev/sda:21474836480B:scsi:512:512:gpt:QEMU QEMU HARDDISK:;
3:1048576B:2096127B:1047552B::PART:;
2:2096128B:2096639B:512B::dummy2:;
1:2096640B:2097151B:512B::dummy1:;

Then delete dummy partition 1 and 2 and resize 3 to its original end.
~~~
