### PR TITLE
Fixes for more than one disk

### DIFF
--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -93,15 +93,17 @@ if ! is_true "$MIGRATION_MODE" ; then
     local found_orig_size_on_replacement_hardware=0
     local orig_size=''
     for orig_size in "${original_system_used_disk_sizes[@]}" ; do
+        found_orig_size_on_replacement_hardware=0
         for current_size in "${replacement_hardware_disk_sizes[@]}" ; do
             test "$current_size" -eq "$orig_size" && (( found_orig_size_on_replacement_hardware += 1 ))
+            # MIGRATION_MODE is needed when more than one possible target disk exists for a disk on the original system:
+            if test "$found_orig_size_on_replacement_hardware" -gt 1 ; then
+                MIGRATION_MODE='true'
+                break 2
+            fi
         done
     done
-    # MIGRATION_MODE is needed when more than one possible target disk exists for a disk on the original system:
-    if test "$found_orig_size_on_replacement_hardware" -gt 1 ; then
-        LogPrint "Ambiguous possible target disks need manual configuration (more than one with same size found)"
-        MIGRATION_MODE='true'
-    fi
+    is_true "$MIGRATION_MODE" && LogPrint "Ambiguous possible target disks need manual configuration (more than one with same size found)"
 fi
 
 # No further disk comparisons are needed when MIGRATION_MODE is already set true above:


### PR DESCRIPTION
* Type: **Minor Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
Found "by the way" while testing https://github.com/rear/rear/pull/2081

* How was this pull request tested?
By me on SLES12 and SLES15 while testing https://github.com/rear/rear/pull/2081

* Brief description of the changes in this pull request:

1.)
The changes in layout/prepare/default/250_compare_disks.sh
avoid that it goes into MIGRATION_MODE with
```
Ambiguous possible target disks need manual configuration (more than one with same size found)
```
in any case when there is more than one disk.

Before it compared for all disks how often any original disk size
matches any possible target disk size and when there are
more disks e.g. both on the original system and on the target system
there are /dev/sda with 10 GiB and /dev/sdb with 20 GiB
then 10 GiB original disk size matches 10 GiB target disk size
and 20 GiB original disk size matches 20 GiB target disk size
which are all together two matches which falsely leads to the
"more than one with same size found".

Now it compares separatedly for each original disk size
if there are more than one (target disk) with same size found.

Basically a reset `found_orig_size_on_replacement_hardware=0`
was missing for each original disk size.

2.)
The changes in finalize/Linux-i386/660_install_grub2.sh
avoid that GRUB2 gets needlessly installed two times on the same device.

When there are more disks like /dev/sda and /dev/sdb it can happen that
for /dev/sda bootdisk=/dev/sda and GRUB2 gets installed on /dev/sda and
also for /dev/sdb bootdisk=/dev/sda and GRUB2 would get installed again there.

Now we remember in the `grub2_installed_disks` array where GRUB2
was already successfully installed and skip installing GRUB2 on a disk
in that array.
