### PR TITLE
Do not copy symlink targets in proc sys dev run (issue#2111)

### DIFF
--- a/usr/share/rear/build/default/985_fix_broken_links.sh
+++ b/usr/share/rear/build/default/985_fix_broken_links.sh
@@ -21,14 +21,8 @@
 # cf. https://github.com/rear/rear/pull/1734#issuecomment-434635175
 local broken_symlinks=$( chroot $ROOTFS_DIR find . -xdev -path './proc' -prune -o -path './sys' -prune -o -path './dev' -prune -o -xtype l -print )
 
-# Some symbolic links inside the recovery system are "broken by intention" here
-# for example ./etc/mtab -> /proc/self/mounts cannot work here because
-# only in the actually running recovery system there is /proc/self/mounts
-# so that such "known to be broken by intention" symlinks are excluded
-# from copying the missing symlink targets into the recovery system:
-local known_broken_symlinks="./etc/mtab"
-
-# Copy missing symlink targets into the recovery system if the symlink target exists.
+# Copy missing symlink targets into the recovery system if the symlink target exists
+# (except the symlink target is in /proc/ /sys/ /dev/ or /run/).
 # Otherwise report that there is something wrong on the original system and
 # assume when things work sufficiently on the original system nevertheless
 # this is no sufficient reason to abort here (i.e. proceed "bona fide")
@@ -38,18 +32,25 @@ pushd $ROOTFS_DIR
     local known_broken_symlink=''
     local link_target=''
     for broken_symlink in $broken_symlinks ; do
-        for known_broken_symlink in $known_broken_symlinks ; do
-            # Skip copying the missing symlink targets for known to be broken symlinks
-            # i.e. continue with the next broken_symlink in the outer for loop:
-            test $known_broken_symlink = $broken_symlink && continue 2
-        done
         link_target=$( readlink $v -e $broken_symlink )
+        # If in the original system there was a chain of symbolic links like
+        #   /some/path/to/file1 -> /another/path/to/file2 -> /final/path/to/file3
+        # where $broken_symlink='/some/path/to/file1' and $link_target='/final/path/to/file3'
+        # the chain of symbolic links gets simplified in the recovery system to $broken_symlink -> $link_target like
+        #   /some/path/to/file1 -> /final/path/to/file3
         if test "$link_target" ; then
-            # If in the original system there was a chain of symbolic links like
-            #   /some/path/to/file1 -> /another/path/to/file2 -> /final/path/to/file3
-            # where $broken_symlink='/some/path/to/file1' and $link_target='/final/path/to/file3'
-            # the chain of symbolic links gets simplified in the recovery system to $broken_symlink -> $link_target like
-            #   /some/path/to/file1 -> /final/path/to/file3
+            # Never copy symlink targets in /proc/ /sys/ /dev/ or /run/ into the ReaR recovery system
+            # for example the symlink ./etc/mtab that points to /proc/self/mounts
+            # cf. https://github.com/rear/rear/issues/2111
+            # also cf. the scripts
+            # finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
+            # finalize/GNU/Linux/250_migrate_lun_wwid.sh
+            # finalize/GNU/Linux/280_migrate_uuid_tags.sh
+            # finalize/GNU/Linux/320_migrate_network_configuration_files.sh
+            if echo $link_target | egrep -q '/proc/|/sys/|/dev/|/run/' ; then
+                DebugPrint "Skip copying broken symlink '$broken_symlink' target '$link_target' on /proc/ /sys/ /dev/ or /run/"
+                continue
+            fi
             # The leading './' is crucial to create the parent directories inside the current working directory ROOTFS_DIR
             # and to copy the symlink target into the current working directory ROOTFS_DIR:
             mkdir $v -p ./$( dirname $link_target ) || LogPrintError "Failed to make parent directories for symlink target '$link_target'"

--- a/usr/share/rear/build/default/985_fix_broken_links.sh
+++ b/usr/share/rear/build/default/985_fix_broken_links.sh
@@ -29,15 +29,14 @@ local broken_symlinks=$( chroot $ROOTFS_DIR find . -xdev -path './proc' -prune -
 # cf. what is done when '$lib is a symbolic link' in build/GNU/Linux/390_copy_binaries_libraries.sh
 pushd $ROOTFS_DIR
     local broken_symlink=''
-    local known_broken_symlink=''
     local link_target=''
     for broken_symlink in $broken_symlinks ; do
-        link_target=$( readlink $v -e $broken_symlink )
         # If in the original system there was a chain of symbolic links like
         #   /some/path/to/file1 -> /another/path/to/file2 -> /final/path/to/file3
         # where $broken_symlink='/some/path/to/file1' and $link_target='/final/path/to/file3'
         # the chain of symbolic links gets simplified in the recovery system to $broken_symlink -> $link_target like
         #   /some/path/to/file1 -> /final/path/to/file3
+        link_target=$( readlink $v -e $broken_symlink )
         if test "$link_target" ; then
             # Never copy symlink targets in /proc/ /sys/ /dev/ or /run/ into the ReaR recovery system
             # for example the symlink ./etc/mtab that points to /proc/self/mounts
@@ -54,6 +53,8 @@ pushd $ROOTFS_DIR
             # The leading './' is crucial to create the parent directories inside the current working directory ROOTFS_DIR
             # and to copy the symlink target into the current working directory ROOTFS_DIR:
             mkdir $v -p ./$( dirname $link_target ) || LogPrintError "Failed to make parent directories for symlink target '$link_target'"
+            # Continue even after "Failed to make parent directories for symlink target ..." and let 'cp' also fail
+            # to also show the explicit "Failed to copy symlink target ..." message to the user:
             cp $v --preserve=all $link_target ./$link_target || LogPrintError "Failed to copy symlink target '$link_target'"
         else
             LogPrintError "Broken symlink '$broken_symlink' in recovery system because 'readlink' cannot determine its link target"


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2111

* How was this pull request tested?
Not yet tested at all

* Brief description of the changes in this pull request:
Never copy symlink targets in /proc/ /sys/ /dev/ or /run/
into the ReaR recovery system
