### PR TITLE
Update 650_check_iso_recoverable.sh

### DIFF
--- a/usr/share/rear/layout/save/NSR/default/650_check_iso_recoverable.sh
+++ b/usr/share/rear/layout/save/NSR/default/650_check_iso_recoverable.sh
@@ -5,7 +5,6 @@ if is_true "$NSR_CLIENT_MODE"; then
     return
 fi
     
-NSRSERVER=$(cat $VAR_DIR/recovery/nsr_server )
 CLIENTNAME=$(hostname)
 
 OBJECTS=$( nsrinfo -s ${NSRSERVER} -N ${ISO_DIR}/${ISO_PREFIX}.iso ${CLIENTNAME} | \


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2162

* How was this pull request tested?
see https://github.com/rear/rear/issues/2162#issuecomment-541343374

* Brief description of the changes in this pull request:
Removed the (unnecessary) line in the code of `650_check_iso_recoverable.sh` which prevents manually setting the NSRSERVER variable in i.e. local.conf
