### PR TITLE
Fix 4 issue 1564

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -56,6 +56,15 @@ if [[ $Disk = *'/mmcblk'+([0-9])p ]] ; then
     Disk=${Disk%p}
 fi
 
+# For NVMe devices the trailing 'p' in the Disk value
+# (as in /dev/nvme0n1p that is derived from /dev/nvme0n1p1)
+# needs to be stripped (to get /dev/nvme0n1), otherwise the
+# efibootmgr call fails because of a wrong disk device name.
+# See also https://github.com/rear/rear/issues/2103
+if [[ $Disk = *'/nvme'+([0-9])n+([0-9])p ]] ; then
+    Disk=${Disk%p}
+fi
+
 # EFI\fedora\shim.efi
 BootLoader=$( echo $UEFI_BOOTLOADER | cut -d"/" -f4- | sed -e 's;/;\\;g' )
 LogPrint "Creating  EFI Boot Manager entry '$OS_VENDOR $OS_VERSION' for '$BootLoader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER')"

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -60,7 +60,7 @@ fi
 # (as in /dev/nvme0n1p that is derived from /dev/nvme0n1p1)
 # needs to be stripped (to get /dev/nvme0n1), otherwise the
 # efibootmgr call fails because of a wrong disk device name.
-# See also https://github.com/rear/rear/issues/2103
+# See also https://github.com/rear/rear/issues/1564
 if [[ $Disk = *'/nvme'+([0-9])n+([0-9])p ]] ; then
     Disk=${Disk%p}
 fi


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL): https://github.com/rear/rear/issues/1564

* How was this pull request tested? Making a recover on Baremetal server with SSD Samsung EVO NVMe disk

* Brief description of the changes in this pull request: for NVMe devices the trailing 'p' in the Disk value (as in /dev/nvme0n1p that is derived from /dev/nvme0n1p1) needs to be stripped (to get /dev/nvme0n1), otherwise the efibootmgr call fails because of a wrong disk device name.
