### PR TITLE
Error out when DHCLIENT_BIN and DHCLIENT6_BIN are empty and USE_DHCLIENT is set

### DIFF
--- a/usr/share/rear/prep/GNU/Linux/210_include_dhclient.sh
+++ b/usr/share/rear/prep/GNU/Linux/210_include_dhclient.sh
@@ -5,8 +5,7 @@
 # on the rescue image (IPv4/IPv6)
 
 define_dhclients_variable()
-{
-    local x
+{   local x
     dhclients=()
     for x in "${DHCLIENT_BIN##*/}" \
         "${DHCLIENT6_BIN##*/}" \
@@ -36,8 +35,7 @@ dhcp_interfaces_active() {
 }
 
 define_dhclient_bins()
-{
-    # purpuse is to define which binaries are being used on this system
+{   # purpuse is to define which binaries are being used on this system
     # other dhcp clients should be hard-coded in the /etc/rear/[site|local].conf file
     case ${1##*/} in
         dhcpcd) DHCLIENT_BIN=dhcpcd ;;
@@ -48,16 +46,16 @@ define_dhclient_bins()
 }
 
 ##### M A I N #####
-###################
 
 # Respect an explicit rejection
 if is_false "$USE_DHCLIENT"; then
-    Log "Excluding DHCP client excluded (USE_DHCLIENT=\"$USE_DHCLIENT\")"
+    Log "Excluding DHCP client excluded (USE_DHCLIENT='$USE_DHCLIENT')"
     return 0
 fi
 
 # if DHCP client binaries were predefined (in the /etc/rear/local.conf file)
 # we pick them up here
+# FIXME: Neither DHCLIENT_BIN nor DHCLIENT6_BIN are described in default.conf
 DHCLIENT_BIN=${DHCLIENT_BIN##*/}
 DHCLIENT6_BIN=${DHCLIENT6_BIN##*/}
 # following function makes an array of all known dhcp clients (more could be added)
@@ -67,23 +65,19 @@ dhcp_interfaces_active      # check if one is running (if found define USE_DHCLI
 # suppose that we filled in variable DHCLIENT_BIN in the /etc/rear/local.conf file
 # but forgot to define USE_DHCLIENT=y in the /etc/rear/local.conf file
 # then we should assume that we meant USE_DHCLIENT=y instead of USE_DHCLIENT=
-[ ! -z "$DHCLIENT_BIN" ] && USE_DHCLIENT=y
-[ ! -z "$DHCLIENT6_BIN" ] && USE_DHCLIENT=y
+test "$DHCLIENT_BIN" && USE_DHCLIENT=y
+test "$DHCLIENT6_BIN" && USE_DHCLIENT=y
 
-# check if we defined in our site/local.conf file the variable USE_DHCLIENT
-# Or, it was defined by function dhcp_interfaces_active if DHCP client was currently running
-# We will always copy dhclient executables as dhcp could be activated at boot time
-#[ -z "$USE_DHCLIENT" ] && return   # empty string means no dhcp client support required
+# Regardless if we defined in our site/local.conf file the variable USE_DHCLIENT
+# or if it was defined by function dhcp_interfaces_active if DHCP client was currently running
+# we will always copy dhclient executables as dhcp could be activated at boot time.
 
 # Ok, at this point we want DHCP client support to be included in the rescue
 # image of Relax-and-Recover. Check which clients are available.
 # Check which executables we want to include - dhcpcd or dhclient or ??
-if [ -z "$DHCLIENT_BIN" ]; then
-    for x in ${dhclients}
-    do
-        if has_binary $x; then
-            define_dhclient_bins `get_path $x`
-        fi
+if [ -z "$DHCLIENT_BIN" ] ; then
+    for x in ${dhclients} ; do
+        has_binary $x && define_dhclient_bins $( get_path $x )
     done
 fi
 
@@ -92,11 +86,26 @@ fi
 COPY_AS_IS=( "${COPY_AS_IS[@]}" "/etc/localtime" "/usr/lib/dhcpcd/*" )
 PROGS=( "${PROGS[@]}" arping ipcalc usleep "${dhclients[@]}" )
 
-# At this point we want DHCP client support and found a binary
-# check if binary was defined in /etc/rear/local.conf; if not append it to rescue.conf
-# as we need this variable at recovery time.
-if [ ! -z "$USE_DHCLIENT" ]; then
-    REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" $DHCLIENT_BIN $DHCLIENT6_BIN )
+# At this point we want DHCP client support:
+if test "$USE_DHCLIENT" ; then
+    # Error out when both DHCLIENT_BIN and DHCLIENT6_BIN are empty
+    # cf. ttps://github.com/rear/rear/issues/2184
+    # It is sufficient here to test if DHCLIENT_BIN and DHCLIENT6_BIN are empty
+    # because when non-empty DHCLIENT_BIN or DHCLIENT6_BIN are added to REQUIRED_PROGS
+    # the subsequent build/default/950_check_missing_programs.sh script checks
+    # that all what is added to REQUIRED_PROGS are actually available binaries.
+    # Note that code like
+    #   test $DHCLIENT_BIN -o $DHCLIENT6_BIN || Error "..."
+    # does not error out when both DHCLIENT_BIN and DHCLIENT6_BIN are empty
+    # because plain 'test -o ' (with empty arguments) results zero exit code
+    # and also things like 'test -n  -o -n ' (with empty arguments) results zero exit code
+    # and things like 'test -z foo -a -z ' or 'test -z  -a -z bar' (with one empty argument) somehow work but
+    # result ugly bash errors "bash: test: argument expected" or "bash: test: too many arguments" respectively
+    # but in contrast plain 'test ' (without argument) results non-zero exit code without a bash error
+    # so that two separated plain test calls with || are intentionally used here:
+    test $DHCLIENT_BIN || test $DHCLIENT6_BIN || Error "USE_DHCLIENT is set but there is no DHCP client binary like dhclient dhclient6 dhcpcd dhcp6c"
+    REQUIRED_PROGSi+=( $DHCLIENT_BIN $DHCLIENT6_BIN )
+    # Append DHCLIENT_BIN and DHCLIENT6_BIN to rescue.conf as we need this variable at recovery time:
     cat - <<EOF >> "$ROOTFS_DIR/etc/rear/rescue.conf"
 # The following 3 lines were added through 210_include_dhclient.sh
 USE_DHCLIENT=$USE_DHCLIENT


### PR DESCRIPTION

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2184

* How was this pull request tested?
Not yet tested - will test it tomorrow...

* Brief description of the changes in this pull request:

Added test to prep/GNU/Linux/210_include_dhclient.sh
to Error out when DHCLIENT_BIN and DHCLIENT6_BIN are empty
and USE_DHCLIENT is set.
