### PR TITLE
Use [*] instead of [@] for array expansion inside a string

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64le/680_install_PPC_bootlist.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/680_install_PPC_bootlist.sh
@@ -46,7 +46,7 @@ if [[ ${#boot_list[@]} -gt 5 ]]; then
 fi
 
 if [[ ${#boot_list[@]} -gt 0 ]]; then
-    LogPrint "Set LPAR bootlist to '${boot_list[@]}'"
+    LogPrint "Set LPAR bootlist to '${boot_list[*]}'"
     bootlist -m normal "${boot_list[@]}"
     LogPrintIfError "Unable to set bootlist. You will have to start in SMS to set it up manually."
 fi


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Style Cleanup**

* Impact: **Low**

* Reference to related issue (URL): 
https://github.com/rear/rear/pull/1887/files#r268264260

* How was this pull request tested?
Code analysis and experimenting with analogous snippets of bash code.
* Brief description of the changes in this pull request:
Array expansion inside strings like `"aaa ${boot_list[@]} bbb"` splits the string into several strings:
```
boot_list=( foo bar )
"aaa ${boot_list[@]} bbb"
```
  -> `"aaa foo" "bar bbb"` instead of `"aaa foo bar bbb"`. This is probably unintended, although harmless in this case.
Change `[@]` to a more intuitive `[*]`, which keeps the result of expansion as one string.
See https://github.com/koalaman/shellcheck/wiki/SC2145