### PR TITLE
Use grub-mkstandalone instead of grub-mkimage for UEFI

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2709,7 +2709,8 @@ test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
 # List of modules that will be included into Grub2 based UEFI boot loader.
 # When empty ReaR will use the defaults of grub-mkstandalone
 # (install all modules in the standalone image ramdisk and load
-# a reasonable set of default modules).
+# a reasonable set of default modules), and add modules needed to access /boot
+# and /boot/efi, if applicable.
 # This variable currently applies when building Grub2 boot loader for UEFI in two scenarios:
 # 1. UEFI boot without secure boot (SECURE_BOOT_BOOTLOADER="")
 # and / or

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2701,20 +2701,35 @@ BOOTLOADER=""
 test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
 
 ##
+# GRUB2_MODULES_LOAD
+#
+# WARNING: Incorrect use of this variable can lead to unusable ReaR recovery system!
+#          Whenever you modify this variable, test of ReaR recovery system is advised!
+#
+# List of modules that will be included into Grub2 based UEFI boot loader (the core image).
+# When empty ReaR will use the defaults of grub-mkstandalone
+# (a reasonable set of default modules), and add modules needed to access /boot
+# and /boot/efi, if applicable.
+# More modules can be installed into the Grub2 standalone image ramdisk without
+# being included in the core image, see GRUB2_MODULES.
+# This variable currently applies when building Grub2 boot loader for UEFI in two scenarios:
+# 1. UEFI boot without secure boot (SECURE_BOOT_BOOTLOADER="")
+# and / or
+# 2. UEFI boot with GRUB_RESCUE="y"
+GRUB2_MODULES_LOAD=()
+
+##
 # GRUB2_MODULES
 #
 # WARNING: Incorrect use of this variable can lead to unusable ReaR recovery system!
 #          Whenever you modify this variable, test of ReaR recovery system is advised!
 #
-# List of modules that will be included into Grub2 based UEFI boot loader.
+# List of modules that will be installed into Grub2 based UEFI boot loader ramdisk.
+# Those will not be preloaded in the core image, but will be available for autoloading
+# or manual loading via insmod.
 # When empty ReaR will use the defaults of grub-mkstandalone
-# (install all modules in the standalone image ramdisk and load
-# a reasonable set of default modules), and add modules needed to access /boot
-# and /boot/efi, if applicable.
-# This variable currently applies when building Grub2 boot loader for UEFI in two scenarios:
-# 1. UEFI boot without secure boot (SECURE_BOOT_BOOTLOADER="")
-# and / or
-# 2. UEFI boot with GRUB_RESCUE="y"
+# (install all modules in the standalone image ramdisk)
+# This variable currently applies in the same scenarios as GRUB2_MODULES_LOAD.
 GRUB2_MODULES=()
 
 ##

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2707,12 +2707,14 @@ test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
 #          Whenever you modify this variable, test of ReaR recovery system is advised!
 #
 # List of modules that will be included into Grub2 based UEFI boot loader.
-# When empty ReaR will fall-back to reasonable set of default modules.
+# When empty ReaR will use the defaults of grub-mkstandalone
+# (install all modules in the standalone image ramdisk and load
+# a reasonable set of default modules).
 # This variable currently applies when building Grub2 boot loader for UEFI in two scenarios:
 # 1. UEFI boot without secure boot (SECURE_BOOT_BOOTLOADER="")
 # and / or
 # 2. UEFI boot with GRUB_RESCUE="y"
