### PR TITLE
Improve handling of partition label type for multipath disks

### DIFF
--- a/doc/user-guide/06-layout-configuration.adoc
+++ b/doc/user-guide/06-layout-configuration.adoc
@@ -608,6 +608,11 @@ part <disk name> <size(B)> <start(B)> <partition name/type> <flags/"none"> <part
 raid /dev/<name> level=<RAID level> raid-devices=<nr of devices> [uuid=<uuid>] [spare-devices=<nr of spares>] [layout=<RAID layout>] [chunk=<chunk size>] devices=<device1,device2,...>
 ----------------------------------
 
+=== Multipath ===
+----------------------------------
+multipath /dev/<name> <size(B)> <partition label> <slave1,slave2,...>
+----------------------------------
+
 === Physical Volumes ===
 ----------------------------------
 lvmdev /dev/<volume group name> <device> <UUID> [<size(K)>]

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -119,9 +119,10 @@ fi
 
 ### Create multipath devices (at least partitions on them).
 function create_multipath() {
-    local device=$1
-    if grep "^multipath $device " "$LAYOUT_FILE" 1>&2 ; then
+    local component device size label junk
+    read component device size label junk < <(grep "^multipath $1 " "$LAYOUT_FILE")
+    if [[ "$device" ]]; then
         Log "Found current or former multipath device $device in $LAYOUT_FILE: Creating partitions on it"
-        create_partitions "$device"
+        create_partitions "$device" "$label"
     fi
 }

--- a/usr/share/rear/layout/prepare/default/520_exclude_components.sh
+++ b/usr/share/rear/layout/prepare/default/520_exclude_components.sh
@@ -7,7 +7,7 @@ for component in "${EXCLUDE_RECREATE[@]}" ; do
 done
 
 ### Make sure we have all dependencies for multipath devices in place.
-while read multipath device dm_size slaves junk ; do
+while read multipath device dm_size label slaves junk ; do
     local -a devices=()
 
     OIFS=$IFS

--- a/usr/share/rear/layout/save/GNU/Linux/280_multipath_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/280_multipath_layout.sh
@@ -23,7 +23,11 @@ while read dm_name junk ; do
         slaves="$slaves$(get_device_name ${slave##*/}),"
     done
 
-    echo "multipath /dev/mapper/$dm_name $dm_size ${slaves%,}" >> $DISKLAYOUT_FILE
+    dm_disktype=$(parted -s $dev_name print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")
+
+    echo "# Multipath /dev/mapper/$dm_name"
+    echo "# Format: multipath <devname> <size(bytes)> <partition label type> <slaves>"
+    echo "multipath /dev/mapper/$dm_name $dm_size $dm_disktype ${slaves%,}" >> $DISKLAYOUT_FILE
 
     extract_partitions "/dev/mapper/$dm_name" >> $DISKLAYOUT_FILE
 done < <( dmsetup ls --target multipath )

--- a/usr/share/rear/layout/save/default/320_autoexclude.sh
+++ b/usr/share/rear/layout/save/default/320_autoexclude.sh
@@ -97,7 +97,7 @@ if is_true "$AUTOEXCLUDE_DISKS" ; then
 fi
 
 ### Prevent partitioning of the underlying devices on multipath
-while read multipath device dm_size slaves junk ; do
+while read multipath device dm_size label slaves junk ; do
     local -a devices=()
 
     OIFS=$IFS

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -187,7 +187,7 @@ generate_layout_dependencies() {
                 ;;
             multipath)
                 name=$(echo "$remainder" | cut -d " " -f "1")
-                disks=$(echo "$remainder" | cut -d " " -f "3" | tr "," " ")
+                disks=$(echo "$remainder" | cut -d " " -f "4" | tr "," " ")
 
                 add_component "$name" "multipath"
 


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?**

  **Bug Fix.**

* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent**

  **Normal.**

* Reference to related issue (URL):

  https://github.com/rear/rear/issues/2234.

* How was this pull request tested?

  Locally tested under KVM. Multipath configuration:

      # multipath -ll
      0QEMU_QEMU_HARDDISK_0001 dm-0 QEMU,QEMU HARDDISK
      size=2.0G features='1 retain_attached_hw_handler' hwhandler='0' wp=rw
      |-+- policy='service-time 0' prio=1 status=active
      | `- 2:0:0:1 sdb 8:16 active ready running
      `-+- policy='service-time 0' prio=1 status=enabled
        `- 2:0:0:2 sda 8:0  active ready running

      # parted /dev/mapper/0QEMU_QEMU_HARDDISK_0001 print
      Model: Linux device-mapper (multipath) (dm)
      Disk /dev/mapper/0QEMU_QEMU_HARDDISK_0001: 2147MB
      Sector size (logical/physical): 512B/512B
      Partition Table: gpt
      Disk Flags: 
      
      Number  Start   End     Size    File system  Name     Flags
       1      1049kB  211MB   210MB   ext4         primary
       2      211MB   2147MB  1937MB  xfs          primary

* Brief description of the changes in this pull request:

  When recording information about a multipath disk, ReaR did not store information about its partition label type (`280_multipath_layout.sh`). The recovery code `create_multipath()` (`210_load_multipath.sh`) -> `create_partitions()` (`100_include_partition_code.sh`) then tried to automatically detect the label type using a heuristic that depends on GPT partition names. The logic would incorrectly detect the device as having the MBR label type instead of GPT if one of the partition names was exactly "primary", "extended" or "logical".

  The patch fixes the problem by explicitly storing the partition label type for multipath devices as is already done for normal disks. The restore logic is accordingly updated to utilize this information.

  Fixes #2234.