### PR TITLE
#1886 - LPAR/PPC64 bootlist is incorrectly set when having multiple '…

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64le/680_install_PPC_bootlist.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/680_install_PPC_bootlist.sh
@@ -47,7 +47,7 @@ fi
 
 if [[ ${#boot_list[@]} -gt 0 ]]; then
     LogPrint "Set LPAR bootlist to '${boot_list[@]}'"
-    bootlist -m normal ${boot_list[@]}
+    bootlist -m normal "${boot_list[@]}"
     LogPrintIfError "Unable to set bootlist. You will have to start in SMS to set it up manually."
 fi
 


### PR DESCRIPTION
…prep' partitions

- Wrap bootlist into quotes
