### PR TITLE
quick hack to copy the real resolv.conf file on ubuntu18.x

### DIFF
--- a/usr/share/rear/build/GNU/Linux/630_verify_resolv_conf_file.sh
+++ b/usr/share/rear/build/GNU/Linux/630_verify_resolv_conf_file.sh
@@ -1,4 +1,3 @@
-
 # Try to verify that the /etc/resolv.conf file in the ReaR recovery system
 # contains content that is actually usable within the recovery system.
 #
@@ -42,7 +41,12 @@ fi
 # so that we need to remove the link and have the actual content in /etc/resolv.conf
 if test -h $ROOTFS_DIR/etc/resolv.conf ; then
     rm -f $ROOTFS_DIR/etc/resolv.conf
-    cp $v /etc/resolv.conf $ROOTFS_DIR/etc/resolv.conf
+    if [[ -f /run/systemd/resolve/resolv.conf ]] ; then
+        # ubuntu18.x real resolv.conf file: quick hack on #2018
+        cp /run/systemd/resolve/resolv.conf $ROOTFS_DIR/etc/resolv.conf
+    else
+        cp $v /etc/resolv.conf $ROOTFS_DIR/etc/resolv.conf
+    fi
 fi
 
 # Check that the content in /etc/resolv.conf in the recovery system
@@ -98,4 +102,3 @@ if is_true "$USE_DHCLIENT" ; then
     fi
 fi
 Error "No nameserver or only loopback addresses in $ROOTFS_DIR/etc/resolv.conf, specify a real nameserver via USE_RESOLV_CONF"
-


### PR DESCRIPTION
Signed-off-by: Gratien D'haese <gratien.dhaese@gmail.com>

##### Pull Request Details:

* Type: **Enhancement**

* Impact: ***Normal**

* Reference to related issue (URL): #2015 and #2018 

* How was this pull request tested? via rea-automated-testing

* Brief description of the changes in this pull request: 
https://github.com/gdha/rear-automated-testing/issues/75 - I did not like to current behaviour and agree with @OliverO2 that ReaR pretends to just work out of the box, which was not correct IMHO in this particular case. I agree with @schlomo too that we should adopt systemd more (not less), but this was a quick-win.
For the next release we can have systemd-resolved incorporated (no rush as systemd is a moving duck anyhow)
