### PR TITLE
Fixed comments and messages about '13X_include_...' scripts that had been renamed via issue 2080

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
@@ -301,7 +301,7 @@ EOF
             ;;
     esac
 
-    # Call the mount_fs function with argument $1 (device):
+    # Call the mount_fs function (in 133_include_mount_filesystem_code.sh) with argument $1 (device):
     mount_fs ${1}
 
     Log "End create_fs( $@ )"

--- a/usr/share/rear/layout/prepare/GNU/Linux/133_include_mount_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/133_include_mount_filesystem_code.sh
@@ -34,8 +34,8 @@ mount_fs() {
                 # from the old system cannot work here for recovery because btrfs subvolumes
                 # are not yet created (and when created their subvolid is likely different)
                 # so that those mount options are removed here. All btrfs subvolume handling
-                # happens in the btrfs_subvolumes_setup_SLES function in 130_include_mount_subvolumes_code.sh
-                # or in the btrfs_subvolumes_setup_generic function in 131_include_mount_subvolumes_code.sh
+                # happens in the btrfs_subvolumes_setup_SLES function in 136_include_btrfs_subvolumes_SLES_code.sh
+                # or in the btrfs_subvolumes_setup_generic function in 135_include_btrfs_subvolumes_generic_code.sh
                 # First add a comma at the end so that it is easier to remove a mount option at the end:
                 value=${value/%/,}
                 # Remove all subvolid= and subvol= mount options (the extglob shell option is enabled in rear):
@@ -57,7 +57,7 @@ mount_fs() {
         (btrfs)
             # The following commands are basically the same as in the default/fallback case.
             # The explicite case for btrfs is only there to be prepared for special adaptions for btrfs related file systems.
-            # Because the btrfs filesystem was created anew just before by the create_fs function in 130_include_filesystem_code.sh
+            # Because the btrfs filesystem was created anew just before by the create_fs function in 131_include_filesystem_code.sh
             # the code here mounts the whole btrfs filesystem because by default when creating a btrfs filesystem
             # its top-level/root subvolume is the btrfs default subvolume which gets mounted when no other subvolume is specified.
             # For a plain btrfs filesystem without subvolumes it is effectively the same as for other filesystems (like ext2/3/4).
@@ -70,8 +70,8 @@ mount_fs() {
             # that different subvolume needs to be first created, then set to be the default subvolume, and
             # finally that btrfs filesystem needs to be unmounted and mounted again so that in the end
             # that special different default subvolume is mounted at the mountpoint $TARGET_FS_ROOT$mountpoint.
-            # All btrfs subvolume handling happens in the btrfs_subvolumes_setup_SLES function in 130_include_mount_subvolumes_code.sh
-            # or in the btrfs_subvolumes_setup_generic function in 131_include_mount_subvolumes_code.sh.
+            # All btrfs subvolume handling happens in the btrfs_subvolumes_setup_SLES function in 136_include_btrfs_subvolumes_SLES_code.sh
+            # or in the btrfs_subvolumes_setup_generic function in 135_include_btrfs_subvolumes_generic_code.sh.
             # For a plain btrfs filesystem without subvolumes the btrfs_subvolumes_setup_* functions do nothing.
             # Call the right btrfs_subvolumes_setup_* function for the btrfs filesystem that was mounted above via an
             # artificial 'for' clause that is run only once to be able to 'continue' with the code after it:

--- a/usr/share/rear/layout/prepare/GNU/Linux/135_include_btrfs_subvolumes_generic_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/135_include_btrfs_subvolumes_generic_code.sh
@@ -1,17 +1,17 @@
 
 # New implementation for generic btrfs subvolume handling.
-# This is "new" compared to the old code in 130_include_mount_subvolumes_code.sh.
+# This is "new" compared to the old code in 136_include_btrfs_subvolumes_SLES_code.sh.
 
 # Btrfs filesystems with subvolumes need a special handling.
-# This script layout/prepare/GNU/Linux/131_include_new_btrfs_subvolumes_code.sh contains the function
-# btrfs_subvolumes_setup_generic for generic btrfs subvolumes setup (e.g. for Ubuntu 18.04)
+# This script layout/prepare/GNU/Linux/135_include_btrfs_subvolumes_generic_code.sh
+# contains the function btrfs_subvolumes_setup_generic for generic btrfs subvolumes setup (e.g. for Ubuntu 18.04)
 # cf. https://github.com/rear/rear/pull/2079
-# The script layout/prepare/GNU/Linux/130_include_mount_subvolumes_code.sh contains the function
-# btrfs_subvolumes_setup_SLES for SLES 12 (and later) special btrfs subvolumes setup.
+# The script layout/prepare/GNU/Linux/136_include_btrfs_subvolumes_SLES_code.sh
+# contains the function btrfs_subvolumes_setup_SLES for SLES 12 (and later) special btrfs subvolumes setup.
 # For a plain btrfs filesystem without subvolumes the btrfs_subvolumes_setup_generic function does nothing.
 
 btrfs_subvolumes_setup_generic() {
-    # Invocation: btrfs_subvolumes_setup $device $top_level_mountpoint [...]
+    # Invocation: btrfs_subvolumes_setup_generic $device $top_level_mountpoint [...]
     #
     # This function
     # (1) assumes that code present so far in $LAYOUT_FILE has
@@ -27,10 +27,10 @@ btrfs_subvolumes_setup_generic() {
     local top_level_mountpoint="$2"  # the btrfs file system's top-level subvolume mount point
 
     if test -z "$device" -o -z "$top_level_mountpoint"; then
-        StopIfError "btrfs_subvolumes_setup: missing required parameter: device='$device', top_level_mountpoint='$top_level_mountpoint'"
+        StopIfError "btrfs_subvolumes_setup_generic: missing required parameter: device='$device', top_level_mountpoint='$top_level_mountpoint'"
     fi
 
-    Log "Begin btrfs_subvolumes_setup( $* ) - new implementation"
+    Log "Begin btrfs_subvolumes_setup_generic( $* )"
 
     # Generate code to create all mounted non top-level subvolumes sorted
     # - in subvolume path order,
@@ -119,7 +119,7 @@ btrfs_subvolumes_setup_generic() {
         fi
     done < <( grep "^btrfsmountedsubvol $device " "$LAYOUT_FILE" | LC_COLLATE=C sort -k 3 ) >> "$LAYOUT_CODE"
 
-    Log "End btrfs_subvolumes_setup( $* ) - new implementation"
+    Log "End btrfs_subvolumes_setup_generic( $* )"
     true
 }
 

--- a/usr/share/rear/layout/prepare/GNU/Linux/136_include_btrfs_subvolumes_SLES_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/136_include_btrfs_subvolumes_SLES_code.sh
@@ -1,35 +1,35 @@
 
 # Btrfs filesystems with subvolumes need a special handling.
-# This script layout/prepare/GNU/Linux/130_include_mount_subvolumes_code.sh contains the function
-# btrfs_subvolumes_setup_SLES for SLES 12 (and later) special btrfs subvolumes setup.
-# The script layout/prepare/GNU/Linux/131_include_new_btrfs_subvolumes_code.sh contains the function
-# btrfs_subvolumes_setup_generic for generic btrfs subvolumes setup (e.g. for Ubuntu 18.04).
+# This script layout/prepare/GNU/Linux/136_include_btrfs_subvolumes_SLES_code.sh
+# contains the function btrfs_subvolumes_setup_SLES for SLES 12 (and later) special btrfs subvolumes setup.
+# The script layout/prepare/GNU/Linux/135_include_btrfs_subvolumes_generic_code.sh
+# contains the function btrfs_subvolumes_setup_generic for generic btrfs subvolumes setup (e.g. for Ubuntu 18.04).
 # All btrfs subvolume handling for SLES 12 (and later) special btrfs subvolumes setup
 # happens in the btrfs_subvolumes_setup_SLES function in this script.
 # For a plain btrfs filesystem without subvolumes the btrfs_subvolumes_setup_SLES function does nothing.
 
 btrfs_subvolumes_setup_SLES() {
-    Log "Begin btrfs_subvolumes_setup( $@ )"
-    # Local variables are visible only in this btrfs_subvolumes_setup function and its children:
+    Log "Begin btrfs_subvolumes_setup_SLES( $@ )"
+    # Local variables are visible only in this btrfs_subvolumes_setup_SLES function and its children:
     local dummy junk keyword info_message
     local device mountpoint mountopts target_system_mountpoint
     local subvolume_path subvolume_directory_path subvolume_mountpoint subvolume_mount_options
     local snapshot_subvolumes_devices_and_paths snapshot_subvolume_device_and_path snapshot_subvolume_device snapshot_subvolume_path
     local default_subvolume_path
     # Assign function arguments to meaningful variable names:
-    # This function is called in 130_include_mount_filesystem_code.sh as follows:
-    #   btrfs_subvolumes_setup $device $mountpoint $mountopts
-    # where $device is the device node where the filesystem was already created by 130_include_filesystem_code.sh
+    # This function is called in 133_include_mount_filesystem_code.sh as follows:
+    #   btrfs_subvolumes_setup_SLES $device $mountpoint $mountopts
+    # where $device is the device node where the filesystem was already created by 131_include_filesystem_code.sh
     # (usually a harddisk partition like e.g. /dev/sda1):
     device=$1
     mountpoint=$2
-    # mountopts are of the form "-o foo,bar,baz" (see 130_include_mount_filesystem_code.sh)
+    # mountopts are of the form "-o foo,bar,baz" (see 133_include_mount_filesystem_code.sh)
     # which means $3 is '-o' and 'foo,bar,baz' is $4:
     mountopts="$3 $4"
     # Empty device or mountpoint may indicate an error. In this case be verbose and inform the user:
     if test -z "$device" -o -z "$mountpoint" ; then
-        LogPrintError "Empty device='$device' or mountpoint='$mountpoint' may indicate an error, skipping btrfs_subvolumes_setup( $@ )."
-        Log "Return 0 from btrfs_subvolumes_setup( $@ )"
+        LogPrintError "Empty device='$device' or mountpoint='$mountpoint' may indicate an error, skipping btrfs_subvolumes_setup_SLES( $@ )."
+        Log "Return 0 from btrfs_subvolumes_setup_SLES( $@ )"
         return 0
     fi
     ###########################################
@@ -104,7 +104,7 @@ btrfs_subvolumes_setup_SLES() {
             continue
         fi
         # In case of SLES 12 SP1 (and later) special btrfs subvolumes setup skip setup of '@/.snapshots' normal btrfs subvolumes:
-        if test -n "$SLES12SP1_btrfs_subvolumes_setup" ; then
+        if test "$SLES12SP1_btrfs_subvolumes_setup" ; then
             # In case of SLES 12 SP1 (and later) special btrfs subvolumes setup
             # skip setup of the normal btrfs subvolume '@/.snapshots' because
             # that one will be created by "snapper/installation-helper --step 1"
@@ -146,7 +146,7 @@ btrfs_subvolumes_setup_SLES() {
         Log $info_message
         (
         echo "# $info_message"
-        if test -n "$subvolume_directory_path" ; then
+        if test "$subvolume_directory_path" ; then
             # Test in the recovery system if the directory path already exists to avoid that
             # useless 'mkdir -p' commands are run which look confusing in the "rear recover" log
             # regardless that 'mkdir -p' does nothing when its argument already exists:
@@ -197,7 +197,7 @@ btrfs_subvolumes_setup_SLES() {
         # that different subvolume needs to be set to be the default subvolume:
         target_system_mountpoint=$TARGET_FS_ROOT$mountpoint
         Log "Setting $subvolume_path as btrfs default subvolume for $device at $mountpoint"
-        if test -n "$SLES12SP1_btrfs_subvolumes_setup" ; then
+        if test "$SLES12SP1_btrfs_subvolumes_setup" ; then
             (
             echo "# Begin btrfs default subvolume setup on $device at $mountpoint"
             echo "# Doing special SLES 12 SP1 btrfs default snapper snapshot subvolume setup"
@@ -355,7 +355,7 @@ btrfs_subvolumes_setup_SLES() {
             echo "# Get the ID of the $subvolume_path subvolume because it must be mounted with subvolid=ID"
             echo "# (using subvol=NAME may not work as long as it is falsely mounted so that subvolume names may not match)"
             echo "subvolumeID=\$( btrfs subvolume list -a $target_system_mountpoint | sed -e 's/<FS_TREE>\///' | grep ' $subvolume_path\$' | tr -s '[:blank:]' ' ' | cut -d ' ' -f 2 )"
-            echo "if test -n \"\$subvolumeID\" ; then"
+            echo "if test \"\$subvolumeID\" ; then"
             echo "    # No remounting when subvolumeID is empty because then umount would work but mount would fail"
             echo "    # Remounting the $subvolume_path subvolume at $target_system_mountpoint"
             echo "    umount $target_system_mountpoint"
@@ -391,7 +391,7 @@ btrfs_subvolumes_setup_SLES() {
     done < <( grep "^btrfsmountedsubvol $device " "$LAYOUT_FILE" )
     ###########################################
     # Return successfully:
-    Log "End btrfs_subvolumes_setup( $@ )"
+    Log "End btrfs_subvolumes_setup_SLES( $@ )"
     true
 }
 


### PR DESCRIPTION
* Type: **Minor Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2080

* How was this pull request tested?
By looking at the new commets and messages ;-)

* Brief description of the changes in this pull request:
The new layout/prepare/GNU/Linux/133_include_... script names are
```
layout/prepare/GNU/Linux/131_include_filesystem_code.sh
layout/prepare/GNU/Linux/133_include_mount_filesystem_code.sh
layout/prepare/GNU/Linux/135_include_btrfs_subvolumes_generic_code.sh
layout/prepare/GNU/Linux/136_include_btrfs_subvolumes_SLES_code.sh
```
and the new btrfs_subvolumes_setup_... function names are
```
btrfs_subvolumes_setup_generic
btrfs_subvolumes_setup_SLES
```
Those new names are now used in comments and messages.
