### PR TITLE
Do not log BACKUP_PROG_CRYPT_KEY value (issue 2155)

### DIFF
--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -34,10 +34,10 @@ To create an ISO rescue image and using a central NFS/NAS server to store it tog
 ----
 OUTPUT=ISO
 BACKUP=NETFS
-#BACKUP_OPTIONS="nfsvers=3,nolock"
+# BACKUP_OPTIONS="nfsvers=3,nolock"
 BACKUP_URL=nfs://your.NFS.server.IP/path/to/your/rear/backup
-#BACKUP_PROG_CRYPT_ENABLED="yes"
-#BACKUP_PROG_CRYPT_KEY="my_secret_key"
+# BACKUP_PROG_CRYPT_ENABLED="yes"
+# { BACKUP_PROG_CRYPT_KEY="my_secret_passphrase" ; } 2>/dev/null
 ----
 
 The above example shows that it is also possible to encrypt the backup archive.
@@ -48,12 +48,20 @@ It gets removed because the ReaR rescue/recovery system must be free of secrets.
 Otherwise the rescue system ISO image and any recovery medium that is made from it
 would have to be carefully protected against any unwanted access.
 Therefore BACKUP_PROG_CRYPT_KEY must be manually set before running "rear recover".
-For example via `export BACKUP_PROG_CRYPT_KEY="my_secret_key"`
+For example via `export BACKUP_PROG_CRYPT_KEY="my_secret_passphrase"`
 before calling "rear recover" and/or also before calling "rear mkbackup"
 so that there is no need to store it ever in a ReaR config file.
 On the other hand it is crucial to remember the BACKUP_PROG_CRYPT_KEY value
 that was used during "rear mkbackup" so that possibly a long time later that
 rescue image can be used (possibly by someone else) to recover from a disaster.
+If the BACKUP_PROG_CRYPT_KEY value should be set in a ReaR config file
+you should avoid that the BACKUP_PROG_CRYPT_KEY value is shown in a log file
+when 'rear' is run in debugscript mode (where 'set -x' is set) by redirecting
+STDERR to /dev/null via `{ command confidential_argument ; } 2>/dev/null`
+where the redirection must be done via a compound group command even for
+a single confidential command to let the redirection also apply for 'set -x'.
+See the comment of the UserInput function in lib/_input-output-functions.sh
+how to keep things confidential when 'rear' is run in debugscript mode.
 
 
 == Bootable USB device with backup to USB

--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -27,19 +27,33 @@ When using one of the above backup solution (commercial or open source) then the
 
 ReaR will incorporate the needed executables and libraries of your chosen backup solution into the rescue image of ReaR.
 
-== Bootable ISO and storing archive on NFS/NAS
-To create an ISO rescue image and using a central NFS/NAS server to store the archive, you could define:
+== Bootable ISO together with backup archive stored on NFS/NAS
+To create an ISO rescue image and using a central NFS/NAS server to store it together with the backup archive, you could define:
 
 [source,bash]
 ----
 OUTPUT=ISO
 BACKUP=NETFS
-BACKUP_URL=nfs://remote-nfs-server/exports
-#BACKUP_PROG_CRYPT_ENABLED=1
-#BACKUP_PROG_CRYPT_KEY="my_Secret_pw"
+#BACKUP_OPTIONS="nfsvers=3,nolock"
+BACKUP_URL=nfs://your.NFS.server.IP/path/to/your/rear/backup
+#BACKUP_PROG_CRYPT_ENABLED="yes"
+#BACKUP_PROG_CRYPT_KEY="my_secret_key"
 ----
 
