### PR TITLE
Use is_true() for AUTOEXCLUDE_MULTIPATH and cleanup of get_partition_number()

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1057,7 +1057,7 @@ BACKUP_INTEGRITY_CHECK=
 # see https://github.com/rear/rear/issues/1285 for details.
 # In general regarding advanced backup functionality (like incremental and differential backup):
 # ReaR is primarily a disaster recovery tool to recreate the basic system after a disaster happened.
-# ReaR is is neither a backup software nor a backup management software and it is not meant to be one
+# ReaR is neither a backup software nor a backup management software and it is not meant to be one
 # (cf. "Relax-and-Recover versus backup and restore" in https://en.opensuse.org/SDB:Disaster_Recovery).
 # In particular do not expect too much from ReaR's internal backup methods like 'tar'.
 # For simple tasks ReaR's internal backup methods should be o.k. but

--- a/usr/share/rear/layout/save/default/320_autoexclude.sh
+++ b/usr/share/rear/layout/save/default/320_autoexclude.sh
@@ -1,5 +1,5 @@
 # Automatically exclude multipath devices
-if [[ "$AUTOEXCLUDE_MULTIPATH" =~ ^[yY1] ]] ; then
+if is_true $AUTOEXCLUDE_MULTIPATH ; then
     while read multipath device devices junk ; do
         Log "Automatically excluding multipath device $device."
         mark_as_done "$device"

--- a/usr/share/rear/layout/save/default/335_remove_excluded_multipath_vgs.sh
+++ b/usr/share/rear/layout/save/default/335_remove_excluded_multipath_vgs.sh
@@ -6,9 +6,8 @@
 # script tries to fix this
 
 if is_true $AUTOEXCLUDE_MULTIPATH ; then
