### PR TITLE
Ignore invalid partitions on eMMC devices of type *rpmb and *boot*

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -39,7 +39,7 @@ extract_partitions() {
     ### Therefore we ignore these special partitions, see also
     ### https://github.com/rear/rear/issues/2087
     for possible_sysfs_partition in "${sysfs_paths_unfiltered[@]}"; do
-	if [[ ! ( $possible_sysfs_partition = *'/mmcblk'[0-9]'rpmb' || $possible_sysfs_partition = *'/mmcblk'[0-9]'boot'[0-9] ) ]] ; then
+	if [[ ! ( $possible_sysfs_partition = *'/mmcblk'+([0-9])'rpmb' || $possible_sysfs_partition = *'/mmcblk'+([0-9])'boot'+([0-9]) ) ]] ; then
 	    sysfs_paths+=($possible_sysfs_partition)
         fi    
     done

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -31,8 +31,13 @@ extract_partitions() {
     ### initialize array
     declare -a sysfs_paths=()
 
-    ### Silently skip invalid partitions on eMMC devices of type *rpmb or *boot[0-9],
-    ### see also github issue #2087. 
+    ### Silently skip invalid partitions on eMMC devices
+    ### of type *rpmb or *boot[0-9] like /dev/mmcblk0rpmb or /dev/mmcblk0boot0
+    ### because sysfs for (some?) eMMC disks recognises partitions,
+    ### which are no usual partitions, but special areas on the eMMC.
+    ### When trying to get the partition layout for such disks, ReaR would exit with an error.
+    ### Therefore we ignore these special partitions, see also
+    ### https://github.com/rear/rear/issues/2087
     for possible_sysfs_partition in ${sysfs_paths_unfiltered[@]}; do
 	if [[ ! ( $possible_sysfs_partition = *'/mmcblk'[0-9]'rpmb' || $possible_sysfs_partition = *'/mmcblk'[0-9]'boot'[0-9] ) ]] ; then
 	    sysfs_paths+=($possible_sysfs_partition)

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -26,7 +26,18 @@ extract_partitions() {
     declare sysfs_name=$(get_sysfs_name $device)
 
     ### check if we can find any partitions
-    declare -a sysfs_paths=(/sys/block/$sysfs_name/$sysfs_name*)
+    declare -a sysfs_paths_unfiltered=(/sys/block/$sysfs_name/$sysfs_name*)
+
+    ### initialize array
+    declare -a sysfs_paths=()
+
+    ### Silently skip invalid partitions on eMMC devices of type *rpmb or *boot[0-9],
+    ### see also github issue #2087. 
+    for possible_sysfs_partition in ${sysfs_paths_unfiltered[@]}; do
+	if [[ ! ( $possible_sysfs_partition = *'/mmcblk'[0-9]'rpmb' || $possible_sysfs_partition = *'/mmcblk'[0-9]'boot'[0-9] ) ]] ; then
+	    sysfs_paths+=($possible_sysfs_partition)
+        fi    
+    done
 
     declare path sysfs_path
     if [[ ${#sysfs_paths[@]} -eq 0 ]] ; then

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -38,7 +38,7 @@ extract_partitions() {
     ### When trying to get the partition layout for such disks, ReaR would exit with an error.
     ### Therefore we ignore these special partitions, see also
     ### https://github.com/rear/rear/issues/2087
-    for possible_sysfs_partition in ${sysfs_paths_unfiltered[@]}; do
+    for possible_sysfs_partition in "${sysfs_paths_unfiltered[@]}"; do
 	if [[ ! ( $possible_sysfs_partition = *'/mmcblk'[0-9]'rpmb' || $possible_sysfs_partition = *'/mmcblk'[0-9]'boot'[0-9] ) ]] ; then
 	    sysfs_paths+=($possible_sysfs_partition)
         fi    


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement** 

* Impact: **Low** 

* Reference to related issue (URL): https://github.com/rear/rear/issues/2087

* How was this pull request tested? Manually on PC with eMMC disk device (Z83-F).

* Brief description of the changes in this pull request: sysfs for (some?) eMMC disks recognises partitions, which are actually no usual partitions, but special areas on the eMMC. When trying to get the partition layout for such disks, ReaR exits with an error. This pull request contains enhancements to silently ignore these special partitions, so that ReaR no longer fails.
