### PR TITLE
Remove dev null redirection where possible issue1395

### DIFF
--- a/usr/share/rear/backup/RSYNC/GNU/Linux/610_start_selinux.sh
+++ b/usr/share/rear/backup/RSYNC/GNU/Linux/610_start_selinux.sh
@@ -8,6 +8,8 @@
 
 	(ssh)
 		# for some reason rsync changes the mode of backup after each run to 666
+                # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
+                # or remove it according to https://github.com/rear/rear/issues/1395
 		ssh $RSYNC_USER@$RSYNC_HOST "chmod $v 755 ${RSYNC_PATH}/${RSYNC_PREFIX}/backup" 2>/dev/null
 		$BACKUP_PROG -a "${TMP_DIR}/selinux.autorelabel" \
 		 "$RSYNC_USER@$RSYNC_HOST:${RSYNC_PATH}/${RSYNC_PREFIX}/backup/.autorelabel" 2>/dev/null

--- a/usr/share/rear/backup/RSYNC/GNU/Linux/620_force_autorelabel.sh
+++ b/usr/share/rear/backup/RSYNC/GNU/Linux/620_force_autorelabel.sh
@@ -6,6 +6,8 @@
 
 	(ssh)
 		# for some reason rsync changes the mode of backup after each run to 666
+                # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
+                # or remove it according to https://github.com/rear/rear/issues/1395
 		ssh $RSYNC_USER@$RSYNC_HOST "chmod $v 755 ${RSYNC_PATH}/${RSYNC_PREFIX}/backup" 2>/dev/null
 		$BACKUP_PROG -a "${TMP_DIR}/selinux.autorelabel" \
 		 "$RSYNC_USER@$RSYNC_HOST:${RSYNC_PATH}/${RSYNC_PREFIX}/backup/.autorelabel" 2>/dev/null

--- a/usr/share/rear/backup/RSYNC/default/450_calculate_req_space.sh
+++ b/usr/share/rear/backup/RSYNC/default/450_calculate_req_space.sh
@@ -4,33 +4,30 @@
 _local_size=0
 _remote_size=0
 while read -r ; do
-	LogPrint "Calculating size of $REPLY"
-	# on Linux output is represented in 1024-blocks (or kB)
-	df -Pl "$REPLY"  >$TMP_DIR/fs_size
-	StopIfError "Failed to determine size of ${REPLY}."
-	fs_size=$(tail -n 1 $TMP_DIR/fs_size | awk '{print $3}')
-	_local_size=$((_local_size+fs_size))
+    LogPrint "Calculating size of $REPLY"
+    # on Linux output is represented in 1024-blocks (or kB)
+    df -Pl "$REPLY" >$TMP_DIR/fs_size
+    StopIfError "Failed to determine size of $REPLY"
+    fs_size=$( tail -n 1 $TMP_DIR/fs_size | awk '{print $3}' )
+    _local_size=$(( _local_size + fs_size ))
 done < $TMP_DIR/backup-include.txt
-LogPrint "Estimated size of local file systems is $((_local_size/1024)) MB"
+LogPrint "Estimated size of local file systems is $(( _local_size / 1024 )) MB"
 
 case $RSYNC_PROTO in
