### PR TITLE
Use mountpoint instead of mount|grep

### DIFF
--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -130,8 +130,7 @@ function cleanup_build_area_and_end_program () {
         # line below put in comment due to issue #465
         #rm -Rf $BUILD_DIR/outputfs
         # in worst case it could not umount; so before remove the BUILD_DIR check if above outputfs is gone
-        mountpoint -q "$BUILD_DIR/outputfs"
-        if [[ $? -eq 0 ]]; then
+        if mountpoint -q "$BUILD_DIR/outputfs" ; then
             # still mounted it seems
             LogPrint "Directory $BUILD_DIR/outputfs still mounted - trying lazy umount"
             sleep 2

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -130,7 +130,7 @@ function cleanup_build_area_and_end_program () {
         # line below put in comment due to issue #465
         #rm -Rf $BUILD_DIR/outputfs
         # in worst case it could not umount; so before remove the BUILD_DIR check if above outputfs is gone
-        mount | grep -q "$BUILD_DIR/outputfs"
+        mountpoint -q "$BUILD_DIR/outputfs"
         if [[ $? -eq 0 ]]; then
             # still mounted it seems
             LogPrint "Directory $BUILD_DIR/outputfs still mounted - trying lazy umount"

--- a/usr/share/rear/verify/DUPLICITY/default/200_check_tmpfs.sh
+++ b/usr/share/rear/verify/DUPLICITY/default/200_check_tmpfs.sh
@@ -2,9 +2,6 @@
 # Public License. Refer to the included COPYING for full text of license.
 
 # mount tmpfs on /tmp if not present
-mount | grep -q /tmp
-if [[ $? -ne 0 ]]; then
-    LogPrint "File system /tmp not present - try to mount it via tmpfs"
-    mount -t tmpfs  tmpfs  /tmp >/dev/null
-    LogIfError "Could not mount tmpfs on /tmp"
-fi
+mountpoint -q /tmp && return 0
+LogPrint "File system /tmp not present - mounting it via tmpfs"
+mount -t tmpfs  tmpfs  /tmp || Error "Failed to mount tmpfs on /tmp"

--- a/usr/share/rear/verify/DUPLICITY/default/200_check_tmpfs.sh
+++ b/usr/share/rear/verify/DUPLICITY/default/200_check_tmpfs.sh
@@ -3,7 +3,5 @@
 
 # mount tmpfs on /tmp if not present
 mountpoint -q /tmp && return 0
-if [[ $? -ne 0 ]]; then
-	LogPrint "File system /tmp not present - mounting it via tmpfs"
-	mount -t tmpfs  tmpfs  /tmp || Error "Failed to mount tmpfs on /tmp"
-fi
+LogPrint "File system /tmp not present - mounting it via tmpfs"
+mount -t tmpfs  tmpfs  /tmp || Error "Failed to mount tmpfs on /tmp"

--- a/usr/share/rear/verify/DUPLICITY/default/200_check_tmpfs.sh
+++ b/usr/share/rear/verify/DUPLICITY/default/200_check_tmpfs.sh
@@ -3,5 +3,7 @@
 
 # mount tmpfs on /tmp if not present
 mountpoint -q /tmp && return 0
-LogPrint "File system /tmp not present - mounting it via tmpfs"
-mount -t tmpfs  tmpfs  /tmp || Error "Failed to mount tmpfs on /tmp"
+if [[ $? -ne 0 ]]; then
+	LogPrint "File system /tmp not present - mounting it via tmpfs"
+	mount -t tmpfs  tmpfs  /tmp || Error "Failed to mount tmpfs on /tmp"
+fi


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: Cleanup

* Impact: **Low** 

* Reference to related issue (URL):  #1390

* How was this pull request tested? Rhel7 (rear -d -v mkrescue)

* Brief description of the changes in this pull request: Instead of using 'mount | grep "$BUILD_DIR/outputfs"' the command 'mountpoint -q "$BUILD_DIR/outputfs"'  is used.

