### PR TITLE
Improve handling of broken symlinks (fix #2129, fix #2130)

### DIFF
--- a/usr/share/rear/build/default/985_fix_broken_links.sh
+++ b/usr/share/rear/build/default/985_fix_broken_links.sh
@@ -12,14 +12,14 @@
 # see https://github.com/rear/rear/pull/1514#discussion_r141031975
 # and for the general issue see https://github.com/rear/rear/issues/1372
 
-# Find broken symbolic links inside the recovery system via 'chroot $ROOTFS_DIR find . -xtype l'
+# Find broken symbolic links inside the recovery system via 'chroot $ROOTFS_DIR find / -xtype l'
 # (but exclude the special proc sys dev directories inside the recovery system)
 # because 'pushd $ROOTFS_DIR ; find . -xtype l ; popd' would not find symlinks that are broken
 # within the recovery system because the symlink target is outside of the recovery system,
 # for example $ROOTFS_DIR/etc/localtime -> /usr/share/zoneinfo/Europe/Berlin is broken
 # and should be $ROOTFS_DIR/etc/localtime -> $ROOTFS_DIR/usr/share/zoneinfo/Europe/Berlin
 # cf. https://github.com/rear/rear/pull/1734#issuecomment-434635175
-local broken_symlinks=$( chroot $ROOTFS_DIR find . -xdev -path './proc' -prune -o -path './sys' -prune -o -path './dev' -prune -o -xtype l -print )
+local broken_symlinks=$( chroot $ROOTFS_DIR find / -xdev -path '/proc' -prune -o -path '/sys' -prune -o -path '/dev' -prune -o -xtype l -print )
 
 # Copy missing symlink targets into the recovery system if the symlink target exists
 # (except the symlink target is in /proc/ /sys/ /dev/ or /run/).
@@ -37,25 +37,32 @@ pushd $ROOTFS_DIR
         # the chain of symbolic links gets simplified in the recovery system to $broken_symlink -> $link_target like
         #   /some/path/to/file1 -> /final/path/to/file3
         link_target=$( readlink $v -e $broken_symlink )
-        if test "$link_target" ; then
+        if [[ "$link_target" != /* ]]; then
+            # convert a relative link target into an absolute one
+            link_target="$broken_symlink/$link_target"
+        fi
+        if [[ -d "$link_target" ]]; then
+            LogPrintError "Symlink '$broken_symlink' -> '$link_target' refers to a non-existing directory on the rescue system."
+            LogPrintError "It will not be copied by default. You can include '$link_target' via the 'COPY_AS_IS' configuration variable."
+        elif test "$link_target" ; then
             # Never copy symlink targets in /proc/ /sys/ /dev/ or /run/ into the ReaR recovery system
-            # for example the symlink ./etc/mtab that points to /proc/self/mounts
+            # for example the symlink /etc/mtab that points to /proc/self/mounts
             # cf. https://github.com/rear/rear/issues/2111
             # also cf. the scripts
             # finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
             # finalize/GNU/Linux/250_migrate_lun_wwid.sh
             # finalize/GNU/Linux/280_migrate_uuid_tags.sh
             # finalize/GNU/Linux/320_migrate_network_configuration_files.sh
-            if echo $link_target | egrep -q '/proc/|/sys/|/dev/|/run/' ; then
+            if echo $link_target | egrep -q '^/(proc|sys|dev|run)/' ; then
                 DebugPrint "Skip copying broken symlink '$broken_symlink' target '$link_target' on /proc/ /sys/ /dev/ or /run/"
                 continue
             fi
-            # The leading './' is crucial to create the parent directories inside the current working directory ROOTFS_DIR
+            # The leading '.' is crucial to create the parent directories inside the current working directory ROOTFS_DIR
             # and to copy the symlink target into the current working directory ROOTFS_DIR:
-            mkdir $v -p ./$( dirname $link_target ) || LogPrintError "Failed to make parent directories for symlink target '$link_target'"
+            mkdir $v -p .$( dirname $link_target ) || LogPrintError "Failed to make parent directories for symlink target '$link_target'"
             # Continue even after "Failed to make parent directories for symlink target ..." and let 'cp' also fail
             # to also show the explicit "Failed to copy symlink target ..." message to the user:
-            cp $v --preserve=all $link_target ./$link_target || LogPrintError "Failed to copy symlink target '$link_target'"
+            cp $v --preserve=all $link_target .$link_target || LogPrintError "Failed to copy target of symlink '$broken_symlink' -> '$link_target'"
         else
             LogPrintError "Broken symlink '$broken_symlink' in recovery system because 'readlink' cannot determine its link target"
         fi

--- a/usr/share/rear/build/default/985_fix_broken_links.sh
+++ b/usr/share/rear/build/default/985_fix_broken_links.sh
@@ -37,12 +37,6 @@ pushd $ROOTFS_DIR
         # the chain of symbolic links gets simplified in the recovery system to $broken_symlink -> $link_target like
         #   /some/path/to/file1 -> /final/path/to/file3
         link_target=$( readlink $v -e $broken_symlink )
-        if [[ "$link_target" != /* ]]; then
-            # Convert a relative link target into an absolute one. This code will possibly never execute. It exists
-            # as a safety net as the readlink(1) manual page does not state clearly whether 'readlink -e' will always
-            # return an absolute path. Cf. https://github.com/rear/rear/pull/2131#discussion_r280424161
-            link_target="$broken_symlink/$link_target"
-        fi
         if [[ -d "$link_target" ]]; then
             LogPrintError "Symlink '$broken_symlink' -> '$link_target' refers to a non-existing directory on the recovery system."
             LogPrintError "It will not be copied by default. You can include '$link_target' via the 'COPY_AS_IS' configuration variable."

--- a/usr/share/rear/build/default/985_fix_broken_links.sh
+++ b/usr/share/rear/build/default/985_fix_broken_links.sh
@@ -38,11 +38,13 @@ pushd $ROOTFS_DIR
         #   /some/path/to/file1 -> /final/path/to/file3
         link_target=$( readlink $v -e $broken_symlink )
         if [[ "$link_target" != /* ]]; then
-            # convert a relative link target into an absolute one
+            # Convert a relative link target into an absolute one. This code will possibly never execute. It exists
+            # as a safety net as the readlink(1) manual page does not state clearly whether 'readlink -e' will always
+            # return an absolute path. Cf. https://github.com/rear/rear/pull/2131#discussion_r280424161
             link_target="$broken_symlink/$link_target"
         fi
         if [[ -d "$link_target" ]]; then
-            LogPrintError "Symlink '$broken_symlink' -> '$link_target' refers to a non-existing directory on the rescue system."
+            LogPrintError "Symlink '$broken_symlink' -> '$link_target' refers to a non-existing directory on the recovery system."
             LogPrintError "It will not be copied by default. You can include '$link_target' via the 'COPY_AS_IS' configuration variable."
         elif test "$link_target" ; then
             # Never copy symlink targets in /proc/ /sys/ /dev/ or /run/ into the ReaR recovery system


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): #2129, #2130

* How was this pull request tested? On Ubuntu 18.04.2 LTS: Compared `$ROOTFS_DIR` contents before and after code changes, verified everything works as intended.

* Brief description of the changes in this pull request:

    1. Relative symbolic links are now properly resolved before checking the link's target.
    2. Directories, which are link targets, no longer fail when trying to copy them. Instead, a meaningful hint is printed for the user to decide.

**Note:** On the test system, there is a relative symbolic link `/etc/ssh/sshd_config` -> `sshd_config.company`, which points to a customized configuration.

###### Output without this PR's changes
```
$ sudo usr/sbin/rear -v mkrescue
Relax-and-Recover 2.4 / Git
[...]
Copying all files in /lib*/firmware/
Broken symlink './etc/ssh/sshd_config' in recovery system because 'readlink' cannot determine its link target
Broken symlink './usr/share/misc/magic' in recovery system because 'readlink' cannot determine its link target
Failed to copy symlink target '/usr/src/linux-headers-4.18.0-18-generic'
Testing that the recovery system in /tmp/rear.2F8DRaogql1zNej/rootfs contains a usable system
[...]
```

###### Output with this PR's changes
```
$ sudo usr/sbin/rear -v mkrescue
Relax-and-Recover 2.4 / Git
Running rear mkrescue (PID 4478)
[...]
Copying all files in /lib*/firmware/
Symlink '/usr/share/misc/magic' -> '/usr/share/file/magic' refers to a non-existing directory on the rescue system.
It will not be copied by default. You can include '/usr/share/file/magic' via the 'COPY_AS_IS' configuration variable.
Symlink '/lib/modules/4.18.0-18-generic/build' -> '/usr/src/linux-headers-4.18.0-18-generic' refers to a non-existing directory on the rescue system.
It will not be copied by default. You can include '/usr/src/linux-headers-4.18.0-18-generic' via the 'COPY_AS_IS' configuration variable.
Testing that the recovery system in /tmp/rear.5TcC1r3dx1c336B/rootfs contains a usable system
[...]
```

