### PR TITLE
Error out in case of insufficient LVM tools (issue 2259)

### DIFF
--- a/doc/user-guide/06-layout-configuration.adoc
+++ b/doc/user-guide/06-layout-configuration.adoc
@@ -615,17 +615,17 @@ multipath /dev/<name> <size(B)> <partition label> <slave1,slave2,...>
 
 === Physical Volumes ===
 ----------------------------------
-lvmdev /dev/<volume group name> <device> <UUID> [<size(K)>]
+lvmdev /dev/<volume_group> <device> [<uuid>] [<size(bytes)>]
 ----------------------------------
 
 === Volume Groups ===
 ----------------------------------
-lvmgrp /dev/<volume group name> <extent size(B)> [<number of extents>] [<size(K)>]
+lvmgrp <volume_group> <extentsize> [<size(extents)>] [<size(bytes)>]
 ----------------------------------
 
 === Logical Volumes ===
 ----------------------------------
-lvmvol /dev/<volume group name> <logical volume name> <number of extents> [<size(K)>]
+lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]
 ----------------------------------
 
 === LUKS Devices ===

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -11,7 +11,6 @@ has_binary lvm || return 0
 
 Log "Begin saving LVM layout ..."
 
-local disklayout_filename=$( basename $DISKLAYOUT_FILE )
 local header_printed
 local pdev vgrp size uuid pvdisplay_exit_code
 local extentsize nrextents vgdisplay_exit_code
@@ -116,7 +115,7 @@ local lvs_exit_code
         # The variables are not quoted because plain 'test' without argument results non-zero exit code
         # and 'test foo bar' fails with "bash: test: foo: unary operator expected"
         # so that this also checks that the variables do not contain blanks or more than one word
-        # because blanks (actually $IFS charactesr) are used as field separators in disklayout.conf
+        # because blanks (actually $IFS characters) are used as field separators in disklayout.conf
         # which means the positional parameter values must be exactly one non-empty word.
         # Two separated simple 'test $vgrp && test $pdev' commands are used here because
         # 'test $vgrp -a $pdev' does not work when $vgrp is empty or only blanks
@@ -124,7 +123,7 @@ local lvs_exit_code
         # so that when $vgrp is empty 'test $vgrp -a $pdev' tests if file $pdev exists
         # which is usually true because $pdev is usually a partition device node (e.g. /dev/sda1)
         # so that when $vgrp is empty 'test $vgrp -a $pdev' would falsely succeed:
-        test $vgrp && test $pdev || Error "LVM 'lvmdev' entry in $disklayout_filename where volume_group or device is empty"
+        test $vgrp && test $pdev || Error "LVM 'lvmdev' entry in $DISKLAYOUT_FILE where volume_group or device is empty or more than one word"
 
     done
     # Check the exit code of "lvm pvdisplay -c"
@@ -164,7 +163,7 @@ local lvs_exit_code
 
         # Check that the required positional parameters in the 'lvmgrp' line are non-empty
         # cf. the code above to "check that the required positional parameters in the 'lvmdev' line are non-empty":
-        test $vgrp && test $extentsize || Error "LVM 'lvmgrp' entry in $disklayout_filename where volume_group or extentsize is empty"
+        test $vgrp && test $extentsize || Error "LVM 'lvmgrp' entry in $DISKLAYOUT_FILE where volume_group or extentsize is empty or more than one word"
 
     done
     # Check the exit code of "lvm vgdisplay -c"
@@ -307,7 +306,7 @@ local lvs_exit_code
             already_processed_lvs+=( "$vg/$lv" )
             # Check that the required positional parameters in the 'lvmvol' line are non-empty
             # cf. the code above to "check that the required positional parameters in the 'lvmdev' line are non-empty":
