### PR TITLE
Issue 2247: draft implementation of 'mountonly' workflow.

### DIFF
--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -1332,12 +1332,12 @@ Finished recovering your system. You can explore it under '/mnt/local'.
 Finished in 361 seconds.
 ----
 
-== Using ReaR to repair your system
+== Using ReaR to mount and repair your system
 Instead of using your ReaR image to completely recover your system from bare
 metal (as illustrated in most of the above scenarios), you can also use it
 as a live media to boot a broken but hopefully repairable system.
 
-Once booted on your recovery image, the `repair` workflow will:
+Once booted on your recovery image, the `mountonly` workflow will:
 
 * activate all Volume Groups
 
@@ -1351,12 +1351,12 @@ correcting any configuration mistake that may have prevented its startup,
 or allowing you to simply `chroot` into it and further repair it using its 
 own administrative tools.
 
-One important point to remember is that the `repair` workflow on its own 
+One important point to remember is that the `mountonly` workflow on its own 
 won't modify the target system in any way. Of course, once the target 
 filesystems are mounted you, as the administrator, may decide to do so
 manually.
 
-**Beware:** The `repair` workflow can only be used on the system where
+**Beware:** The `mountonly` workflow can only be used on the system where
 the rescue image was generated, as it bases its logic on the filesystem
 layout description file generated during the run of the `mkrescue` or
 `mkbackup` workflows.
