### PR TITLE
Fix including of multipath disks in backup

### DIFF
--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -318,10 +318,8 @@ find_disk() {
 }
 
 find_disk_and_multipath() {
-    res=$(find_disk "$1")
-    if [[ -n "$res" || "$AUTOEXCLUDE_MULTIPATH" =~ ^[yY1] ]]; then
-        echo $res
-    else
+    find_disk "$1"
+    if ! is_true "$AUTOEXCLUDE_MULTIPATH" ; then
         find_multipath "$1"
     fi
 }


### PR DESCRIPTION
#### Pull Request Details:

* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?**

  **Bug Fix**.

* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent**

  **Normal**.

* Reference to related issue (URL):

  https://github.com/rear/rear/issues/2236.

* How was this pull request tested?

  Locally tested under KVM. Multipath configuration:

      # multipath -ll
      0QEMU_QEMU_HARDDISK_0001 dm-0 QEMU,QEMU HARDDISK
      size=2.0G features='1 retain_attached_hw_handler' hwhandler='0' wp=rw
      |-+- policy='service-time 0' prio=1 status=active
      | `- 2:0:0:1 sdb 8:16 active ready running
      `-+- policy='service-time 0' prio=1 status=enabled
        `- 2:0:0:2 sda 8:0  active ready running
      
      # parted /dev/mapper/0QEMU_QEMU_HARDDISK_0001 print
      Model: Linux device-mapper (multipath) (dm)
      Disk /dev/mapper/0QEMU_QEMU_HARDDISK_0001: 2147MB
      Sector size (logical/physical): 512B/512B
      Partition Table: gpt
      Disk Flags: 
      
      Number  Start   End     Size    File system  Name     Flags
       1      1049kB  211MB   210MB   ext4         primary
       2      211MB   2147MB  1937MB  xfs          primary
      
      # mount | grep 'on \(/ \|/mnt\)'
      /dev/vda2 on / type btrfs (rw,relatime,space_cache,subvolid=259,subvol=/@/.snapshots/1/snapshot)
      /dev/mapper/0QEMU_QEMU_HARDDISK_0001-part1 on /mnt/mp-1 type ext4 (rw,relatime,data=ordered)
      /dev/mapper/0QEMU_QEMU_HARDDISK_0001-part2 on /mnt/mp-2 type xfs (rw,relatime,attr2,inode64,noquota)

* Brief description of the changes in this pull request:

  The `AUTOEXCLUDE_DISKS` logic (`320_autoexclude.sh`) traverses filesystems and tries to determine the associated underlying disks that should be kept. When having a filesystem `fs:/A` that is present on a multipath device `MP` and the root filesystem `fs:/` that is present on a normal disk `D`, the code first established that `fs:/A` depends on `fs:/` resulting in marking `D` as used and then short-circuited processing of multipath devices. This resulted in `MP` not being considered as a used device and removed from the backup.

  The patch fixes this problem by removing the short-circuit logic in `find_disk_and_multipath()` so multipath devices get processed too (unless `AUTOEXCLUDE_MULTIPATH` is true).

  Fixes #2236.