### PR TITLE
Cosmetic fix for RHEL 6 and missing name_assign_type for LAN interfac…

### DIFF
--- a/usr/share/rear/lib/network-functions.sh
+++ b/usr/share/rear/lib/network-functions.sh
@@ -184,7 +184,11 @@ function is_persistent_ethernet_name () {
     local _name_assign_type="0"
 
     [ -f "/sys/class/net/$_netif/name_assign_type" ] \
-        && _name_assign_type=$(cat "/sys/class/net/$_netif/name_assign_type")
+        && _name_assign_type=$(cat "/sys/class/net/$_netif/name_assign_type" 2>/dev/null)
+
+    # On RHEL 6 "name_assign_type" does not exist, therefore, the value of _name_assign_type=""
+    # Read https://github.com/rear/rear/issues/2197 for the details
+    [ "$_name_assign_type" = "" ] && return 1
 
     # NET_NAME_ENUM 1
     [ "$_name_assign_type" = "1" ] && return 1


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): #2197

* How was this pull request tested? Manual

* Brief description of the changes in this pull request: cosmetic fix to prevent the error message "/sys/class/net/eth0/name_assign_type: Invalid argument" - however, the return code is 1 (with the fix, but also with the code untouched). Therefore, it is a cosmetic fix only.

