### PR TITLE
Revive old 100_populate_dev.sh code for SLES11 (follow up of issue 2045)

### DIFF
--- a/usr/share/rear/finalize/default/110_bind_mount_proc_sys_dev_run.sh
+++ b/usr/share/rear/finalize/default/110_bind_mount_proc_sys_dev_run.sh
@@ -38,32 +38,39 @@ for mount_olddir in proc sys dev run ; do
     if ! mountpoint /$mount_olddir ; then
         Log "/$mount_olddir not mounted - cannot bind-mount it at $TARGET_FS_ROOT/$mount_olddir"
         if test "dev" = $mount_olddir ; then
-            # FIXME: Dirty hack to keep things still working on SLES11:
-            # On SLES11 it does not work to bind-mount /dev into TARGET_FS_ROOT
+            # Special case code to keep things still working on SLES11:
+            # On SLES11 it does not work to bind-mount /dev at TARGET_FS_ROOT/dev
             # see https://github.com/rear/rear/issues/2045#issuecomment-481195463
             # because within the recovery system /dev is no mountpoint
-            # (in a running SLES11 system 'udev' is mounted on /dev) and
+            # (in a running SLES11 system 'mount' shows "udev on /dev type tmpfs") and
             # within the recovery system bind-mounting of the /dev directory fails.
             # It seems the root cause is that within the recovery system / is no mountpoint
             # like in a normal running system where e.g. /dev/sda2 is mounted on /
             # but within the recovery system / is the plain content of ReaR's initrd
             # so /dev does not belong to any mountpoint and that lets bind-mount fail.
-            # As a dirty hack to keep things still working on SLES11 we do here
-            # the same as we did in our old finalize/default/100_populate_dev.sh
+            # To keep things still working on SLES11 we do here basically the same
+            # as we did in our old finalize/default/100_populate_dev.sh that was:
             #   # many systems now use udev and thus have an empty /dev
             #   # this prevents our chrooted grub install later on, so we copy
             #   # the /dev from our rescue system to the freshly installed system
             #   cp -fa /dev $TARGET_FS_ROOT/
             # cf. https://github.com/rear/rear/issues/2045#issuecomment-464737610
-            # This hack is especially dirty because it copies device node files into TARGET_FS_ROOT
-            # after the backup was restored (i.e. it writes files on the target system disk) and
-            # this hack is especially sneaky because usually on the rebooted target system
-            # something will be mounted at /dev (e.g. on SLES11 'udev' is mounted on /dev)
-            # so that our copied device nodes on the target system disk get obscured and
-            # hidden behind what is mounted at /dev in the normal running target system:
-            Log "Copying /dev contents from ReaR recovery system to $TARGET_FS_ROOT/dev"
+            DebugPrint "Copying /dev contents from ReaR recovery system to $TARGET_FS_ROOT/dev"
+            # But only a plain "cp -fa /dev $TARGET_FS_ROOT/" would be especially dirty because
+            # it would copy device node files into TARGET_FS_ROOT after the backup was restored
+            # (i.e. it would write and modify files on the sacrosanct user's target system disk)
+            # and it would be especially sneaky because usually on the rebooted target system
+            # something will be mounted at /dev (e.g. on SLES11 "udev on /dev type tmpfs" is mounted)
+            # so that our copied device nodes on the target system disk would get obscured and
+            # hidden behind what is mounted at /dev in the normal running target system.
+            # To avoid such dirtiness and sneakiness we first mount TARGET_FS_ROOT/dev as tmpfs
+            # and then copy all /dev contents from the recovery system into TARGET_FS_ROOT/dev
+            # which makes the recovery system /dev contents available at TARGET_FS_ROOT/dev
+            # only as long as the recovery system runs but on the rebooted target system
+            # its original unmodifies /dev contents will be there again:
+            mount -t tmpfs tmpfs $TARGET_FS_ROOT/dev || DebugPrint "Failed to mount a tmpfs on $TARGET_FS_ROOT/dev"
             # Do not error out at this late state of "rear recover" but inform the user:
-            cp -fa /dev $TARGET_FS_ROOT/ || LogPrintError "Failed to copy /dev contents from ReaR recovery system to $TARGET_FS_ROOT/dev"
+            cp -a /dev/. $TARGET_FS_ROOT/dev || LogPrintError "Failed to copy /dev contents from ReaR recovery system to $TARGET_FS_ROOT/dev"
         fi
         continue
     fi


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2045#issuecomment-481195463

* How was this pull request tested?
Works for me on SLES11

* Brief description of the changes in this pull request:

Dirty hack to keep things still working on SLES11:
On SLES11 it does not work to bind-mount /dev into TARGET_FS_ROOT
see https://github.com/rear/rear/issues/2045#issuecomment-481195463
because within the recovery system /dev is no mountpoint
(in a running SLES11 system 'udev' is mounted on /dev) and
within the recovery system bind-mounting of the /dev directory fails.
It seems the root cause is that within the recovery system / is no mountpoint
like in a normal running system where e.g. /dev/sda2 is mounted on /
but within the recovery system / is the plain content of ReaR's initrd
so /dev does not belong to any mountpoint and that lets bind-mount fail.
As a dirty hack to keep things still working on SLES11 we do here
the same as we did in our old finalize/default/100_populate_dev.sh
```
cp -fa /dev $TARGET_FS_ROOT/
```
cf. https://github.com/rear/rear/issues/2045#issuecomment-464737610
This hack is especially dirty because it copies device node files into TARGET_FS_ROOT
after the backup was restored (i.e. it writes files on the target system disk) and
this hack is especially sneaky because usually on the rebooted target system
something will be mounted at /dev (e.g. on SLES11 'udev' is mounted on /dev)
so that our copied device nodes on the target system disk get obscured and
hidden behind what is mounted at /dev in the normal running target system.
