### PR TITLE
Enhanced AUTOEXCLUDE_PATH /media /run /mnt and /tmp

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2414,10 +2414,21 @@ AUTOEXCLUDE_MULTIPATH=y
 # Automatically exclude automounter paths from the backup
 AUTOEXCLUDE_AUTOFS=
 
-# Automatically exclude filesystems mounted under directories given here
-# The default is /media to exclude USB devices mounted there.
+# Automatically exclude filesystems with mountpoints that are sub-directories
+# of the directories that are specified in the AUTOEXCLUDE_PATH array.
 # This is different from EXCLUDE_MOUNTPOINTS, which accepts only mountpoints.
-AUTOEXCLUDE_PATH=( /media )
+# Filesystems with mountpoints in the AUTOEXCLUDE_PATH array are not excluded.
+# For details see the layout/save/default/320_autoexclude.sh script.
+# For example a separated filesystem with mountpoint /tmp is not excluded
+# but the files in the /tmp directory are excluded from the backup
+# when an internal backup method is used by BACKUP_PROG_EXCLUDE=( '/tmp/*' ... )
+# so that this filesystem will be recreated as an empty filesystem.
+# The AUTOEXCLUDE_PATH default /media /run[/media] /mnt and /tmp
+# intends to exclude temporarily mounted things (e.g. USB devices)
+# because mountpoints for temporarily mounted things are usually
+# sub-directories below /media /run[/media] /mnt and /tmp
+# see https://github.com/rear/rear/issues/2239
+AUTOEXCLUDE_PATH=( /media /run /mnt /tmp )
 
 #### New Style include/excludes
 # Exclude components from being backed up, recreation information is active


### PR DESCRIPTION
This pull request supersedes https://github.com/rear/rear/pull/2244

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2239

* How was this pull request tested?

I used a test system with a separated ext2 filesystem on /tmp
cf. https://github.com/rear/rear/issues/2239#issuecomment-538647867

With `AUTOEXCLUDE_PATH=( /media /run /mnt /tmp )`
I still got in disklayout.conf the ext2 filesystem on /tmp
which is the intended behaviour.

* Brief description of the changes in this pull request:

Enhanced AUTOEXCLUDE_PATH in default.conf
from only `AUTOEXCLUDE_PATH=( /media )`
to `AUTOEXCLUDE_PATH=( /media /run /mnt /tmp )`
plus explanatory comment in default.conf
how AUTOEXCLUDE_PATH works.
