### PR TITLE
On-board packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,8 @@
+specfile_path: packaging/rpm/rear.spec
+synced_files:
+  - .packit.yaml
+  - src: packaging/rpm/rear.spec
+    dest: rear.spec
+upstream_project_name: rear
+downstream_package_name: rear
+


### PR DESCRIPTION
This PR adds support for packit https://github.com/packit-service/packit, which syncs upstream releases into downstream automatically. See docu on packit side https://github.com/packit-service/packit/blob/master/README.md.