### PR TITLE
let each ldd output line match only once

### DIFF
--- a/usr/share/rear/lib/linux-functions.sh
+++ b/usr/share/rear/lib/linux-functions.sh
@@ -174,9 +174,9 @@ function RequiredSharedObjects () {
     #  4. Line: "        lib => /path/to/lib (mem-addr)" -> print $3 '/path/to/lib'
     #  5. Line: "        /path/to/lib => /path/to/lib2 (mem-addr)" -> print $3 '/path/to/lib2'
     #  6. Line: "        /path/to/lib (mem-addr)"        -> print $1 '/path/to/lib'
-    ldd "$@" | awk ' /^\t.+ => not found/ { print "Shared object " $1 " not found" > "/dev/stderr" }
-                     /^\t.+ => \// { print $3 }
-                     /^\t\// && !/ => / { print $1 } ' | sort -u
+    ldd "$@" | awk ' /^\t.+ => not found/ { print "Shared object " $1 " not found" > "/dev/stderr"; next }
+                     /^\t.+ => \// { print $3; next }
+                     /^\t\// && !/ => / { print $1; next } ' | sort -u
 }
 
 # Provide a shell, with custom exit-prompt and history


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?**
Bug Fix

* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent**
Normal

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2109

* How was this pull request tested?
locally on my system

* Brief description of the changes in this pull request:
This change lets ldd output lines match only once in the awk statement.
So it prohibits "wrong" double matches.
