### PR TITLE
Append to CLONE_USERS and CLONE_GROUPS by using +=

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -230,6 +230,6 @@ COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" '/etc/pki/tls/private' '/etc/pki
 # some stuff for the Linux command line
 KERNEL_CMDLINE="$KERNEL_CMDLINE selinux=0"
 # common users and groups
-CLONE_USERS=( "${CLONE_USERS[@]:-}" daemon rpc usbmuxd usbmux vcsa nobody dbus )
-CLONE_GROUPS=( "${CLONE_GROUPS[@]:-}" tty usbmuxd usbmux fuse kvm oinstall dbus )
+CLONE_USERS+=( daemon rpc usbmuxd usbmux vcsa nobody dbus )
+CLONE_GROUPS+=( tty usbmuxd usbmux fuse kvm oinstall dbus )
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):
#2220
* How was this pull request tested?
Running rear mkrescue, the new code logs:
```
Cloning users: daemon rpc usbmuxd usbmux vcsa nobody dbus sshd
Cloning groups: disk cdrom floppy tape audio video lp tty dialout kmem uucp ssh_keys plugdev tty usbmuxd usbmux fuse kvm oinstall dbus input daemon rpc nobody sshd
```
the old code logs:
```
Cloning users:  daemon rpc usbmuxd usbmux vcsa nobody dbus sshd
Cloning groups: disk cdrom floppy tape audio video lp tty dialout kmem uucp ssh_keys plugdev tty usbmuxd usbmux fuse kvm oinstall dbus input root
```
(note the extra space which should not be there).
Difference in /etc/passwd:
```diff
--- passwd.bad  2019-09-03 15:16:37.406403905 -0400
+++ /tmp/rear.I9zRM7TxPWQgTDv/rootfs/etc/passwd 2019-09-03 15:20:04.173403905 -0400
@@ -1,23 +1,6 @@
 root::0:0:root:/root:/bin/bash
-root:x:0:0:root:/root:/bin/bash
-bin:x:1:1:bin:/bin:/sbin/nologin
 daemon:x:2:2:daemon:/sbin:/sbin/nologin
-adm:x:3:4:adm:/var/adm:/sbin/nologin
-lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
-sync:x:5:0:sync:/sbin:/bin/sync
-shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
-halt:x:7:0:halt:/sbin:/sbin/halt
-mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
-operator:x:11:0:operator:/root:/sbin/nologin
-games:x:12:100:games:/usr/games:/sbin/nologin
-ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin
 nobody:x:99:99:Nobody:/:/sbin/nologin
-systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin
 dbus:x:81:81:System message bus:/:/sbin/nologin
-polkitd:x:999:998:User for polkitd:/:/sbin/nologin
 sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin
-postfix:x:89:89::/var/spool/postfix:/sbin/nologin
-chrony:x:998:996::/var/lib/chrony:/sbin/nologin
-rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin
-rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin
-nfsnobody:x:65534:65534:Anonymous NFS User:/var/lib/nfs:/sbin/nologin
```
Note the removed duplicate or extraneous entries.
Difference in /etc/group:
```diff
--- group.bad   2019-09-03 15:16:55.615403905 -0400
+++ /tmp/rear.I9zRM7TxPWQgTDv/rootfs/etc/group  2019-09-03 15:20:04.236403905 -0400
@@ -12,3 +12,7 @@
 ssh_keys:x:997:
 dbus:x:81:
 input:x:999:
+daemon:x:2:
+rpc:x:32:
+nobody:x:99:
+sshd:x:74:
```
Note the extra entries, which correspond to the users and were previously mistakenly omitted.

* Brief description of the changes in this pull request:
Append to CLONE_USERS and CLONE_GROUPS by using +=, instead of expanding the previous value to an empty element, which then causes problems later (introduced in #699 to pacify set -ue in bash 3).

The fix is still compatible with bash 3 and set -ue.