### PR TITLE
Do not keep the build dir when used noninteractively

### DIFF
--- a/usr/share/rear/build/default/990_verify_rootfs.sh
+++ b/usr/share/rear/build/default/990_verify_rootfs.sh
@@ -152,7 +152,7 @@ if contains_visible_char "$broken_binaries" ; then
         PrintError "$( grep 'not found' <<<"$ldd_output" )"
     done
     LogPrintError "ReaR recovery system in '$ROOTFS_DIR' needs additional libraries, check $RUNTIME_LOGFILE for details"
-    keep_build_dir
+    is_true "$fatal_missing_library" && keep_build_dir
 fi
 
 # Testing that each program in the PROGS array can be found as executable command within the recovery system

--- a/usr/share/rear/build/default/990_verify_rootfs.sh
+++ b/usr/share/rear/build/default/990_verify_rootfs.sh
@@ -5,19 +5,27 @@
 
 LogPrint "Testing that the recovery system in $ROOTFS_DIR contains a usable system"
 
-if tty -s ; then
-    KEEP_BUILD_DIR_ON_ERRORS=1
+if is_true "$KEEP_BUILD_DIR_ON_ERRORS"; then
+    local effective_keep_build_dir_on_errors=1
+elif is_false "$KEEP_BUILD_DIR_ON_ERRORS"; then
+    # empty = false
+    local effective_keep_build_dir_on_errors=
 else
-    KEEP_BUILD_DIR_ON_ERRORS=
+    # KEEP_BUILD_DIR_ON_ERRORS not set - effective value depends on whether we are running interactively
+    if tty -s ; then
+        local effective_keep_build_dir_on_errors=1
+    else
+        local effective_keep_build_dir_on_errors=
+    fi
 fi
 
 function keep_build_dir() {
-    KEEP_BUILD_DIR=${KEEP_BUILD_DIR:-${KEEP_BUILD_DIR_ON_ERRORS}}
+    KEEP_BUILD_DIR=${KEEP_BUILD_DIR:-${effective_keep_build_dir_on_errors}}
     if test "$KEEP_BUILD_DIR" ; then
         LogPrintError "Build area kept for investigation in $BUILD_DIR, remove it when not needed"
     else
         LogPrintError "Build area $BUILD_DIR will be removed"
-        LogPrintError "To preserve it for investigation set KEEP_BUILD_DIR=1 or run ReaR with -d"
+        LogPrintError "To preserve it for investigation set KEEP_BUILD_DIR_ON_ERRORS=y or run ReaR with -d"
     fi
 }
 

--- a/usr/share/rear/build/default/990_verify_rootfs.sh
+++ b/usr/share/rear/build/default/990_verify_rootfs.sh
@@ -5,27 +5,28 @@
 
 LogPrint "Testing that the recovery system in $ROOTFS_DIR contains a usable system"
 
-if is_true "$KEEP_BUILD_DIR_ON_ERRORS"; then
-    local effective_keep_build_dir_on_errors=1
-elif is_false "$KEEP_BUILD_DIR_ON_ERRORS"; then
-    # empty = false
-    local effective_keep_build_dir_on_errors=
+if test "$KEEP_BUILD_DIR" = "errors"; then
+    local keep_build_dir_on_errors=1
 else
-    # KEEP_BUILD_DIR_ON_ERRORS not set - effective value depends on whether we are running interactively
+    # KEEP_BUILD_DIR does not say to keep it on errors
+    # - effective value depends on whether we are running interactively
     if tty -s ; then
-        local effective_keep_build_dir_on_errors=1
+        local keep_build_dir_on_errors=1
     else
-        local effective_keep_build_dir_on_errors=
+        local keep_build_dir_on_errors=0
     fi
 fi
 
 function keep_build_dir() {
-    KEEP_BUILD_DIR=${KEEP_BUILD_DIR:-${effective_keep_build_dir_on_errors}}
-    if test "$KEEP_BUILD_DIR" ; then
+    if ! is_true "$KEEP_BUILD_DIR" && ! is_false "$KEEP_BUILD_DIR"; then
+        # is either empty or equal to "errors" ... or some garbage value
+        KEEP_BUILD_DIR="${keep_build_dir_on_errors}"
+    fi
+    if is_true "$KEEP_BUILD_DIR" ; then
         LogPrintError "Build area kept for investigation in $BUILD_DIR, remove it when not needed"
     else
         LogPrintError "Build area $BUILD_DIR will be removed"
-        LogPrintError "To preserve it for investigation set KEEP_BUILD_DIR_ON_ERRORS=y or run ReaR with -d"
+        LogPrintError "To preserve it for investigation set KEEP_BUILD_DIR=errors or run ReaR with -d"
     fi
 }
 

