### PR TITLE
Add 'net-tools' to Debian dependencies as required for 'route' command

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 9)
 Package: rear
 Architecture: i386 ia64 amd64 ppc64el
 Provides: rear
-Depends: ethtool, ${shlibs:Depends}, lsb-release, iputils-ping, dosfstools, binutils, parted, openssl, gawk, attr, bc, ${misc:Depends}
+Depends: ethtool, ${shlibs:Depends}, lsb-release, iputils-ping, net-tools, dosfstools, binutils, parted, openssl, gawk, attr, bc, ${misc:Depends}
 Suggests: nfs-client, portmap, xorriso, isolinux, gdisk, syslinux[!ppc64el], syslinux-common[!ppc64el], syslinux-efi[!ppc64el], iproute, iproute2
 Description: Relax-and-Recover is a bare metal disaster recovery and system
  migration framework. See http://relax-and-recover.org/ for all the details.


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal** (rear fails startup)

* Reference to related issue (URL):

* How was this pull request tested? By manually installing the 'net-tools' package on Ubuntu 18.04.2 LTS

* Brief description of the changes in this pull request:

On a Ubuntu 18.04.2 LTS desktop system, `rear -h` fails with:
```
ERROR: Cannot find required programs:  route
```

Route is required by `usr/share/rear/conf/GNU/Linux.conf` (line 8).

Running `apt install net-tools` fixed the situation.