### PR TITLE
Add alternative for 'poweroff.com' ('poweroff.c32' on RHEL8)

### DIFF
--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -89,91 +89,91 @@ function find_yaboot_file {
 }
 
 function set_syslinux_features {
-	# Test for features in syslinux
-	# true if isolinux supports booting from /boot/syslinux, /boot or only from / of the ISO
-	FEATURE_ISOLINUX_BOOT_SYSLINUX=
-	# true if syslinux supports booting from /boot/syslinux, /boot or only from / of the USB media
-	FEATURE_SYSLINUX_BOOT_SYSLINUX=
-	# true if syslinux and extlinux support localboot
-	FEATURE_SYSLINUX_EXTLINUX_WITH_LOCALBOOT=
-	# true if extlinux supports the -i option
-	FEATURE_SYSLINUX_EXTLINUX_INSTALL=
-	# true if syslinux supports INCLUDE directive
-	FEATURE_SYSLINUX_INCLUDE=
-	# true if syslinux supports advanced label names (eg. linux-2.6.18)
-	FEATURE_SYSLINUX_LABEL_NAMES=
-	# true if syslinux supports MENU DEFAULT directive
-	FEATURE_SYSLINUX_MENU_DEFAULT=
-	# true if syslinux supports MENU HELP directive
-	FEATURE_SYSLINUX_MENU_HELP=
-	# true if syslinux supports MENU BEGIN/MENU END/MENU QUIT directives
-	FEATURE_SYSLINUX_SUBMENU=
-	# true if syslinux supports MENU HIDDEN directive
-	FEATURE_SYSLINUX_MENU_HIDDEN=
-	# true if syslinux supports TEXT HELP directive
-	FEATURE_SYSLINUX_TEXT_HELP=
+    # Test for features in syslinux
+    # true if isolinux supports booting from /boot/syslinux, /boot or only from / of the ISO
+    FEATURE_ISOLINUX_BOOT_SYSLINUX=
+    # true if syslinux supports booting from /boot/syslinux, /boot or only from / of the USB media
+    FEATURE_SYSLINUX_BOOT_SYSLINUX=
+    # true if syslinux and extlinux support localboot
+    FEATURE_SYSLINUX_EXTLINUX_WITH_LOCALBOOT=
+    # true if extlinux supports the -i option
+    FEATURE_SYSLINUX_EXTLINUX_INSTALL=
+    # true if syslinux supports INCLUDE directive
+    FEATURE_SYSLINUX_INCLUDE=
+    # true if syslinux supports advanced label names (eg. linux-2.6.18)
+    FEATURE_SYSLINUX_LABEL_NAMES=
+    # true if syslinux supports MENU DEFAULT directive
+    FEATURE_SYSLINUX_MENU_DEFAULT=
+    # true if syslinux supports MENU HELP directive
+    FEATURE_SYSLINUX_MENU_HELP=
+    # true if syslinux supports MENU BEGIN/MENU END/MENU QUIT directives
+    FEATURE_SYSLINUX_SUBMENU=
+    # true if syslinux supports MENU HIDDEN directive
+    FEATURE_SYSLINUX_MENU_HIDDEN=
+    # true if syslinux supports TEXT HELP directive
+    FEATURE_SYSLINUX_TEXT_HELP=
         # true if syslinux supports modules sub-dir (Version > 5.00)
         FEATURE_SYSLINUX_MODULES=
-	# If ISO_DEFAULT is not set, set it to default 'boothd'
-	if [ -z "$ISO_DEFAULT" ]; then
-		ISO_DEFAULT="boothd"
-	fi
-	# Define the syslinux directory for later usage (since version 5 the bins and c32 are in separate dirs)
-	if [[ -z "$SYSLINUX_DIR" ]]; then
-		ISOLINUX_BIN=$(find_syslinux_file isolinux.bin)
-		if [[ -s "$ISOLINUX_BIN" ]]; then
-			SYSLINUX_DIR="$(dirname $ISOLINUX_BIN)"
-		fi
-	fi
-	[[ "$SYSLINUX_DIR" ]]
-	StopIfError "Could not find a working syslinux path."
+    # If ISO_DEFAULT is not set, set it to default 'boothd'
+    if [ -z "$ISO_DEFAULT" ]; then
+        ISO_DEFAULT="boothd"
+    fi
+    # Define the syslinux directory for later usage (since version 5 the bins and c32 are in separate dirs)
+    if [[ -z "$SYSLINUX_DIR" ]]; then
+        ISOLINUX_BIN=$(find_syslinux_file isolinux.bin)
+        if [[ -s "$ISOLINUX_BIN" ]]; then
+            SYSLINUX_DIR="$(dirname $ISOLINUX_BIN)"
+        fi
+    fi
+    [[ "$SYSLINUX_DIR" ]]
+    StopIfError "Could not find a working syslinux path."
 
-	local syslinux_version=$(get_syslinux_version)
-	if [[ "$1" ]] && version_newer "$1" "$syslinux_version"; then
-		syslinux_version="$1"
-	fi
-	Log "Features based on syslinux version: $syslinux_version"
+    local syslinux_version=$(get_syslinux_version)
+    if [[ "$1" ]] && version_newer "$1" "$syslinux_version"; then
+        syslinux_version="$1"
+    fi
+    Log "Features based on syslinux version: $syslinux_version"
 
-	if version_newer "$syslinux_version" 4.00; then
-		FEATURE_SYSLINUX_MENU_HELP="y"
-		FEATURE_ISOLINUX_BOOT_SYSLINUX="y"
-	fi
-	if version_newer "$syslinux_version" 3.72; then
-		FEATURE_SYSLINUX_MENU_DEFAULT="y"
-	fi
-	if version_newer "$syslinux_version" 3.70; then
-		FEATURE_SYSLINUX_EXTLINUX_WITH_LOCALBOOT="y"
-	fi
-	if version_newer "$syslinux_version" 3.62; then
-		FEATURE_SYSLINUX_SUBMENU="y"
-	fi
-	if version_newer "$syslinux_version" 3.52; then
-		FEATURE_SYSLINUX_MENU_HIDDEN="y"
-	fi
-	if version_newer "$syslinux_version" 3.50; then
-		FEATURE_SYSLINUX_INCLUDE="y"
-		FEATURE_SYSLINUX_TEXT_HELP="y"
-	fi
-	if version_newer "$syslinux_version" 3.35; then
-		FEATURE_SYSLINUX_BOOT_SYSLINUX="y"
-		FEATURE_SYSLINUX_LABEL_NAMES="y"
-	fi
-	if version_newer "$syslinux_version" 3.20; then
-		FEATURE_SYSLINUX_EXTLINUX_INSTALL="y"
-	fi
+    if version_newer "$syslinux_version" 4.00; then
+        FEATURE_SYSLINUX_MENU_HELP="y"
+        FEATURE_ISOLINUX_BOOT_SYSLINUX="y"
+    fi
+    if version_newer "$syslinux_version" 3.72; then
+        FEATURE_SYSLINUX_MENU_DEFAULT="y"
+    fi
+    if version_newer "$syslinux_version" 3.70; then
+        FEATURE_SYSLINUX_EXTLINUX_WITH_LOCALBOOT="y"
+    fi
+    if version_newer "$syslinux_version" 3.62; then
+        FEATURE_SYSLINUX_SUBMENU="y"
+    fi
+    if version_newer "$syslinux_version" 3.52; then
+        FEATURE_SYSLINUX_MENU_HIDDEN="y"
+    fi
+    if version_newer "$syslinux_version" 3.50; then
+        FEATURE_SYSLINUX_INCLUDE="y"
+        FEATURE_SYSLINUX_TEXT_HELP="y"
+    fi
+    if version_newer "$syslinux_version" 3.35; then
+        FEATURE_SYSLINUX_BOOT_SYSLINUX="y"
+        FEATURE_SYSLINUX_LABEL_NAMES="y"
+    fi
+    if version_newer "$syslinux_version" 3.20; then
+        FEATURE_SYSLINUX_EXTLINUX_INSTALL="y"
+    fi
 
-	if version_newer "$syslinux_version" 5.00; then
-		FEATURE_SYSLINUX_MODULES="y"
-	fi
+    if version_newer "$syslinux_version" 5.00; then
+        FEATURE_SYSLINUX_MODULES="y"
+    fi
 
-	if [[ "$FEATURE_SYSLINUX_BOOT_SYSLINUX" ]]; then
-		SYSLINUX_PREFIX="boot/syslinux"
-	else
-		SYSLINUX_PREFIX=
-	fi
-	Log "Using syslinux prefix: $SYSLINUX_PREFIX"
+    if [[ "$FEATURE_SYSLINUX_BOOT_SYSLINUX" ]]; then
+        SYSLINUX_PREFIX="boot/syslinux"
+    else
+        SYSLINUX_PREFIX=
+    fi
+    Log "Using syslinux prefix: $SYSLINUX_PREFIX"
 
-	FEATURE_SYSLINUX_IS_SET=1
+    FEATURE_SYSLINUX_IS_SET=1
 }
 
 
