### PR TITLE
More fail safe BACKUP_PROG_CRYPT_KEY handling (issue 2157)

### DIFF
--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -37,7 +37,7 @@ BACKUP=NETFS
 # BACKUP_OPTIONS="nfsvers=3,nolock"
 BACKUP_URL=nfs://your.NFS.server.IP/path/to/your/rear/backup
 # BACKUP_PROG_CRYPT_ENABLED="yes"
-# { BACKUP_PROG_CRYPT_KEY="my_secret_passphrase" ; } 2>/dev/null
+# { BACKUP_PROG_CRYPT_KEY='my_secret_passphrase' ; } 2>/dev/null
 ----
 
 The above example shows that it is also possible to encrypt the backup archive.
@@ -48,7 +48,7 @@ It gets removed because the ReaR rescue/recovery system must be free of secrets.
 Otherwise the rescue system ISO image and any recovery medium that is made from it
 would have to be carefully protected against any unwanted access.
 Therefore BACKUP_PROG_CRYPT_KEY must be manually set before running "rear recover".
-For example via `export BACKUP_PROG_CRYPT_KEY="my_secret_passphrase"`
+For example via `export BACKUP_PROG_CRYPT_KEY='my_secret_passphrase'`
 before calling "rear recover" and/or also before calling "rear mkbackup"
 so that there is no need to store it ever in a ReaR config file.
 On the other hand it is crucial to remember the BACKUP_PROG_CRYPT_KEY value

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -129,7 +129,7 @@ case "$(basename ${BACKUP_PROG})" in
                 "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f -                         \
                 $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |               \
-            { $BACKUP_PROG_CRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null |   \
+            { $BACKUP_PROG_CRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null | \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
         else

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -129,7 +129,7 @@ case "$(basename ${BACKUP_PROG})" in
                 "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f -                         \
                 $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |               \
-            { $BACKUP_PROG_CRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY ; } 2>/dev/null |   \
+            { $BACKUP_PROG_CRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null |   \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
         else

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -21,6 +21,10 @@ local path=$( url_path $BACKUP_URL )
 local opath=$( backup_path $scheme $path )
 test "$opath" && mkdir $v -p "$opath"
 
+# In any case show an initial basic info what is currently done
+# so that it is more clear where subsequent messages belong to:
+LogPrint "Making backup (using backup method $BACKUP)"
+
 # Verify that preconditions to make the backup are fulfilled and error out if not:
 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
     # Backup archive encryption is only supported with 'tar':
