### PR TITLE
Update OPALPBA workflow

### DIFF
--- a/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
+++ b/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
@@ -24,7 +24,7 @@ USE_RESOLV_CONF='no'
 
 # Include plymouth boot animation and 'clear' if available
 PROGS+=( plymouth plymouthd clear )
-COPY_AS_IS+=( /etc/alternatives /usr/lib/x86_64-linux-gnu/plymouth /usr/share/plymouth )
+COPY_AS_IS+=( /etc/alternatives/*plymouth* /usr/lib/x86_64-linux-gnu/plymouth /usr/share/plymouth )
 
 # Redirect output
 [[ -n "$OPAL_PBA_OUTPUT_URL" ]] || Error "The OPAL_PBA_OUTPUT_URL configuration variable must be set."

--- a/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
+++ b/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
@@ -20,6 +20,7 @@ SSH_ROOT_PASSWORD=''
 # Disable non-essential stuff
 SSH_FILES='no'
 USE_DHCLIENT='no'
+USE_RESOLV_CONF='no'
 
 # Include plymouth boot animation and 'clear' if available
 PROGS+=( plymouth plymouthd clear )

--- a/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
+++ b/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
@@ -101,9 +101,6 @@ See history for useful commands. Exit the shell to shut down the system.
     shutdown now
 }
 
-trap emergency_response EXIT
-use_plymouth && plymouth update-root-fs --read-write
-
 function stop_error_handling() {
     trap - EXIT
 }
@@ -135,15 +132,23 @@ function instant_poweroff() {
 }
 
 
+trap emergency_response EXIT
+
+
+if use_plymouth; then
+    # Initialize boot splash screen animation if available
+    plymouth update-root-fs --read-write
+else
+    # Clear screen if running without plymouth boot animation and if 'clear' is available
+    type -p clear &>/dev/null && clear
+fi
+
+
 # Minimal system setup
 # TODO: split system setup scripts into PBA and rescue categories to protect against script renaming
 for system_setup_script in 00-functions.sh 10-console-setup.sh 40-start-udev-or-load-modules.sh; do
     source "/etc/scripts/system-setup.d/$system_setup_script"
 done
-
-
-# Clear screen if running without plymouth boot animation and if 'clear' is available
-! use_plymouth && type -p clear &>/dev/null && clear
 
 
 # Find TCG Opal 2-compliant disks

--- a/usr/share/rear/skel/default/usr/lib/systemd/system/plymouth-start.service
+++ b/usr/share/rear/skel/default/usr/lib/systemd/system/plymouth-start.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Show Plymouth Boot Screen
 DefaultDependencies=no
-Before=systemd-udev-trigger.service systemd-udevd.service
+After=systemd-udev-trigger.service systemd-udevd.service rear-boot-helper.service
+Before=systemd-journald.service
 ConditionKernelCommandLine=!plymouth.enable=0
 ConditionKernelCommandLine=!nosplash
 ConditionKernelCommandLine=splash


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/1947
https://github.com/rear/rear/pull/2018

* How was this pull request tested? On Ubuntu 18.04.2 LTS

* Brief description of the changes in this pull request:

This PR updates the OPALPBA workflow in light of recent changes:
* It sets `USE_RESOLV_CONF='no'` as networking is not required/available in the PBA
* It avoids copying in the entire `/etc/alternatives` directory as since d97cfbe74477e7849ccee9880c57ba4d6a31ee25 its links could pull in lots of unwanted stuff, which is not required in rescue systems (i.e. graphical editors).