### PR TITLE
Minor adjustments to #2194

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -163,8 +163,6 @@ create_lvmvol() {
     for kv in $kval ; do
         local key=$(awk -F ':' '{ print $1 }' <<< "$kv")
         local value=$(awk -F ':' '{ print $2 }' <<< "$kv")
-        # Skip 'segmentsize', it's a tip for the administrator only
-        [ "$key" != "segmentsize" ] || continue
         lvopts="${lvopts:+$lvopts }--$key $value"
     done
 

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -88,10 +88,11 @@ Log "Saving LVM layout."
             segmentsize="$(echo "$line" | awk -F ':' '{ print $10 }')"
 
             kval=""
+            infokval=""
             [ -z "$thinpool" ] || kval="${kval:+$kval }thinpool:$thinpool"
             [ $chunksize -eq 0 ] || kval="${kval:+$kval }chunksize:${chunksize}b"
             [ $stripesize -eq 0 ] || kval="${kval:+$kval }stripesize:${stripesize}b"
-            [ $segmentsize -eq $size ] || kval="${kval:+$kval }segmentsize:${segmentsize}b"
+            [ $segmentsize -eq $size ] || infokval="${infokval:+$infokval }segmentsize:${segmentsize}b"
             if [[ ,$layout, == *,mirror,* ]] ; then
                 kval="${kval:+$kval }mirrors:$(($stripes - 1))"
             elif [[ ,$layout, == *,striped,* ]] ; then
@@ -103,11 +104,17 @@ Log "Saving LVM layout."
                 # 110_include_lvm_code.sh is not able to recreate this, but
                 # keep the information for the administrator anyway.
                 echo "#lvmvol /dev/$vg $lv ${size}b $layout $kval"
+                if [ -n "$infokval" ] ; then
+                    echo "# extra parameters for the line above not taken into account when restoring using 'lvcreate': $infokval"
+                fi
             else
                 if [ $segmentsize -ne $size ] ; then
                     echo "# WARNING: Volume $vg/$lv has multiple segments. Restoring it in Migration Mode using 'lvcreate' won't preserve segments and properties of the other segments as well!"
                 fi
                 echo "lvmvol /dev/$vg $lv ${size}b $layout $kval"
+                if [ -n "$infokval" ] ; then
+                    echo "# extra parameters for the line above not taken into account when restoring using 'lvcreate': $infokval"
+                fi
                 already_processed_lvs="${already_processed_lvs:+$already_processed_lvs }$vg/$lv"
             fi
         done
@@ -142,10 +149,11 @@ Log "Saving LVM layout."
             segmentsize="$(echo "$line" | awk -F ':' '{ print $10 }')"
 
             kval=""
+            infokval=""
             [ -z "$thinpool" ] || kval="${kval:+$kval }thinpool:$thinpool"
             [ $chunksize -eq 0 ] || kval="${kval:+$kval }chunksize:${chunksize}b"
             [ $stripesize -eq 0 ] || kval="${kval:+$kval }stripesize:${stripesize}b"
-            [ $segmentsize -eq $size ] || kval="${kval:+$kval }segmentsize:${segmentsize}b"
+            [ $segmentsize -eq $size ] || infokval="${infokval:+$infokval }segmentsize:${segmentsize}b"
             if [[ "$modules" == "" ]] ; then
                 layout="linear"
                 [ $stripes -eq 0 ] || kval="${kval:+$kval }stripes:$stripes"
@@ -169,11 +177,17 @@ Log "Saving LVM layout."
                 # 110_include_lvm_code.sh is not able to recreate this, but
                 # keep the information for the administrator anyway.
                 echo "#lvmvol /dev/$vg $lv ${size}b $layout $kval"
+                if [ -n "$infokval" ] ; then
+                    echo "# extra parameters for the line above not taken into account when restoring using 'lvcreate': $infokval"
+                fi
             else
                 if [ $segmentsize -ne $size ] ; then
                     echo "# WARNING: Volume $vg/$lv has multiple segments. Restoring it in Migration Mode using 'lvcreate' won't preserve segments and properties of the other segments as well!"
                 fi
                 echo "lvmvol /dev/$vg $lv ${size}b $layout $kval"
+                if [ -n "$infokval" ] ; then
+                    echo "# extra parameters for the line above not taken into account when restoring using 'lvcreate': $infokval"
+                fi
                 already_processed_lvs="${already_processed_lvs:+$already_processed_lvs }$vg/$lv"
             fi
         done


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL): #2187

* How was this pull request tested? 
Comparing disklayout generated before and after. Here is the difference:
```diff
 # Format for LVM LVs
 # lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]
 # WARNING: Volume rhel_ibm-p9wr-08/home has multiple segments. Restoring it in Migration Mode using 'lvcreate' won't preserve segments and properties of the other segments as well!
-lvmvol /dev/rhel_ibm-p9wr-08 home 3941727207424b linear segmentsize:2000393601024b
-#lvmvol /dev/rhel_ibm-p9wr-08 home 3941727207424b linear segmentsize:1941333606400b
+lvmvol /dev/rhel_ibm-p9wr-08 home 3941727207424b linear 
+# extra parameters for the line above not taken into account when restoring using 'lvcreate': segmentsize:2000393601024b
+#lvmvol /dev/rhel_ibm-p9wr-08 home 3941727207424b linear 
+# extra parameters for the line above not taken into account when restoring using 'lvcreate': segmentsize:1941333606400b
```
* Brief description of the changes in this pull request:
Minor adjustments to #2194. Do not overload the `kval` variable - intended for passing options to lvcreate - by adding extra keys to it, which are not supported by lvcreate. Introduce another variable `infokval` for this purpose and print those unsupported and purely informational keys only in comments.