-
-	(ssh)
-		LogPrint "Calculating size of $RSYNC_HOST:$RSYNC_PATH"
-		ssh -l $RSYNC_USER $RSYNC_HOST "df -P ${RSYNC_PATH}" >$TMP_DIR/rs_size 2>/dev/null
-		StopIfError "Failed to determine size of ${RSYNC_PATH}"
-		_div=1	# 1024-blocks
-		grep -q "512-blocks" $TMP_DIR/rs_size && _div=2 # HPUX: divide with 2 to get kB size
-		_remote_size=$(tail -n 1 $TMP_DIR/rs_size | awk '{print $2}')
-		_remote_size=$((_remote_size/_div))
-		[[ $_remote_size -gt $_local_size ]]
-		StopIfError "Not enough disk space available on $RSYNC_HOST:$RSYNC_PATH ($_remote_size < $_local_size)"
-		;;
-
-	(rsync)
-		# TODO: how can we calculate the free size on remote system via rsync protocol??
-		:
-		;;
-
+    (ssh)
+        LogPrint "Calculating size of $RSYNC_HOST:$RSYNC_PATH"
+        ssh -l $RSYNC_USER $RSYNC_HOST "df -P $RSYNC_PATH" >$TMP_DIR/rs_size
+        StopIfError "Failed to determine size of $RSYNC_PATH"
+        _div=1 # 1024-blocks
+        grep -q "512-blocks" $TMP_DIR/rs_size && _div=2 # HPUX: divide with 2 to get kB size
+        _remote_size=$( tail -n 1 $TMP_DIR/rs_size | awk '{print $2}' )
+        _remote_size=$(( _remote_size / _div ))
+        [[ $_remote_size -gt $_local_size ]]
+        StopIfError "Not enough disk space available on $RSYNC_HOST:$RSYNC_PATH ($_remote_size < $_local_size)"
+        ;;
+    (rsync)
+        # TODO: how can we calculate the free size on remote system via rsync protocol??
+        :
+        ;;
 esac
 

--- a/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
+++ b/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
@@ -25,7 +25,7 @@ ProgressStart "Running archive operation"
 				(ssh)
 					Log $BACKUP_PROG "${BACKUP_RSYNC_OPTIONS[@]}" $(cat $TMP_DIR/backup-include.txt) "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/backup"
 					$BACKUP_PROG "${BACKUP_RSYNC_OPTIONS[@]}" $(cat $TMP_DIR/backup-include.txt) \
-					"${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/backup"  #2>/dev/null
+					"${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/backup"
 					;;
 
 				(rsync)

--- a/usr/share/rear/backup/RSYNC/default/700_copy_backup_log.sh
+++ b/usr/share/rear/backup/RSYNC/default/700_copy_backup_log.sh
@@ -1,25 +1,24 @@
+
 # copy the backup.log & rear.log file to remote destination with timestamp added
-Timestamp=$(date +%Y%m%d.%H%M)
+Timestamp=$( date +%Y%m%d.%H%M )
 
 # compress the log file first
-gzip "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log"
-StopIfError "Could not gzip ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log"
+gzip "$TMP_DIR/$BACKUP_PROG_ARCHIVE.log" || Error "Failed to 'gzip $TMP_DIR/$BACKUP_PROG_ARCHIVE.log'"
 
 case $RSYNC_PROTO in
+    (ssh)
+        # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
+        # or remove it according to https://github.com/rear/rear/issues/1395
+        $BACKUP_PROG -a "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log.gz" \
+        "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/${BACKUP_PROG_ARCHIVE}-${Timestamp}.log.gz" 2>/dev/null
 
-	(ssh)
-		$BACKUP_PROG -a "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log.gz" \
-		"${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/${BACKUP_PROG_ARCHIVE}-${Timestamp}.log.gz" 2>/dev/null
+        $BACKUP_PROG -a "$RUNTIME_LOGFILE" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/rear-${Timestamp}.log" 2>/dev/null
+        ;;
+    (rsync)
+        $BACKUP_PROG -a "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log.gz" ${BACKUP_RSYNC_OPTIONS[@]} \
+        "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/${BACKUP_PROG_ARCHIVE}-${Timestamp}.log.gz"
 
-		$BACKUP_PROG -a "$RUNTIME_LOGFILE" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/rear-${Timestamp}.log" 2>/dev/null
-		;;
-
-	(rsync)
-		$BACKUP_PROG -a "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log.gz" ${BACKUP_RSYNC_OPTIONS[@]} \
-		"${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/${BACKUP_PROG_ARCHIVE}-${Timestamp}.log.gz"
-
-		$BACKUP_PROG -a "$RUNTIME_LOGFILE" ${BACKUP_RSYNC_OPTIONS[@]} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}//rear-${Timestamp}.log"
-		;;
-
+        $BACKUP_PROG -a "$RUNTIME_LOGFILE" ${BACKUP_RSYNC_OPTIONS[@]} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}//rear-${Timestamp}.log"
+        ;;
 esac
 

