### PR TITLE
Improvements and fixes for 950_copy_result_files (related to issue2137)

### DIFF
--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -1,5 +1,11 @@
 #
-# copy resulting files to network output location
+# output/default/950_copy_result_files.sh
+# Copy the resulting files to the output location.
+#
+
+# For example for "rear mkbackuponly" there are usually no result files
+# that would need to be copied here to the output location:
+test "$RESULT_FILES" || return 0
 
 local scheme=$( url_scheme $OUTPUT_URL )
 local host=$( url_host $OUTPUT_URL )
@@ -7,34 +13,31 @@ local path=$( url_path $OUTPUT_URL )
 local opath=$( output_path $scheme $path )
 
 # if $opath is empty return silently (e.g. scheme tape)
-if [[ -z "$opath" || -z "$OUTPUT_URL" || "$scheme" == "obdr" || "$scheme" == "tape" ]]; then
+if [[ -z "$opath" || -z "$OUTPUT_URL" || "$scheme" == "obdr" || "$scheme" == "tape" ]] ; then
     return 0
 fi
 
 LogPrint "Copying resulting files to $scheme location"
 
 echo "$VERSION_INFO" >"$TMP_DIR/VERSION" || Error "Could not create $TMP_DIR/VERSION file"
-if test -s $(get_template "RESULT_usage_$OUTPUT.txt") ; then
-    cp $v $(get_template "RESULT_usage_$OUTPUT.txt") "$TMP_DIR/README" >&2
-    StopIfError "Could not copy '$(get_template RESULT_usage_$OUTPUT.txt)'"
+RESULT_FILES+=( "$TMP_DIR/VERSION" )
+
+local usage_readme_file=$( get_template "RESULT_usage_$OUTPUT.txt" )
+if test -s $usage_readme_file ; then
+    cp $v $usage_readme_file "$TMP_DIR/README" || Error "Could not copy $usage_readme_file to $TMP_DIR/README"
+    RESULT_FILES+=( "$TMP_DIR/README" )
 fi
 
 # Usually RUNTIME_LOGFILE=/var/log/rear/rear-$HOSTNAME.log
 # The RUNTIME_LOGFILE name is set by the main script from LOGFILE in default.conf
 # but later user config files are sourced in the main script where LOGFILE can be set different
 # so that the user config LOGFILE basename is used as final logfile name:
-final_logfile_name=$( basename $LOGFILE )
+local final_logfile_name=$( basename $LOGFILE )
 cat "$RUNTIME_LOGFILE" > "$TMP_DIR/$final_logfile_name" || Error "Could not copy $RUNTIME_LOGFILE to $TMP_DIR/$final_logfile_name"
+RESULT_FILES+=( "$TMP_DIR/$final_logfile_name" )
 LogPrint "Saving $RUNTIME_LOGFILE as $final_logfile_name to $scheme location"
 
-# Add the README, VERSION and the final logfile to the RESULT_FILES array
-RESULT_FILES=( "${RESULT_FILES[@]}" "$TMP_DIR/VERSION" "$TMP_DIR/README" "$TMP_DIR/$final_logfile_name" )
-
-# For example for "rear mkbackuponly" there are usually no result files
-# that would need to be copied here to the network output location:
-test "$RESULT_FILES" || return 0
-
-# The real work (actually copying resulting files to the network output location):
+# The real work (actually copying resulting files to the output location):
 case "$scheme" in
     (nfs|cifs|usb|file|sshfs|ftpfs|davfs)
         LogPrint "Copying result files '${RESULT_FILES[@]}' to $opath at $scheme location"
@@ -53,7 +56,7 @@ case "$scheme" in
         # The -f option won't help for this case, it only applies when there already is a target file that will be overwritten.
         # Accordingly it is sufficient (even without '-f') to copy each result file one by one:
         for result_file in "${RESULT_FILES[@]}" ; do
-            cp $v "$result_file" "${opath}/" >&2 || Error "Could not copy result file $result_file to $opath at $scheme location"
+            cp $v "$result_file" "${opath}/" || Error "Could not copy result file $result_file to $opath at $scheme location"
         done
         ;;
     (fish|ftp|ftps|hftp|http|https|sftp)


### PR DESCRIPTION
* Type: **Bug Fix** 

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2142#issuecomment-494426331
https://github.com/rear/rear/pull/2142#issuecomment-495010023
https://github.com/rear/rear/issues/2137

* How was this pull request tested?
By me via
https://github.com/rear/rear/pull/2142#issuecomment-494426331

* Brief description of the changes in this pull request:

Before output/default/950_copy_result_files.sh falsely errors out with
```
Could not copy '/usr/share/rear/conf/templates/RESULT_usage_FOO.txt'
```
cf. https://github.com/rear/rear/pull/2142#issuecomment-495010023
when `OUTPUT=FOO` is used where no
usr/share/rear/conf/templates/RESULT_usage_FOO.txt
exists.
Currently only
usr/share/rear/conf/templates/RESULT_usage_PXE.txt
usr/share/rear/conf/templates/RESULT_usage_RAMDISK.txt
usr/share/rear/conf/templates/RESULT_usage_ISO.txt
usr/share/rear/conf/templates/RESULT_usage_RAWDISK.txt
usr/share/rear/conf/templates/RESULT_usage_USB.txt
exists so that 950_copy_result_files.sh falsely errors out for all
other OUTPUT methods.

Additionally 950_copy_result_files.sh is now skipped
if RESULT_FILES is empty at the beginning of the script
because I think if there are no actual RESULT_FILES
it means there is no actual output and then is is useless
to copy VERSION and README and LOGFILE
to the output location.
I think it could be questionable if perhaps LOGFILE
should be always copied to the output location
even if there is no actual output.
If LOGFILE should be always copied to the output location
I can easily fix that.