--- a/usr/share/rear/build/default/990_verify_rootfs.sh
+++ b/usr/share/rear/build/default/990_verify_rootfs.sh
@@ -143,8 +143,8 @@ if contains_visible_char "$broken_binaries" ; then
         # Show only the missing libraries to the user to not flood his screen with tons of other ldd output lines:
         PrintError "$( grep 'not found' <<<"$ldd_output" )"
     done
-    keep_build_dir
     LogPrintError "ReaR recovery system in '$ROOTFS_DIR' needs additional libraries, check $RUNTIME_LOGFILE for details"
+    keep_build_dir
 fi
 
 # Testing that each program in the PROGS array can be found as executable command within the recovery system

--- a/usr/share/rear/build/default/990_verify_rootfs.sh
+++ b/usr/share/rear/build/default/990_verify_rootfs.sh
@@ -20,11 +20,13 @@ fi
 function keep_build_dir() {
     if ! is_true "$KEEP_BUILD_DIR" && ! is_false "$KEEP_BUILD_DIR"; then
         # is either empty or equal to "errors" ... or some garbage value
+        local orig_keep_build_dir="$KEEP_BUILD_DIR"
         KEEP_BUILD_DIR="${keep_build_dir_on_errors}"
     fi
     if is_true "$KEEP_BUILD_DIR" ; then
         LogPrintError "Build area kept for investigation in $BUILD_DIR, remove it when not needed"
-    else
+    elif ! is_false "$orig_keep_build_dir" ; then
+        # if users disabled preserving the build dir explicitly, let's not bother them with messages
         LogPrintError "Build area $BUILD_DIR will be removed"
         LogPrintError "To preserve it for investigation set KEEP_BUILD_DIR=errors or run ReaR with -d"
     fi

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -129,9 +129,17 @@ OS_VERSION=none
 # Useful to inspect the ReaR recovery system content in $TMPDIR/rear.XXXXXXXXXXXXXXX/rootfs/
 # directly without the need to extract it from the initramfs/initrd in the ISO image.
 # KEEP_BUILD_DIR is automatically set to true in debug mode (-d) and in debugscript mode (-D)
-# and, if running in an interactive terminal,
-# by build/default/990_verify_rootfs.sh when it detects errors in the ReaR recovery system.
+# and by build/default/990_verify_rootfs.sh according to KEEP_BUILD_DIR_ON_ERRORS (below)
+# when it detects errors in the ReaR recovery system
 KEEP_BUILD_DIR=""
+
+# Keep the build area on errors (ternary).
+# Set to "y", "Yes", etc, to obtain the old behaviour where KEEP_BUILD_DIR was always set
+# to true to keep the build area when errors in the ReaR recovery system were detected. Set to
+# "n", "No", etc. to never enable KEEP_BUILD_DIR on errors.
+# An empty value KEEP_BUILD_DIR_ON_ERRORS="" is equivalent to 'yes' if running interactively
+# (in a terminal) and 'no' if not (to avoid cluttering /tmp by cron jobs).
+KEEP_BUILD_DIR_ON_ERRORS=""
 
 # No default workflows. This variable is filled in where the workflows are defined
 # without the empty string as initial value WORKFLOWS and LOCKLESS_WORKFLOWS would

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -129,7 +129,8 @@ OS_VERSION=none
 # Useful to inspect the ReaR recovery system content in $TMPDIR/rear.XXXXXXXXXXXXXXX/rootfs/
 # directly without the need to extract it from the initramfs/initrd in the ISO image.
 # KEEP_BUILD_DIR is automatically set to true in debug mode (-d) and in debugscript mode (-D)
-# and by build/default/990_verify_rootfs.sh when it detects errors in the ReaR recovery system.
+# and, if running in an interactive terminal,
+# by build/default/990_verify_rootfs.sh when it detects errors in the ReaR recovery system.
 KEEP_BUILD_DIR=""
 
 # No default workflows. This variable is filled in where the workflows are defined

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -125,21 +125,20 @@ OS_VERSION=none
 # supported values that could make it work even for your system.
 # See the SetOSVendorAndVersion function in the config-functions.sh script.
 
-# Keep the build area after we are done (BOOL).
+# Keep the build area after we are done (ternary).
 # Useful to inspect the ReaR recovery system content in $TMPDIR/rear.XXXXXXXXXXXXXXX/rootfs/
 # directly without the need to extract it from the initramfs/initrd in the ISO image.
-# KEEP_BUILD_DIR is automatically set to true in debug mode (-d) and in debugscript mode (-D)
-# and by build/default/990_verify_rootfs.sh according to KEEP_BUILD_DIR_ON_ERRORS (below)
-# when it detects errors in the ReaR recovery system
+# Set to "y", "Yes", etc. to always keep the build area, to "n", "No", etc. to never keep it.
+# KEEP_BUILD_DIR is automatically set to true in debug mode (-d) and in debugscript mode (-D).
+# In addition to true (any value that is recognized as 'yes' by the is_true function)
+# and false (any value that is recognized as 'no' by the is_false function) it can be set
+# to several special values:
+# - "errors" to obtain the old behaviour where KEEP_BUILD_DIR was always set
+# to true to keep the build area when errors in the ReaR recovery system were detected.
+# - empty (KEEP_BUILD_DIR="") which means that the build area will be kept on errors
+# if running interactively (in a terminal) and not otherwise (to avoid cluttering
+# /tmp by cron or other automated jobs in case of errors).
 KEEP_BUILD_DIR=""
-
-# Keep the build area on errors (ternary).
-# Set to "y", "Yes", etc, to obtain the old behaviour where KEEP_BUILD_DIR was always set
-# to true to keep the build area when errors in the ReaR recovery system were detected. Set to
-# "n", "No", etc. to never enable KEEP_BUILD_DIR on errors.
-# An empty value KEEP_BUILD_DIR_ON_ERRORS="" is equivalent to 'yes' if running interactively
-# (in a terminal) and 'no' if not (to avoid cluttering /tmp by cron jobs).
-KEEP_BUILD_DIR_ON_ERRORS=""
 
 # No default workflows. This variable is filled in where the workflows are defined
 # without the empty string as initial value WORKFLOWS and LOCKLESS_WORKFLOWS would

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -121,7 +121,7 @@ function SourceStage () {
 function cleanup_build_area_and_end_program () {
     # Cleanup build area
     Log "Finished in $((SECONDS-STARTTIME)) seconds"
-    if test "$KEEP_BUILD_DIR" ; then
+    if is_true "$KEEP_BUILD_DIR" ; then
         LogPrint "You should also rm -Rf $BUILD_DIR"
     else
         Log "Removing build area $BUILD_DIR"


### PR DESCRIPTION
Print helpful messages about keeping/not keeping the build directory in case of errors.

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):
#2121, https://bugzilla.redhat.com/show_bug.cgi?id=1693608
* How was this pull request tested?
```
yum -y install rear
echo 'COPY_AS_IS+=( /usr/bin/xterm )' >> /etc/rear/local.conf
yum -y install xterm
rpm  -e --nodeps libXaw.x86_64 # don't do it on a workstation
```
This makes ReaR complain about broken xterm and abort. To test it interactively:
```
rear mkrescue
```
Result:
```
Broken symlink '/usr/lib/modules/3.10.0-1077.el7.x86_64/build' in recovery system because 'readlink' cannot determine its link target
Broken symlink '/usr/lib/modules/3.10.0-1077.el7.x86_64/source' in recovery system because 'readlink' cannot determine its link target
There are binaries or libraries in the ReaR recovery system that need additional libraries
/bin/xterm requires additional libraries (fatal error)
        libXaw.so.7 => not found
Build area kept for investigation in /tmp/rear.YiON7zQALRvXj6Q, remove it when not needed
ReaR recovery system in '/tmp/rear.YiON7zQALRvXj6Q/rootfs' needs additional libraries, check /root/rear/var/log/rear/rear-ci-vm-10-0-137-193.log for details
ERROR: ReaR recovery system in '/tmp/rear.YiON7zQALRvXj6Q/rootfs' not usable (required libraries are missing)
Some latest log messages since the last called script 990_verify_rootfs.sh:
  stty is /bin/stty
  parted is /bin/parted
  partprobe is /bin/partprobe
  wipefs is /bin/wipefs
  mkfs is /bin/mkfs
  mkfs.xfs is /bin/mkfs.xfs
  xfs_admin is /bin/xfs_admin
  ldconfig is /bin/ldconfig
Aborting due to an error, check /root/rear/var/log/rear/rear-ci-vm-10-0-137-193.log for details
Terminated
```
To test noninteractively:
```
crontab -e
#add
#*/5 * * * * /usr/sbin/rear mkrescue
```
and wait several minutes. Mail from cron will read:
```
There are binaries or libraries in the ReaR recovery system that need additional
 libraries
Build area /tmp/rear.pHJTicEpfOCMZVf will be removed
To preserve it for investigation set KEEP_BUILD_DIR=1 or run ReaR with -d
/bin/xterm requires additional libraries (fatal error)
        libXaw.so.7 => not found
ERROR: ReaR recovery system in '/tmp/rear.pHJTicEpfOCMZVf/rootfs' not usable
Aborting due to an error, check /var/log/rear/rear-ci-vm-10-0-137-193.log for details
```
* Brief description of the changes in this pull request:
The rear package in Fedora and derived distributions drops a file to /etc/cron.d which runs `rear mkrescue`.
When the recovery system is broken (an example is #2144), `rear mkrescue` will fail and leave the build area behind, without giving a hint that the build area should be removed (because this hit is printed only when running rear with the -v flag).
This change:
  - does not disable the removal of the build area when used noninteractively - instead it gives a hint how to keep the build area should one really want it
  - when the build area is kept, print a more prominent message, even when run without -v.