--- a/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
@@ -46,7 +46,7 @@ create_disk() {
 #
 
 Log "Stop mdadm"
-if grep -q md /proc/mdstat &>/dev/null; then
+if grep -q md /proc/mdstat 2>/dev/null; then
     mdadm --stop -s >&2 || echo "stop mdadm failed"
     # Prevent udev waking up mdadm later.
     # Reasoning: At least on RHEL6 when parted created a raid partition on disk,

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -304,7 +304,7 @@ extract_partitions() {
             if has_binary sfdisk ; then
                 # make sfdisk output safe against unwanted characters (in particular blanks)
                 # cf. https://github.com/rear/rear/issues/1106
-                declare partition_id=$( sfdisk -c $device $partition_nr 2>/dev/null | tr -c -d '[:alnum:]' )
+                declare partition_id=$( sfdisk -c $device $partition_nr | tr -c -d '[:alnum:]' )
                 ### extended partitions are either DOS_EXT, EXT_LBA or LINUX_EXT
                 if [[ "$partition_id" = 5 || "$partition_id" = f || "$partition_id" = 85 ]]; then
                     sed -i /^$partition_nr\ /s/\ primary\ /\ extended\ / $TMP_DIR/partitions

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -57,7 +57,7 @@ read_filesystems_command="$read_filesystems_command | sort -t ' ' -k 1,1 -u"
 # Usually this is done via a kind of cookbook (Chef, puppet or ansible).
 docker_is_running=""
 docker_root_dir=""
-if service docker status &>/dev/null ; then
+if service docker status ; then
     docker_is_running="yes"
     # When the Docker daemon/service is running, try to get its 'Docker Root Dir':
     # Kill 'docker info' with SIGTERM after 5 seconds and with SIGKILL after additional 2 seconds

--- a/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
+++ b/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
@@ -6,14 +6,14 @@ LogPrint "Copying resulting files to $OUTPUT_URL location"
 # if called as mkbackuponly then we just don't have any result files.
 if test "$RESULT_FILES" ; then
     Log "Copying files '${RESULT_FILES[@]}' to $OUTPUT_URL location"
-    cp $v "${RESULT_FILES[@]}" "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" >&2
+    cp $v "${RESULT_FILES[@]}" "${TMP_DIR}/rsync/${RSYNC_PREFIX}/"
     StopIfError "Could not copy files to local rsync location"
 fi
 
 echo "$VERSION_INFO" >"${TMP_DIR}/rsync/${RSYNC_PREFIX}/VERSION"
 StopIfError "Could not create VERSION file on local rsync location"
 
-cp $v $(get_template "RESULT_usage_$OUTPUT.txt") "${TMP_DIR}/rsync/${RSYNC_PREFIX}/README" >&2
+cp $v $(get_template "RESULT_usage_$OUTPUT.txt") "${TMP_DIR}/rsync/${RSYNC_PREFIX}/README"
 StopIfError "Could not copy usage file to local rsync location"
 
 cat "$RUNTIME_LOGFILE" >"${TMP_DIR}/rsync/${RSYNC_PREFIX}/rear.log"
@@ -23,12 +23,16 @@ case $RSYNC_PROTO in
 
     (ssh)
     Log "$BACKUP_PROG -a ${TMP_DIR}/rsync/${RSYNC_PREFIX}/ ${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/"
+    # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
+    # or remove it according to https://github.com/rear/rear/issues/1395
     $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null
     StopIfError "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
     ;;
 
     (rsync)
     Log "$BACKUP_PROG -a ${TMP_DIR}/rsync/${RSYNC_PREFIX}/ ${BACKUP_RSYNC_OPTIONS[@]} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/"
+    # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
+    # or remove it according to https://github.com/rear/rear/issues/1395
     $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" ${BACKUP_RSYNC_OPTIONS[@]} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null
     StopIfError "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
     ;;

--- a/usr/share/rear/prep/NETFS/default/400_automatic_exclude_recreate.sh
+++ b/usr/share/rear/prep/NETFS/default/400_automatic_exclude_recreate.sh
@@ -28,7 +28,7 @@ case $scheme in
             mkdir $v -p "$backup_directory" >&2 || Error "Could not create backup directory '$backup_directory' (from URL '$BACKUP_URL')."
         fi
         test -d "$backup_directory" || Error "URL '$BACKUP_URL' specifies '$backup_directory' which is not a directory."
-        backup_directory_mountpoint=$( df -P "$backup_directory" 2>/dev/null | tail -1 | awk '{print $6}' )
+        backup_directory_mountpoint=$( df -P "$backup_directory" | tail -1 | awk '{print $6}' )
         test "/" = "$backup_directory_mountpoint" && Error "URL '$BACKUP_URL' has the backup directory '$backup_directory' in the '/' filesystem which is forbidden."
         # When the mountpoint of the backup directory is not yet excluded add its mountpoint to the EXCLUDE_RECREATE array:
         if ! grep -q "$backup_directory_mountpoint" <<< $( echo ${EXCLUDE_RECREATE[@]} ) ; then

--- a/usr/share/rear/verify/NBU/default/390_request_point_in_time_restore_parameters.sh
+++ b/usr/share/rear/verify/NBU/default/390_request_point_in_time_restore_parameters.sh
@@ -1,33 +1,38 @@
-# Ask for point in time to recover with NBU.
+
+# Ask for NBU NetBackup Point-In-Time Restore.
 # One point in time is used for all filespaces.
 # This causes the bprecover to use the input date or date/time to be used as the endtime -e option
+# see the usr/share/rear/restore/NBU/default/400_restore_with_nbu.sh script.
 
 NBU_ENDTIME=()
 
 LogPrint ""
-LogPrint "Netbackup restores by default the latest backup data. Alternatively you can specify"
-LogPrint "a different date and time to enable Point-In-Time Restore. Press ENTER to"
-LogPrint "use the most recent available backup"
-# Use the original STDIN STDOUT and STDERR when rear was launched by the user
-# to get input from the user and to show output to the user (cf. _input-output-functions.sh):
-read -t $WAIT_SECS -r -p "Enter date (mm/dd/yyyy) or date/time (mm/dd/yyyy HH:MM:SS) or press ENTER [$WAIT_SECS secs]: " 0<&6 1>&7 2>&8
+LogPrint "NetBackup restores by default the latest backup data."
+LogPrint "Press ENTER to restore the most recent available backup."
+LogPrint "Alternatively specify date (and time) for Point-In-Time Restore."
 
-# validate input
-if test -z "${REPLY}"; then
-        LogPrint "Skipping Point-In-Time Restore, will restore most recent data."
-else
-        BAD_ENDTIME=0
-        # validate date
-        NBU_ENDTIME_DATE=$( date -d "$REPLY" +%m/%d/%Y 2>/dev/null ) || BAD_ENDTIME=1
-        # validate time
-        NBU_ENDTIME_TIME=$( date -d "$REPLY" +%T 2>/dev/null ) || BAD_ENDTIME=1
-        [ ${BAD_ENDTIME} -ne 1 ]
-        BugIfError "Incorrect date and/or time definition used: ${REPLY} Ending NetBackup Restore Attempt..."
-        if test "$NBU_ENDTIME_TIME" = "00:00:00"; then
-            NBU_ENDTIME=( "${NBU_ENDTIME_DATE}" )
-        else
-            NBU_ENDTIME=( "${NBU_ENDTIME_DATE}" "${NBU_ENDTIME_TIME}" )
-        fi
+local answer=""
+answer=$( UserInput -I NBU_RESTORE_PIT -t $WAIT_SECS -r -p "Enter date (mm/dd/yyyy) or date and time (mm/dd/yyyy HH:MM:SS) or press ENTER" )
 
-        LogPrint "Restoring all filespaces from backup at or before ${NBU_ENDTIME[@]}"
+if test -z "$answer"; then
+    LogPrint "Skipping NetBackup Point-In-Time Restore, will restore most recent backup."
+    return
 fi
+
+# Validate user date and time input:
+local valid_date_and_time_input="yes"
+local nbu_endtime_date=""
+local nbu_endtime_time=""
+# Validate date:
+nbu_endtime_date=$( date -d "$answer" +%m/%d/%Y ) || valid_date_and_time_input="no"
+# Validate time:
+nbu_endtime_time=$( date -d "$answer" +%T ) || valid_date_and_time_input="no"
+# It is an Error (not a BugError) when user input is invalid:
+is_true $valid_date_and_time_input || Error "Invalid date and/or time '$answer' specified. Ending NetBackup Restore attempt..."
+
+NBU_ENDTIME=( "$nbu_endtime_date" )
+# When also an actual time was specified (i.e. when it is not "00:00:00") add it:
+test "$nbu_endtime_time" != "00:00:00" && NBU_ENDTIME+=( "$nbu_endtime_time" )
+
+LogPrint "Doing NetBackup Point-In-Time Restore of all filespaces at or before ${NBU_ENDTIME[@]}"
+

--- a/usr/share/rear/verify/TSM/default/390_request_point_in_time_restore_parameters.sh
+++ b/usr/share/rear/verify/TSM/default/390_request_point_in_time_restore_parameters.sh
@@ -27,6 +27,8 @@ TSM_DSMC_RESTORE_OPTIONS+=( -date=5 -pitd="$tsm_restore_pit_date" )
 # Validate time:
 tsm_restore_pit_time=$( date -d "$answer" +%T ) || Error "Invalid time specified for TSM recovery: '$answer'"
 # Add valid actual time (i.e. when it is not "00:00:00") to dsmc options:
+# FIXME: Is it right to add '-date=5' here a second time to the TSM_DSMC_RESTORE_OPTIONS array
+# because it was already added above in the "Add valid date to dsmc options" step?
 test "$tsm_restore_pit_time" != "00:00:00" && TSM_DSMC_RESTORE_OPTIONS+=( -date=5 -pitt="$tsm_restore_pit_time" )
 
 LogPrint "Restoring all TSM filespaces from backup before $tsm_restore_pit_date $tsm_restore_pit_time (MM/DD/YYYY HH:mm:ss)"

--- a/usr/share/rear/verify/TSM/default/390_request_point_in_time_restore_parameters.sh
+++ b/usr/share/rear/verify/TSM/default/390_request_point_in_time_restore_parameters.sh
@@ -1,31 +1,34 @@
+
 # Ask for point in time to recover with TSM.
 # One point in time is used for all filespaces.
 
 LogPrint ""
-LogPrint "TSM restores by default the latest backup data. Alternatively you can specify"
-LogPrint "a different date and time to enable Point-In-Time Restore. Press ENTER to"
-LogPrint "use the most recent available backup"
+LogPrint "TSM restores by default the latest backup data."
+LogPrint "Press ENTER to restore the most recent available backup."
+LogPrint "Alternatively specify date and time for Point-In-Time restore."
 
-answer=$(UserInput -I TSM_RESTORE_PIT -t $WAIT_SECS -r -p "Enter date/time (YYYY-MM-DD HH:mm:ss) or press ENTER")
-if test -z "${answer}"; then
-    LogPrint "Skipping Point-In-Time Restore, will restore most recent data."
-else
-    # validate date
-    tsm_restore_pit_date=$( date -d "$answer" +%Y.%m.%d 2>/dev/null ) ||\
-    Error "Invalid date for recovery: '$answer'"
-    # correct date, add to dsmc options
-    TSM_DSMC_RESTORE_OPTIONS=( "${TSM_DSMC_RESTORE_OPTIONS[@]}" -date=5 -pitd="$tsm_restore_pit_date" )
+local answer=""
 
-    # validate time
-    tsm_restore_pit_time=$( date -d "$answer" +%T 2>/dev/null ) ||\
-    Error "Invalid time for recovery: '$answer'"
-    if test "$tsm_restore_pit_time" != "00:00:00" ; then
-        # valid time, add to dsmc options
-        TSM_DSMC_RESTORE_OPTIONS=( "${TSM_DSMC_RESTORE_OPTIONS[@]}" -date=5 -pitt="$tsm_restore_pit_time" )
-    fi
-    LogPrint "Restoring all filespaces from backup before ${tsm_restore_pit_date} ${tsm_restore_pit_time} (MM/DD/YYYY HH:mm:ss)"
-    LogPrint "Please note that the following list of file spaces always shows the latest backup"
-    LogPrint "and not the date/time you specified here."
+answer=$( UserInput -I TSM_RESTORE_PIT -t $WAIT_SECS -r -p "Enter date/time (YYYY-MM-DD HH:mm:ss) or press ENTER" )
+
+if test -z "$answer"; then
+    LogPrint "Skipping TSM Point-In-Time restore, will restore most recent backup."
+    return
 fi
 
-unset answer tsm_restore_pit_date tsm_restore_pit_time
+local tsm_restore_pit_date=""
+local tsm_restore_pit_time=""
+
+# Validate date:
+tsm_restore_pit_date=$( date -d "$answer" +%Y.%m.%d ) || Error "Invalid date specified for TSM recovery: '$answer'"
+# Add valid date to dsmc options:
+TSM_DSMC_RESTORE_OPTIONS+=( -date=5 -pitd="$tsm_restore_pit_date" )
+
+# Validate time:
+tsm_restore_pit_time=$( date -d "$answer" +%T ) || Error "Invalid time specified for TSM recovery: '$answer'"
+# Add valid actual time (i.e. when it is not "00:00:00") to dsmc options:
+test "$tsm_restore_pit_time" != "00:00:00" && TSM_DSMC_RESTORE_OPTIONS+=( -date=5 -pitt="$tsm_restore_pit_time" )
+
+LogPrint "Restoring all TSM filespaces from backup before $tsm_restore_pit_date $tsm_restore_pit_time (MM/DD/YYYY HH:mm:ss)"
+LogPrint "Note: The following list of file spaces always shows the latest backup and not the date/time you specified here."
+

--- a/usr/share/rear/verify/default/020_cciss_scsi_engage.sh
+++ b/usr/share/rear/verify/default/020_cciss_scsi_engage.sh
@@ -1,14 +1,13 @@
-# We need to re-engage CCISS scsi subsystem to make sure the tape device is
-# present again
+# We need to re-engage CCISS scsi subsystem to make sure the tape device is present again.
 
-if ! grep -q '^cciss ' /proc/modules; then
-    return
-fi
+# Nothing to do when no cciss kernel module is loaded:
+grep -q '^cciss ' /proc/modules || return 0
 
-# make the CCISS tape device visible
-for host in /proc/driver/cciss/cciss?; do
+# Make the CCISS tape device visible:
+for host in /proc/driver/cciss/cciss? ; do
     Log "Engage SCSI on host $host"
-    echo engage scsi >$host 2>/dev/null
+    echo engage scsi >$host
 done
 
 sleep 2
+


### PR DESCRIPTION
* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1395

* How was this pull request tested?
Not yet tested by me in any way and
I cannot test all those affected code parts,
in particulart not the changes for TSM and NBU.

* Brief description of the changes in this pull request:
Some general cleanup for ReaR 2.6. in all scripts
by removing '2>/dev/null' where it makes sense
and replacing '&>/dev/null' by '1>/dev/null' where it makes sense
or also removing '&>/dev/null' where that seems to be better, see
https://github.com/rear/rear/issues/1395#issuecomment-541083321