-            test $vg && test $lv && test $size && test $layout || Error "LVM 'lvmvol' entry in $disklayout_filename where volume_group or name or size or layout is empty"
+            test $vg && test $lv && test $size && test $layout || Error "LVM 'lvmvol' entry in $DISKLAYOUT_FILE where volume_group or name or size or layout is empty or more than one word"
         fi
 
     done

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -29,24 +29,28 @@ local lvs_exit_code
 # The reason is that in case of process substitution COMMAND seems to be run "very asynchronously"
 # where it seems it it not possible (in a simple and clean way) to get the exit status of COMMAND.
 # At least not with bash version 3.2.57 on SLES11-SP4 and not with bash version 4.3.42 on SLES12-SP4
-# where I <jsmeix@suse.de> get with both bash versions the same "always fail" result
-#   # while read line ; do echo $line ; done < <( pstree -Aplau $$ ) ; wait $! && echo OK || echo FAIL
+# where I <jsmeix@suse.de> get with both bash versions the same "always failed with exit status 127" result
+#   # while read line ; do echo $line ; done < <( pstree -Aplau $$ ) ; wait $! && echo OK || echo FAILED with $?
 #   bash,885
 #   `-bash,5627
 #   `-pstree,5628 -Aplau 885
 #   -bash: wait: pid 5627 is not a child of this shell
-#   FAIL
-# which looks like a bug in bash at least up to version 4.3.42 because
-# pstree reports pid 5627 as a child of pid 885 in contrast to what bash reports.
-# It seems that works with bash version 4.4.23 on openSUSE Leap 15.0
-#   # while read line ; do echo $line ; done < <( pstree -Aplau $$ ) ; wait $! && echo OK || echo FAIL
+#   FAILED with 127
+#   # while read line ; do echo $line ; done < <( echo | grep -Q foo ) ; wait $! && echo OK || echo FAILED with $?
+#   grep: invalid option -- 'Q'
+#   -bash: wait: pid 6030 is not a child of this shell
+#   FAILED with 127
+# which looks like a bug in bash at least up to version 4.3.42 because I think
+# pstree correctly reports pid 5627 as a child of pid 885 in contrast to what bash reports.
+# It seems that works with bash version 4.4.23 on openSUSE Leap 15.0 where I get
+#   # while read line ; do echo $line ; done < <( pstree -Aplau $$ ) ; wait $! && echo OK || echo FAILED with $?
 #   bash,5821
 #   `-bash,14287
 #   `-pstree,14288 -Aplau 5821
 #   OK
-#   # while read line ; do echo $line ; done < <( cat qqq ) ; wait $! && echo OK || echo FAIL
-#   cat: qqq: No such file or directory
-#   FAIL
+#   # while read line ; do echo $line ; done < <( echo | grep -Q foo ) ; wait $! && echo OK || echo FAILED with $?
+#   grep: invalid option -- 'Q'
+#   FAILED with 2
 # Because ReaR must work with bash version 3.x we cannot use 'wait $!' to get
 # the exit status of a COMMAND that is run asynchronously via process substitution.
 # In contrast for a pipe ${PIPESTATUS[0]} provides the exit status of its first command


### PR DESCRIPTION
* Type: **Minor Bug Fix** / **Enhancement**

* Impact: **Low** / **High**
Normally (i.e. on SLES and RHEL) nothing should be noticed
but when there are insufficient LVM tools used
(as in https://github.com/rear/rear/issues/2259)
the impact is high because without the check the error is unnoticed
so that things fail when it is too late during "rear recover".

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2259

* How was this pull request tested?
Works for me on SLES12-SP4 with its default LVM(+btrfs) setup.
My disklayout.conf is identical compared to before the changes here.

* Brief description of the changes in this pull request:

According to
https://github.com/rear/rear/issues/2259#issuecomment-557019729
there is now a check before the longer `lvs` calls
to ensure all needed lvs fields are actually supported
and if not it errors out now during "rear mkrescue/mkbackup".

By the way I also removed the strange looking `8>&- 7>&-` cf.
https://github.com/rear/rear/issues/2259#issuecomment-544999137
