### PR TITLE
In apply_layout_mappings it is no error when there are leftover replacement strings in comments

### DIFF
--- a/usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
+++ b/usr/share/rear/layout/prepare/default/420_autoresize_last_partitions.sh
@@ -398,7 +398,7 @@ while read component_type disk_device old_disk_size disk_label junk ; do
     disk_size_difference=$( mathlib_calculate "$new_disk_size - $old_disk_size" )
     if test $disk_size_difference -gt 0 ; then
         # The size of the new disk is bigger than the size of the old disk:
-        DebugPrint "New $disk_device is $disk_size_difference bigger than old disk"
+        DebugPrint "New $disk_device is $disk_size_difference bytes bigger than old disk"
         increase_threshold_difference=$( mathlib_calculate "$old_disk_size / 100 * $AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE" )
         if test $disk_size_difference -lt $increase_threshold_difference ; then
             if is_true "$last_part_is_resizeable" ; then
@@ -422,7 +422,7 @@ while read component_type disk_device old_disk_size disk_label junk ; do
         # The size of the new disk is smaller than the size of the old disk:
         # Currently disk_size_difference is negative but we prefer to use its absolute value:
         disk_size_difference=$( mathlib_calculate "0 - $disk_size_difference" )
-        DebugPrint "New $disk_device is $disk_size_difference smaller than old disk"
+        DebugPrint "New $disk_device is $disk_size_difference bytes smaller than old disk"
         # There is no need to shrink the last partition when the original last partition still fits on the new smaller disk:
         if test $last_part_end -le $new_disk_remainder_start ; then
             if is_true "$last_part_is_resizeable" ; then

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -982,7 +982,10 @@ function apply_layout_mappings() {
     while read original replacement junk ; do
         # Skip lines that have wrong syntax:
         test "$original" -a "$replacement" || continue
-        if grep -q "$replacement" "$file_to_migrate" ; then
+        # Only treat leftover temporary replacement words as an error
+        # if they are in a non-comment line (comments have '#' as first non-space character)
+        # cf. https://github.com/rear/rear/issues/2183
+        if grep -v '^[[:space:]]*#' "$file_to_migrate" | grep -q "$replacement" ; then
             apply_layout_mappings_succeeded="no"
             LogPrintError "Failed to apply layout mappings to $file_to_migrate for $original (probably no mapping for $original in $MAPPING_FILE)"
         fi


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2183

* How was this pull request tested?
By me, see
https://github.com/rear/rear/issues/2183#issuecomment-512791873

* Brief description of the changes in this pull request:

In the function apply_layout_mappings (therein in its "step 3")
only treat leftover temporary replacement words as an error
if they are in a non-comment line (comments have '#' as first non-space character),
see https://github.com/rear/rear/issues/2183#issuecomment-511394129

Additionally I added in 420_autoresize_last_partitions.sh
the missing word 'bytes' to DebugPrint messages
so that the output changes e.g. from
```
New /dev/vda is 21474836480 smaller than old disk
```
to
```
New /dev/vda is 21474836480 bytes smaller than old disk
```
