### PR TITLE
Enable copr builds for packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,8 +1,16 @@
+downstream_package_name: rear
+jobs:
+- job: copr_build
+  metadata:
+    targets:
+    - fedora-29-x86_64
+    - fedora-30-x86_64
+    - fedora-31-x86_64
+    - fedora-rawhide-x86_64
+  trigger: pull_request
 specfile_path: packaging/rpm/rear.spec
 synced_files:
-  - .packit.yaml
-  - src: packaging/rpm/rear.spec
-    dest: rear.spec
+- .packit.yaml
+- dest: rear.spec
+  src: packaging/rpm/rear.spec
 upstream_project_name: rear
-downstream_package_name: rear
-


### PR DESCRIPTION
We enabled copr builds in the packit config for you.

After merging this PR, you are just a few steps away from RPM builds being automatically triggered on your PR's.
It means, that you'll be able to try and play with your change, packaged as an RPM.

What are the next steps?
* Install [Packit-as-a-Service github application](https://github.com/marketplace/packit-as-a-service) in your repo
* In case you are first user, wait for account approval
* Enjoy the built RPMs!

For more info, please:
 * check out the documentation: https://packit.dev/docs/
 * contact [@packit-service/the-packit-team](https://github.com/orgs/packit-service/teams/the-packit-team)