### PR TITLE
NBU: exclude '/usr/openv/netbackup/logs' directory instead of files in directory only

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1565,7 +1565,7 @@ OBDR_BLOCKSIZE=2048
 ##
 #
 COPY_AS_IS_NBU=( /usr/openv/bin/vnetd /usr/openv/bin/vopied /usr/openv/lib /usr/openv/netbackup /usr/openv/var/auth/[mn]*.txt )
-COPY_AS_IS_EXCLUDE_NBU=( "/usr/openv/netbackup/logs/*" "/usr/openv/netbackup/bin/bpjava*" /usr/openv/netbackup/bin/xbp /usr/openv/netbackup/bin/private /usr/openv/lib/java /usr/openv/lib/shared/vddk /usr/openv/netbackup/baremetal )
+COPY_AS_IS_EXCLUDE_NBU=( /usr/openv/netbackup/logs "/usr/openv/netbackup/bin/bpjava*" /usr/openv/netbackup/bin/xbp /usr/openv/netbackup/bin/private /usr/openv/lib/java /usr/openv/lib/shared/vddk /usr/openv/netbackup/baremetal )
 # See https://github.com/rear/rear/issues/2105 why /usr/openv/netbackup/sec/at/lib/ is needed:
 NBU_LD_LIBRARY_PATH="/usr/openv/lib:/usr/openv/netbackup/sec/at/lib/"
 PROGS_NBU=( )


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* How was this pull request tested? Tested on RHEL7

* Brief description of the changes in this pull request:

When using the NetBackup method, the files in the logs directory are excluded because they are useless. However, if, for some reason `/usr/openv/netbackup/logs` is a symlink to some other directory (a user customization), then ReaR will fail to create the ISO, due to having a skeleton directory for NBU in ReaR, causing the 'tar | untar' of `COPY_AS_IS` items to fail.