@@ -1366,7 +1366,7 @@ Here are the steps you would typically follow:
 === Create your recovery image
 Using any of the techniques described in the other scenarios, create a 
 ReaR recovery image for your system (through `rear mkrescue` or `rear 
-mkbackup`). If you only take the `repair` workflow into consideration, it 
+mkbackup`). If you only take the `mountonly` workflow into consideration, it 
 doesn't matter whether you also make a backup of your system or not 
 (obviously, you'd better cover all your bases and make sure you'd be able to 
 perform a full `recover` as well should the need occur).
@@ -1383,26 +1383,24 @@ comments in `default.conf` for the exact meaning of each).
 Arrange for the target system to boot on your recovery image as you would in
 any of the other scenarios.
 
-=== Launching the repair workflow
-Issue the `rear repair` command to launch the workflow:
+=== Launching the "mount only" workflow
+Issue the `rear mountonly` command to launch the workflow (that one is always 
+verbose):
 
 ----
-RESCUE pc-pan:~ # rear -v repair
+RESCUE pc-pan:~ # rear mountonly
 Relax-and-Recover 2.5 / Git
-Running rear repair (PID 779)
+Running rear mountonly (PID 639)
 Using log file: /var/log/rear/rear-pc-pan.log
-Running workflow repair within the ReaR rescue/recovery system
+Running workflow mountonly within the ReaR rescue/recovery system
 Will do driver migration (recreating initramfs/initrd)
 Comparing disks
 Device sda has expected (same) size 34359738368 (will be used for recovery)
 Disk configuration looks identical
-UserInput -I DISK_LAYOUT_PROCEED_RECOVERY needed in /usr/share/rear/layout/prep-for-mount/default/250_compare_disks.sh line 148
-Proceed with recovery (yes) otherwise manual disk layout configuration is enforced
+Proceed with 'mountonly' (yes) otherwise manual disk layout configuration is enforced
 (default 'yes' timeout 30 seconds)
 
-UserInput: No real user input (empty or only spaces) - using default input
-UserInput: No choices - result is 'yes'
-User confirmed to proceed with recovery
+User confirmed to proceed with 'mountonly'
 Start target system mount.
 Mounting filesystem /
 Mounting filesystem /home
@@ -1410,17 +1408,18 @@ Mounting filesystem /boot/efi
 Please enter the password for LUKS device cr_vg00-lvol4 (/dev/mapper/vg00-lvol4):
 Enter passphrase for /dev/mapper/vg00-lvol4: 
 Mounting filesystem /products
-Mounting virtual filesystems below target root.
-Target system now ready for chrooting into it.
 Disk layout processed.
 Finished recovering your system. You can explore it under '/mnt/local'.
+Exiting rear mountonly (PID 639) and its descendant processes ...
+Running exit tasks
 ----
 
 As you can see in the output above, you will first be asked to confirm 
-(`Proceed with recovery`) -- simply press return. All the target filesystems 
-should now be mounted below `/mnt/local` (including LUKS-encrypted ones, if 
-present). In case any of them fails to mount, you will be offered to review 
-the mount script and to re-execute it if needed.
+running the workflow (`Proceed with 'mountonly'`) -- simply press return. 
+All the target filesystems should now be mounted below `/mnt/local` (including 
+LUKS-encrypted ones if present and all needed virtual ones). In case any of 
+them fails to mount, you will be offered to review the mount script and to 
+re-execute it if needed.
 
 Once the system is in the desired state, you can start exploring it, correcting
 any configuration mistake or filesystem corruption that prevented it from 

--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -1337,17 +1337,29 @@ Instead of using your ReaR image to completely recover your system from bare
 metal (as illustrated in most of the above scenarios), you can also use it
 as a live media to boot a broken but hopefully repairable system.
 
-Once booted on your recovery image, the `repair` workflow will mount all the
-target filesystems (including the most important virtual ones) below 
-`/mnt/local`, making it possible for you to explore your system at will,
+Once booted on your recovery image, the `repair` workflow will:
+
+* activate all Volume Groups
+
+* offer to decrypt any LUKS-encrypted filesystem that may be present
+
+* mount all the target filesystems (including the most important virtual 
+  ones) below `/mnt/local`
+
+thereby making it possible for you to explore your system at will,
 correcting any configuration mistake that may have prevented its startup, 
-or you can even `chroot` into it and further repair it using its own
-administrative tools.
+or allowing you to simply `chroot` into it and further repair it using its 
+own administrative tools.
 
 One important point to remember is that the `repair` workflow on its own 
 won't modify the target system in any way. Of course, once the target 
 filesystems are mounted you, as the administrator, may decide to do so
 manually.
+
+**Beware:** The `repair` workflow can only be used on the system where
+the rescue image was generated, as it bases its logic on the filesystem
+layout description file generated during the run of the `mkrescue` or
+`mkbackup` workflows.
 
 Here are the steps you would typically follow:
 

--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -1331,3 +1331,97 @@ Finished recovering your system. You can explore it under '/mnt/local'.
 
 Finished in 361 seconds.
 ----
+
+== Using ReaR to repair your system
+Instead of using your ReaR image to completely recover your system from bare
+metal (as illustrated in most of the above scenarios), you can also use it
+as a live media to boot a broken but hopefully repairable system.
+
+Once booted on your recovery image, the `repair` workflow will mount all the
+target filesystems (including the most important virtual ones) below 
+`/mnt/local`, making it possible for you to explore your system at will,
+correcting any configuration mistake that may have prevented its startup, 
+or you can even `chroot` into it and further repair it using its own
+administrative tools.
+
+One important point to remember is that the `repair` workflow on its own 
+won't modify the target system in any way. Of course, once the target 
+filesystems are mounted you, as the administrator, may decide to do so
+manually.
+
+Here are the steps you would typically follow:
+
+=== Create your recovery image
+Using any of the techniques described in the other scenarios, create a 
+ReaR recovery image for your system (through `rear mkrescue` or `rear 
+mkbackup`). If you only take the `repair` workflow into consideration, it 
+doesn't matter whether you also make a backup of your system or not 
+(obviously, you'd better cover all your bases and make sure you'd be able to 
+perform a full `recover` as well should the need occur).
+
+Please note, that by default ReaR only includes in the recovery image the 
+tools it will need to recover the system. If you anticipate the need for 
+some extra tools in the context of a repair operation (e.g. tools that you 
+might need in the event `chroot`ing into the target system doesn't work), you 
+should make sure to include them in your recovery image by adding to the 
+`PROGS` or `REQUIRED_PROGS` configuration variables (please refer to the 
+comments in `default.conf` for the exact meaning of each).
+
+=== Booting on the recovery image
+Arrange for the target system to boot on your recovery image as you would in
+any of the other scenarios.
+
+=== Launching the repair workflow
+Issue the `rear repair` command to launch the workflow:
+
+----
+RESCUE pc-pan:~ # rear -v repair
+Relax-and-Recover 2.5 / Git
+Running rear repair (PID 779)
+Using log file: /var/log/rear/rear-pc-pan.log
+Running workflow repair within the ReaR rescue/recovery system
+Will do driver migration (recreating initramfs/initrd)
+Comparing disks
+Device sda has expected (same) size 34359738368 (will be used for recovery)
+Disk configuration looks identical
+UserInput -I DISK_LAYOUT_PROCEED_RECOVERY needed in /usr/share/rear/layout/prep-for-mount/default/250_compare_disks.sh line 148
+Proceed with recovery (yes) otherwise manual disk layout configuration is enforced
+(default 'yes' timeout 30 seconds)
+
+UserInput: No real user input (empty or only spaces) - using default input
+UserInput: No choices - result is 'yes'
+User confirmed to proceed with recovery
+Start target system mount.
+Mounting filesystem /
+Mounting filesystem /home
+Mounting filesystem /boot/efi
+Please enter the password for LUKS device cr_vg00-lvol4 (/dev/mapper/vg00-lvol4):
+Enter passphrase for /dev/mapper/vg00-lvol4: 
+Mounting filesystem /products
+Mounting virtual filesystems below target root.
+Target system now ready for chrooting into it.
+Disk layout processed.
+Finished recovering your system. You can explore it under '/mnt/local'.
+----
+
+As you can see in the output above, you will first be asked to confirm 
+(`Proceed with recovery`) -- simply press return. All the target filesystems 
+should now be mounted below `/mnt/local` (including LUKS-encrypted ones, if 
+present). In case any of them fails to mount, you will be offered to review 
+the mount script and to re-execute it if needed.
+
+Once the system is in the desired state, you can start exploring it, correcting
+any configuration mistake or filesystem corruption that prevented it from 
+booting properly. In this state, the only tools at your disposal are those 
+included by default in ReaR recovery image, or those you saw fit to add
+yourself (see above).
+
+If this is not enough and you need to run the native administrative tools
+hosted inside your target system (such as YaST in the case of SUSE 
+distributions), you are now in a position where you can `chroot` inside 
+your system to reach them (`chroot /mnt/local`).
+
+=== Closing the session
+Once done, don't forget to leave the `chroot` environment if applicable 
+(Ctrl-D), then issue the `shutdown` command. This will ensure that all the 
+target filesystems will be cleanly unmounted before the system is restarted.

--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -1390,16 +1390,15 @@ verbose):
 ----
 RESCUE pc-pan:~ # rear mountonly
 Relax-and-Recover 2.5 / Git
-Running rear mountonly (PID 639)
+Running rear mountonly (PID 625)
 Using log file: /var/log/rear/rear-pc-pan.log
 Running workflow mountonly within the ReaR rescue/recovery system
-Will do driver migration (recreating initramfs/initrd)
 Comparing disks
-Device sda has expected (same) size 34359738368 (will be used for recovery)
+Device sda has expected (same) size 34359738368 (will be used for 'mountonly')
 Disk configuration looks identical
 Proceed with 'mountonly' (yes) otherwise manual disk layout configuration is enforced
 (default 'yes' timeout 30 seconds)
-
+yes
 User confirmed to proceed with 'mountonly'
 Start target system mount.
 Mounting filesystem /
@@ -1409,8 +1408,8 @@ Please enter the password for LUKS device cr_vg00-lvol4 (/dev/mapper/vg00-lvol4)
 Enter passphrase for /dev/mapper/vg00-lvol4: 
 Mounting filesystem /products
 Disk layout processed.
-Finished recovering your system. You can explore it under '/mnt/local'.
-Exiting rear mountonly (PID 639) and its descendant processes ...
+Finished 'mountonly'. The target system is mounted at '/mnt/local'.
+Exiting rear mountonly (PID 625) and its descendant processes ...
 Running exit tasks
 ----
 

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -236,7 +236,7 @@ ARGS=( "$@" )
 
 # The following workflows are always verbose:
 case "$WORKFLOW" in
-    (validate|shell|recover)
+    (validate|shell|recover|mountonly)
         VERBOSE=1
         ;;
 esac

--- a/usr/share/rear/check/GNU
+++ b/usr/share/rear/check/GNU
@@ -1,0 +1,1 @@
+../verify/GNU

--- a/usr/share/rear/check/default
+++ b/usr/share/rear/check/default
@@ -1,0 +1,1 @@
+../verify/default

--- a/usr/share/rear/final-mount/default/110_bind_mount_proc_sys_dev_run.sh
+++ b/usr/share/rear/final-mount/default/110_bind_mount_proc_sys_dev_run.sh
@@ -1,0 +1,1 @@
+../../finalize/default/110_bind_mount_proc_sys_dev_run.sh

--- a/usr/share/rear/final-mount/default/900_remount_sync.sh
+++ b/usr/share/rear/final-mount/default/900_remount_sync.sh
@@ -1,0 +1,1 @@
+../../finalize/default/900_remount_sync.sh

--- a/usr/share/rear/finalize/default/900_remount_sync.sh
+++ b/usr/share/rear/finalize/default/900_remount_sync.sh
@@ -14,8 +14,8 @@
 # scripts that do umount plus sync to safely shut down the recovery system,
 # cf. https://github.com/rear/rear/pull/1011
 
-# Skip if not recover WORKFLOW:
-test "recover" = "$WORKFLOW" || return 0
+# Skip if not 'recover' or 'mountonly' WORKFLOW:
+test "recover" = "$WORKFLOW" -o "mountonly" = "$WORKFLOW" || return 0
 
 # Skip if systemd is used
 # systemctl gets copied into the recovery system as /bin/systemctl:

--- a/usr/share/rear/init/default/050_check_rear_recover_mode.sh
+++ b/usr/share/rear/init/default/050_check_rear_recover_mode.sh
@@ -1,5 +1,6 @@
 # In the ReaR rescue/recovery system the only possible workflows are
 # - 'recover' and its partial workflows 'layoutonly' 'restoreonly' 'finalizeonly'
+# - 'repair'
 # - 'opaladmin'
 # - 'help'
 # cf. https://github.com/rear/rear/issues/987
@@ -8,7 +9,7 @@
 # In the ReaR rescue/recovery system /etc/rear-release is unique (it does not exist otherwise):
 test -f /etc/rear-release || return 0
 case "$WORKFLOW" in
-    (recover|layoutonly|restoreonly|finalizeonly|opaladmin|help)
+    (recover|layoutonly|restoreonly|finalizeonly|repair|opaladmin|help)
         LogPrint "Running workflow $WORKFLOW within the ReaR rescue/recovery system"
         ;;
     (*)

--- a/usr/share/rear/init/default/050_check_rear_recover_mode.sh
+++ b/usr/share/rear/init/default/050_check_rear_recover_mode.sh
@@ -1,6 +1,6 @@
 # In the ReaR rescue/recovery system the only possible workflows are
 # - 'recover' and its partial workflows 'layoutonly' 'restoreonly' 'finalizeonly'
-# - 'repair'
+# - 'mountonly'
 # - 'opaladmin'
 # - 'help'
 # cf. https://github.com/rear/rear/issues/987
@@ -9,7 +9,7 @@
 # In the ReaR rescue/recovery system /etc/rear-release is unique (it does not exist otherwise):
 test -f /etc/rear-release || return 0
 case "$WORKFLOW" in
-    (recover|layoutonly|restoreonly|finalizeonly|repair|opaladmin|help)
+    (recover|layoutonly|restoreonly|finalizeonly|mountonly|opaladmin|help)
         LogPrint "Running workflow $WORKFLOW within the ReaR rescue/recovery system"
         ;;
     (*)

--- a/usr/share/rear/layout/do-mount/default/100_confirm_layout_code.sh
+++ b/usr/share/rear/layout/do-mount/default/100_confirm_layout_code.sh
@@ -1,0 +1,1 @@
+../../recreate/default/100_confirm_layout_code.sh

--- a/usr/share/rear/layout/do-mount/default/200_run_layout_code.sh
+++ b/usr/share/rear/layout/do-mount/default/200_run_layout_code.sh
@@ -1,0 +1,1 @@
+../../recreate/default/200_run_layout_code.sh

--- a/usr/share/rear/layout/do-mount/default/250_verify_mount.sh
+++ b/usr/share/rear/layout/do-mount/default/250_verify_mount.sh
@@ -1,0 +1,1 @@
+../../recreate/default/250_verify_mount.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/100_include_partition_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/100_include_partition_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/100_include_partition_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/110_include_lvm_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/110_include_lvm_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/120_include_raid_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/120_include_raid_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/120_include_raid_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/131_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/131_include_filesystem_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/131_include_filesystem_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/133_include_mount_filesystem_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/133_include_mount_filesystem_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/133_include_mount_filesystem_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/135_include_btrfs_subvolumes_generic_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/135_include_btrfs_subvolumes_generic_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/135_include_btrfs_subvolumes_generic_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/136_include_btrfs_subvolumes_SLES_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/136_include_btrfs_subvolumes_SLES_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/136_include_btrfs_subvolumes_SLES_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/140_include_swap_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/140_include_swap_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/140_include_swap_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/150_include_drbd_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/150_include_drbd_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/150_include_drbd_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/160_include_luks_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/160_include_luks_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/160_include_luks_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/170_include_hpraid_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/170_include_hpraid_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/170_include_hpraid_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/180_include_opaldisk_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/180_include_opaldisk_code.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/180_include_opaldisk_code.sh

--- a/usr/share/rear/layout/prep-for-mount/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prep-for-mount/GNU/Linux/210_load_multipath.sh
@@ -1,0 +1,1 @@
+../../../prepare/GNU/Linux/210_load_multipath.sh

--- a/usr/share/rear/layout/prep-for-mount/default/010_prepare_files.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/010_prepare_files.sh
@@ -1,0 +1,1 @@
+../../prepare/default/010_prepare_files.sh

--- a/usr/share/rear/layout/prep-for-mount/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/250_compare_disks.sh
@@ -1,0 +1,1 @@
+../../prepare/default/250_compare_disks.sh

--- a/usr/share/rear/layout/prep-for-mount/default/270_overrule_migration_mode.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/270_overrule_migration_mode.sh
@@ -1,0 +1,1 @@
+../../prepare/default/270_overrule_migration_mode.sh

--- a/usr/share/rear/layout/prep-for-mount/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/300_map_disks.sh
@@ -1,0 +1,1 @@
+../../prepare/default/300_map_disks.sh

--- a/usr/share/rear/layout/prep-for-mount/default/310_remove_exclusions.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/310_remove_exclusions.sh
@@ -1,0 +1,1 @@
+../../prepare/default/310_remove_exclusions.sh

--- a/usr/share/rear/layout/prep-for-mount/default/320_apply_mappings.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/320_apply_mappings.sh
@@ -1,0 +1,1 @@
+../../prepare/default/320_apply_mappings.sh

--- a/usr/share/rear/layout/prep-for-mount/default/500_confirm_layout_file.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/500_confirm_layout_file.sh
@@ -1,0 +1,1 @@
+../../prepare/default/500_confirm_layout_file.sh

--- a/usr/share/rear/layout/prep-for-mount/default/510_list_dependencies.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/510_list_dependencies.sh
@@ -1,0 +1,1 @@
+../../prepare/default/510_list_dependencies.sh

--- a/usr/share/rear/layout/prep-for-mount/default/520_exclude_components.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/520_exclude_components.sh
@@ -1,0 +1,1 @@
+../../prepare/default/520_exclude_components.sh

--- a/usr/share/rear/layout/prep-for-mount/default/540_generate_device_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/540_generate_device_code.sh
@@ -9,6 +9,10 @@ save_original_file "$LAYOUT_CODE"
 cat <<EOF >"$LAYOUT_CODE"
 #!/bin/bash
 
+# Create "breadcrumb" file (used as interlock by other workflows),
+# defined and checked by ./setup/default/002_clean_start.sh
+echo "$WORKFLOW" > $BREADCRUMB
+
 LogPrint "Start target system mount."
 
 mkdir -p $TARGET_FS_ROOT
@@ -63,17 +67,3 @@ while [ -z "$all_done" ] ; do
     fi
 
 done
-
-# Now mount needed virtual filesystems below the target root to support
-# chrooting into it and running YaST (a.o.)
-cat <<EOF >>"$LAYOUT_CODE"
-
-LogPrint "Mounting virtual filesystems below target root."
-
-mount -t proc proc $TARGET_FS_ROOT/proc
-mount -t sysfs sysfs $TARGET_FS_ROOT/sys
-mount -o rbind /dev $TARGET_FS_ROOT/dev
-
-LogPrint "Target system now ready for chrooting into it."
-
-EOF

--- a/usr/share/rear/layout/prep-for-mount/default/540_generate_device_code.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/540_generate_device_code.sh
@@ -1,0 +1,79 @@
+# Use the dependencies to order device processing and generate code for them.
+
+# LAYOUT_CODE is the script to mount the target system based on its disk 
+# layout (diskrestore.sh).
+
+save_original_file "$LAYOUT_CODE"
+
+# Initialize diskrestore.sh:
+cat <<EOF >"$LAYOUT_CODE"
+#!/bin/bash
+
+LogPrint "Start target system mount."
+
+mkdir -p $TARGET_FS_ROOT
+if create_component "vgchange" "rear" ; then
+    lvm vgchange -a y >/dev/null
+    component_created "vgchange" "rear"
+fi
+
+set -e
+set -x
+
+EOF
+
+# Populate diskrestore.sh with further code to (re)-mount all disk layout components:
+all_done=
+while [ -z "$all_done" ] ; do
+    # Cycle through all components and find one that can be mounted.
+    willdodev=
+    willdotype=
+
+    cp "$LAYOUT_TODO" "${LAYOUT_TODO}.tmp"
+    while read status thisdev type; do
+        # Test if all dependencies are already created.
+        Debug "Testing $thisdev for dependencies..."
+        deps=($(grep "^$thisdev\ " "$LAYOUT_DEPS" | cut -d " " -f "2"))
+        Debug "deps (${#deps[@]}): ${deps[*]}"
+
+        donedeps=0
+        for dep in "${deps[@]}" ; do
+            if grep -q "done $dep " "$LAYOUT_TODO.tmp"; then
+                let donedeps++
+            fi
+        done
+
+        if [ ${#deps[@]} -eq $donedeps ] ; then
+            Debug "All dependencies for $thisdev are present, processing..."
+            willdodev="$thisdev"
+            willdotype="$type"
+            break
+        fi
+    done < <(grep "^todo" "$LAYOUT_TODO")
+    rm "$LAYOUT_TODO.tmp"
+
+    # Write the code to mount a device.
+    if [ -n "$willdodev" ] ; then
+        do_mount_device "$willdodev" "$willdotype"
+
+        mark_as_done "$willdodev"
+    else
+        # No device to be mounted, no additional dependencies can be satisfied.
+        all_done="y"
+    fi
+
+done
+
+# Now mount needed virtual filesystems below the target root to support
+# chrooting into it and running YaST (a.o.)
+cat <<EOF >>"$LAYOUT_CODE"
+
+LogPrint "Mounting virtual filesystems below target root."
+
+mount -t proc proc $TARGET_FS_ROOT/proc
+mount -t sysfs sysfs $TARGET_FS_ROOT/sys
+mount -o rbind /dev $TARGET_FS_ROOT/dev
+
+LogPrint "Target system now ready for chrooting into it."
+
+EOF

--- a/usr/share/rear/layout/prep-for-mount/default/550_finalize_script.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/550_finalize_script.sh
@@ -1,0 +1,10 @@
+# Add final information to the script.
+
+cat >> $LAYOUT_CODE <<EOF
+
+set +x
+set +e
+
+LogPrint "Disk layout processed."
+
+EOF

--- a/usr/share/rear/layout/prep-for-mount/default/600_show_unprocessed.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/600_show_unprocessed.sh
@@ -1,0 +1,58 @@
+
+# Warn about missing components and for each missing component
+# offer the user a way to manually add code that recreates it.
+
+rear_workflow="rear $WORKFLOW"
+rear_shell_history="$( echo -e "vi $LAYOUT_CODE\nless $LAYOUT_CODE" )"
+
+unset choices
+choices[0]="View $LAYOUT_CODE"
+choices[1]="Edit $LAYOUT_CODE"
+choices[2]="Go to Relax-and-Recover shell"
+choices[3]="Continue '$rear_workflow'"
+choices[4]="Abort '$rear_workflow'"
+
+while read status name type junk ; do
+    missing_component="$name ($type)"
+    LogUserOutput "No code has been generated to mount $missing_component.
+    To mount it manually add code to $LAYOUT_CODE or abort."
+    while true ; do
+        # The default user input is "Continue" to make it possible to run ReaR unattended
+        # so that 'rear recover' proceeds after the timeout regardless that it probably fails
+        # when the component is not recreated but perhaps it could succeed in migration mode
+        # on different replacement hardware where it might be even right to simply "Continue".
+        # Generate a runtime-specific user_input_ID so that for each missing component
+        # a different user_input_ID is used for the UserInput call so that the user can specify
+        # for each missing component a different predefined user input.
+        # Only uppercase letters and digits are used to ensure the user_input_ID is a valid bash variable name
+        # (otherwise the UserInput call could become invalid which aborts 'rear recover' with a BugError) and
+        # hopefully only uppercase letters and digits are sufficient to distinguish different missing components:
+        current_missing_component_alnum_uppercase="$( echo "$missing_component" | tr -d -c '[:alnum:]' | tr '[:lower:]' '[:upper:]' )"
+        test "$current_missing_component_alnum_uppercase" || current_missing_component_alnum_uppercase="COMPONENT"
+        user_input_ID="ADD_CODE_TO_RECREATE_MISSING_$current_missing_component_alnum_uppercase"
+        case "$( UserInput -I $user_input_ID -p "Manually add code that mounts $missing_component" -D "${choices[3]}" "${choices[@]}" )" in
+            (${choices[0]})
+                # Run 'less' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+                less $LAYOUT_CODE 0<&6 1>&7 2>&8
+                ;;
+            (${choices[1]})
+                # Run 'vi' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+                vi $LAYOUT_CODE 0<&6 1>&7 2>&8
+                ;;
+            (${choices[2]})
+                # rear_shell runs 'bash' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+                rear_shell "" "$rear_shell_history"
+                ;;
+            (${choices[3]})
+                # Continue with the next missing component:
+                break
+                ;;
+            (${choices[4]})
+                abort_recreate
+                Error "User chose to abort '$rear_workflow' in ${BASH_SOURCE[0]}"
+                ;;
+            # No default case is needed here because the 'while true' loop repeats for invalid user input.
+        esac
+    done
+done < <(grep "^todo" "$LAYOUT_TODO")
+

--- a/usr/share/rear/layout/prep-for-mount/default/600_show_unprocessed.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/600_show_unprocessed.sh
@@ -1,6 +1,6 @@
 
 # Warn about missing components and for each missing component
-# offer the user a way to manually add code that recreates it.
+# offer the user a way to manually add code that mounts it.
 
 rear_workflow="rear $WORKFLOW"
 rear_shell_history="$( echo -e "vi $LAYOUT_CODE\nless $LAYOUT_CODE" )"
@@ -14,8 +14,8 @@ choices[4]="Abort '$rear_workflow'"
 
 while read status name type junk ; do
     missing_component="$name ($type)"
-    LogUserOutput "No code has been generated to mount $missing_component.
-    To mount it manually add code to $LAYOUT_CODE or abort."
+    LogUserOutput "No code has been generated to mount $missing_component."
+    LogUserOutput "To mount $missing_component manually add code to $LAYOUT_CODE or abort."
     while true ; do
         # The default user input is "Continue" to make it possible to run ReaR unattended
         # so that 'rear recover' proceeds after the timeout regardless that it probably fails

--- a/usr/share/rear/layout/prep-for-mount/default/600_show_unprocessed.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/600_show_unprocessed.sh
@@ -18,14 +18,14 @@ while read status name type junk ; do
     LogUserOutput "To mount $missing_component manually add code to $LAYOUT_CODE or abort."
     while true ; do
         # The default user input is "Continue" to make it possible to run ReaR unattended
-        # so that 'rear recover' proceeds after the timeout regardless that it probably fails
+        # so that 'rear mountonly' proceeds after the timeout regardless that it probably fails
         # when the component is not recreated but perhaps it could succeed in migration mode
         # on different replacement hardware where it might be even right to simply "Continue".
         # Generate a runtime-specific user_input_ID so that for each missing component
         # a different user_input_ID is used for the UserInput call so that the user can specify
         # for each missing component a different predefined user input.
         # Only uppercase letters and digits are used to ensure the user_input_ID is a valid bash variable name
-        # (otherwise the UserInput call could become invalid which aborts 'rear recover' with a BugError) and
+        # (otherwise the UserInput call could become invalid which aborts 'rear mountonly' with a BugError) and
         # hopefully only uppercase letters and digits are sufficient to distinguish different missing components:
         current_missing_component_alnum_uppercase="$( echo "$missing_component" | tr -d -c '[:alnum:]' | tr '[:lower:]' '[:upper:]' )"
         test "$current_missing_component_alnum_uppercase" || current_missing_component_alnum_uppercase="COMPONENT"

--- a/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
@@ -62,7 +62,7 @@ create_crypt() {
     ) >> "$LAYOUT_CODE"
 }
 
-# Function open_crypt() is meant to be used by the 'repair' workflow
+# Function open_crypt() is meant to be used by the 'mountonly' workflow
 open_crypt() {
     local crypt target_device source_device options
     read crypt target_device source_device options < <(grep "^crypt $1 " "$LAYOUT_FILE")
@@ -88,7 +88,7 @@ open_crypt() {
     (
     echo "Log \"Opening LUKS device $target_name on $source_device\""
     if [ -n "$keyfile" ] ; then
-        # During a 'repair' workflow, the original keyfile is supposed to be
+        # During a 'mountonly' workflow, the original keyfile is supposed to be
         # available at this point.
         echo "cryptsetup luksOpen --key-file $keyfile $source_device $target_name"
     elif [ -n "$password" ] ; then

--- a/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
@@ -1,4 +1,4 @@
-# Code to recreate LUKS volumes.
+# Code to recreate and/or open LUKS volumes.
 
 create_crypt() {
     local crypt target_device source_device options
@@ -56,6 +56,45 @@ create_crypt() {
         echo "LogPrint \"Please enter the password for LUKS device $target_name ($source_device):\""
         echo "cryptsetup luksFormat --batch-mode $cryptsetup_options $source_device"
         echo "LogPrint \"Please re-enter the password for LUKS device $target_name ($source_device):\""
+        echo "cryptsetup luksOpen $source_device $target_name"
+    fi
+    echo ""
+    ) >> "$LAYOUT_CODE"
+}
+
+# Function open_crypt() is meant to be used by the 'repair' workflow
+open_crypt() {
+    local crypt target_device source_device options
+    read crypt target_device source_device options < <(grep "^crypt $1 " "$LAYOUT_FILE")
+
+    local target_name=${target_device#/dev/mapper/}
+
+    local cryptsetup_options="" keyfile="" password=""
+    local option key value
+    for option in $options ; do
+        key=${option%=*}
+        value=${option#*=}
+
+        case "$key" in
+            keyfile)
+                keyfile=$value
+                ;;
+            password)
+                password=$value
+                ;;
+        esac
+    done
+
+    (
+    echo "Log \"Opening LUKS device $target_name on $source_device\""
+    if [ -n "$keyfile" ] ; then
+        # During a 'repair' workflow, the original keyfile is supposed to be
+        # available at this point.
+        echo "cryptsetup luksOpen --key-file $keyfile $source_device $target_name"
+    elif [ -n "$password" ] ; then
+        echo "echo \"$password\" | cryptsetup luksOpen $source_device $target_name"
+    else
+        echo "LogPrint \"Please enter the password for LUKS device $target_name ($source_device):\""
         echo "cryptsetup luksOpen $source_device $target_name"
     fi
     echo ""

--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -142,12 +142,12 @@ else
     # e.g. for automated testing a small USER_INPUT_TIMEOUT may be specified and
     # we do not want to delay it here more than what USER_INPUT_TIMEOUT specifies:
     test "$timeout" -gt "$USER_INPUT_TIMEOUT" && timeout="$USER_INPUT_TIMEOUT"
-    local prompt="Proceed with recovery (yes) otherwise manual disk layout configuration is enforced"
+    local prompt="Proceed with '$WORKFLOW' (yes) otherwise manual disk layout configuration is enforced"
     local input_value=""
     local wilful_input=""
     input_value="$( UserInput -I DISK_LAYOUT_PROCEED_RECOVERY -t "$timeout" -p "$prompt" -D 'yes' )" && wilful_input="yes" || wilful_input="no"
     if is_true "$input_value" ; then
-        is_true "$wilful_input" && LogPrint "User confirmed to proceed with recovery" || LogPrint "Proceeding with recovery by default"
+        is_true "$wilful_input" && LogPrint "User confirmed to proceed with '$WORKFLOW'" || LogPrint "Proceeding with '$WORKFLOW' by default"
     else
         # The user enforced MIGRATION_MODE uses the special 'TRUE' value in upper case letters
         # that is needed to overrule the prepare/default/270_overrule_migration_mode.sh script:

--- a/usr/share/rear/layout/prepare/default/250_compare_disks.sh
+++ b/usr/share/rear/layout/prepare/default/250_compare_disks.sh
@@ -116,7 +116,7 @@ if ! is_true "$MIGRATION_MODE" ; then
             Log "Device /sys/block/$dev exists"
             newsize=$( get_disk_size $dev )
             if test "$newsize" -eq "$size" ; then
-                LogPrint "Device $dev has expected (same) size $size (will be used for recovery)"
+                LogPrint "Device $dev has expected (same) size $size (will be used for '$WORKFLOW')"
             else
                 LogPrint "Device $dev has size $newsize but $size is expected (needs manual configuration)"
                 MIGRATION_MODE='true'

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -58,7 +58,7 @@ fi
 EOF
 }
 
-# Generate code to mount a device $1 of type $2 ('repair' workflow).
+# Generate code to mount a device $1 of type $2 ('mountonly' workflow).
 do_mount_device() {
     local device="$1"
     local type="$2"

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -35,7 +35,7 @@ restore_original_file() {
     cp -ar $saved_original_file $filename
 }
 
-# Generate code to restore a device $1 of type $2.
+# Generate code to recreate a device $1 of type $2 and then mount it.
 # Note that we do not handle partitioning here.
 create_device() {
     local device="$1"
@@ -53,6 +53,35 @@ EOF
 component_created "$device" "$type"
 else
     LogPrint "Skipping $device ($type) as it has already been created."
+fi
+
+EOF
+}
+
+# Generate code to mount a device $1 of type $2 ('repair' workflow).
+do_mount_device() {
+    local device="$1"
+    local type="$2"
+    local name # used to extract the actual name of the device
+
+    cat <<EOF >> "$LAYOUT_CODE"
+if create_component "$device" "$type" ; then
+EOF
+    # This can be used a.o. to decrypt a LUKS device
+    echo "# Open $device ($type)" >> "$LAYOUT_CODE"
+    if type -t open_$type >/dev/null ; then
+        open_$type "$device"
+    fi
+
+    # If the device is mountable, it will then be mounted
+    echo "# Mount $device ($type)" >> "$LAYOUT_CODE"
+    if type -t mount_$type >/dev/null ; then
+        mount_$type "$device"
+    fi
+    cat <<EOF >> "$LAYOUT_CODE"
+component_created "$device" "$type"
+else
+    LogPrint "Skipping $device ($type) as it has already been mounted."
 fi
 
 EOF

--- a/usr/share/rear/lib/mountonly-workflow.sh
+++ b/usr/share/rear/lib/mountonly-workflow.sh
@@ -1,19 +1,19 @@
-# recover-workflow.sh
+# mountonly-workflow.sh
 #
-# repair workflow for Relax-and-Recover
+# "mount only" workflow for Relax-and-Recover
 #
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-WORKFLOW_repair_DESCRIPTION="use ReaR as live media to repair the system"
-WORKFLOWS=( ${WORKFLOWS[@]} repair )
-function WORKFLOW_repair () {
-    # Adapt /etc/motd in the ReaR recovery system when 'rear recover' is running
+WORKFLOW_mountonly_DESCRIPTION="use ReaR as live media to mount and repair the system"
+WORKFLOWS=( ${WORKFLOWS[@]} mountonly )
+function WORKFLOW_mountonly () {
+    # Adapt /etc/motd in the ReaR recovery system when 'rear mountonly' is running
     # to avoid the additional 'Run "rear recover" to restore your system !' message
-    # that only makes sense as long as 'rear recover' was not ever started,
+    # that only makes sense as long as 'rear mountonly' was not ever started,
     # see https://github.com/rear/rear/issues/1433
     # but do not (over)-write /etc/motd on the original system
-    # which could happen in simulation mode via 'rear -s recover'
+    # which could happen in simulation mode via 'rear -s mountonly'
     # that simulates sourcing scripts in the Source function
     # but this WORKFLOW_recover function call is not simulated (cf. usr/sbin/rear)
     # see https://github.com/rear/rear/issues/1670
@@ -34,5 +34,6 @@ function WORKFLOW_repair () {
     SourceStage "layout/prep-for-mount"
     SourceStage "layout/do-mount"
 
+    SourceStage "final-mount"
     SourceStage "wrapup"
 }

--- a/usr/share/rear/lib/repair-workflow.sh
+++ b/usr/share/rear/lib/repair-workflow.sh
@@ -1,0 +1,38 @@
+# recover-workflow.sh
+#
+# repair workflow for Relax-and-Recover
+#
+# This file is part of Relax-and-Recover, licensed under the GNU General
+# Public License. Refer to the included COPYING for full text of license.
+
+WORKFLOW_repair_DESCRIPTION="use ReaR as live media to repair the system"
+WORKFLOWS=( ${WORKFLOWS[@]} repair )
+function WORKFLOW_repair () {
+    # Adapt /etc/motd in the ReaR recovery system when 'rear recover' is running
+    # to avoid the additional 'Run "rear recover" to restore your system !' message
+    # that only makes sense as long as 'rear recover' was not ever started,
+    # see https://github.com/rear/rear/issues/1433
+    # but do not (over)-write /etc/motd on the original system
+    # which could happen in simulation mode via 'rear -s recover'
+    # that simulates sourcing scripts in the Source function
+    # but this WORKFLOW_recover function call is not simulated (cf. usr/sbin/rear)
+    # see https://github.com/rear/rear/issues/1670
+    # and do not (over)-write /etc/motd in the recovery system in simulation mode
+    # which results with the above to never (over)-write /etc/motd in simulation mode:
+    if ! is_true "$SIMULATE" ; then
+        # In the recovery system /etc/rear-release is unique (it does not exist otherwise)
+        # cf. init/default/050_check_rear_recover_mode.sh
+        test -f /etc/rear-release -a -w /etc/motd && echo -e '\nWelcome to Relax-and-Recover.\n' >/etc/motd
+    fi
+
+    SourceStage "setup"
+
+    # 'check' stage is a minimal version of 'verify' that ignores all the
+    # backup engines
+    SourceStage "check"
+
+    SourceStage "layout/prep-for-mount"
+    SourceStage "layout/do-mount"
+
+    SourceStage "wrapup"
+}

--- a/usr/share/rear/setup/default/002_clean_start.sh
+++ b/usr/share/rear/setup/default/002_clean_start.sh
@@ -1,0 +1,25 @@
+# Ensure we start from a known-clean initial state.
+# E.g. request reboot before launching another workflow if 'mountonly' has
+# been run already, except in certain cases.
+#
+# This file is part of Relax-and-Recover, licensed under the GNU General
+# Public License. Refer to the included COPYING for full text of license.
+
+# Define our breadcrumb
+BREADCRUMB="$VAR_DIR/last_run_workflow"
+local last_run=""
+
+if test -r "$BREADCRUMB"; then
+    last_run=`cat $BREADCRUMB`
+    case $last_run in
+        mountonly)
+            case $WORKFLOW in
+                restoreonly|finalizeonly)
+                    # allowed sequence
+                    ;;
+                *)
+                    Error "The '$last_run' workflow has already run in this session. Slate no longer clean. Please reboot before calling workflow '$WORKFLOW'!"
+                    ;;
+            esac
+    esac
+fi

--- a/usr/share/rear/verify/GNU/Linux/260_recovery_storage_drivers.sh
+++ b/usr/share/rear/verify/GNU/Linux/260_recovery_storage_drivers.sh
@@ -1,5 +1,8 @@
 # Find the storage drivers for the recovery hardware.
 
+# Skip if not recover WORKFLOW:
+test "recover" = "$WORKFLOW" || return 0
+
 # A longer time ago udev was optional on some distros.
 # This changed and nowadays udev is not optional any more.
 # See https://github.com/rear/rear/pull/1171#issuecomment-274442700

--- a/usr/share/rear/wrapup/default/980_good_bye.sh
+++ b/usr/share/rear/wrapup/default/980_good_bye.sh
@@ -1,4 +1,4 @@
 ### Indicate successful recovery
 ###
 
-Print "Finished recovering your system. You can explore it under '$TARGET_FS_ROOT'."
+Print "Finished '$WORKFLOW'. The target system is mounted at '$TARGET_FS_ROOT'."


### PR DESCRIPTION
* Type: **New Feature**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/2247

* How was this pull request tested?

First a rescue image + backup archive (`mkbackup` workflow) has been created for a VM (openSUSE Leap 15.0). The VM has then been booted off the rescue ISO and the new `repair` workflow executed to make sure that all local filesystems ended up mounted below `/mnt/local` (these included LVM Logical Volumes and a LUKS-encrypted filesystem), as well as the most important virtual ones (sys, proc, dev). I then checked that it was possible to `chroot` inside the system and run YaST. I also verified that once I exited the `chroot` environment and shut down the VM, that process cleanly unmounted all target filesystems.

In a second test, I also verified that I was able to do the same even when no backup archive was present (i.e. having only run the `mkrescue` workflow during the preparation phase).

* Brief description of the changes in this pull request:

The philosophy I followed was to take advantage of the existing `disklayout.conf` (generated during the `rescue` workflow) and to reuse as much as possible of the filesystem recreation mechanism while implementing an alternative version of it that would only mount but not recreate anything (but still based on the same dependency analysis and the auto-generation of an intermediate script).

* More detailed overview of the changes:
    - a new `repair` workflow has been created, described as "use ReaR as live 
      media to repair the system" in the online help message
    
    - the `repair` workflow is composed of the following stages: `setup`, 
      `check`, `layout/prep-for-mount`, `layout/do-mount` and `wrapup` 
      (`setup` and `wrapup` are reused as they are -- the other three stages
      are new)
    
    - `layout/prep-for-mount` is mostly a clone of `layout/prepare` (through
      symlinks), but with a few files of its own (`540_generate_device_code.sh`,
      `550_finalize_script.sh` and `600_show_unprocessed.sh`), modified versions
      of the original ones
    
    - `layout/do-mount` is a clone of `layout/recreate` (through symlinks), but
      with only three action scripts kept (`100_confirm_layout_code.sh`, 
      `200_run_layout_code.sh` and `250_verify_mount.sh` -- no local 
      modification as of yet)
    
    - `check` is a minimalist clone of `verify` (through symlinks) that ignores
      all the supported backup engines. This also makes it possible for the
      `repair` workflow to be used even when no backup is available

    - in `layout/prepare/GNU/Linux/160_include_luks_code.sh` (sourced through
      its symlink `layout/prep-for-mount/GNU/Linux/160_include_luks_code.sh`),
      I've added a new function `open_crypt()` (cloned from `create_crypt()`)
      that only performs the `cryptsetup luksOpen` operation
    
    - in `lib/layout-functions.sh`, a new function `do_mount_device()`
      (cloned from `create_device()`) deals with opening (as in the case of
      LUKS-encrypted filesystems) and then mounting the filesystems. To do 
      this, it may call the new function `open_crypt()` or existing `mount_*()`
      functions
    
    - a new action script `540_generate_device_code.sh`, specific to the 
      `prep-for-mount` stage (cloned from the one that comes with the 
      `prepare` stage) will process the disk layout and generate a custom 
      script (still called `diskrestore.sh`) to perform the actual mount of
      all the needed filesystems (including the virtual ones -- that part is 
      currently hardcoded). That script will be called later by 
      `layout/do-mount/default/200_run_layout_code.sh`
    
    - a new example scenario has been added to chapter 4 of the User Guide,
      describing how to use the new `repair` workflow and why you would 
      want to do so
    
**Still TBD:** once the `repair` workflow has been run, disable call to `rear recover` without rebooting first to make sure we always start from a known state, as suggested by @schlomo  (in an email dated March 14, 2019).