-GRUB2_MODULES=""
+GRUB2_MODULES=()
 
 ##
 # USING_UEFI_BOOTLOADER

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -39,21 +39,24 @@ function trim {
 function build_bootx86_efi {
     local outfile="$1"
     local embedded_config=""
-    local gmkimage=""
+    local gmkstandalone=""
+    # modules is the list of modules to load
+    # If GRUB2_MODULES is nonempty, it determines both what modules to install and to load
+    local modules=( ${GRUB2_MODULES:+"${GRUB2_MODULES[@]}"} )
 
     # Configuration file is optional for image creation.
-    [[ -n "$2" ]] && embedded_config="--config $2"
+    [[ -n "$2" ]] && embedded_config="/boot/grub/grub.cfg=$2"
 
-    if has_binary grub-mkimage ; then
-        gmkimage=grub-mkimage
-    elif has_binary grub2-mkimage ; then
+    if has_binary grub-mkstandalone ; then
+        gmkstandalone=grub-mkstandalone
+    elif has_binary grub2-mkstandalone ; then
         # At least SUSE systems use 'grub2' prefixed names for GRUB2 programs:
-        gmkimage=grub2-mkimage
+        gmkstandalone=grub2-mkstandalone
     else
         # This build_bootx86_efi function is only called in output/ISO/Linux-i386/250_populate_efibootimg.sh
         # which runs only if UEFI is used so that we simply error out here if we cannot make a bootable EFI image of GRUB2
         # (normally a function should not exit out but return to its caller with a non-zero return code):
-        Error "Cannot make bootable EFI image of GRUB2 (neither grub-mkimage nor grub2-mkimage found)"
+        Error "Cannot make bootable EFI image of GRUB2 (neither grub-mkstandalone nor grub2-mkstandalone found)"
     fi
     # grub-mkimage needs /usr/lib/grub/x86_64-efi/moddep.lst (cf. https://github.com/rear/rear/issues/1193)
     # and at least on SUSE systems grub2-mkimage needs /usr/lib/grub2/x86_64-efi/moddep.lst (in 'grub2' directory)
@@ -61,24 +64,9 @@ function build_bootx86_efi {
     # Careful: usr/sbin/rear sets nullglob so that /usr/lib/grub*/x86_64-efi/moddep.lst gets empty if nothing matches
     # and 'test -f' succeeds with empty argument so that we cannot use 'test -f /usr/lib/grub*/x86_64-efi/moddep.lst'
     # also 'test -n' succeeds with empty argument but (fortunately/intentionally?) plain 'test' fails with empty argument:
-    test /usr/lib/grub*/x86_64-efi/moddep.lst || Error "$gmkimage would not make bootable EFI image of GRUB2 (no /usr/lib/grub*/x86_64-efi/moddep.lst file)"
-    # As not all Linux distros have the same GRUB2 modules present we verify what we have (see also https://github.com/rear/rear/pull/2001)
-    local grub_module=""
-    local grub_modules=""
-
-    # Use a reasonable fallback value, cf. https://github.com/rear/rear/pull/2283
-    test "$GRUB2_MODULES" || GRUB2_MODULES="part_gpt part_msdos fat ext2 \
-normal chain boot configfile linux linuxefi multiboot jfs iso9660 usb \
-usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search \
-test echo btrfs lvm"
-
-    LogPrint "Using '$GRUB2_MODULES' modules to build $outfile"
-
-    for grub_module in $GRUB2_MODULES ; do
-        test "$( find /usr/lib/grub*/x86_64-efi -type f -name "$grub_module.mod" 2>/dev/null )" && grub_modules="$grub_modules $grub_module"
-    done
-    if ! $gmkimage $v -O x86_64-efi $embedded_config -o $outfile -p "/EFI/BOOT" $grub_modules ; then
-        Error "Failed to make bootable EFI image of GRUB2 (error during $gmkimage of $outfile)"
+    test /usr/lib/grub*/x86_64-efi/moddep.lst || Error "$gmkstandalone would not make bootable EFI image of GRUB2 (no /usr/lib/grub*/x86_64-efi/moddep.lst file)"
+    if ! $gmkstandalone $v ${GRUB2_MODULES:+"--install-modules=${GRUB2_MODULES[*]}"} ${modules:+"--modules=${modules[*]}"} -O x86_64-efi -o $outfile $embedded_config ; then
+        Error "Failed to make bootable EFI image of GRUB2 (error during $gmkstandalone of $outfile)"
     fi
 }
 

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -94,7 +94,6 @@ function build_bootx86_efi {
                              $gprobe --target=abstraction "$p"
                          done | sort -u ) )
         fi
-        Log "GRUB2 modules to load: ${modules:+${modules[*]}}"
     fi
 
     # grub-mkimage needs /usr/lib/grub/x86_64-efi/moddep.lst (cf. https://github.com/rear/rear/issues/1193)
@@ -104,6 +103,10 @@ function build_bootx86_efi {
     # and 'test -f' succeeds with empty argument so that we cannot use 'test -f /usr/lib/grub*/x86_64-efi/moddep.lst'
     # also 'test -n' succeeds with empty argument but (fortunately/intentionally?) plain 'test' fails with empty argument:
     test /usr/lib/grub*/x86_64-efi/moddep.lst || Error "$gmkstandalone would not make bootable EFI image of GRUB2 (no /usr/lib/grub*/x86_64-efi/moddep.lst file)"
+
+    (( ${#GRUB2_MODULES[@]} )) && LogPrint "Installing only ${GRUB2_MODULES[*]} modules into $outfile memdisk"
+    (( ${#modules[@]} )) && LogPrint "GRUB2 modules to load: ${modules[*]}"
+
     if ! $gmkstandalone $v ${GRUB2_MODULES:+"--install-modules=${GRUB2_MODULES[*]}"} ${modules:+"--modules=${modules[*]}"} -O x86_64-efi -o $outfile $embedded_config ; then
         Error "Failed to make bootable EFI image of GRUB2 (error during $gmkstandalone of $outfile)"
     fi

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -43,8 +43,8 @@ function build_bootx86_efi {
     local gprobe=""
     local dirs=()
     # modules is the list of modules to load
-    # If GRUB2_MODULES is nonempty, it determines both what modules to install and to load
-    local modules=( ${GRUB2_MODULES:+"${GRUB2_MODULES[@]}"} )
+    # If GRUB2_MODULES_LOAD is nonempty, it determines what modules to load
+    local modules=( ${GRUB2_MODULES_LOAD:+"${GRUB2_MODULES_LOAD[@]}"} )
 
     # Configuration file is optional for image creation.
     shift
@@ -69,7 +69,7 @@ function build_bootx86_efi {
     fi
 
     # Determine what modules need to be loaded in order to access given directories
-    # (if the list of modules is not overriden by GRUB2_MODULES)
+    # (if the list of modules is not overriden by GRUB2_MODULES_LOAD)
     if (( ${#dirs[@]} )) && ! (( ${#modules[@]} )) ; then
         if has_binary grub-probe ; then
             gprobe=grub-probe

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -61,11 +61,6 @@ title Relax-and-Recover (no Secure Boot)
 
 EOF
 else
-    # create small embedded grub.cfg file for grub-mkimage
-    cat > $efi_boot_tmp_dir/embedded_grub.cfg <<EOF
-set prefix=(cd0)/EFI/BOOT
-configfile /EFI/BOOT/grub.cfg
-EOF
     # create a grub.cfg
     create_grub2_cfg > $efi_boot_tmp_dir/grub.cfg
 fi
@@ -76,7 +71,7 @@ fi
 # See issue #1374
 # build_bootx86_efi () can be safely used for other scenarios.
 if ! test -f "$SECURE_BOOT_BOOTLOADER" ; then
-    build_bootx86_efi $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi $TMP_DIR/mnt/EFI/BOOT/embedded_grub.cfg
+    build_bootx86_efi $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi $efi_boot_tmp_dir/grub.cfg
 fi
 
 # We will be using grub-efi or grub2 (with efi capabilities) to boot from ISO.

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -72,7 +72,7 @@ fi
 # See issue #1374
 # build_bootx86_efi () can be safely used for other scenarios.
 if ! test -f "$SECURE_BOOT_BOOTLOADER" ; then
-    build_bootx86_efi $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi $efi_boot_tmp_dir/grub.cfg
+    build_bootx86_efi $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi $efi_boot_tmp_dir/grub.cfg "$boot_dir" "$UEFI_BOOTLOADER"
 fi
 
 # We will be using grub-efi or grub2 (with efi capabilities) to boot from ISO.

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -7,6 +7,7 @@ is_true $USING_UEFI_BOOTLOADER || return 0
 # There much of Grub/Elilo code here exclude it in menaningfull way.
 is_true $EFI_STUB && return 0
 
+local boot_dir="/boot"
 local efi_boot_tmp_dir="$TMP_DIR/mnt/EFI/BOOT"
 mkdir $v -p $efi_boot_tmp_dir || Error "Could not create $efi_boot_tmp_dir"
 mkdir $v -p $efi_boot_tmp_dir/fonts || Error "Could not create $efi_boot_tmp_dir/fonts"
@@ -77,9 +78,9 @@ fi
 # We will be using grub-efi or grub2 (with efi capabilities) to boot from ISO.
 # Because usr/sbin/rear sets 'shopt -s nullglob' the 'echo -n' command
 # outputs nothing if nothing matches the bash globbing pattern '/boot/grub*'
-local grubdir="$( echo -n /boot/grub* )"
+local grubdir="$( echo -n ${boot_dir}/grub* )"
 # Use '/boot/grub' as fallback if nothing matches '/boot/grub*'
-test -d "$grubdir" || grubdir='/boot/grub'
+test -d "$grubdir" || grubdir="${boot_dir}/grub"
 
 local font_files_dir=""
 local grub_font_files="no_fonts"

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -150,6 +150,13 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     # Create configuration file for "Relax-and-Recover" UEFI boot entry.
     # This file will not interact with existing Grub2 configuration in any way.
     (   echo "set btrfs_relative_path=y"
+        echo "insmod efi_gop"
+        echo "insmod efi_uga"
+        echo "insmod video_bochs"
+        echo "insmod video_cirrus"
+        echo "insmod all_video"
+        echo ""
+        echo "set gfxpayload=keep"
         echo ""
         echo "menuentry '$grub_rear_menu_entry_name' --class os {"
         echo "          search --no-floppy --fs-uuid --set=root $grub_boot_uuid"

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -161,7 +161,7 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     ) > $grub_config_dir/rear.cfg
 
     # Create rear.efi at UEFI default boot directory location.
-    build_bootx86_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear.cfg "$boot_dir" /boot/efi
+    build_bootx86_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear.cfg "$boot_dir" "$UEFI_BOOTLOADER"
 
     # If UEFI boot entry for "Relax-and-Recover" does not exist, create it.
     # This will also add "Relax-and-Recover" to boot order because if UEFI entry is not listed in BootOrder,

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -161,7 +161,7 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     ) > $grub_config_dir/rear.cfg
 
     # Create rear.efi at UEFI default boot directory location.
-    build_bootx86_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear.cfg
+    build_bootx86_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear.cfg "$boot_dir" /boot/efi
 
     # If UEFI boot entry for "Relax-and-Recover" does not exist, create it.
     # This will also add "Relax-and-Recover" to boot order because if UEFI entry is not listed in BootOrder,

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -149,7 +149,9 @@ if is_true $USING_UEFI_BOOTLOADER ; then
 
     # Create configuration file for "Relax-and-Recover" UEFI boot entry.
     # This file will not interact with existing Grub2 configuration in any way.
-    (   echo "menuentry '$grub_rear_menu_entry_name' --class os {"
+    (   echo "set btrfs_relative_path=y"
+        echo ""
+        echo "menuentry '$grub_rear_menu_entry_name' --class os {"
         echo "          search --no-floppy --fs-uuid --set=root $grub_boot_uuid"
         echo "          echo 'Loading kernel $boot_kernel_file ...'"
         echo "          linux $grub_boot_dir/$boot_kernel_name root=UUID=$root_uuid $KERNEL_CMDLINE"
@@ -158,17 +160,8 @@ if is_true $USING_UEFI_BOOTLOADER ; then
         echo "}"
     ) > $grub_config_dir/rear.cfg
 
-    # Tell rear.efi which configuration file to load
-    (   echo "search --no-floppy --fs-uuid --set=root $grub_boot_uuid"
-        echo ""
-        echo "set btrfs_relative_path=y"
-        echo "set prefix=(\$root)${grub_boot_dir}/grub${grub_num}"
-        echo ""
-        echo "configfile (\$root)${grub_boot_dir}/grub${grub_num}/rear.cfg"
-    ) > $grub_config_dir/rear_embed.cfg
-
     # Create rear.efi at UEFI default boot directory location.
-    build_bootx86_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear_embed.cfg
+    build_bootx86_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear.cfg
 
     # If UEFI boot entry for "Relax-and-Recover" does not exist, create it.
     # This will also add "Relax-and-Recover" to boot order because if UEFI entry is not listed in BootOrder,


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix** / **Cleanup**

* Impact: **Normal**

* Reference to related issue (URL):
#2199 #2283  #2001 https://github.com/rear/rear/issues/1996#issuecomment-445201012 
* How was this pull request tested?
the two cases that use the code touched by this PR:
  - creating a rescue ISO on a RHEL 8.1 UEFI system and booting it
  - creating a rescue system using GRUB_RESCUE and booting it using the EFI boot menu
  - repeating both with GRUB2_MODULES=(part_gpt part_msdos fat ext2 normal chain boot configfile linux jfs iso9660 usb usbms usb_keyboard video udf ntfs all_video gzio efi_gop reboot search test echo btrfs lvm)
* Brief description of the changes in this pull request:
There have been several cases recently where ReaR on UEFI was broken due to either a wrong assumption about what Grub2 modules to load (#2001) or, in an attempt to fix it, a wrong assumption about where to search for them (see #2199). I believe that such Grub internal details are better handled by Grub itself and we should not hardcode them (making them configurable is only a workaround - the default should work in most scenarios). Therefore this change switches to using grub-mkstandalone for te Grub2 UEFI image generation, which, unlike grub-mkimage, relies less on supplied information about modules. It embeds a ramdisk in the Grub2 image and by defaults includes all modules in it.
I found that the current method is broken at least on RHEL and GRUB_RESCUE, because the current default set of modules does not include xfs and /boot is XFS by default on RHEL, making it inaccessible from Grub2. This change also fixes this, therefore it is a bugfix in addition to a cleanup.
I found that the image creation using grub-mkstandalone still needs to be told to load partition modules, otherwise partitions will not be detected out of the box. I therefore added a dynamic detection of all modules needed to access /boot (partitions, filesystems, and others like lvm, should it be needed) using grub-probe, as it is more robust and relies on less assumptions than trying to guess a reasonable set of default modules.
The change still honors GRUB2_MODULES, but changes it into an array. (Other lists in configuration are specified as arrays already, like MODULES, so having GRUB2_MODULES an a string with blank-separated words is not consistent with the rest of the configuration.) If GRUB2_MODULES is set and nonempty, only the specified modules will be embedded in the standalone image ramdisk and also only those will be loaded. The detection using grub-probe will be switched off.