-The above example shows that it is even possible to protect the archives with a password.  Be aware, that the password entry +BACKUP_PROG_CRYPT_KEY="my_Secret_pw"+ will be deleted in the +/etc/rear/local.conf+ file within the rescue image. So, it is important to remember the password (if you use the rescue image months later could cause problems I guess).
+The above example shows that it is also possible to encrypt the backup archive.
+Currently only 'tar' is supported for backup archive encryption and decryption.
+When BACKUP_PROG_CRYPT_ENABLED is set to a true value, BACKUP_PROG_CRYPT_KEY must be also set.
+There is no BACKUP_PROG_CRYPT_KEY value in the /etc/rear/local.conf file in the rescue image.
+It gets removed because the ReaR rescue/recovery system must be free of secrets.
+Otherwise the rescue system ISO image and any recovery medium that is made from it
+would have to be carefully protected against any unwanted access.
+Therefore BACKUP_PROG_CRYPT_KEY must be manually set before running "rear recover".
+For example via `export BACKUP_PROG_CRYPT_KEY="my_secret_key"`
+before calling "rear recover" and/or also before calling "rear mkbackup"
+so that there is no need to store it ever in a ReaR config file.
+On the other hand it is crucial to remember the BACKUP_PROG_CRYPT_KEY value
+that was used during "rear mkbackup" so that possibly a long time later that
+rescue image can be used (possibly by someone else) to recover from a disaster.
 
 
 == Bootable USB device with backup to USB

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -28,7 +28,7 @@ function get_bash_flags_and_options_commands () {
     # Output bash commands that set the currently set flags
     # in reverse ordering to have "set ... xtrace" (i.e. "set +/- x") first
     # so that this flag is set first via apply_bash_flags_and_options_commands
-    # which results better matching logging output in debugscripts mode:
+    # which results better matching logging output in debugscript mode:
     set +o | tac | tr '\n' ';'
     # Output bash commands that set the currently set options:
     shopt -p | tr '\n' ';'

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -1,3 +1,4 @@
+#
 # 500_make_backup.sh
 #
 
@@ -37,16 +38,16 @@ if [[ "$opath" ]]; then
     mkdir -p $v "${opath}" >&2
 fi
 
-# Disable BACKUP_PROG_CRYPT_OPTIONS by replacing the default with 'cat' when encryption is disabled
-# (by default encryption is disabled but the default BACKUP_PROG_CRYPT_OPTIONS is not 'cat'):
 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
     # Backup archive encryption is only supported with 'tar':
     test "tar" = "$BACKUP_PROG" || Error "Backup archive encryption is only supported with BACKUP_PROG=tar"
-    LogPrint "Encrypting backup archive with key defined in variable \$BACKUP_PROG_CRYPT_KEY"
-else
-    Log "Encrypting backup archive is disabled"
-    BACKUP_PROG_CRYPT_OPTIONS="cat"
-    BACKUP_PROG_CRYPT_KEY=""
+    # Backup archive encryption is impossible without a BACKUP_PROG_CRYPT_KEY value.
+    # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode
+    # cf. the comment of the UserInput function in lib/_input-output-functions.sh
+    # how to keep things confidential when usr/sbin/rear is run in debugscript mode
+    # ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
+    { test "$BACKUP_PROG_CRYPT_KEY" || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive encryption" ; } 2>/dev/null
+    LogPrint "Encrypting backup archive with key defined in BACKUP_PROG_CRYPT_KEY"
 fi
 
 # Check if the backup needs to be splitted or not (on multiple ISOs)
@@ -71,6 +72,17 @@ fi
 FAILING_BACKUP_PROG_FILE="$TMP_DIR/failing_backup_prog"
 FAILING_BACKUP_PROG_RC_FILE="$TMP_DIR/failing_backup_prog_rc"
 
+# Do not show the BACKUP_PROG_CRYPT_KEY value in a log file
+# where BACKUP_PROG_CRYPT_KEY is only used if BACKUP_PROG_CRYPT_ENABLED is true
+# therefore 'Log ... BACKUP_PROG_CRYPT_KEY ...' is used (and not '$BACKUP_PROG_CRYPT_KEY')
+# but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
+# the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
+# so that stderr of the whole actual command is redirected to /dev/null
+# cf. the comment of the UserInput function in lib/_input-output-functions.sh
+# how to keep things confidential when rear is run in debugscript mode
+# because it is more important to not leak out user secrets into a log file
+# than having stderr error messages when a confidential command fails
+# cf. https://github.com/rear/rear/issues/2155
 LogPrint "Creating $BACKUP_PROG archive '$backuparchive'"
 ProgressStart "Preparing archive operation"
 (
@@ -78,13 +90,24 @@ case "$(basename ${BACKUP_PROG})" in
     # tar compatible programs here
     (tar)
         set_tar_features
-        Log $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
-            --no-wildcards-match-slash --one-file-system \
-            --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}" \
-            $BACKUP_PROG_CREATE_NEWER_OPTIONS \
-            ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
-            -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
-            $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
+
+        if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
+            Log $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
+                --no-wildcards-match-slash --one-file-system \
+                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}" \
+                $BACKUP_PROG_CREATE_NEWER_OPTIONS \
+                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
+                -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
+        else
+            Log $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
+                --no-wildcards-match-slash --one-file-system \
+                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}" \
+                $BACKUP_PROG_CREATE_NEWER_OPTIONS \
+                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
+                -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $SPLIT_COMMAND
+        fi
 
         # Variable used to record the short name of piped commands in case of
         # error, e.g. ( "tar" "cat" "dd" ) in case of unencrypted and unsplit backup.
@@ -97,19 +120,30 @@ case "$(basename ${BACKUP_PROG})" in
             [ -n "${backup_prog_shortnames[$index]}" ] || BugError "No computed shortname for pipe component $index"
         done
 
