### PR TITLE
Handle ppc64el kernel naming

### DIFF
--- a/usr/share/rear/prep/GNU/Linux/400_guess_kernel.sh
+++ b/usr/share/rear/prep/GNU/Linux/400_guess_kernel.sh
@@ -34,6 +34,9 @@ for dummy in "once" ; do
     # Try /boot/vmlinuz-$KERNEL_VERSION:
     KERNEL_FILE="/boot/vmlinuz-$KERNEL_VERSION"
     test -s "$KERNEL_FILE" && continue
+    # ppc64el uses uncompressed kernel
+    KERNEL_FILE="/boot/vmlinux-$KERNEL_VERSION"
+    test -s "$KERNEL_FILE" && continue
     Log "No kernel file '$KERNEL_FILE' found"
 
     # Try all files in /boot if one matches KERNEL_VERSION="$( uname -r )" cf. default.conf: 


### PR DESCRIPTION
As it is, rear does not detect the kernel on ppc64el as it looks for
something like vmlinuz whether vmlinux is used on that arch.

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): No issue opened, just I just fixed it

* How was this pull request tested? I tested it on a Debian VM with rear mkbackup and recover afterwards.

* Brief description of the changes in this pull request: I added case for the specific ppc64el kernel naming in /boot