### PR TITLE
Revert part of #1961 : move route back from REQUIRED_PROGS to PROGS

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -5,7 +5,6 @@ chroot
 ip
 less
 parted
-route
 readlink
 )
 
@@ -37,6 +36,7 @@ killall
 tee
 ifconfig
 nslookup
+route
 ifenslave
 ifrename
 nameif


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/1961/files#r356220735
https://github.com/rear/rear/issues/1652

* How was this pull request tested?
Backup to ISO and restore on RHEL 7.6 vagrant box with UEFI and CentOS 7 vagrant box without UEFI.

* Brief description of the changes in this pull request:

Revert part of #1961 : move `route` back from REQUIRED_PROGS to PROGS. `route` is actually not required, ReaR uses `ip route` everywhere. As it is not always installed nowadays (e.g. on CentOS 7 Vagrant images), having it in REQUIRED_PROGS breaks ReaR on those installs where it would work just fine.
