### PR TITLE
uefi: Search for Grub2 modules in /usr/lib/grub*/x86_64-efi and not in /boot

### DIFF
--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -60,7 +60,7 @@ function build_bootx86_efi {
     local grub_module=""
     local grub_modules=""
     for grub_module in part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs ; do
-        test "$( find /boot /usr/lib/grub* -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
+        test "$( find /usr/lib/grub*/x86_64-efi -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
     done
     if ! $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" $grub_modules ; then
         Error "Failed to make bootable EFI image of GRUB2 (error during $gmkimage of BOOTX64.efi)"


### PR DESCRIPTION
## Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**
* Impact: **Normal**

* Reference to related issue (URL): #2001 

* How was this pull request tested?

Tested on RHEL7 UEFI, RHEL8 UEFI + SLES12SP3 UEFI

* Brief description of the changes in this pull request:

On Fedora and RHEL systems, Grub2 UEFI modules live in /usr/lib/grub*/x86_64-efi, not /boot, unless grub2-install is executed, but executing this tool is not needed with UEFI at all.

On SuSE systems, Grub2 UEFI modules also live in /usr/lib/grub*/x86_64-efi, but there is also a copy in /boot, so it's not needed searching in /boot at all.

Additionally, only UEFI modules should be looked for, so /boot cannot be
searched but only /boot/grub2/x86_64-efi (similarly /usr/lib/grub*/x86_64-efi), otherwise we could get some false positives on dual boot systems (UEFI + Legacy), since modules for Legacy will also match, which is wrong.