@@ -183,23 +183,23 @@ function set_syslinux_features {
 # binaries will be copied to
 # the optional second argment is the target flavour and defaults to isolinux
 function make_syslinux_config {
-	[[ -d "$1" ]]
-	BugIfError "Required argument for BOOT_DIR is missing"
-	[[ -d "$SYSLINUX_DIR" ]]
-	BugIfError "Required environment SYSLINUX_DIR ($SYSLINUX_DIR) is not set or not a directory"
-	[[ "$FEATURE_SYSLINUX_IS_SET" ]]
-	BugIfError "You must call set_syslinux_features before"
+    [[ -d "$1" ]]
+    BugIfError "Required argument for BOOT_DIR is missing"
+    [[ -d "$SYSLINUX_DIR" ]]
+    BugIfError "Required environment SYSLINUX_DIR ($SYSLINUX_DIR) is not set or not a directory"
+    [[ "$FEATURE_SYSLINUX_IS_SET" ]]
+    BugIfError "You must call set_syslinux_features before"
 
-	local BOOT_DIR="$1" ; shift
-	local flavour="${1:-isolinux}" ; shift
-	# syslinux v5 and higher has now its modules in a separate directory structure
-	local syslinux_modules_dir=
+    local BOOT_DIR="$1" ; shift
+    local flavour="${1:-isolinux}" ; shift
+    # syslinux v5 and higher has now its modules in a separate directory structure
+    local syslinux_modules_dir=
 
-	if [[ "$FEATURE_SYSLINUX_MODULES" ]]; then
-		syslinux_modules_dir=$( find_syslinux_modules_dir menu.c32 )
-		# the modules dir is the base for SYSLINUX_DIR (to comply with versions < 5)
-		SYSLINUX_DIR="$syslinux_modules_dir"
-	fi
+    if [[ "$FEATURE_SYSLINUX_MODULES" ]]; then
+        syslinux_modules_dir=$( find_syslinux_modules_dir menu.c32 )
+        # the modules dir is the base for SYSLINUX_DIR (to comply with versions < 5)
+        SYSLINUX_DIR="$syslinux_modules_dir"
+    fi
 
     # Enable serial console, unless explicitly disabled (only last entry is used :-/)
     if [[ "$USE_SERIAL_CONSOLE" =~ ^[yY1] ]]; then
@@ -211,240 +211,240 @@ function make_syslinux_config {
         done
     fi
 
-	# if we have the menu.c32 available we use it. if not we make sure that there will be no menu lines in the result
-	# so that we don't confuse older syslinux
-	if [[ -r "$SYSLINUX_DIR/menu.c32" ]] ; then
-		cp $v "$SYSLINUX_DIR/menu.c32" "$BOOT_DIR/menu.c32" >&2
-		function syslinux_menu {
-			echo "MENU $@"
-		}
-	else
-		# without menu we don't set a default but we ask syslinux to prompt for user input
-		echo "prompt 1"
-		function syslinux_menu {
-			: #noop
-		}
-	fi
+    # if we have the menu.c32 available we use it. if not we make sure that there will be no menu lines in the result
+    # so that we don't confuse older syslinux
+    if [[ -r "$SYSLINUX_DIR/menu.c32" ]] ; then
+        cp $v "$SYSLINUX_DIR/menu.c32" "$BOOT_DIR/menu.c32" >&2
+        function syslinux_menu {
+            echo "MENU $@"
+        }
+    else
+        # without menu we don't set a default but we ask syslinux to prompt for user input
+        echo "prompt 1"
+        function syslinux_menu {
+            : #noop
+        }
+    fi
 
-	function syslinux_menu_help {
-		if [[ "$FEATURE_SYSLINUX_MENU_HELP" ]]; then
-			echo "TEXT HELP"
-			for line in "$@" ; do echo "$line" ; done
-			echo "ENDTEXT"
-		fi
-	}
+    function syslinux_menu_help {
+        if [[ "$FEATURE_SYSLINUX_MENU_HELP" ]]; then
+            echo "TEXT HELP"
+            for line in "$@" ; do echo "$line" ; done
+            echo "ENDTEXT"
+        fi
+    }
 
-	echo "say ENTER - boot local hard disk"
-	echo "say --------------------------------------------------------------------------------"
-	echo "$VERSION_INFO" >$BOOT_DIR/message
-	echo "display message"
-	echo "F1 message"
+    echo "say ENTER - boot local hard disk"
+    echo "say --------------------------------------------------------------------------------"
+    echo "$VERSION_INFO" >$BOOT_DIR/message
+    echo "display message"
+    echo "F1 message"
 
-	if [[ -s $(get_template "rear.help") ]]; then
-		cp $v $(get_template "rear.help") "$BOOT_DIR/rear.help" >&2
-		echo "F2 rear.help"
-		echo "say F2 - Show help"
-		syslinux_menu "TABMSG Press [Tab] to edit, [F2] for help, [F1] for version info"
-	else
-		syslinux_menu "TABMSG Press [Tab] to edit options and [F1] for version info"
-	fi
+    if [[ -s $(get_template "rear.help") ]]; then
+        cp $v $(get_template "rear.help") "$BOOT_DIR/rear.help" >&2
+        echo "F2 rear.help"
+        echo "say F2 - Show help"
+        syslinux_menu "TABMSG Press [Tab] to edit, [F2] for help, [F1] for version info"
+    else
+        syslinux_menu "TABMSG Press [Tab] to edit options and [F1] for version info"
+    fi
 
-	echo "timeout 300"
-	echo "#noescape 1"
-	syslinux_menu title $PRODUCT v$VERSION
+    echo "timeout 300"
+    echo "#noescape 1"
+    syslinux_menu title $PRODUCT v$VERSION
 
-	echo "say rear - Recover $HOSTNAME"
-	echo "label rear"
-	syslinux_menu "label ^Recover $HOSTNAME"
-	syslinux_menu_help "Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)" \
-			"${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}"
-	echo "kernel kernel"
-	echo "append initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE"
-	if [ "$ISO_DEFAULT" == "manual" ] ; then
+    echo "say rear - Recover $HOSTNAME"
+    echo "label rear"
+    syslinux_menu "label ^Recover $HOSTNAME"
+    syslinux_menu_help "Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)" \
+            "${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}"
+    echo "kernel kernel"
+    echo "append initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE"
+    if [ "$ISO_DEFAULT" == "manual" ] ; then
                echo "default rear"
                syslinux_menu "default"
         fi
-	echo ""
+    echo ""
 
-	echo "say rear - Recover $HOSTNAME"
-	echo "label rear-automatic"
-	syslinux_menu "label ^Automatic Recover $HOSTNAME"
-	syslinux_menu_help "Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)" \
-			"${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}"
-	echo "kernel kernel"
-	echo "append initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover $ISO_RECOVER_MODE"
+    echo "say rear - Recover $HOSTNAME"
+    echo "label rear-automatic"
+    syslinux_menu "label ^Automatic Recover $HOSTNAME"
+    syslinux_menu_help "Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)" \
+            "${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}"
+    echo "kernel kernel"
+    echo "append initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover $ISO_RECOVER_MODE"
 
-	if [ "$ISO_DEFAULT" == "automatic" ] ; then
+    if [ "$ISO_DEFAULT" == "automatic" ] ; then
                echo "default rear-automatic"
                syslinux_menu "default"
                echo "timeout 50"
         fi
-	echo ""
+    echo ""
 
-	syslinux_menu separator
-	echo "label -"
-	syslinux_menu "label Other actions"
-	syslinux_menu "disable"
-	echo ""
+    syslinux_menu separator
+    echo "label -"
+    syslinux_menu "label Other actions"
+    syslinux_menu "disable"
+    echo ""
 
-	if [[ "$FEATURE_SYSLINUX_MENU_HELP" && -r $(get_template "rear.help") ]]; then
-		echo "label help"
-		syslinux_menu "label ^Help for $PRODUCT"
-		syslinux_menu_help "More information about Relax-and-Recover and the steps for recovering your system"
-		syslinux_menu "help rear.help"
-	fi
+    if [[ "$FEATURE_SYSLINUX_MENU_HELP" && -r $(get_template "rear.help") ]]; then
+        echo "label help"
+        syslinux_menu "label ^Help for $PRODUCT"
+        syslinux_menu_help "More information about Relax-and-Recover and the steps for recovering your system"
+        syslinux_menu "help rear.help"
+    fi
 
-	# Use chain booting for booting disk, if chain.c32 is available
-	if [[ -r "$SYSLINUX_DIR/chain.c32" ]]; then
-		cp $v "$SYSLINUX_DIR/chain.c32" "$BOOT_DIR/chain.c32" >&2
+    # Use chain booting for booting disk, if chain.c32 is available
+    if [[ -r "$SYSLINUX_DIR/chain.c32" ]]; then
+        cp $v "$SYSLINUX_DIR/chain.c32" "$BOOT_DIR/chain.c32" >&2
 
-		echo "say boothd0 - boot first local disk"
-		echo "label boothd0"
-		syslinux_menu "label Boot First ^Local disk (hd0)"
-		if [[ "$flavour" == "isolinux" ]] && [ "$ISO_DEFAULT" == "boothd" ] ; then
-			# for isolinux local boot means boot from first disk
-			echo "default boothd0"
-			syslinux_menu "default"
-		fi
-		echo "kernel chain.c32"
-		echo "append hd0"
-		echo ""
+        echo "say boothd0 - boot first local disk"
+        echo "label boothd0"
+        syslinux_menu "label Boot First ^Local disk (hd0)"
+        if [[ "$flavour" == "isolinux" ]] && [ "$ISO_DEFAULT" == "boothd" ] ; then
+            # for isolinux local boot means boot from first disk
+            echo "default boothd0"
+            syslinux_menu "default"
+        fi
+        echo "kernel chain.c32"
+        echo "append hd0"
+        echo ""
 
-		echo "say boothd1 - boot second local disk"
-		echo "label boothd1"
-		syslinux_menu "label Boot ^Second Local disk (hd1)"
-		if [[ "$flavour" == "extlinux" ]] && [ "$ISO_DEFAULT" == "boothd" ]; then
-			# for extlinux local boot means boot from second disk because the boot disk became the first disk
-			# which usually allows us to access the original first disk as second disk
-			echo "default boothd1"
-			syslinux_menu "default"
-		fi
-		echo "kernel chain.c32"
-		echo "append hd1"
-		echo ""
+        echo "say boothd1 - boot second local disk"
+        echo "label boothd1"
+        syslinux_menu "label Boot ^Second Local disk (hd1)"
+        if [[ "$flavour" == "extlinux" ]] && [ "$ISO_DEFAULT" == "boothd" ]; then
+            # for extlinux local boot means boot from second disk because the boot disk became the first disk
+            # which usually allows us to access the original first disk as second disk
+            echo "default boothd1"
+            syslinux_menu "default"
+        fi
+        echo "kernel chain.c32"
+        echo "append hd1"
+        echo ""
 
-	fi
+    fi
 
-	if [[ "$flavour" != "extlinux" || "$FEATURE_SYSLINUX_EXTLINUX_WITH_LOCALBOOT" ]]; then
-		# localboot is a isolinux and pxelinux feature only, see http://syslinux.zytor.com/wiki/index.php/SYSLINUX#LOCALBOOT_type_.5BISOLINUX.2C_PXELINUX.5D
-		# but extlinux >= 3.70 actually also supports localboot, see http://syslinux.zytor.com/wiki/index.php/Syslinux_3_Changelog#Changes_in_3.70
+    if [[ "$flavour" != "extlinux" || "$FEATURE_SYSLINUX_EXTLINUX_WITH_LOCALBOOT" ]]; then
+        # localboot is a isolinux and pxelinux feature only, see http://syslinux.zytor.com/wiki/index.php/SYSLINUX#LOCALBOOT_type_.5BISOLINUX.2C_PXELINUX.5D
+        # but extlinux >= 3.70 actually also supports localboot, see http://syslinux.zytor.com/wiki/index.php/Syslinux_3_Changelog#Changes_in_3.70
 
-		if [[ ! -r "$SYSLINUX_DIR/chain.c32" ]]; then
-			# this should be above under the if chain.c32 section but it comes here because it will work only if localboot is supported
-			# if you use old extlinux then you just cannot boot from other device unless chain.c32 is available :-(
-			echo "say boot80 - Boot from first BIOS disk 0x80"
-			echo "label boot80"
-			syslinux_menu "label Boot First ^Local BIOS disk (0x80)"
-			if [[ "$flavour" == "isolinux" ]]; then
-				# for isolinux local boot means boot from first disk
-				echo "default boot80"
-				syslinux_menu default
-			fi
-			echo "localboot 0x80"
-			echo
-			echo "say boot81 - Boot from second BIOS disk 0x81"
-			echo "label boot81"
-			syslinux_menu "label Boot Second ^Local BIOS disk (0x81)"
-			if [[ "$flavour" == "extlinux" ]]; then
-				# for extlinux local boot means boot from second disk because the boot disk became the first disk
-				# which usually allows us to access the original first disk as second disk
-				echo "default boot81"
-				syslinux_menu default
-			fi
-			echo "localboot 0x81"
-			echo ""
-		fi
+        if [[ ! -r "$SYSLINUX_DIR/chain.c32" ]]; then
+            # this should be above under the if chain.c32 section but it comes here because it will work only if localboot is supported
+            # if you use old extlinux then you just cannot boot from other device unless chain.c32 is available :-(
+            echo "say boot80 - Boot from first BIOS disk 0x80"
+            echo "label boot80"
+            syslinux_menu "label Boot First ^Local BIOS disk (0x80)"
+            if [[ "$flavour" == "isolinux" ]]; then
+                # for isolinux local boot means boot from first disk
+                echo "default boot80"
+                syslinux_menu default
+            fi
+            echo "localboot 0x80"
+            echo
+            echo "say boot81 - Boot from second BIOS disk 0x81"
+            echo "label boot81"
+            syslinux_menu "label Boot Second ^Local BIOS disk (0x81)"
+            if [[ "$flavour" == "extlinux" ]]; then
+                # for extlinux local boot means boot from second disk because the boot disk became the first disk
+                # which usually allows us to access the original first disk as second disk
+                echo "default boot81"
+                syslinux_menu default
+            fi
+            echo "localboot 0x81"
+            echo ""
+        fi
 
-		echo "say local - Boot from next boot device"
-		echo "label local"
-		syslinux_menu "label Boot ^Next device"
-		syslinux_menu_help "Boot from the next device in the BIOS boot order list."
-		if [[ "$flavour" == "pxelinux" ]]; then
-			echo "localboot 0"
-		else
-			# iso/extlinux support -1 for try next boot device
-			echo "localboot -1"
-		fi
-		echo ""
-	fi
+        echo "say local - Boot from next boot device"
+        echo "label local"
+        syslinux_menu "label Boot ^Next device"
+        syslinux_menu_help "Boot from the next device in the BIOS boot order list."
+        if [[ "$flavour" == "pxelinux" ]]; then
+            echo "localboot 0"
+        else
+            # iso/extlinux support -1 for try next boot device
+            echo "localboot -1"
+        fi
+        echo ""
+    fi
 
-	# Add needed libraries for syslinux v5 and hdt
-	if [[ -r "$SYSLINUX_DIR/ldlinux.c32" ]]; then
-		cp $v "$SYSLINUX_DIR/ldlinux.c32" "$BOOT_DIR/ldlinux.c32" >&2
-	fi
-	if [[ -r "$SYSLINUX_DIR/libcom32.c32" ]]; then
-		cp $v "$SYSLINUX_DIR/libcom32.c32" "$BOOT_DIR/libcom32.c32" >&2
-	fi
-	if [[ -r "$SYSLINUX_DIR/libgpl.c32" ]]; then
-		cp $v "$SYSLINUX_DIR/libgpl.c32" "$BOOT_DIR/libgpl.c32" >&2
-	fi
-	if [[ -r "$SYSLINUX_DIR/libmenu.c32" ]]; then
-		cp $v "$SYSLINUX_DIR/libmenu.c32" "$BOOT_DIR/libmenu.c32" >&2
-	fi
-	if [[ -r "$SYSLINUX_DIR/libutil.c32" ]]; then
-		cp $v "$SYSLINUX_DIR/libutil.c32" "$BOOT_DIR/libutil.c32" >&2
-	fi
-	if [[ -r "$SYSLINUX_DIR/vesamenu.c32" ]]; then
-		cp $v "$SYSLINUX_DIR/vesamenu.c32" "$BOOT_DIR/vesamenu.c32" >&2
-	fi
+    # Add needed libraries for syslinux v5 and hdt
+    if [[ -r "$SYSLINUX_DIR/ldlinux.c32" ]]; then
+        cp $v "$SYSLINUX_DIR/ldlinux.c32" "$BOOT_DIR/ldlinux.c32" >&2
+    fi
+    if [[ -r "$SYSLINUX_DIR/libcom32.c32" ]]; then
+        cp $v "$SYSLINUX_DIR/libcom32.c32" "$BOOT_DIR/libcom32.c32" >&2
+    fi
+    if [[ -r "$SYSLINUX_DIR/libgpl.c32" ]]; then
+        cp $v "$SYSLINUX_DIR/libgpl.c32" "$BOOT_DIR/libgpl.c32" >&2
+    fi
+    if [[ -r "$SYSLINUX_DIR/libmenu.c32" ]]; then
+        cp $v "$SYSLINUX_DIR/libmenu.c32" "$BOOT_DIR/libmenu.c32" >&2
+    fi
+    if [[ -r "$SYSLINUX_DIR/libutil.c32" ]]; then
+        cp $v "$SYSLINUX_DIR/libutil.c32" "$BOOT_DIR/libutil.c32" >&2
+    fi
+    if [[ -r "$SYSLINUX_DIR/vesamenu.c32" ]]; then
+        cp $v "$SYSLINUX_DIR/vesamenu.c32" "$BOOT_DIR/vesamenu.c32" >&2
+    fi
 
-	if [[ -r "$SYSLINUX_DIR/hdt.c32" ]]; then
-		cp $v "$SYSLINUX_DIR/hdt.c32" "$BOOT_DIR/hdt.c32" >&2
-		if [[ -r "/usr/share/hwdata/pci.ids" ]]; then
-			cp $v "/usr/share/hwdata/pci.ids" "$BOOT_DIR/pci.ids" >&2
-		elif [[ -r "/usr/share/pci.ids" ]]; then
-			cp $v "/usr/share/pci.ids" "$BOOT_DIR/pci.ids" >&2
-		fi
-		if [[ -r "/lib/modules/$KERNEL_VERSION/modules.pcimap" ]]; then
-			cp $v "/lib/modules/$KERNEL_VERSION/modules.pcimap" "$BOOT_DIR/modules.pcimap" >&2
-		fi
-		echo "say hdt - Hardware Detection Tool"
-		echo "label hdt"
-		syslinux_menu "label ^Hardware Detection Tool"
-		syslinux_menu_help "Information about your current hardware configuration"
-		echo "kernel hdt.c32"
-		echo ""
-	fi
+    if [[ -r "$SYSLINUX_DIR/hdt.c32" ]]; then
+        cp $v "$SYSLINUX_DIR/hdt.c32" "$BOOT_DIR/hdt.c32" >&2
+        if [[ -r "/usr/share/hwdata/pci.ids" ]]; then
+            cp $v "/usr/share/hwdata/pci.ids" "$BOOT_DIR/pci.ids" >&2
+        elif [[ -r "/usr/share/pci.ids" ]]; then
+            cp $v "/usr/share/pci.ids" "$BOOT_DIR/pci.ids" >&2
+        fi
+        if [[ -r "/lib/modules/$KERNEL_VERSION/modules.pcimap" ]]; then
+            cp $v "/lib/modules/$KERNEL_VERSION/modules.pcimap" "$BOOT_DIR/modules.pcimap" >&2
+        fi
+        echo "say hdt - Hardware Detection Tool"
+        echo "label hdt"
+        syslinux_menu "label ^Hardware Detection Tool"
+        syslinux_menu_help "Information about your current hardware configuration"
+        echo "kernel hdt.c32"
+        echo ""
+    fi
 
-	# Because usr/sbin/rear sets 'shopt -s nullglob' the 'ls' command will list all files
-	# in the current working directory if nothing matches the globbing pattern '/boot/memtest86+-*'
-	# which results '.' in MEMTEST_BIN (the plain 'ls -d' output in the current working directory).
-	# You need the memtest86+ package installed for this to work
-	MEMTEST_BIN=$(ls -d /boot/memtest86+-* 2>/dev/null | tail -1)
-	if [[ "$MEMTEST_BIN" != "." && -r "$MEMTEST_BIN" ]]; then
-		cp $v "$MEMTEST_BIN" "$BOOT_DIR/memtest" >&2
-		echo "memtest - Run memtest86+"
-		echo "label memtest"
-		syslinux_menu "label ^Memory test"
-		syslinux_menu_help "Test your memory for problems with memtest86+"
-		echo "kernel memtest"
-		echo "append -"
-		echo ""
-	fi
+    # Because usr/sbin/rear sets 'shopt -s nullglob' the 'ls' command will list all files
+    # in the current working directory if nothing matches the globbing pattern '/boot/memtest86+-*'
+    # which results '.' in MEMTEST_BIN (the plain 'ls -d' output in the current working directory).
+    # You need the memtest86+ package installed for this to work
+    MEMTEST_BIN=$(ls -d /boot/memtest86+-* 2>/dev/null | tail -1)
+    if [[ "$MEMTEST_BIN" != "." && -r "$MEMTEST_BIN" ]]; then
+        cp $v "$MEMTEST_BIN" "$BOOT_DIR/memtest" >&2
+        echo "memtest - Run memtest86+"
+        echo "label memtest"
+        syslinux_menu "label ^Memory test"
+        syslinux_menu_help "Test your memory for problems with memtest86+"
+        echo "kernel memtest"
+        echo "append -"
+        echo ""
+    fi
 
-	if [[ -r "$SYSLINUX_DIR/reboot.c32" ]] ; then
-		cp $v "$SYSLINUX_DIR/reboot.c32" "$BOOT_DIR/reboot.c32" >&2
-		echo "say reboot - Reboot the system"
-		echo "label reboot"
-		syslinux_menu "label Re^Boot system"
-		syslinux_menu_help "Reboot the system now"
-		echo "kernel reboot.c32"
-		echo ""
-	fi
+    if [[ -r "$SYSLINUX_DIR/reboot.c32" ]] ; then
+        cp $v "$SYSLINUX_DIR/reboot.c32" "$BOOT_DIR/reboot.c32" >&2
+        echo "say reboot - Reboot the system"
+        echo "label reboot"
+        syslinux_menu "label Re^Boot system"
+        syslinux_menu_help "Reboot the system now"
+        echo "kernel reboot.c32"
+        echo ""
+    fi
 
-	if [[ -r "$SYSLINUX_DIR/poweroff.com" ]]; then
-		cp $v "$SYSLINUX_DIR/poweroff.com" "$BOOT_DIR/poweroff.com" >&2
-		echo "say poweroff - Poweroff the system"
-		echo "label poweroff"
-		syslinux_menu "label ^Power off system"
-		syslinux_menu_help "Power off the system now"
-		echo "kernel poweroff.com"
-		echo ""
-	fi
+    if [[ -r "$SYSLINUX_DIR/poweroff.com" ]]; then
+        cp $v "$SYSLINUX_DIR/poweroff.com" "$BOOT_DIR/poweroff.com" >&2
+        echo "say poweroff - Poweroff the system"
+        echo "label poweroff"
+        syslinux_menu "label ^Power off system"
+        syslinux_menu_help "Power off the system now"
+        echo "kernel poweroff.com"
+        echo ""
+    fi
 
-	if [[ -r "$SYSLINUX_DIR/menu.c32" ]]; then
-		echo "default menu.c32"
-	fi
+    if [[ -r "$SYSLINUX_DIR/menu.c32" ]]; then
+        echo "default menu.c32"
+    fi
 }
 
 # Create configuration file for elilo
@@ -683,3 +683,5 @@ function make_pxelinux_config_grub {
     echo "initrd (tftp)/$PXE_INITRD"
     echo "}"
 }
+
+# vim: set et ts=4 sw=4

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -432,13 +432,20 @@ function make_syslinux_config {
         echo ""
     fi
 
-    if [[ -r "$SYSLINUX_DIR/poweroff.com" ]]; then
-        cp $v "$SYSLINUX_DIR/poweroff.com" "$BOOT_DIR/poweroff.com" >&2
+    local prog=
+    if [[ -r "$SYSLINUX_DIR/poweroff.com" ]] ; then
+        prog="$SYSLINUX_DIR/poweroff.com"
+    elif [[ -r "$SYSLINUX_DIR/poweroff.c32" ]] ; then
+        prog="$SYSLINUX_DIR/poweroff.c32"
+    fi
+
+    if [[ -n "$prog" ]] ; then
+        cp $v "$prog" "$BOOT_DIR/" >&2
         echo "say poweroff - Poweroff the system"
         echo "label poweroff"
         syslinux_menu "label ^Power off system"
         syslinux_menu_help "Power off the system now"
-        echo "kernel poweroff.com"
+        echo "kernel $(basename "$prog")"
         echo ""
     fi
 
@@ -609,14 +616,20 @@ function make_pxelinux_config {
         echo "kernel reboot.c32"
         echo "say ----------------------------------------------------------"
     fi
-    if [[ -f $syslinux_modules_dir/poweroff.com ]] ; then
+    local prog=
+    if [[ -r "$syslinux_modules_dir/poweroff.com" ]] ; then
+        prog="$syslinux_modules_dir/poweroff.com"
+    elif [[ -r "$syslinux_modules_dir/poweroff.c32" ]] ; then
+        prog="$syslinux_modules_dir/poweroff.c32"
+    fi
+    if [[ -n "$prog" ]] ; then
         echo "say poweroff - Poweroff the system"
         echo "label poweroff"
         echo "MENU label ^Power off system"
         echo "TEXT HELP"
         echo "Power off the system now"
         echo "ENDTEXT"
-        echo "kernel poweroff.com"
+        echo "kernel $(basename "$prog")"
     fi
 
     # And, finally define the default entry to boot off

--- a/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
+++ b/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
@@ -61,7 +61,11 @@ if [[ ! -z "$PXE_TFTP_URL" ]] && [[ "$PXE_RECOVER_MODE" = "unattended" ]] ; then
     cp $v $syslinux_modules_dir/chain.c32 $BUILD_DIR/tftpbootfs >&2
     cp $v $syslinux_modules_dir/hdt.c32 $BUILD_DIR/tftpbootfs >&2
     cp $v $syslinux_modules_dir/reboot.c32 $BUILD_DIR/tftpbootfs >&2
-    cp $v $syslinux_modules_dir/poweroff.com $BUILD_DIR/tftpbootfs >&2
+    if [[ -r "$syslinux_modules_dir/poweroff.com" ]] ; then
+        cp $v $syslinux_modules_dir/poweroff.com $BUILD_DIR/tftpbootfs >&2
+    elif [[ -r "$syslinux_modules_dir/poweroff.c32" ]] ; then
+        cp $v $syslinux_modules_dir/poweroff.c32 $BUILD_DIR/tftpbootfs >&2
+    fi
     chmod 644 $BUILD_DIR/tftpbootfs/*.c32
     chmod 644 $BUILD_DIR/tftpbootfs/*.0
 fi
@@ -81,3 +85,4 @@ else
     RESULT_FILES=( "${RESULT_FILES[@]}" "$PXE_TFTP_LOCAL_PATH/$PXE_KERNEL" "$PXE_TFTP_LOCAL_PATH/$PXE_INITRD" "$PXE_TFTP_LOCAL_PATH/$PXE_MESSAGE" )
 fi
 
+# vim: set et ts=4 sw=4

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -456,8 +456,21 @@ Power off the system now
     kernel poweroff.com
 
 EOF
+    elif syslinux_has "poweroff.c32"; then
+        syslinux_write <<EOF
+label poweroff
+    say poweroff - Power off the system
+    menu label ^Power off system
+    text help
+Power off the system now
+    endtext
+    kernel poweroff.c32
+
+EOF
     fi
 
 } 4>"$BUILD_DIR/outputfs/$SYSLINUX_PREFIX/extlinux.conf"
 
 Log "Created extlinux configuration '$SYSLINUX_PREFIX/extlinux.conf'"
+
+# vim: set et ts=4 sw=4


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested? Tested on RHEL7 (poweroff.com) and RHEL8 (poweroff.c32)

* Brief description of the changes in this pull request:

RHEL8 (syslinux-6.04) is shipping `poweroff.c32`, not `poweroff.com`.