### PR TITLE
Enhanced AUTOEXCLUDE_PATH in default.conf

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2396,10 +2396,11 @@ AUTOEXCLUDE_MULTIPATH=y
 # Automatically exclude automounter paths from the backup
 AUTOEXCLUDE_AUTOFS=
 
-# Automatically exclude filesystems mounted under directories given here
-# The default is /media to exclude USB devices mounted there.
+# Automatically exclude filesystems mounted under directories given here.
 # This is different from EXCLUDE_MOUNTPOINTS, which accepts only mountpoints.
-AUTOEXCLUDE_PATH=( /media )
+# The default contains /media /run[/media] and /mnt to exclude temporarily mounted things
+# like USB devices, see https://github.com/rear/rear/issues/2239
+AUTOEXCLUDE_PATH=( /media /run /mnt /tmp )
 
 #### New Style include/excludes
 # Exclude components from being backed up, recreation information is active


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **High**
Normally there should be no impact but in certain cases
the impact could be high because now more filesystems
are automatically excluded which could cause regressions
for some users (e.g. when someone has /tmp mounted
and wants that to be included).

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2239

* How was this pull request tested?
It was not at all tested by me.

* Brief description of the changes in this pull request:
Enhanced AUTOEXCLUDE_PATH in default.conf
from only AUTOEXCLUDE_PATH=( /media )
to AUTOEXCLUDE_PATH=( /media /run /mnt /tmp )
