### PR TITLE
Fix disk device name in efibootmgr call for eMMC devices

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -44,6 +44,12 @@ if [[ ${Dev/mapper//} != $Dev ]] ; then
         (*_part) Disk=${Disk%_part} ;;
         (*)      Log "Unsupported kpartx partition delimiter for $Dev"
     esac
+# For eMMC devices the trailing "p" in the disk device name
+# needs to be stripped, otherwise the efibootmgr call will fail
+# because of a wrong disk device name. See also
+# https://github.com/rear/rear/issues/2103
+elif [[ $Disk = *'/mmcblk'+([0-9])p ]] ; then
+    Disk=${Disk%p}
 fi
 
 # EFI\fedora\shim.efi

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -32,7 +32,7 @@ BootEfiDev="$( mount | grep "$esp_mountpoint" | awk '{print $1}' )"
 Dev=$( get_device_name $BootEfiDev )
 # 1 (must anyway be a low nr <9)
 ParNr=$( get_partition_number $Dev )
-# /dev/sda or /dev/mapper/vol34_part or /dev/mapper/mpath99p
+# /dev/sda or /dev/mapper/vol34_part or /dev/mapper/mpath99p or /dev/mmcblk0p
 Disk=$( echo ${Dev%$ParNr} )
 
 # we have 'mapper' in devname
@@ -44,11 +44,13 @@ if [[ ${Dev/mapper//} != $Dev ]] ; then
         (*_part) Disk=${Disk%_part} ;;
         (*)      Log "Unsupported kpartx partition delimiter for $Dev"
     esac
+fi
+
 # For eMMC devices the trailing "p" in the disk device name
 # needs to be stripped, otherwise the efibootmgr call will fail
 # because of a wrong disk device name. See also
 # https://github.com/rear/rear/issues/2103
-elif [[ $Disk = *'/mmcblk'+([0-9])p ]] ; then
+if [[ $Disk = *'/mmcblk'+([0-9])p ]] ; then
     Disk=${Disk%p}
 fi
 


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?**
Enhancement

* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent**
Low

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2103

* How was this pull request tested?
Manually on corresponding hardware (Z83-F Mini PC)

* Brief description of the changes in this pull request:
For eMMC devices strip the trailing "p" in the disk device name,
so that during recovery the efibootmgr call will not fail, but create an UEFI boot entry.
