### PR TITLE
btrfs subvolumes generic: fix 'subvolume set-default' for older versions

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/135_include_btrfs_subvolumes_generic_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/135_include_btrfs_subvolumes_generic_code.sh
@@ -64,7 +64,8 @@ btrfs_subvolumes_setup_generic() {
                 info_message="Setting default subvolume to $subvolume_path"
                 Log "$info_message"
                 echo "# $info_message"
-                echo "btrfs subvolume set-default '$target_subvolume_path'"
+                echo "subvolumeID=\$( btrfs subvolume list -a '$target_subvolume_path' | sed -e 's/<FS_TREE>\///' | grep ' $subvolume_path\$' | tr -s '[:blank:]' ' ' | cut -d ' ' -f 2 )"
+                echo "btrfs subvolume set-default \$subvolumeID '$target_subvolume_path'"
             fi
         fi
 


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/pull/2080#issuecomment-472448686

* How was this pull request tested? On Ubuntu 16.04 and 18.04