### PR TITLE
Added $BACKUP_OPTIONS to the line with mount_url in 800_copy_to_tftp.…

### DIFF
--- a/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
+++ b/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
@@ -12,7 +12,7 @@ if [[ ! -z "$PXE_TFTP_URL" ]] ; then
     mkdir -p $v "$BUILD_DIR/tftpbootfs" >&2
     StopIfError "Could not mkdir '$BUILD_DIR/tftpbootfs'"
     AddExitTask "rm -Rf $v $BUILD_DIR/tftpbootfs >&2"
-    mount_url $PXE_TFTP_URL $BUILD_DIR/tftpbootfs
+    mount_url $PXE_TFTP_URL $BUILD_DIR/tftpbootfs $BACKUP_OPTIONS
     # However, we copy under $OUTPUT_PREFIX_PXE directory (usually HOSTNAME) to have different clients on one pxe server
     PXE_TFTP_LOCAL_PATH=$BUILD_DIR/tftpbootfs
     # mode must readable for others for pxe and we copy under the client HOSTNAME (=OUTPUT_PREFIX_PXE)

--- a/usr/share/rear/output/PXE/default/810_create_pxelinux_cfg.sh
+++ b/usr/share/rear/output/PXE/default/810_create_pxelinux_cfg.sh
@@ -15,7 +15,7 @@ if [[ ! -z "$PXE_CONFIG_URL" ]] ; then
     mkdir -p $v "$BUILD_DIR/tftpbootfs" >&2
     StopIfError "Could not mkdir '$BUILD_DIR/tftpbootfs'"
     AddExitTask "rm -Rf $v $BUILD_DIR/tftpbootfs >&2"
-    mount_url $PXE_CONFIG_URL $BUILD_DIR/tftpbootfs
+    mount_url $PXE_CONFIG_URL $BUILD_DIR/tftpbootfs $BACKUP_OPTIONS
     PXE_LOCAL_PATH=$BUILD_DIR/tftpbootfs
 else
     # legacy way using PXE_LOCAL_PATH default


### PR DESCRIPTION
…sh and 810_create_pxelinux_cfg.sh otherwise in case of OUTPUT=PXE, mounting the NFS will fail

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): [#2216](https://github.com/rear/rear/issues/2216)

* How was this pull request tested?
`rear -v mkbackup`

* Brief description of the changes in this pull request:
If the NFS server is running AIX, BACKUP_OPTIONS="nfsvers=3,nolock" has to be specified.
This also works fine when using OUTPUT=ISO and BACKUP=NETFS.
However in case of OUTPUT=PXE, mounting the NFS will fail with "mount.nfs: Remote I/O error" because in 800_copy_to_tftp.sh and 810_create_pxelinux_cfg.sh there is no $BACKUP_OPTIONS specified when "mount_url" is issued.
I have added $BACKUP_OPTIONS to the line with mount_url in 800_copy_to_tftp.sh and 810_create_pxelinux_cfg.sh otherwise in case of OUTPUT=PXE, mounting the NFS will fail.