### PR TITLE
Accommodate logs from multiple FDR/Upstream services.  Improve logging.

### DIFF
--- a/usr/share/rear/restore/FDRUPSTREAM/default/260_copy_log_and_report.sh
+++ b/usr/share/rear/restore/FDRUPSTREAM/default/260_copy_log_and_report.sh
@@ -6,6 +6,21 @@ PREFIX="rear_$( date +%F_%T_%N )"
 SERVICENAME=( $(ps -ef | grep uscmd1 | grep servicename | grep -Po 'servicename=\K[^"]+') )
 REARLOGPATH="$FDRUPSTREAM_DATA_PATH/rear/logs"
 
+# If SERVICENAME is empty, then FDR/Upstream is not running and we won't 
+# be able to find the log files.
+if [[ ! ${SERVICENAME[@]} ]]; then 
+	echo
+	LogPrintError "***************"
+	LogPrintError "***************"
+	LogPrintError "No FDR/Upstream services were detected.  Unable to automatically copy logs and reports to the recovered system."
+	LogPrintError "Before rebooting, copy any necessary logs and reports from $FDRUPSTREAM_DATA_PATH into the $TARGET_FS_ROOT file tree."
+	LogPrintError "***************"
+	LogPrintError "***************"
+	echo
+	exit 1
+fi
+
+
 if [[ ! -d $TARGET_FS_ROOT/$REARLOGPATH ]]; then
 	mkdir -p $TARGET_FS_ROOT/$REARLOGPATH
 fi
@@ -33,11 +48,11 @@ for dir in "${SERVICENAME[@]}"; do
 	# variable.
 	if (( $count >= $countmax )); then
 		echo
-		LogPrint "***************"
-		LogPrint "***************"
-		LogPrint "Number of detected FDR/Upstream services has reached $countmax, which is not normal.  Before rebooting, copy any necessary logs and reports from $FDRUPSTREAM_DATA_PATH into the $TARGET_FS_ROOT file tree."
-		LogPrint "***************"
-		LogPrint "***************"
+		LogPrintError "***************"
+		LogPrintError "***************"
+		LogPrintError "Number of detected FDR/Upstream services has reached $countmax, which is not normal.  Before rebooting, copy any necessary logs and reports from $FDRUPSTREAM_DATA_PATH into the $TARGET_FS_ROOT file tree."
+		LogPrintError "***************"
+		LogPrintError "***************"
 		echo
 		break
 	fi

--- a/usr/share/rear/restore/FDRUPSTREAM/default/260_copy_log_and_report.sh
+++ b/usr/share/rear/restore/FDRUPSTREAM/default/260_copy_log_and_report.sh
@@ -17,7 +17,7 @@ if [[ ! ${SERVICENAME[@]} ]]; then
 	LogPrintError "***************"
 	LogPrintError "***************"
 	echo
-	exit 1
+	Error exit 1
 fi
 
 

--- a/usr/share/rear/restore/FDRUPSTREAM/default/260_copy_log_and_report.sh
+++ b/usr/share/rear/restore/FDRUPSTREAM/default/260_copy_log_and_report.sh
@@ -1,14 +1,44 @@
-# upstream.log and upstream.rpt on the ReaR system contains valuable 
+# upstream.log and upstream.rpt on the ReaR system contain valuable 
 # information about the disaster recovery, so we archive *.log and *.rpt
 # to the restored system.
 
-EXTENSION="restore_$( date +%F_%T )"
+PREFIX="rear_$( date +%F_%T_%N )"
+SERVICENAME=( $(ps -ef | grep uscmd1 | grep servicename | grep -Po 'servicename=\K[^"]+') )
+REARLOGPATH="$FDRUPSTREAM_DATA_PATH/rear/logs"
+
+if [[ ! -d $TARGET_FS_ROOT/$REARLOGPATH ]]; then
+	mkdir -p $TARGET_FS_ROOT/$REARLOGPATH
+fi
 
 echo
-for file in $FDRUPSTREAM_INSTALL_PATH/*.log $FDRUPSTREAM_INSTALL_PATH/*.rpt; do
-    LogPrint "Archiving "$( basename "$file" )" to the restored system as:"
-    LogPrint "  $( basename "$file" ).$EXTENSION"
-    cp "$file" "$TARGET_FS_ROOT/$file.$EXTENSION"
-    LogPrintIfError "Error archiving $file.  Before rebooting, be sure to copy logs and/or reports from $FDRUPSTREAM_INSTALL_PATH into the $TARGET_FS_ROOT file tree."
-    echo
+
+countmax=100
+count=0
+# We need to identify all the running FDR/Upstream services, so we
+# can put their logs in the correct directory on the rescued system.
+for dir in "${SERVICENAME[@]}"; do
+	count=$count+1
+	LIVELOGPATH="$FDRUPSTREAM_DATA_PATH/$dir/logs"
+	for file in $LIVELOGPATH/*.log $LIVELOGPATH/*.rpt; do
+	    LogPrint "Archiving "$( basename "$file" )" to the restored system as:"
+	    LogPrint "  $REARLOGPATH/$PREFIX.$( basename "$file" )"
+	    cp "$file" "$TARGET_FS_ROOT/$REARLOGPATH/$PREFIX.$( basename "$file" )"
+	    LogPrintIfError "Error archiving $file.  Before rebooting, be sure to copy logs and/or reports from $FDRUPSTREAM_DATA_PATH into the $TARGET_FS_ROOT file tree."
+	    echo
+	done
+	# Normally there is only a single FDR/Upstream service, but sometimes
+	# users have reason to run two or more services.  If service detection
+	# goes wrong, we risk having an infinite loop.  To avoid that we break
+	# out of the loop if we detect too many services, using the $countmax
+	# variable.
+	if (( $count >= $countmax )); then
+		echo
+		LogPrint "***************"
+		LogPrint "***************"
+		LogPrint "Number of detected FDR/Upstream services has reached $countmax, which is not normal.  Before rebooting, copy any necessary logs and reports from $FDRUPSTREAM_DATA_PATH into the $TARGET_FS_ROOT file tree."
+		LogPrint "***************"
+		LogPrint "***************"
+		echo
+		break
+	fi
 done


### PR DESCRIPTION
* Type: **Bug Fix** / **Enhancement**

* Impact:  **Normal**

* Reference to related issue (URL):

* How was this pull request tested?

Tested on CentOS 7, running 7 FDR/Upstream services.  Temporarily set $countmax=3 to verify that the infinite loop detection works properly.

* Brief description of the changes in this pull request:

Users may run multiple FDR/Upstream services on a single machine.  This code change allows ReaR to copy FDR/Upstream logs from the recovery environment to the restored system for all running services.  Previously the code was expecting to find only one set of logs and reports in the FDR/Upstream installation directory.  For several years now, logs and reports have been stored in a new location ($FDRUPSTREAM_DATA_PATH), so we check here instead.

