### PR TITLE
RAWDISK and TCG Opal 2 Self-Encrypting Disks: add Secure Boot support

### DIFF
--- a/doc/user-guide/13-tcg-opal-support.adoc
+++ b/doc/user-guide/13-tcg-opal-support.adoc
@@ -236,8 +236,6 @@ cp dist/Release_x86_64/GNU-Linux/sedutil-cli /usr/local/bin
 
 === Setting up UEFI Firmware to Boot From a Self-Encrypting Disk
 
-NOTE: UEFI support currently requires that Secure Boot be turned off.
-
 If the UEFI firmware is configured to boot from the disk _device_ (instead of
 some specific operating system entry), no further configuration is necessary.
 

--- a/usr/share/rear/output/RAWDISK/Linux-i386/260_create_syslinux_efi_bootloader.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/260_create_syslinux_efi_bootloader.sh
@@ -4,8 +4,11 @@
 
 ### Check prerequisites
 
-# Run only if no EFI bootloader has been created yet and syslinux is available
-([[ -n "$RAWDISK_BOOT_EFI_STAGING_ROOT" ]] || ! has_binary syslinux) && return 0
+# Run only if
+# a) no EFI bootloader has been created yet and
+# b) secure boot (which is assumed to require Grub) is disabled and
+# c) syslinux is available.
+([[ -n "$RAWDISK_BOOT_EFI_STAGING_ROOT" || -n "$SECURE_BOOT_BOOTLOADER" ]] || ! has_binary syslinux) && return 0
 
 # Find syslinux files (unfortunately, installations vary in locations and naming)
 local syslinux_efi="$(find /usr/lib /usr/share -iname syslinux.efi -print | grep -i "/efi64/" | head -n 1)"
@@ -25,6 +28,7 @@ fi
 LogPrint "Using syslinux to create an EFI bootloader"
 
 RAWDISK_BOOT_EFI_STAGING_ROOT="$TMP_DIR/EFI"
+RAWDISK_BOOT_USING_SYSLINUX="true"
 local efi_boot_directory="$RAWDISK_BOOT_EFI_STAGING_ROOT/BOOT"
 
 mkdir $v -p "$efi_boot_directory" || Error "Could not create $efi_boot_directory"

--- a/usr/share/rear/output/RAWDISK/Linux-i386/270_create_grub2_efi_bootloader.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/270_create_grub2_efi_bootloader.sh
@@ -17,27 +17,52 @@ fi
 
 LogPrint "Using Grub 2 to create an EFI bootloader"
 
-if is_true $USING_UEFI_BOOTLOADER ; then
+if is_true $USING_UEFI_BOOTLOADER && [[ -z "$SECURE_BOOT_BOOTLOADER" ]]; then
     LogPrint "TIP: You can achieve a faster EFI boot by installing syslinux for EFI on this system"
 fi
 
 RAWDISK_BOOT_EFI_STAGING_ROOT="$TMP_DIR/EFI"
-local efi_boot_directory="$RAWDISK_BOOT_EFI_STAGING_ROOT/BOOT"
-
-mkdir $v -p "$efi_boot_directory"
-StopIfError "Could not create $efi_boot_directory"
 
 # Create a Grub 2 configuration file
-cat > "$efi_boot_directory/grub.cfg" << EOF
+local new_grub_config_file="$TMP_DIR/grub.cfg"
+cat > "$new_grub_config_file" << EOF
 set timeout=0
 set default=0
