### PR TITLE
Fix for issue 2151: only the first 2 parameters in /etc/crypttab are …

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -40,7 +40,7 @@ while read target_name junk ; do
     key_size=$(cryptsetup luksDump $source_device | grep "MK bits" | sed -r 's/^.+:\s*(.+)$/\1/')
     hash=$(cryptsetup luksDump $source_device | grep "Hash spec" | sed -r 's/^.+:\s*(.+)$/\1/')
     uuid=$(cryptsetup luksDump $source_device | grep "UUID" | sed -r 's/^.+:\s*(.+)$/\1/')
-    keyfile_option=$([ -f /etc/crypttab ] && awk '$1 == "'"$target_name"'" && $3 != "none" && $3 != "-" { print "keyfile=" $3; }' /etc/crypttab)
+    keyfile_option=$([ -f /etc/crypttab ] && awk '$1 == "'"$target_name"'" && $3 != "none" && $3 != "-" && $3 != "" { print "keyfile=" $3; }' /etc/crypttab)
 
     echo "crypt /dev/mapper/$target_name $source_device cipher=$cipher-$mode key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE
 done < <( dmsetup ls --target crypt )


### PR DESCRIPTION
…mandatory on openSUSE.

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/2151

* How was this pull request tested?
    - aligned working copy on trunk/LATEST
    - added encrypted LV inside VM (using simple password for key)
    - created recovery image and backup from test VM
    - stopped VM, deleted and recreated virtual HDD
    - recovered VM from ReaR image + backup
    - new LV was recreated as encrypted, a new password was asked for interactively during recovery phase

* Brief description of the changes in this pull request:

The `awk` script on line 43 of `layout/save/GNU/Linux/260_crypt_layout.sh` was modified to also allow for an empty third parameter in `/etc/crypttab` (in addition to the existing values of 'none' and '-').

This difference in the `/etc/crypttab` format is documented in its openSUSE man page, quoted here: https://github.com/rear/rear/issues/2151#issuecomment-496575055 (Leap 15.0 version).
