### PR TITLE
Issue #2187 - disklayout.conf file contains duplicate lines

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -163,6 +163,8 @@ create_lvmvol() {
     for kv in $kval ; do
         local key=$(awk -F ':' '{ print $1 }' <<< "$kv")
         local value=$(awk -F ':' '{ print $2 }' <<< "$kv")
+        # Skip 'segmentsize', it's a tip for the administrator only
+        [ "$key" != "segmentsize" ] || continue
         lvopts="${lvopts:+$lvopts }--$key $value"
     done
 


### PR DESCRIPTION
#1356 ## Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**
* Impact: **Low**
* Reference to related issue (URL): #2187 

* How was this pull request tested? Tested on RHEL8 with multiple segments

* Brief description of the changes in this pull request:

Create the 'lvmvol' lines commented out when multiple segments exist for a given LV.
This is not an issue unless Migration Mode is used.
In such case, using 'lvcreate' commands already does best effort and loses LV information.

**Reproducer**:

1. Add 2 disks to an existing system
2. Create a VG with the disks

     ~~~
    # vgcreate data /dev/sdb /dev/sdc
    ~~~

3. Create 2 LVs with segments

    ~~~
    # lvcreate -n lv1 -L 1G data
    # lvcreate -n lv2 -L 1G data
    # lvextend /dev/data/lv1 -L +1G -i 2
    # lvextend /dev/data/lv2 -L +1G -i 2
    # lvextend /dev/data/lv1 -L +1G -i 1
    # lvextend /dev/data/lv2 -L +1G -i 1
    ~~~

4. Format and mount the LVs

    ~~~
    # mkdir -p /lv1 /lv2
    # mkfs.ext4 /dev/data/lv1
    # mkfs.ext4 /dev/data/lv2
    # mount /dev/data/lv1 /lv1
    # mount /dev/data/lv2 /lv2
    ~~~

5. Create rescue ISO

6. Check `/var/lib/rear/layout/disklayout.conf`

    ~~~
    # Format for LVM LVs
    # lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]
    # WARNING: Volume data/lv1 has multiple segments. Restoring it in Migration Mode using 'lvcreate' won't preserve segments and volume properties of the other segments!
    lvmvol /dev/data lv1 3221225472b linear,striped segmentsize:1073741824b stripes:1
    #lvmvol /dev/data lv1 3221225472b linear,striped stripesize:65536b segmentsize:1073741824b stripes:2
    #lvmvol /dev/data lv1 3221225472b linear,striped segmentsize:1073741824b stripes:1
    # WARNING: Volume data/lv2 has multiple segments. Restoring it in Migration Mode using 'lvcreate' won't preserve segments and volume properties of the other segments!
    lvmvol /dev/data lv2 2147483648b linear,striped segmentsize:1073741824b stripes:1
    #lvmvol /dev/data lv2 2147483648b linear,striped stripesize:65536b segmentsize:1073741824b stripes:2
    ~~~

With the fix (see above), the other segments of the LV `lv1` and `lv2` are created commented out, which allows the administrator to recreate them manually if needed.
Note in particular that `lvcreate` code will create the `lv1` and `lv2` LVs with only 1 stripe, i.e. the number of stripes specified for the first segment only.