### PR TITLE
usr/share/rear/prep/USB/Linux-i386/350_check_usb_disk.sh - if we pass…

### DIFF
--- a/usr/share/rear/prep/USB/Linux-i386/350_check_usb_disk.sh
+++ b/usr/share/rear/prep/USB/Linux-i386/350_check_usb_disk.sh
@@ -21,7 +21,7 @@ if [ "$TEMP_USB_DEVICE" -a -b "/dev/$TEMP_USB_DEVICE" ]; then
     RAW_USB_DEVICE="/dev/$(my_udevinfo -q name -n "$TEMP_USB_DEVICE")"
 elif [ "$TEMP_USB_DEVICE" -a -d "/sys/block/$TEMP_USB_DEVICE" ]; then
     RAW_USB_DEVICE="/dev/$(my_udevinfo -q name -p "$TEMP_USB_DEVICE")"
-elif [ -z "$TEMP_USB_DEVICE" ]; then
+elif [ -z "$TEMP_USB_DEVICE" ] || [ -z "$RAW_USB_DEVICE" ] ; then
     RAW_USB_DEVICE="/dev/$(my_udevinfo -q name -n "$REAL_USB_DEVICE")"
 else
     BugError "Unable to determine raw USB device for $REAL_USB_DEVICE"

--- a/usr/share/rear/prep/USB/Linux-i386/350_check_usb_disk.sh
+++ b/usr/share/rear/prep/USB/Linux-i386/350_check_usb_disk.sh
@@ -21,6 +21,12 @@ if [ "$TEMP_USB_DEVICE" -a -b "/dev/$TEMP_USB_DEVICE" ]; then
     RAW_USB_DEVICE="/dev/$(my_udevinfo -q name -n "$TEMP_USB_DEVICE")"
 elif [ "$TEMP_USB_DEVICE" -a -d "/sys/block/$TEMP_USB_DEVICE" ]; then
     RAW_USB_DEVICE="/dev/$(my_udevinfo -q name -p "$TEMP_USB_DEVICE")"
+
+# If we're passed a raw device, ala /dev/sdb, TEMP_USB_DEVICE will be set to "block"
+# and RAW_USB_DEVICE won't be set.  "block" is not useful.  TEMP_USB_DEVICE will not be
+# set if udev doesn't know anything about the device we were passed. So, if we've 
+# gotten here and either are not set, let's just assert what we know from udev
+# about the device.
 elif [ -z "$TEMP_USB_DEVICE" ] || [ -z "$RAW_USB_DEVICE" ] ; then
     RAW_USB_DEVICE="/dev/$(my_udevinfo -q name -n "$REAL_USB_DEVICE")"
 else


### PR DESCRIPTION
… in the actual raw block device, we fail to confirm it via udev since TEMP_USB_DEVICE never gets set via the first two conditions... so, let's check to see if we've set RAW_USB_DEVICE also.

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: Bug Fix

* Impact: Normal

* Reference to related issue (URL): https://github.com/rear/rear/issues/2171

* How was this pull request tested? Tested in situ on affected server using real usb device.

* Brief description of the changes in this pull request:
Allows us to assert the original raw block device inferred from udev info.