-menuentry "${RAWDISK_BOOT_GRUB_MENUENTRY_TITLE:-Rescue System}" {
+menuentry "${RAWDISK_BOOT_GRUB_MENUENTRY_TITLE:-Recovery System}" {
     linux /$(basename "$KERNEL_FILE") $KERNEL_CMDLINE
     initrd /$REAR_INITRD_FILENAME
 }
 EOF
 
-# Create a Grub 2 EFI core image
-local grub_modules=( part_gpt fat normal configfile linux video all_video )
-grub-mkimage -O x86_64-efi -o "$efi_boot_directory/BOOTX64.efi" -p "/EFI/BOOT" "${grub_modules[@]}"
-StopIfError "Error occurred during grub-mkimage of $efi_boot_directory/BOOTX64.efi"
+if [[ -n "$SECURE_BOOT_BOOTLOADER" ]]; then
+    # Using Secure Boot:
+    # We use '$SECURE_BOOT_BOOTLOADER' as a pointer into the original system's EFI tree, which should consist of
+    # signed EFI executables (and possibly companion files). We cannot touch those signed executables without
+    # breaking Secure Boot and we cannot know which companion files are actually required, so we play it safe
+    # and copy the entire EFI tree as is.
+    local original_efi_root="$(findmnt --noheadings --output TARGET --target "$SECURE_BOOT_BOOTLOADER")/EFI"
+    LogPrint "Secure Boot: Using the original EFI configuration from '$original_efi_root'"
+    cp -a $v "$original_efi_root/." "$RAWDISK_BOOT_EFI_STAGING_ROOT" || Error "Could not copy EFI configuration"
+
+    # Now we look for existing Grub configuration files and overwrite those with our own configuration. Again, to
+    # be safe, we are prepared for the situation where we might find more than one grub.cfg without knowing which
+    # one is effective, so we overwrite every one.
+    find "$RAWDISK_BOOT_EFI_STAGING_ROOT" -iname grub.cfg -print -exec cp $v "$new_grub_config_file" '{}' \;
+    StopIfError "Could not copy Grub configuration"
+else
+    # Not Using Secure Boot:
+    # Populate the EFI file system with a newly created Grub boot loader image and the Grub configuration file.
+    local efi_boot_directory="$RAWDISK_BOOT_EFI_STAGING_ROOT/BOOT"
+    mkdir $v -p "$efi_boot_directory" || Error "Could not create $efi_boot_directory"
+
+    cp $v "$new_grub_config_file" "$efi_boot_directory/grub.cfg"
+
+    # Create a Grub 2 EFI core image and install it as boot loader. (NOTE: This version will not be signed.)
+    # Use the UEFI default boot loader name, so that firmware will find it without an existing boot entry.
+    local boot_loader="$efi_boot_directory/BOOTX64.EFI"
+    local grub_modules=( part_gpt fat normal configfile linux video all_video )
+    grub-mkimage -O x86_64-efi -o "$boot_loader" -p "/EFI/BOOT" "${grub_modules[@]}"
+    StopIfError "Error occurred during grub-mkimage of $boot_loader"
+fi
+
+rm "$new_grub_config_file"

--- a/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
@@ -11,7 +11,7 @@
 ### Check prerequisites
 
 local use_syslinux_legacy=no
-if has_binary syslinux; then
+if has_binary syslinux && [[ -z "$SECURE_BOOT_BOOTLOADER" ]]; then
     if is_true "${RAWDISK_BOOT_EXCLUDE_SYSLINUX_LEGACY:-no}"; then
         LogPrint "DISABLED: Using syslinux to create a BIOS Legacy bootloader"
     else
@@ -135,7 +135,7 @@ cp -rL $v "${staged_boot_partition_contents[@]}" "$boot_partition_root" >&2 || E
 # After installing a Legacy BIOS bootloader, files on the boot partition should not change: The bootloader file is
 # patched during installation with a list of its exact on-disk block locations.
 
-if has_binary syslinux; then
+if is_true "$RAWDISK_BOOT_USING_SYSLINUX" || is_true $use_syslinux_legacy; then
     # Install syslinux configuration, which may be shared between syslinux/EFI and syslinux/Legacy bootloaders.
     local syslinux_installation_dir="$boot_partition_root/syslinux"
     mkdir -p "$syslinux_installation_dir" || Error "Could not create syslinux bootloader directory"


### PR DESCRIPTION
##### Pull Request Details:

* Type: **New Feature**

* Impact: **Normal**

* How was this pull request tested? 
    * Tests were based on current ReaR master (d7b587cb5b7a14432e7c4f9e5f4d94e50abea740) on Ubuntu 18.04.2 LTS:
    * Tested booting recovery systems in these configurations:
        1. Legacy Boot
        1. EFI Boot via syslinux (Secure Boot disabled)
        1. EFI Boot via Grub 2 (Secure Boot disabled)
        1. EFI Boot via Grub 2 (Secure Boot enabled)
    * Tested TCG Opal 2 PBA disk unlocking with Secure Boot enabled.

* Brief description of the changes in this pull request:

This PR adds Secure Boot support to the RAWDISK output format.

This in turn enables Secure Boot in conjunction with the PBA (pre-boot authentication) system required to unlock TCG Opal 2-compatible self-encrypting disks. (BTW: AFAIK there is no other solution available supporting Secure Boot with TCG Opal 2 SEDs on the market.)

As is the case with other output formats within ReaR, Secure Boot support has to be explicitly enabled. On Ubuntu, the following line must be added to the configuration:
```
SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/ubuntu/shimx64.efi"
```

That's all.