-    # if all multipath devices are automatically excluded then there is no need
-    # to further investigate if  EXCLUDE_VG or ONLY_INCLUDE_VG was respected
-    # for multipath devices
+    # If all multipath devices are automatically excluded then there is no need
+    # to further investigate if EXCLUDE_VG or ONLY_INCLUDE_VG was respected for multipath devices:
     return
 fi
 

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -353,7 +353,7 @@ get_partition_number() {
 
     # Catch if $number is too big, report it as a bug:
     # FIXME: Why are more than 128 partitions not supported?
-    # Why is is a bug in ReaR when more than 128 partitions are not supported?
+    # Why is it a bug in ReaR when more than 128 partitions are not supported?
     # A GPT must be for at least 128 partitions but why does ReaR not support bigger GPT?
     test $number -le 128 || BugError "Partition $partition is numbered '$number'. More than 128 partitions are not supported."
 

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -330,28 +330,28 @@ find_partition() {
     get_parent_components "$1" "part"
 }
 
-# Function returns partition number of partition block device name
-#
+# The get_partition_number function
+# outputs the trailing digits of a partition block device as its partition number.
+# Requires: grep v2.5 or higher (option -o)
 # This function should support:
 #   /dev/mapper/36001438005deb05d0000e00005c40000p1
 #   /dev/mapper/36001438005deb05d0000e00005c40000_part1
 #   /dev/sda1
 #   /dev/cciss/c0d0p1
-#
-# Requires: grep v2.5 or higher (option -o)
 get_partition_number() {
-    local partition=$1
-    # The partition number is the trailing digits of the partition block device:
-    local number=$( echo "$partition" | grep -o -E '[0-9]+$' )
+    local partition_block_device=$1
 
-    # Test if $number is a positive integer, if not it is a bug.
+    # The partition number is the trailing digits of the partition block device:
+    local partition_number=$( echo "$partition_block_device" | grep -o -E '[0-9]+$' )
+
+    # Test if partition_number is a positive integer, if not it is likely a bug in ReaR.
     # Because the above 'grep' outputs only trailing digits this BugError gets triggred
-    # when the partition block device does not contain trailing digits so that $number is empty
+    # when partition_block_device device does not contain trailing digits so that partition_number is empty
     # which can happen when get_partition_number is called with a block device as argument
     # that is not a partition block device (e.g. /dev/sda instead of /dev/sda1) which is likely a bug in ReaR:
-    test $number -gt 0 || BugError "Partition number '$number' of partition $partition is not a valid partition number."
+    test $partition_number -gt 0 || BugError "Partition number '$partition_number' of partition $partition_block_device is not a valid partition number."
 
-    # Catch if $number is too big, report it as a bug:
+    # Test if partition_number is greater than 128 and report it as a bug in ReaR.
     # FIXME: Why are more than 128 partitions not supported?
     # Why is it a bug in ReaR when more than 128 partitions are not supported?
     # A GPT must be for at least 128 partitions but why does ReaR not support bigger GPT?
@@ -365,9 +365,17 @@ get_partition_number() {
     # "The UEFI specification stipulates that a minimum of 16384 bytes ... are allocated for the Partition Entry Array. Each entry has a size of 128 bytes."
     # and because 16384 / 128 = 128 it results that 128 partition table entries (each of 128 bytes) are possible as a minimum
     # which means that the GPT standard requires a minimum of 128 possible partitions per disk.
-    test $number -le 128 || BugError "Partition $partition is numbered '$number'. More than 128 partitions are not supported."
+    # So the current BugError here might be changed into only a user notification, for example something like
+    #   LogPrintError "Partition $partition_block_device is numbered '$number'. More than 128 partitions may not work (GPT must be extra large)."
+    # But on the other hand ReaR errors out relatively often at that place here in particular
+    # when weird partition related errors before had been ignored and it proceeded until it finally errors out here
+    # cf. "Try hard to care about possible errors" in https://github.com/rear/rear/wiki/Coding-Style
+    # so we keep the BugError for the time being as some kind of generic safeguard to catch bugs in ReaR elsewhere
+    # until we fully understand what is going on in our partitioning related code, cf. https://github.com/rear/rear/pull/2260
+    test $partition_number -le 128 || BugError "Partition $partition_block_device is numbered '$partition_number'. More than 128 partitions are not supported."
 
-    echo $number
+    # Output the trailing digits of the partition block device as its partition number:
+    echo $partition_number
 }
 
 # Returns partition start block or 'unknown'

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -355,6 +355,16 @@ get_partition_number() {
     # FIXME: Why are more than 128 partitions not supported?
     # Why is it a bug in ReaR when more than 128 partitions are not supported?
     # A GPT must be for at least 128 partitions but why does ReaR not support bigger GPT?
+    # I <jsmeix@suse.de> found https://github.com/rear/rear/commit/e758bba0a415173952cc588e5cf80570a6385f7e that links to
+    # https://github.com/rear/rear/issues/263 that contains https://github.com/rear/rear/issues/263#issuecomment-20464763
+    # which reads (excerpt): "The GPT standard allows maximum of 128 partitions per disk" which is not true
+    # according to how I understand the German https://de.wikipedia.org/wiki/GUID_Partition_Table that reads (excerpt)
+    # "Die EFI-Spezifikationen schreiben ein Minimum von 16384 Bytes für die Partitionstabelle vor, so dass es Platz für 128 Einträge gibt."
+    # in English "EFI specification mandate a minimum of 16384 bytes for the partition table so that there is space for 128 entries"
+    # which matches the English https://en.wikipedia.org/wiki/GUID_Partition_Table that reads (excerpt)
+    # "The UEFI specification stipulates that a minimum of 16384 bytes ... are allocated for the Partition Entry Array. Each entry has a size of 128 bytes."
+    # and because 16384 / 128 = 128 it results that 128 partition table entries (each of 128 bytes) are possible as a minimum
+    # which means that the GPT standard requires a minimum of 128 possible partitions per disk.
     test $number -le 128 || BugError "Partition $partition is numbered '$number'. More than 128 partitions are not supported."
 
     echo $number

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -333,7 +333,7 @@ find_partition() {
 # The get_partition_number function
 # outputs the trailing digits of a partition block device as its partition number.
 # Usually only the basename of the partition block device is used as function argument
-# i.e. "get_partition_number sda2" instead of "get_partition_number /dev/sda2".
+# e.g. "get_partition_number sda2" instead of "get_partition_number /dev/sda2".
 # The implementation requires grep v2.5 or higher (option -o is used).
 # This function should support:
 #   /dev/mapper/36001438005deb05d0000e00005c40000p1
@@ -368,7 +368,7 @@ get_partition_number() {
     # and because 16384 / 128 = 128 it results that 128 partition table entries (each of 128 bytes) are possible as a minimum
     # which means that the GPT standard requires a minimum of 128 possible partitions per disk.
     # So the current BugError here might be changed into only a user notification, for example something like
-    #   LogPrintError "Partition $partition_block_device is numbered '$number'. More than 128 partitions may not work (GPT must be extra large)."
+    #   LogPrintError "Partition $partition_block_device is numbered '$partition_number'. More than 128 partitions may not work (GPT must be extra large)."
     # But on the other hand ReaR errors out relatively often at that place here in particular
     # when weird partition related errors before had been ignored and it proceeded until it finally errors out here
     # cf. "Try hard to care about possible errors" in https://github.com/rear/rear/wiki/Coding-Style

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -332,7 +332,9 @@ find_partition() {
 
 # The get_partition_number function
 # outputs the trailing digits of a partition block device as its partition number.
-# Requires: grep v2.5 or higher (option -o)
+# Usually only the basename of the partition block device is used as function argument
+# i.e. "get_partition_number sda2" instead of "get_partition_number /dev/sda2".
+# The implementation requires grep v2.5 or higher (option -o is used).
 # This function should support:
 #   /dev/mapper/36001438005deb05d0000e00005c40000p1
 #   /dev/mapper/36001438005deb05d0000e00005c40000_part1

--- a/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
+++ b/usr/share/rear/prep/NETFS/default/070_set_backup_archive.sh
@@ -106,7 +106,7 @@ local current_yyyy_mm_dd="${current_date_output[1]}"
 local current_hhmm="${current_date_output[2]}"
 # The date FULLBACKUP_OUTDATED_DAYS ago is needed to check if the latest full backup is too old.
 # When the latest full backup is more than FULLBACKUP_OUTDATED_DAYS ago a new full backup is made.
-# This separated call of the 'date' command which is technically needed because is is
+# This separated call of the 'date' command which is technically needed because it is
 # for another point in time (e.g. 7 days ago) is run after the above call of the 'date'
 # command for the current time to be on the safe side when midnight passes in between
 # both 'date' commands which would then result that a new full backup is made

--- a/usr/share/rear/prep/YUM/default/070_set_backup_archive.sh
+++ b/usr/share/rear/prep/YUM/default/070_set_backup_archive.sh
@@ -98,7 +98,7 @@ local current_yyyy_mm_dd="${current_date_output[1]}"
 local current_hhmm="${current_date_output[2]}"
 # The date FULLBACKUP_OUTDATED_DAYS ago is needed to check if the latest full backup is too old.
 # When the latest full backup is more than FULLBACKUP_OUTDATED_DAYS ago a new full backup is made.
-# This separated call of the 'date' command which is technically needed because is is
+# This separated call of the 'date' command which is technically needed because it is
 # for another point in time (e.g. 7 days ago) is run after the above call of the 'date'
 # command for the current time to be on the safe side when midnight passes in between
 # both 'date' commands which would then result that a new full backup is made

--- a/usr/share/rear/verify/YUM/default/070_set_backup_archive.sh
+++ b/usr/share/rear/verify/YUM/default/070_set_backup_archive.sh
@@ -98,7 +98,7 @@ local current_yyyy_mm_dd="${current_date_output[1]}"
 local current_hhmm="${current_date_output[2]}"
 # The date FULLBACKUP_OUTDATED_DAYS ago is needed to check if the latest full backup is too old.
 # When the latest full backup is more than FULLBACKUP_OUTDATED_DAYS ago a new full backup is made.
-# This separated call of the 'date' command which is technically needed because is is
+# This separated call of the 'date' command which is technically needed because it is
 # for another point in time (e.g. 7 days ago) is run after the above call of the 'date'
 # command for the current time to be on the safe side when midnight passes in between
 # both 'date' commands which would then result that a new full backup is made


### PR DESCRIPTION
* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2245

* How was this pull request tested?
Not tested because I cannot test multipath.

* Brief description of the changes in this pull request:

Using `is_true "$AUTOEXCLUDE_MULTIPATH"`
instead of `[[ "$AUTOEXCLUDE_MULTIPATH" =~ ^[yY1] ]]`
according to "Relax-and-Recover functions" in
https://github.com/rear/rear/wiki/Coding-Style

Additionally a cleanup of the `get_partition_number` function:
When the comments talk about `bug` then `BugError` should be called.
Plus hopefully more comprehensible comments,
cf. "Code must be easy to understand" in
https://github.com/rear/rear/wiki/Coding-Style
