### PR TITLE
Simplify awk constructs in 320_include_uefi_env.sh (issue #2095)

### DIFF
--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -54,8 +54,14 @@ test "$( find /boot -maxdepth 1 -iname efi -type d )" || return 0
 local esp_proc_mounts_line=()
 # The output of
 #   egrep ' /boot/efi | /boot ' /proc/mounts
-# may look like (here on a openSUSE Leap 15.0 system)
+# may look like the following examples
+# on a openSUSE Leap 15.0 system
 #   /dev/sda1 /boot/efi vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
+# cf. https://github.com/rear/rear/issues/2095#issuecomment-475548960
+# or like this on a Debian buster system
+#   /dev/sda1 /boot/efi vfat rw,relatime,fmask=0077,dmask=0077,codepage=437,iocharset=ascii,shortname=mixed,utf8,errors=remount-ro 0 0
+# cf. https://github.com/rear/rear/issues/2095#issuecomment-475684942
+# and https://github.com/rear/rear/issues/2095#issuecomment-481739166
 # The ESP could be mounted on /boot/efi or on /boot.
 # First try /boot/efi:
 esp_proc_mounts_line=( $( grep ' /boot/efi ' /proc/mounts || echo false ) )

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -1,4 +1,5 @@
-# in conf/default.conf we defined an empty variable USING_UEFI_BOOTLOADER
+
+# In conf/default.conf we defined an empty variable USING_UEFI_BOOTLOADER
 # This script will try to guess if we're using UEFI or not, and if yes,
 # then add all the required executables, kernel modules, etc...
 # Most likely, only recent OSes will be UEFI capable, such as SLES11, RHEL6, Ubuntu 12.10, Fedora 18, Arch Linux
@@ -8,7 +9,7 @@ if grep -qw 'noefi' /proc/cmdline; then
     return
 fi
 
-# by default the variable USING_UEFI_BOOTLOADER is empty which means ReaR will decide (this script)
+# By default the variable USING_UEFI_BOOTLOADER is empty which means ReaR will decide (this script)
 # except when the variable USING_UEFI_BOOTLOADER has an explicit 'false' value set:
 if is_false $USING_UEFI_BOOTLOADER ; then
     # we forced the variable to zero (in local.conf) so we do not want UEFI stuff
@@ -31,8 +32,8 @@ fi
 # Be aware, efivars is not listed with 'lsmod'
 modprobe -q efivars
 
-# next step, is checking the presence of UEFI variables directory
-# However, we should first check kernel command line to see whether we hide on purpose the UEFI vars with 'noefi'
+# Next step is checking the presence of UEFI variables directory.
+# However, we should first check kernel command line to see whether we hide on purpose the UEFI vars with 'noefi':
 SYSFS_DIR_EFI_VARS=
 if [[ -d /sys/firmware/efi/vars ]] ; then
     SYSFS_DIR_EFI_VARS=/sys/firmware/efi/vars
@@ -43,11 +44,11 @@ else
 fi
 
 # mount-point: efivarfs on /sys/firmware/efi/efivars type efivarfs (rw,nosuid,nodev,noexec,relatime)
-if grep -qw efivars /proc/mounts; then
+if grep -qw efivars /proc/mounts ; then
     SYSFS_DIR_EFI_VARS=/sys/firmware/efi/efivars
 fi
 
-# next step, is case-sensitive checking /boot for case-insensitive /efi directory (we need it)
+# Next step is case-sensitive checking /boot for case-insensitive /efi directory (we need it):
 test "$( find /boot -maxdepth 1 -iname efi -type d )" || return 0
 
 # Next step is to get the EFI (Extensible Firmware Interface) system partition (ESP):
@@ -66,7 +67,7 @@ local esp_proc_mounts_line=()
 # First try /boot/efi:
 esp_proc_mounts_line=( $( grep ' /boot/efi ' /proc/mounts || echo false ) )
 if is_false $esp_proc_mounts_line ; then
-    # If nothing is mounted on on /boot/efi try /boot:
+    # If nothing is mounted on /boot/efi try /boot:
     esp_proc_mounts_line=( $( grep ' /boot ' /proc/mounts || echo false ) )
     if is_false $esp_proc_mounts_line ; then
         DebugPrint "No EFI system partition found (nothing mounted on /boot/efi or /boot)"

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -50,24 +50,37 @@ fi
 # next step, is case-sensitive checking /boot for case-insensitive /efi directory (we need it)
 test "$( find /boot -maxdepth 1 -iname efi -type d )" || return 0
 
-local esp_mount_point=""
-
-# next step, check filesystem partition type (vfat?)
-esp_mount_point='/\/boot\/efi/'
-UEFI_FS_TYPE=$(awk $esp_mount_point' { print $3 }' /proc/mounts)
-# if not mounted at /boot/efi, try /boot
-if [[ -z "$UEFI_FS_TYPE" ]]; then
-    esp_mount_point='/\/boot/'
-    UEFI_FS_TYPE=$(awk $esp_mount_point' { print $3 }' /proc/mounts)
+# Next step is to get the EFI (Extensible Firmware Interface) system partition (ESP):
+local esp_proc_mounts_line=()
+# The output of
+#   egrep ' /boot/efi | /boot ' /proc/mounts
+# may look like (here on a openSUSE Leap 15.0 system)
+#   /dev/sda1 /boot/efi vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0
+# The ESP could be mounted on /boot/efi or on /boot.
+# First try /boot/efi:
+esp_proc_mounts_line=( $( grep ' /boot/efi ' /proc/mounts || echo false ) )
+if is_false $esp_proc_mounts_line ; then
+    # If nothing is mounted on on /boot/efi try /boot:
+    esp_proc_mounts_line=( $( grep ' /boot ' /proc/mounts || echo false ) )
+    if is_false $esp_proc_mounts_line ; then
+        DebugPrint "No EFI system partition found (nothing mounted on /boot/efi or /boot)"
+        return
+    fi
 fi
 
-# ESP must be type vfat (under Linux)
-if [[ "$UEFI_FS_TYPE" != "vfat" ]]; then
-    return
+# The ESP filesystem type must be vfat (under Linux):
+if ! test "vfat" = "${esp_proc_mounts_line[2]}" ; then
+    DebugPrint "No 'vfat' EFI system partition found (${esp_proc_mounts_line[0]} on ${esp_proc_mounts_line[1]} is type ${esp_proc_mounts_line[2]})"
+    return 0
 fi
 
-# we are still here? Ok, now it is safe to turn on USING_UEFI_BOOTLOADER=1
+# When we are still here we have a filesystem type 'vfat' mounted on /boot/efi or on /boot.
+# In this case we assume what is mounted there actually is a EFI system partition (ESP)
+# so we assume it is safe to turn on USING_UEFI_BOOTLOADER=1
+DebugPrint "Found EFI system partition ${esp_proc_mounts_line[0]} on ${esp_proc_mounts_line[1]} type ${esp_proc_mounts_line[2]}"
 USING_UEFI_BOOTLOADER=1
 LogPrint "Using UEFI Boot Loader for Linux (USING_UEFI_BOOTLOADER=1)"
 
-awk $esp_mount_point' { print $1 }' /proc/mounts >$VAR_DIR/recovery/bootdisk 2>/dev/null
+# Remember the ESP device node in VAR_DIR/recovery/bootdisk:
+echo "${esp_proc_mounts_line[0]}" >$VAR_DIR/recovery/bootdisk
+


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2095

* How was this pull request tested?

Seems to work well for me on openSUSE Leap 15.0
```
# usr/sbin/rear -D mkrescue
...
Found EFI system partition /dev/sda1 on /boot/efi type vfat
Using UEFI Boot Loader for Linux (USING_UEFI_BOOTLOADER=1)
```

* Brief description of the changes in this pull request:

The - from my point of view - needlessly overcomplicated
local variables (sometimes uppercased) and their `awk` constructs
are simplified into using plain `grep` and a bash array
to avoid inexplicable wrong behaviour is some cases
that is somehow related to the `nullglob` bash option, cf.
https://github.com/rear/rear/issues/2095#issuecomment-481833946
together with different kind of `awk`, cf.
https://github.com/rear/rear/issues/2095#issuecomment-481838163

Additionally there is better user info in debug mode via `DebugPrint`
(in particular when things do not work as usually expected).
