### PR TITLE
Added support for CentOS 7.7 and 8.0 for Rubrik-CDM

### DIFF
--- a/doc/user-guide/16-Rubrik-CDM.adoc
+++ b/doc/user-guide/16-Rubrik-CDM.adoc
@@ -64,6 +64,17 @@ Bare Metal Recovery is performed by first restoring the ReaR ISO file from Rubri
 * Recovery from a replica CDM cluster is only supported with CDM v4.2.1 and higher.
 * Care must be taken with SUSE systems on DHCP. They tend to request the same IP as the original host. If this is not the desired behavior the system will have to be adjusted after booting from the ReaR ISO.  
 * If multiple restores are performed using the same temporary IP, the temporary IP must first be deleted from Servers & Apps -> Linux and Unix Servers and re-added upon each reuse.
+* ReaR's `ldd` check of other binaries or libraries may result in libraries not being found. This can generally be fixed by adding the path to those libraries to the `LD_LIBRARY_PATH` variable in `/etc/rear/local.conf`. Do this by adding the following line in `/etc/rear/local.conf`:
++
+  export LD_LIBRARY_PATH-"$LD_LIBRARY_PATH:<path>"
++
+To make CentoOS v7.7 work the following line was needed:
++
+  export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib64/bind9-export"
++
+To make CentOS v8.0 work the following line was needed:
++
+  export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib64/bind9-export:/usr/lib64/eog:/usr/lib64/python3.6/site-packages:/usr/lib64/samba:/usr/lib64/firefox"
 
 == Troubleshooting
 
@@ -78,6 +89,8 @@ Bare Metal Recovery is performed by first restoring the ReaR ISO file from Rubri
 Operating System,DHCP,Static IP,Virtual,Physical,LVM Root Disk,Plain Root Disk,EXT3,EXT4,XFS,BTRFS,Original Cluster,Replication Cluster
 CentOS 7.3,,pass,Pass,,Pass,,,,Pass,,Pass,
 CentOS 7.6,Pass,,Pass,,Pass,,,,Pass,,Pass,
+CentOS 7.7,Pass,,Pass,Pass,Pass,,,,Pass,,Pass,
+CentOS 8.0,Pass,,Pass,,Pass,,,,Pass,,Pass,
 CentOS 5.11,,,,,,,,,,,,
 CentOS 6.10,,,,,,,,,,,,
 RHEL 7.6,Pass,,Pass,,Pass,,,,,,,


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
#2266 

* How was this pull request tested?
Ran `rear mkrecover` and `rear recover` on CentOS 7.7 and 8.0 virtual systems. Errors from missing libraries were not displayed and system recovery was successful.

* Brief description of the changes in this pull request:

Added instructions for using `LD_LIBRARY_PATH` in `/etc/rear/local.conf` to capture point to libraries not being found by `ldd`. 