-        $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose    \
-            --no-wildcards-match-slash --one-file-system                        \
-            --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                    \
-            $BACKUP_PROG_CREATE_NEWER_OPTIONS                                   \
-            ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                       \
-            "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                \
-            -X $TMP_DIR/backup-exclude.txt -C / -c -f -                         \
-            $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |   \
-                                                                    \
-        $BACKUP_PROG_CRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY |         \
-                                                                    \
-        $SPLIT_COMMAND
-        pipes_rc=( ${PIPESTATUS[@]} )
+        if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
+            { $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose    \
+                  --no-wildcards-match-slash --one-file-system                        \
+                  --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                    \
+                  $BACKUP_PROG_CREATE_NEWER_OPTIONS                                   \
+                  ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                       \
+                  "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                \
+                  -X $TMP_DIR/backup-exclude.txt -C / -c -f -                         \
+                  $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |   \
+              $BACKUP_PROG_CRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY |         \
+              $SPLIT_COMMAND ; } 2>/dev/null
+            pipes_rc=( ${PIPESTATUS[@]} )
+        else
+            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose    \
+                --no-wildcards-match-slash --one-file-system                        \
+                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                    \
+                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                   \
+                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                       \
+                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                \
+                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                         \
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |   \
+            $SPLIT_COMMAND
+            pipes_rc=( ${PIPESTATUS[@]} )
+        fi
 
         # Exit code logic:
         # - never return rc=1 (this is reserved for "tar" warning about modified files)

--- a/usr/share/rear/build/default/960_remove_encryption_keys.sh
+++ b/usr/share/rear/build/default/960_remove_encryption_keys.sh
@@ -18,11 +18,12 @@
 # and BACKUP_PROG_CRYPT_ENABLED=false the BACKUP_PROG_CRYPT_KEY value is still there.
 
 LogPrint "Removing BACKUP_PROG_CRYPT_KEY value from config files in the recovery system"
-for configfile in $( find ${ROOTFS_DIR}/etc/rear ${ROOTFS_DIR}/usr/share/rear/conf -name "*.conf" -type f )
-do
-    # Avoid running 'sed' needlessly on files that do not contain 'BACKUP_PROG_CRYPT_KEY='.
+for configfile in $( find ${ROOTFS_DIR}/etc/rear ${ROOTFS_DIR}/usr/share/rear/conf -name "*.conf" -type f ) ; do
+    # Avoid running 'sed' needlessly on files that do not contain 'BACKUP_PROG_CRYPT_KEY=' with its actual value
+    # which is the case for default.conf that contains the example BACKUP_PROG_CRYPT_KEY="my_secret_passphrase".
+    # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode as described above.
     # Without '-q' grep would output the BACKUP_PROG_CRYPT_KEY value on stdout which is redirected to the log:
-    grep -q 'BACKUP_PROG_CRYPT_KEY=' $configfile || continue
+    { grep -q "BACKUP_PROG_CRYPT_KEY=.*$BACKUP_PROG_CRYPT_KEY" $configfile ; } 2>/dev/null || continue
     # It must work for simple unquoted assignment as in
     #   BACKUP_PROG_CRYPT_KEY=my_secret_passphrase
     # but also for more advanced things like

--- a/usr/share/rear/build/default/960_remove_encryption_keys.sh
+++ b/usr/share/rear/build/default/960_remove_encryption_keys.sh
@@ -31,7 +31,10 @@ do
     # To avoid arbitrary syntax matching via complicated regular expressions
     # we simply remove all BACKUP_PROG_CRYPT_KEY values in lines that contain 'BACKUP_PROG_CRYPT_KEY='
     # and we avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode as described above:
-    { sed -i -e "/BACKUP_PROG_CRYPT_KEY=/s/$BACKUP_PROG_CRYPT_KEY//g" $configfile ; } 2>/dev/null && continue
-    LogPrintError "Failed to remove BACKUP_PROG_CRYPT_KEY value from $configfile"
+    if { sed -i -e "/BACKUP_PROG_CRYPT_KEY=/s/$BACKUP_PROG_CRYPT_KEY//g" $configfile ; } 2>/dev/null ; then
+        DebugPrint "Removed BACKUP_PROG_CRYPT_KEY value from $configfile"
+    else
+        LogPrintError "Failed to remove BACKUP_PROG_CRYPT_KEY value from $configfile"
+    fi
 done
 

--- a/usr/share/rear/build/default/960_remove_encryption_keys.sh
+++ b/usr/share/rear/build/default/960_remove_encryption_keys.sh
@@ -1,12 +1,28 @@
-# Remove all encryption Keys from initrd
+#
+# build/default/960_remove_encryption_keys.sh
+#
+# Remove the BACKUP_PROG_CRYPT_KEY value from ReaR's initrd
+# because the ReaR recovery system must be free of secrets
+# cf. the reasoning about SSH_UNPROTECTED_PRIVATE_KEYS in default.conf
+# and see https://github.com/rear/rear/issues/2155
 
-if is_false "$BACKUP_PROG_CRYPT_ENABLED" ; then
-  return
-fi
+# Nothing to do when there is no BACKUP_PROG_CRYPT_KEY value.
+# Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode
+# cf. the comment of the UserInput function in lib/_input-output-functions.sh
+# how to keep things confidential when usr/sbin/rear is run in debugscript mode
+# ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
+{ test "$BACKUP_PROG_CRYPT_KEY" || return 0 ; } 2>/dev/null
 
-LogPrint "Removing all encryption Keys from initrd"
-for configfile in $(find ${ROOTFS_DIR}/etc/rear ${ROOTFS_DIR}/usr/share/rear/conf -name "*.conf" -type f -print 2>&1)
+# BACKUP_PROG_CRYPT_KEY must be removed regardless if BACKUP_PROG_CRYPT_ENABLED is true or false
+# because when the user has in his etc/rear/local.conf BACKUP_PROG_CRYPT_KEY=my_secret_key
+# and BACKUP_PROG_CRYPT_ENABLED=false the BACKUP_PROG_CRYPT_KEY value is still there.
+
+LogPrint "Removing BACKUP_PROG_CRYPT_KEY value from config files in the recovery system"
+for configfile in $( find ${ROOTFS_DIR}/etc/rear ${ROOTFS_DIR}/usr/share/rear/conf -name "*.conf" -type f )
 do
-  sed -i -e 's/BACKUP_PROG_CRYPT_KEY=.*/BACKUP_PROG_CRYPT_KEY=""/' $configfile
+    # Without '-q' grep would output the BACKUP_PROG_CRYPT_KEY value on stdout which is redirected to the log:
+    grep -q 'BACKUP_PROG_CRYPT_KEY=' $configfile || continue
+    sed -i -e 's/BACKUP_PROG_CRYPT_KEY=.*/BACKUP_PROG_CRYPT_KEY=""/' $configfile && continue
+    LogPrintError "Failed to remove BACKUP_PROG_CRYPT_KEY value from $configfile"
 done
 

--- a/usr/share/rear/build/default/960_remove_encryption_keys.sh
+++ b/usr/share/rear/build/default/960_remove_encryption_keys.sh
@@ -11,7 +11,7 @@
 # cf. the comment of the UserInput function in lib/_input-output-functions.sh
 # how to keep things confidential when usr/sbin/rear is run in debugscript mode
 # ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
-{ test "$BACKUP_PROG_CRYPT_KEY" || return 0 ; } 2>/dev/null
+{ test "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null || return 0
 
 # BACKUP_PROG_CRYPT_KEY must be removed regardless if BACKUP_PROG_CRYPT_ENABLED is true or false
 # because when the user has in his etc/rear/local.conf BACKUP_PROG_CRYPT_KEY=my_secret_key

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -918,9 +918,27 @@ BACKUP_PROG_SUFFIX=".tar"
 # http://git.savannah.gnu.org/cgit/tar.git/plain/NEWS?id=release_1_27
 BACKUP_PROG_COMPRESS_OPTIONS=( --gzip )
 BACKUP_PROG_COMPRESS_SUFFIX=".gz"
-# Addons for encryption of the backup (currently only tar is supported)
-BACKUP_PROG_CRYPT_ENABLED=0
-BACKUP_PROG_CRYPT_KEY=""
+# Addons for encryption and decryption of the backup (currently only tar is supported):
+BACKUP_PROG_CRYPT_ENABLED="false"
+# When BACKUP_PROG_CRYPT_ENABLED is set to a true value, BACKUP_PROG_CRYPT_KEY must be also set.
+# There is no BACKUP_PROG_CRYPT_KEY value in etc/rear/local.conf in the ReaR recovery system.
+# It gets removed by build/default/960_remove_encryption_keys.sh
+# because the ReaR recovery system must be free of secrets
+# cf. the reasoning about SSH_UNPROTECTED_PRIVATE_KEYS below
+# and see https://github.com/rear/rear/issues/2155
+# Therefore BACKUP_PROG_CRYPT_KEY must be manually set before running "rear recover".
+# BACKUP_PROG_CRYPT_KEY is set to a default value here only
+# if not already set so that the user can set it also like
+#   export BACKUP_PROG_CRYPT_KEY="my_secret_key"
+# directly before he calls "rear ..." so that there is no need to store it in a config file.
+# Avoid that the BACKUP_PROG_CRYPT_KEY value is shown when usr/sbin/rear was called with 'set -x'
+# for debugging usr/sbin/rear cf. https://github.com/rear/rear/issues/2144#issuecomment-493908133
+# In debugscript mode only scripts sourced by the Source function in lib/framework-functions.sh
+# are run with 'set -x' but default.conf is sourced by usr/sbin/rear directly.
+# See the comment of the UserInput function in lib/_input-output-functions.sh
+# how to keep things confidential when usr/sbin/rear is run in debugscript mode
+# ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
+{ test "$BACKUP_PROG_CRYPT_KEY" || BACKUP_PROG_CRYPT_KEY="" ; } 2>/dev/null
 BACKUP_PROG_CRYPT_OPTIONS="/usr/bin/openssl des3 -salt -k "
 BACKUP_PROG_DECRYPT_OPTIONS="/usr/bin/openssl des3 -d -k "
 # One might even create a dynamic name like BACKUP_PROG_ARCHIVE="backup_$( date -Iseconds )"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -929,7 +929,7 @@ BACKUP_PROG_CRYPT_ENABLED="false"
 # Therefore BACKUP_PROG_CRYPT_KEY must be manually set before running "rear recover".
 # BACKUP_PROG_CRYPT_KEY is set to a default value here only
 # if not already set so that the user can set it also like
-#   export BACKUP_PROG_CRYPT_KEY="my_secret_key"
+#   export BACKUP_PROG_CRYPT_KEY="my_secret_passphrase"
 # directly before he calls "rear ..." so that there is no need to store it in a config file.
 # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown when usr/sbin/rear was called with 'set -x'
 # for debugging usr/sbin/rear cf. https://github.com/rear/rear/issues/2144#issuecomment-493908133
@@ -938,8 +938,14 @@ BACKUP_PROG_CRYPT_ENABLED="false"
 # See the comment of the UserInput function in lib/_input-output-functions.sh
 # how to keep things confidential when usr/sbin/rear is run in debugscript mode
 # ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
-{ test "$BACKUP_PROG_CRYPT_KEY" || BACKUP_PROG_CRYPT_KEY="" ; } 2>/dev/null
+{ test "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null || BACKUP_PROG_CRYPT_KEY=""
+# The command for backup encryption during "rear mkbackup" will be basically
+#    tar ... | BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY
+# for details see the backup/NETFS/default/500_make_backup.sh script:
 BACKUP_PROG_CRYPT_OPTIONS="/usr/bin/openssl des3 -salt -k "
+# The command for backup decryption during "rear recover" will be basically
+#    BACKUP_PROG_DECRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY | tar ...
+# for details see the restore/NETFS/default/400_restore_backup.sh script:
 BACKUP_PROG_DECRYPT_OPTIONS="/usr/bin/openssl des3 -d -k "
 # One might even create a dynamic name like BACKUP_PROG_ARCHIVE="backup_$( date -Iseconds )"
 # in particular one can use BACKUP_PROG_ARCHIVE="$( date '+%Y-%m-%d-%H%M' )-F"

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -365,7 +365,7 @@ function trap () {
 # but only when the user launched 'rear -v' in verbose mode:
 function Print () {
     # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV when $DISPENSABLE_OUTPUT_DEV is not 'null'.
-    # In debugscripts mode $DISPENSABLE_OUTPUT_DEV is 'stderr' (see usr/sbin/rear)
+    # In debugscript mode $DISPENSABLE_OUTPUT_DEV is 'stderr' (see usr/sbin/rear)
     # and /dev/stderr is fd2 which is redirected to append to RUNTIME_LOGFILE (see usr/sbin/rear)
     # so that 2>/dev/stderr would truncate RUNTIME_LOGFILE to zero size (see 'REDIRECTION' in "man bash")
     # but 2>>/dev/stderr does not change things so that fd2 output is still appended to RUNTIME_LOGFILE:
@@ -545,7 +545,7 @@ function Error () {
     # (but do not stop at lines that are logged like '++ StopIfError ...' or '++ PrintError ...')
     # if such a '+ Error' or '+ BugError' line exists, otherwise sed proceeds to the end
     # (the sed pattern '[Bug]*Error' is fuzzy because it would also match things like 'uuggError').
-    # The reason to stop at a line that contains '+ [Bug]*Error ' is that in debugscripts mode '-D'
+    # The reason to stop at a line that contains '+ [Bug]*Error ' is that in debugscript mode '-D'
     # a BugError or Error function call with a multi line error message (e.g. BugError does that)
     # results 'set -x' debug output of that function call in the log file that looks like:
     #   ++ [Bug]Error 'first error message line
@@ -756,9 +756,9 @@ function LogPrintIfError () {
 #       the prompt, the actual input, the default value, and the choices are still shown on the user's terminal.
 #       In confidential user input mode the actual input coming from the user's terminal is still echoed
 #       on the user's terminal unless also the -s option is specified.
-#       When usr/sbin/rear is run in debugscripts mode (which runs the scripts with 'set -x') arbitrary values
-#       appear in the log file so that the confidential user input mode does not help in debugscripts mode.
-#       If confidential user input is needed also in debugscripts mode the caller of the UserInput function
+#       When usr/sbin/rear is run in debugscript mode (which runs the scripts with 'set -x') arbitrary values
+#       appear in the log file so that the confidential user input mode does not help in debugscript mode.
+#       If confidential user input is needed also in debugscript mode the caller of the UserInput function
 #       must call it in an appropriate (temporary) environment e.g. with STDERR redirected to /dev/null like:
 #           { password="$( UserInput -I PASSWORD -C -r -s -p 'Enter the pasword' )" ; } 2>/dev/null
 # Result:

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -759,8 +759,13 @@ function LogPrintIfError () {
 #       When usr/sbin/rear is run in debugscript mode (which runs the scripts with 'set -x') arbitrary values
 #       appear in the log file so that the confidential user input mode does not help in debugscript mode.
 #       If confidential user input is needed also in debugscript mode the caller of the UserInput function
-#       must call it in an appropriate (temporary) environment e.g. with STDERR redirected to /dev/null like:
+#       must call it in an appropriate (temporary) environment e.g. with STDERR redirected to /dev/null like
 #           { password="$( UserInput -I PASSWORD -C -r -s -p 'Enter the pasword' )" ; } 2>/dev/null
+#       The redirection must be done via a compound group command { confidential_command ; } 2>/dev/null
+#       even for a single confidential command to ensure STDERR is redirected to /dev/null also for 'set -x'
+#       otherwise the confidential command and its arguments would be shown in the log file, for example
+#           { openssl des3 -salt -k secret_passphrase ; } 2>/dev/null
+#       where the secret passphrase must not appear in the log, cf. https://github.com/rear/rear/issues/2155
 # Result:
 #   Any actual user input or an automated user input or the default response is output via STDOUT.
 # Return code:

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -42,7 +42,7 @@ function Source () {
     Log "Including $relname"
     # DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        Debug "Entering debugscripts mode via 'set -$DEBUGSCRIPTS_ARGUMENT'."
+        Debug "Entering debugscript mode via 'set -$DEBUGSCRIPTS_ARGUMENT'."
         local saved_bash_flags_and_options_commands="$( get_bash_flags_and_options_commands )"
         set -$DEBUGSCRIPTS_ARGUMENT
     fi
@@ -58,7 +58,7 @@ function Source () {
     test "0" -eq "$source_return_code" || Debug "Source function: 'source $source_file' returns $source_return_code"
     # Undo DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
-        Debug "Leaving debugscripts mode (back to previous bash flags and options settings)."
+        Debug "Leaving debugscript mode (back to previous bash flags and options settings)."
         # The only known way how to do 'set +x' after 'set -x' without 'set -x' output for the 'set +x' call
         # is a current shell environment where stderr is redirected to /dev/null before 'set +x' is run via
         #   { set +x ; } 2>/dev/null

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -1,3 +1,4 @@
+#
 # 400_restore_backup.sh
 #
 
@@ -21,18 +22,6 @@ test "$CONFIG_APPEND_FILES" && backup_restore_log_prefix=$backup_restore_log_pre
 local restore_input_basename=""
 
 mkdir -p $BUILD_DIR/outputfs/$NETFS_PREFIX
-
-# Disable BACKUP_PROG_DECRYPT_OPTIONS by replacing the default with 'cat' when encryption is disabled
-# (by default encryption is disabled but the default BACKUP_PROG_DECRYPT_OPTIONS is not 'cat'):
-if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
-    # Backup archive decryption is only supported with 'tar':
-    test "tar" = "$BACKUP_PROG" || Error "Backup archive decryption is only supported with BACKUP_PROG=tar"
-    LogPrint "Decrypting backup archive with key defined in variable \$BACKUP_PROG_CRYPT_KEY"
-else
-    Log "Decrypting backup archive is disabled"
-    BACKUP_PROG_DECRYPT_OPTIONS="cat"
-    BACKUP_PROG_CRYPT_KEY=""
-fi
 
 # The RESTORE_ARCHIVES array contains the restore input files.
 # If it is not set, RESTORE_ARCHIVES is only one element which is the backup archive:
@@ -137,13 +126,31 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
     # output of a possibly simultaneously running process that likes to append to the log file
     # (e.g. when background processes run that also uses the log file for logging)
     # cf. https://github.com/rear/rear/issues/885#issuecomment-310308763
+    # Do not show the BACKUP_PROG_CRYPT_KEY value in a log file
+    # where BACKUP_PROG_CRYPT_KEY is only used if BACKUP_PROG_CRYPT_ENABLED is true
+    # therefore 'Log ... BACKUP_PROG_CRYPT_KEY ...' is used (and not '$BACKUP_PROG_CRYPT_KEY')
+    # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
+    # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
+    # so that stderr of the whole actual command is redirected to /dev/null
+    # cf. the comment of the UserInput function in lib/_input-output-functions.sh
+    # how to keep things confidential when rear is run in debugscript mode
+    # because it is more important to not leak out user secrets into a log file
+    # than having stderr error messages when a confidential command fails
+    # cf. https://github.com/rear/rear/issues/2155
     (   case "$BACKUP_PROG" in
             (tar)
                 if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then
                     BACKUP_PROG_OPTIONS=( "${BACKUP_PROG_OPTIONS[@]}" "--exclude-from=$TMP_DIR/restore-exclude-list.txt" )
                 fi
-                Log dd if=$restore_input \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
-                dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then 
+                    Log "dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose ${BACKUP_PROG_OPTIONS[@]} ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C $TARGET_FS_ROOT/ -x -f -"
+                    { dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f - ; } 2>/dev/null
+
+                else
+                    Log "dd if=$restore_input | $BACKUP_PROG --block-number --totals --verbose ${BACKUP_PROG_OPTIONS[@]} ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C $TARGET_FS_ROOT/ -x -f -"
+
+                    dd if=$restore_input | $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                fi
                 ;;
             (rsync)
                 if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -131,7 +131,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
     # therefore 'Log ... BACKUP_PROG_CRYPT_KEY ...' is used (and not '$BACKUP_PROG_CRYPT_KEY')
     # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
     # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
-    # so that stderr of the whole actual command is redirected to /dev/null
+    # so that stderr of the confidential command is redirected to /dev/null
     # cf. the comment of the UserInput function in lib/_input-output-functions.sh
     # how to keep things confidential when rear is run in debugscript mode
     # because it is more important to not leak out user secrets into a log file
@@ -144,7 +144,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                 fi
                 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then 
                     Log "dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose ${BACKUP_PROG_OPTIONS[@]} ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C $TARGET_FS_ROOT/ -x -f -"
-                    { dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f - ; } 2>/dev/null
+                    dd if=$restore_input | { $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY ; } 2>/dev/null | $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
 
                 else
                     Log "dd if=$restore_input | $BACKUP_PROG --block-number --totals --verbose ${BACKUP_PROG_OPTIONS[@]} ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C $TARGET_FS_ROOT/ -x -f -"

--- a/usr/share/rear/restore/YUM/default/405_recreate_users_and_groups.sh
+++ b/usr/share/rear/restore/YUM/default/405_recreate_users_and_groups.sh
@@ -20,24 +20,26 @@ IsInArray "yes" "${RECREATE_USERS_GROUPS[@]}" || return
 
 [ -z "$TMPDIR" ] && TMPDIR=$(mktemp -d -t rear_405.XXXXXXXXXXXXXXX)
 
-# code snippet from restore/NETFS/default/400_restore_backup.sh...
-# Disable BACKUP_PROG_DECRYPT_OPTIONS by replacing the default with 'cat' when encryption is disabled
-# (by default encryption is disabled but the default BACKUP_PROG_DECRYPT_OPTIONS is not 'cat'):
-if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
-    # Backup archive decryption is only supported with 'tar':
-    test "tar" = "$BACKUP_PROG" || Error "Backup archive decryption is only supported with BACKUP_PROG=tar"
-    LogPrint "Decrypting backup archive with key defined in variable \$BACKUP_PROG_CRYPT_KEY"
-else
-    Log "Decrypting backup archive is disabled"
-    BACKUP_PROG_DECRYPT_OPTIONS="cat"
-    BACKUP_PROG_CRYPT_KEY=""
-fi
-# ...code snippet from restore/NETFS/default/400_restore_backup.sh
-
+# Do not show the BACKUP_PROG_CRYPT_KEY value in a log file
+# where BACKUP_PROG_CRYPT_KEY is only used if BACKUP_PROG_CRYPT_ENABLED is true
+# therefore 'Log ... BACKUP_PROG_CRYPT_KEY ...' is used (and not '$BACKUP_PROG_CRYPT_KEY')
+# but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
+# the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
+# so that stderr of the whole actual command is redirected to /dev/null
+# cf. the comment of the UserInput function in lib/_input-output-functions.sh
+# how to keep things confidential when rear is run in debugscript mode
+# because it is more important to not leak out user secrets into a log file
+# than having stderr error messages when a confidential command fails
+# cf. https://github.com/rear/rear/issues/2155
 # Extract the passwd, shadow and group files from our backup to our rescue /tmp so we can use those files to repopulate the users in the target system
-dd if=$backuparchive | \
-	$BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | \
-	$BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TMPDIR -x -f - etc/passwd etc/shadow etc/group
+if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
+    { dd if=$backuparchive | \
+        $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | \
+        $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TMPDIR -x -f - etc/passwd etc/shadow etc/group ; } 2>/dev/null
+else
+    dd if=$backuparchive | \
+        $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TMPDIR -x -f - etc/passwd etc/shadow etc/group
+fi
 
 RECREATE_USERS=($(cut -d ':' -f '1' $TMPDIR/etc/passwd))
 RECREATE_GROUPS=($(cut -d ':' -f '1' $TMPDIR/etc/group))

--- a/usr/share/rear/restore/YUM/default/405_recreate_users_and_groups.sh
+++ b/usr/share/rear/restore/YUM/default/405_recreate_users_and_groups.sh
@@ -25,7 +25,7 @@ IsInArray "yes" "${RECREATE_USERS_GROUPS[@]}" || return
 # therefore 'Log ... BACKUP_PROG_CRYPT_KEY ...' is used (and not '$BACKUP_PROG_CRYPT_KEY')
 # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
 # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
-# so that stderr of the whole actual command is redirected to /dev/null
+# so that stderr of the confidential command is redirected to /dev/null
 # cf. the comment of the UserInput function in lib/_input-output-functions.sh
 # how to keep things confidential when rear is run in debugscript mode
 # because it is more important to not leak out user secrets into a log file
@@ -33,9 +33,9 @@ IsInArray "yes" "${RECREATE_USERS_GROUPS[@]}" || return
 # cf. https://github.com/rear/rear/issues/2155
 # Extract the passwd, shadow and group files from our backup to our rescue /tmp so we can use those files to repopulate the users in the target system
 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
-    { dd if=$backuparchive | \
-        $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | \
-        $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TMPDIR -x -f - etc/passwd etc/shadow etc/group ; } 2>/dev/null
+    dd if=$backuparchive | \
+        { $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY ; } 2>/dev/null | \
+        $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TMPDIR -x -f - etc/passwd etc/shadow etc/group
 else
     dd if=$backuparchive | \
         $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TMPDIR -x -f - etc/passwd etc/shadow etc/group

--- a/usr/share/rear/restore/YUM/default/410_restore_backup.sh
+++ b/usr/share/rear/restore/YUM/default/410_restore_backup.sh
@@ -1,4 +1,5 @@
-# 400_restore_backup.sh
+#
+# restore/YUM/default/410_restore_backup.sh
 #
 
 if ! is_true "$YUM_BACKUP_FILES" ; then
@@ -14,18 +15,6 @@ set -e -u -o pipefail
 local scheme=$(url_scheme $BACKUP_URL)
 local path=$(url_path $BACKUP_URL)
 local opath=$(backup_path $scheme $path)
-
-# Disable BACKUP_PROG_DECRYPT_OPTIONS by replacing the default with 'cat' when encryption is disabled
-# (by default encryption is disabled but the default BACKUP_PROG_DECRYPT_OPTIONS is not 'cat'):
-if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
-    # Backup archive decryption is only supported with 'tar':
-    test "tar" = "$BACKUP_PROG" || Error "Backup archive decryption is only supported with BACKUP_PROG=tar"
-    LogPrint "Decrypting backup archive with key defined in variable \$BACKUP_PROG_CRYPT_KEY"
-else
-    Log "Decrypting backup archive is disabled"
-    BACKUP_PROG_DECRYPT_OPTIONS="cat"
-    BACKUP_PROG_CRYPT_KEY=""
-fi
 
 # The RESTORE_ARCHIVES array contains the restore input files.
 # If it is not set, RESTORE_ARCHIVES is only one element which is the backup archive:
@@ -107,6 +96,17 @@ fi
 
 # The actual restoring:
 for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
+    # Do not show the BACKUP_PROG_CRYPT_KEY value in a log file
+    # where BACKUP_PROG_CRYPT_KEY is only used if BACKUP_PROG_CRYPT_ENABLED is true
+    # therefore 'Log ... BACKUP_PROG_CRYPT_KEY ...' is used (and not '$BACKUP_PROG_CRYPT_KEY')
+    # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
+    # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
+    # so that stderr of the whole actual command is redirected to /dev/null
+    # cf. the comment of the UserInput function in lib/_input-output-functions.sh
+    # how to keep things confidential when rear is run in debugscript mode
+    # because it is more important to not leak out user secrets into a log file
+    # than having stderr error messages when a confidential command fails
+    # cf. https://github.com/rear/rear/issues/2155
     LogPrint "Restoring from '$restore_input'..."
     # Launch a subshell that runs the backup restore prog:
     (   case "$BACKUP_PROG" in
@@ -128,8 +128,13 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                     cp -a $TMP_DIR/restore-exclude-list.txt $TARGET_FS_ROOT/tmp
                     BACKUP_PROG_OPTIONS="$BACKUP_PROG_OPTIONS --exclude-from=/tmp/restore-exclude-list.txt "
                 fi
-                Log dd if=$restore_input \| $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY \| chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -
-                dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -
+                if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
+                    Log "dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C / -x -f -"
+                    { dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f - ; } 2>/dev/null
+                else
+                    Log "dd if=$restore_input | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C / -x -f -"
+                    dd if=$restore_input | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -
+                fi
                 ;;
             (rsync)
                 if [ -s $TMP_DIR/restore-exclude-list.txt ] ; then

--- a/usr/share/rear/restore/YUM/default/410_restore_backup.sh
+++ b/usr/share/rear/restore/YUM/default/410_restore_backup.sh
@@ -101,7 +101,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
     # therefore 'Log ... BACKUP_PROG_CRYPT_KEY ...' is used (and not '$BACKUP_PROG_CRYPT_KEY')
     # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
     # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
-    # so that stderr of the whole actual command is redirected to /dev/null
+    # so that stderr of the confidential command is redirected to /dev/null
     # cf. the comment of the UserInput function in lib/_input-output-functions.sh
     # how to keep things confidential when rear is run in debugscript mode
     # because it is more important to not leak out user secrets into a log file
@@ -130,7 +130,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                 fi
                 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
                     Log "dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C / -x -f -"
-                    { dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f - ; } 2>/dev/null
+                    dd if=$restore_input | { $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY ; } 2>/dev/null | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -
                 else
                     Log "dd if=$restore_input | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C / -x -f -"
                     dd if=$restore_input | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -

--- a/usr/share/rear/verify/NETFS/default/600_check_encryption_key.sh
+++ b/usr/share/rear/verify/NETFS/default/600_check_encryption_key.sh
@@ -1,8 +1,17 @@
-# Stop if no key is configured
+#
+# verify/NETFS/default/600_check_encryption_key.sh
+#
+# Stop if BACKUP_PROG_CRYPT_ENABLED but no BACKUP_PROG_CRYPT_KEY is set.
 
-if is_false "$BACKUP_PROG_CRYPT_ENABLED" ; then
-  return
-fi
+is_true "$BACKUP_PROG_CRYPT_ENABLED" || return 0
 
-[ ! -z "$BACKUP_PROG_CRYPT_KEY" ]
-StopIfError "Please enter BACKUP_PROG_CRYPT_KEY in $CONFIG_DIR/local.conf !"
+# There is no BACKUP_PROG_CRYPT_KEY value in etc/rear/local.conf in the recovery system
+# (it was removed by build/default/960_remove_encryption_keys.sh see the comment there)
+# so we need to ensure the BACKUP_PROG_CRYPT_KEY value was manually set again.
+# Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode
+# cf. the comment of the UserInput function in lib/_input-output-functions.sh
+# how to keep things confidential when usr/sbin/rear is run in debugscript mode
+# ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
+{ test "$BACKUP_PROG_CRYPT_KEY" || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive decryption" ; } 2>/dev/null
+LogPrint "Decrypting backup archive with key defined in BACKUP_PROG_CRYPT_KEY"
+

--- a/usr/share/rear/verify/NETFS/default/600_check_encryption_key.sh
+++ b/usr/share/rear/verify/NETFS/default/600_check_encryption_key.sh
@@ -1,7 +1,7 @@
 #
 # verify/NETFS/default/600_check_encryption_key.sh
 #
-# Stop if BACKUP_PROG_CRYPT_ENABLED but no BACKUP_PROG_CRYPT_KEY is set.
+# Error out when BACKUP_PROG_CRYPT_ENABLED but no BACKUP_PROG_CRYPT_KEY is set.
 
 is_true "$BACKUP_PROG_CRYPT_ENABLED" || return 0
 
@@ -12,6 +12,6 @@ is_true "$BACKUP_PROG_CRYPT_ENABLED" || return 0
 # cf. the comment of the UserInput function in lib/_input-output-functions.sh
 # how to keep things confidential when usr/sbin/rear is run in debugscript mode
 # ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
-{ test "$BACKUP_PROG_CRYPT_KEY" || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive decryption" ; } 2>/dev/null
+{ test "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive decryption"
 LogPrint "Decrypting backup archive with key defined in BACKUP_PROG_CRYPT_KEY"
 


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Critical**
This is a critical security issue only if BACKUP_PROG_CRYPT_ENABLED
with a BACKUP_PROG_CRYPT_KEY is used.

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2155
therein in particular
https://github.com/rear/rear/issues/2155#issuecomment-499376750

* How was this pull request tested?
This is an early submit so that you can have an early look
that is not yet tested at all by me because I never used
BACKUP_PROG_CRYPT_ENABLED myself.

* Brief description of the changes in this pull request:

Separate the special case when BACKUP_PROG_CRYPT_ENABLED
with a BACKUP_PROG_CRYPT_KEY is used
from the usual case when it is not used.

Only when BACKUP_PROG_CRYPT_ENABLED with
a BACKUP_PROG_CRYPT_KEY is used do special stuff
(in particular redirect stderr to /dev/null for certain commands)
to avoid that the BACKUP_PROG_CRYPT_KEY value appears
in a log file in particular when `set -x` is set.

I think it is more important to not leak out user secrets into a log file
than having stderr error messages when a confidential command fails.

That separation caused "mostly duplicated" code parts, i.e. code parts
that are almost same - except the differences that are related to
the "BACKUP_PROG_CRYPT_ENABLED" case but I have no better idea
how to redirect stderr to /dev/null versus not redirect stderr to /dev/null
for the two cases in a clean way without making the code even more
complicated and oversophisticated than it already is.

By the way I also corrected the spelling typo
from `debugscripts mode` to `debugscript mode`
to match the spelling in "man rear" that reads
```
       -D
           debugscript mode ...
```
