### PR TITLE
Currently, ReaR is using hard-coded set of Grub2 modules for UEFI

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2680,10 +2680,16 @@ test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
 ##
 # GRUB2_MODULES
 #
+# WARNING: Incorrect use of this variable can lead to unusable ReaR recovery system!
+#          Whenever you modify this variable, test of ReaR recovery system is advised!
+#
 # List of modules that will be included into Grub2 based UEFI boot loader.
-GRUB2_MODULES="part_gpt part_msdos fat ext2 normal chain boot configfile linux \
-linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video \
-gzio efi_gop reboot search test echo btrfs lvm"
+# When empty ReaR will fall-back to reasonable set of default modules.
+# This variable currently applies when building Grub2 boot loader for UEFI in two scenarios:
+# 1. UEFI boot without secure boot (SECURE_BOOT_BOOTLOADER="")
+# and / or
+# 2. UEFI boot with GRUB_RESCUE="y"
+GRUB2_MODULES=""
 
 ##
 # USING_UEFI_BOOTLOADER

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1509,8 +1509,8 @@ LUKS_CRYPTSETUP_OPTIONS="--iter-time 2000 --use-random"
 ##
 # BACKUP=CDM (Rubrik CDM; Cloud Data Managemnt)
 ##
-# ReaR support for Rubrik Cloud Data Managment (CDM). 
-# ReaR will copy the Rubrk RBS agent and required OS binaries to its ISO for incluson on boot. 
+# ReaR support for Rubrik Cloud Data Managment (CDM).
+# ReaR will copy the Rubrk RBS agent and required OS binaries to its ISO for incluson on boot.
 # ReaR will start the Rubrik RBS agent when 'rear recover' is run.
 COPY_AS_IS_CDM=( /etc/rubrik /usr/bin/rubrik /var/log/rubrik /etc/pki /usr/lib64 )
 COPY_AS_IS_EXCLUDE_CDM=( /var/log/rubrik/* )
@@ -2676,6 +2676,14 @@ BOOTLOADER=""
 #   export GRUB2_INSTALL_DEVICES="/dev/sdb"
 # to the right device directly before he calls "rear recover":
 test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
+
+##
+# GRUB2_MODULES
+#
+# List of modules that will be included into Grub2 based UEFI boot loader.
+GRUB2_MODULES="part_gpt part_msdos fat ext2 normal chain boot configfile linux \
+linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video \
+gzio efi_gop reboot search test echo btrfs lvm"
 
 ##
 # USING_UEFI_BOOTLOADER

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -78,7 +78,7 @@ test echo btrfs lvm"
         test "$( find /usr/lib/grub*/x86_64-efi -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
     done
     if ! $gmkimage $v -O x86_64-efi $embedded_config -o $outfile -p "/EFI/BOOT" $grub_modules ; then
-        Error "Failed to make bootable EFI image of GRUB2 (error during $gmkimage of BOOTX64.efi)"
+        Error "Failed to make bootable EFI image of GRUB2 (error during $gmkimage of $outfile)"
     fi
 }
 

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -59,7 +59,7 @@ function build_bootx86_efi {
     # As not all Linux distros have the same GRUB2 modules present we verify what we have (see also https://github.com/rear/rear/pull/2001)
     local grub_module=""
     local grub_modules=""
-    for grub_module in part_gpt part_msdos fat ext2 normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs ; do
+    for grub_module in $GRUB2_MODULES ; do
         test "$( find /usr/lib/grub*/x86_64-efi -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
     done
     if ! $gmkimage $v -O x86_64-efi -c $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg -o $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi -p "/EFI/BOOT" $grub_modules ; then

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -76,7 +76,7 @@ fi
 # See issue #1374
 # build_bootx86_efi () can be safely used for other scenarios.
 if ! test -f "$SECURE_BOOT_BOOTLOADER" ; then
-    build_bootx86_efi
+    build_bootx86_efi $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg
 fi
 
 # We will be using grub-efi or grub2 (with efi capabilities) to boot from ISO.

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -147,10 +147,6 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     # probably a bug, as I was able to boot with value set to root=anything
     root_uuid=$(get_root_disk_UUID)
 
-    # Grub2 modules that will be used for booting "Relax-and-Recover"
-    # It might be useful to make this variable global in the future
-    grub2_modules="linux echo all_video part_gpt ext2 btrfs search configfile"
-
     # Create configuration file for "Relax-and-Recover" UEFI boot entry.
     # This file will not interact with existing Grub2 configuration in any way.
     (   echo "menuentry '$grub_rear_menu_entry_name' --class os {"
@@ -172,9 +168,7 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     ) > $grub_config_dir/rear_embed.cfg
 
     # Create rear.efi at UEFI default boot directory location.
-    if ! grub${grub_num}-mkimage -o $boot_dir/efi/EFI/BOOT/rear.efi -O x86_64-efi -c $grub_config_dir/rear_embed.cfg -p /EFI/BOOT $grub2_modules ; then
-        Error "Could not create UEFI boot image"
-    fi
+    build_bootx86_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear_embed.cfg
 
     # If UEFI boot entry for "Relax-and-Recover" does not exist, create it.
     # This will also add "Relax-and-Recover" to boot order because if UEFI entry is not listed in BootOrder,


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): N/A

* How was this pull request tested?
Full backup && restore

* Brief description of the changes in this pull request:
Currently, ReaR is using hard-coded set of Grub2 modules for UEFI
boot-loader. This patch introduces global GRUB2_MODULES variable, so
that user can add or remove modules according his needs.

**Rationale:**
If one uses  `GRUB_RESCUE=y` in `UEFI mode` (yet another nice combination :-)), _rear.efi_ will be created with [different set of modules](https://github.com/rear/rear/blob/4e2a1819d54e0e1a9800a9405907c17253cec7f2/usr/share/rear/output/default/940_grub2_rescue.sh#L152) compared to _BOOTX64.efi_.

It is not so important for user to have possibility to add/remove Grub2 modules to _BOOTX64.efi_ because _BOOTX64.efi_ serves mainly for ReaR recovery system and doesn't need to be changed that much. _rear.efi_ on the other hand might need some modification from time-to-time.

In my particular example, I was not able to boot _rear.efi_ because I was using BTRFS on LVM (don't ask me why, I know it is nasty ;-)), and _rear.efi_ was not able to boot because `lvm` module was missing. For this reason I think there should be possibility to configure what modules should be included into *.efi boot-loaders.

I'd like to use this PR as corner stone for my future PR that will unify way how_rear.efi_ and _BOOTX64.efi_ are created and what modules are they using.

V.