### PR TITLE
bacula: Fixed 'bconsole' prompt not displaying at all when doing a recover

### DIFF
--- a/usr/share/rear/restore/BACULA/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/BACULA/default/400_restore_backup.sh
@@ -110,7 +110,11 @@ WARNING: The new root is mounted under '$TARGET_FS_ROOT'.
 Press ENTER to start bconsole"
     read
 
-    bconsole
+    if bconsole 0<&6 1>&7 2>&8 ; then
+        Log "bconsole finished with zero exit code"
+    else
+        Log "bconsole finished with non-zero exit code $?"
+    fi
 
     LogPrint "
 Please verify that the backup has been restored correctly to '$TARGET_FS_ROOT'


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested? Tested a recovery with bacula until `bconsole` is executed

* Brief description of the changes in this pull request:

With this change, the bconsole output is sent to FD 7, which is stdout. Previously the output was sent to FD 1 which is redirected to the ReaR log.
