### PR TITLE
Fix layout mapping

### DIFF
--- a/usr/share/rear/layout/save/default/330_remove_exclusions.sh
+++ b/usr/share/rear/layout/save/default/330_remove_exclusions.sh
@@ -32,9 +32,13 @@ while read status name type junk ; do
 
             sed -i -r "s|^($type /dev/$vg $lv )|\#\1|" "$LAYOUT_FILE"
             ;;
-        fs|btrfsmountedsubvol|lvmdev|opaldisk)
+        fs|btrfsmountedsubvol|lvmdev)
             name=${name#$type:}
             remove_second_component "$type" "$name"
+            ;;
+        opaldisk)
+            name=${name#$type:}
+            remove_component "$type" "$name"
             ;;
         swap)
             name=${name#swap:}

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -982,7 +982,7 @@ function apply_layout_mappings() {
     while read original replacement junk ; do
         # Skip lines that have wrong syntax:
         test "$original" -a "$replacement" || continue
-        if grep -q "'^[^#].*$replacement" "$file_to_migrate" ; then
+        if grep -q "$replacement" "$file_to_migrate" ; then
             apply_layout_mappings_succeeded="no"
             LogPrintError "Failed to apply layout mappings to $file_to_migrate for $original (probably no mapping for $original in $MAPPING_FILE)"
         fi

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -982,7 +982,7 @@ function apply_layout_mappings() {
     while read original replacement junk ; do
         # Skip lines that have wrong syntax:
         test "$original" -a "$replacement" || continue
-        if grep -q "$replacement" "$file_to_migrate" ; then
+        if grep -q "'^[^#].*$replacement" "$file_to_migrate" ; then
             apply_layout_mappings_succeeded="no"
             LogPrintError "Failed to apply layout mappings to $file_to_migrate for $original (probably no mapping for $original in $MAPPING_FILE)"
         fi


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): none

* How was this pull request tested? Ran `rear mkrescue` and `rear recover` on Ubuntu 18.04.2 LTS server before and after patching. Verified fix works as intended.

* Brief description of the changes in this pull request:

This PR corrects a mapping error when TCG Opal 2 self-encrypting disks were present but had to be excluded due to a non-existent disk during recovery. This exclusion was not handled properly.

(Edit: dropped second change)