@@ -31,10 +35,7 @@ if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
     # how to keep things confidential when usr/sbin/rear is run in debugscript mode
     # ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
     { test "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive encryption"
-    LogPrint "Encrypting $BACKUP backup archive with key defined in BACKUP_PROG_CRYPT_KEY"
-else
-    # In any case show an info what is done:
-    LogPrint "Making $BACKUP backup"
+    LogPrint "Encrypting backup archive with key defined in BACKUP_PROG_CRYPT_KEY"
 fi
 
 # Log what is included in the backup and what is excluded from the backup

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -921,14 +921,14 @@ BACKUP_PROG_COMPRESS_SUFFIX=".gz"
 # Addons for encryption and decryption of the backup (currently only tar is supported):
 BACKUP_PROG_CRYPT_ENABLED="false"
 # When BACKUP_PROG_CRYPT_ENABLED is set to a true value, BACKUP_PROG_CRYPT_KEY must be also set.
-# It is strongly recommended to avoid special characters in the BACKUP_PROG_CRYPT_KEY value,
+# It is recommended to avoid special characters in the BACKUP_PROG_CRYPT_KEY value,
 # in particular bash metacharacters, bash control operator characters, bash grammar characters,
-# globbing metacharacters, regexp metacharacters, and slash or whitespace characters like the following
-#   $  `  '  "  |  &  ;  (  )  <  >  {  }  [  ]  .  *  @  !  ?  /  \  space  tab  newline
-# so that only alphanumeric characters and the underscore should be used to be on the safe side
-# otherwise things might break in unexpected weird ways when certain code in ReaR is not yet safe
-# against arbitrary special characters in values cf. https://github.com/rear/rear/issues/1372
-# and https://github.com/rear/rear/issues/2157#issuecomment-506630936
+# globbing metacharacters, regexp metacharacters, and slash or whitespace characters like
+#   $ ` ' " | & ; ( ) < > { } [ ] . * @ ! ? / \ space tab newline
+# so that only alphanumeric characters and the underscore should be used to be on the safe side.
+# Otherwise things might break in weird ways when certain code in ReaR is not yet safe
+# against special characters in values cf. https://github.com/rear/rear/issues/1372
+# and https://github.com/rear/rear/issues/2157
 # There is no BACKUP_PROG_CRYPT_KEY value in etc/rear/local.conf in the ReaR recovery system.
 # It gets removed by build/default/960_remove_encryption_keys.sh
 # because the ReaR recovery system must be free of secrets

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -921,6 +921,14 @@ BACKUP_PROG_COMPRESS_SUFFIX=".gz"
 # Addons for encryption and decryption of the backup (currently only tar is supported):
 BACKUP_PROG_CRYPT_ENABLED="false"
 # When BACKUP_PROG_CRYPT_ENABLED is set to a true value, BACKUP_PROG_CRYPT_KEY must be also set.
+# It is strongly recommended to avoid special characters in the BACKUP_PROG_CRYPT_KEY value,
+# in particular bash metacharacters, bash control operator characters, bash grammar characters,
+# globbing metacharacters, regexp metacharacters, and slash or whitespace characters like the following
+#   $  `  '  "  |  &  ;  (  )  <  >  {  }  [  ]  .  *  @  !  ?  /  \  space  tab  newline
+# so that only alphanumeric characters and the underscore should be used to be on the safe side
+# otherwise things might break in unexpected weird ways when certain code in ReaR is not yet safe
+# against arbitrary special characters in values cf. https://github.com/rear/rear/issues/1372
+# and https://github.com/rear/rear/issues/2157#issuecomment-506630936
 # There is no BACKUP_PROG_CRYPT_KEY value in etc/rear/local.conf in the ReaR recovery system.
 # It gets removed by build/default/960_remove_encryption_keys.sh
 # because the ReaR recovery system must be free of secrets
@@ -929,7 +937,7 @@ BACKUP_PROG_CRYPT_ENABLED="false"
 # Therefore BACKUP_PROG_CRYPT_KEY must be manually set before running "rear recover".
 # BACKUP_PROG_CRYPT_KEY is set to a default value here only
 # if not already set so that the user can set it also like
-#   export BACKUP_PROG_CRYPT_KEY="my_secret_passphrase"
+#   export BACKUP_PROG_CRYPT_KEY='my_secret_passphrase'
 # directly before he calls "rear ..." so that there is no need to store it in a config file.
 # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown when usr/sbin/rear was called with 'set -x'
 # for debugging usr/sbin/rear cf. https://github.com/rear/rear/issues/2144#issuecomment-493908133
@@ -938,7 +946,7 @@ BACKUP_PROG_CRYPT_ENABLED="false"
 # See the comment of the UserInput function in lib/_input-output-functions.sh
 # how to keep things confidential when usr/sbin/rear is run in debugscript mode
 # ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
-{ test "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null || BACKUP_PROG_CRYPT_KEY=""
+{ test "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null || BACKUP_PROG_CRYPT_KEY=''
 # The command for backup encryption during "rear mkbackup" will be basically
 #    tar ... | BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY
 # for details see the backup/NETFS/default/500_make_backup.sh script:

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -144,7 +144,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                 fi
                 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then 
                     Log "dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose ${BACKUP_PROG_OPTIONS[@]} ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C $TARGET_FS_ROOT/ -x -f -"
-                    dd if=$restore_input | { $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY ; } 2>/dev/null | $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                    dd if=$restore_input | { $BACKUP_PROG_DECRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null | $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
 
                 else
                     Log "dd if=$restore_input | $BACKUP_PROG --block-number --totals --verbose ${BACKUP_PROG_OPTIONS[@]} ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C $TARGET_FS_ROOT/ -x -f -"

--- a/usr/share/rear/restore/YUM/default/405_recreate_users_and_groups.sh
+++ b/usr/share/rear/restore/YUM/default/405_recreate_users_and_groups.sh
@@ -34,7 +34,7 @@ IsInArray "yes" "${RECREATE_USERS_GROUPS[@]}" || return
 # Extract the passwd, shadow and group files from our backup to our rescue /tmp so we can use those files to repopulate the users in the target system
 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
     dd if=$backuparchive | \
-        { $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY ; } 2>/dev/null | \
+        { $BACKUP_PROG_DECRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null | \
         $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TMPDIR -x -f - etc/passwd etc/shadow etc/group
 else
     dd if=$backuparchive | \

--- a/usr/share/rear/restore/YUM/default/410_restore_backup.sh
+++ b/usr/share/rear/restore/YUM/default/410_restore_backup.sh
@@ -130,7 +130,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                 fi
                 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
                     Log "dd if=$restore_input | $BACKUP_PROG_DECRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C / -x -f -"
-                    dd if=$restore_input | { $BACKUP_PROG_DECRYPT_OPTIONS $BACKUP_PROG_CRYPT_KEY ; } 2>/dev/null | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -
+                    dd if=$restore_input | { $BACKUP_PROG_DECRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -
                 else
                     Log "dd if=$restore_input | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C / -x -f -"
                     dd if=$restore_input | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose $BACKUP_PROG_OPTIONS "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -


### PR DESCRIPTION
* Type: **Bug Fix** **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2157

* How was this pull request tested?
Not yet tested at all by me - I will do that later...

* Brief description of the changes in this pull request:

Make the code that deals with BACKUP_PROG_CRYPT_KEY more fail safe:

1. Use double quotes `"$BACKUP_PROG_CRYPT_KEY"` so that
the BACKUP_PROG_CRYPT_KEY value can contain spaces.

2. Escape special regexp characters in the BACKUP_PROG_CRYPT_KEY value
when it is used as a regexp in `grep` or `sed`.

3. Use single quotes `BACKUP_PROG_CRYPT_KEY='my_secret_passphrase'`
in the documentation examples so that the BACKUP_PROG_CRYPT_KEY value
can contain special characters like `$`,
cf. https://github.com/rear/rear/issues/2157#issuecomment-506496775

4. Recommend to not use special characters in the
BACKUP_PROG_CRYPT_KEY value to be to be on the safe side
against things breaking in unexpected weird ways when certain code
in ReaR is not yet safe against arbitrary special characters in values
cf. https://github.com/rear/rear/issues/1372
