### PR TITLE
Fix #2120: avoid unwanted "Welcome to" messages in log file

### DIFF
--- a/usr/share/rear/build/default/990_verify_rootfs.sh
+++ b/usr/share/rear/build/default/990_verify_rootfs.sh
@@ -81,7 +81,8 @@ for binary in $( find $ROOTFS_DIR -type f -executable -printf '/%P\n' ); do
     # The login shell is there so that we can call commands as in a normal working shell,
 
     # cf. https://github.com/rear/rear/issues/862#issuecomment-274068914
-    chroot $ROOTFS_DIR /bin/bash --login -c "cd $( dirname $binary ) && ldd $binary" | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
+    # Redirected stdin for login shell avoids motd welcome message, cf. https://github.com/rear/rear/issues/2120.
+    chroot $ROOTFS_DIR /bin/bash --login -c "cd $( dirname $binary ) && ldd $binary" < /dev/null | grep -q 'not found' && broken_binaries="$broken_binaries $binary"
 done
 test $old_LD_LIBRARY_PATH && export LD_LIBRARY_PATH=$old_LD_LIBRARY_PATH || unset LD_LIBRARY_PATH
 
@@ -132,7 +133,8 @@ for program in "${PROGS[@]}" ; do
     type $program || continue
     # Use the basename because the path within the recovery system is usually different compared to the path on the original system:
     program=$( basename $program )
-    chroot $ROOTFS_DIR /bin/bash --login -c "type $program" || missing_programs="$missing_programs $program"
+    # Redirected stdin for login shell avoids motd welcome message, cf. https://github.com/rear/rear/issues/2120.
+    chroot $ROOTFS_DIR /bin/bash --login -c "type $program" < /dev/null || missing_programs="$missing_programs $program"
 done
 
 # Report programs in the PROGS array that cannot be found as executable command within the recovery system:
@@ -150,7 +152,8 @@ local fatal_missing_program=""
 for required_program in "${REQUIRED_PROGS[@]}" ; do
     # Use the basename because the path within the recovery system is usually different compared to the path on the original system:
     required_program=$( basename $required_program )
-    chroot $ROOTFS_DIR /bin/bash --login -c "type $required_program" || missing_required_programs="$missing_required_programs $required_program"
+    # Redirected stdin for login shell avoids motd welcome message, cf. https://github.com/rear/rear/issues/2120.
+    chroot $ROOTFS_DIR /bin/bash --login -c "type $required_program" < /dev/null || missing_required_programs="$missing_required_programs $required_program"
 done
 # Report programs in the REQUIRED_PROGS array that cannot be found as executable command within the recovery system:
 if contains_visible_char "$missing_required_programs" ; then


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): #2120

* How was this pull request tested? Ran `rear mkrescue` on Ubuntu 18.04.2 LTS server before and after patching. Verifying log output changes as intended. Also tested a full restore successfully.

* Brief description of the changes in this pull request:

This PR intends to fix #2120, avoiding unwanted "Welcome to" messages in the log file from `rear mkrescue`.

These invocations of `bash --login` in `usr/share/rear/build/default/990_verify_rootfs.sh` were affected as follows:
1. Motd message does not appear in log file, as output is filtered by _grep_. But if someone would change the welcome message text to something containing the phrase "not found", the grep expression would always match and subsequent code would behave erroneously. The fix prevents this.
1. Motd does appear in log file. Fix has been verified to suppress it.
1. Motd does appear in log file. Fix has been verified to suppress it.

Other invocations of `bash --login` across rear scripts are not affected in the same way: They do not chroot into the rescue system (`chroot $ROOTFS_DIR`), but into the recovered target system instead (`chroot $TARGET_FS_ROOT`). The target system has its own set of bash profile files, so it does not emit the ReaR welcome message. Examples tested:
* `usr/share/rear/finalize/Debian/i386/550_rebuild_initramfs.sh`
* `usr/share/rear/finalize/Linux-i386/660_install_grub2.sh`
* `usr/share/rear/restore/default/900_create_missing_directories.sh`

