### PR TITLE
Better is_multipath_path function (issue #2298) plus some other stuff

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -1,6 +1,5 @@
 # Architecture-independend Files
-REQUIRED_PROGS=(
-"${REQUIRED_PROGS[@]:-}"
+REQUIRED_PROGS+=(
 chroot
 ip
 less
@@ -9,8 +8,7 @@ route
 readlink
 )
 
-PROGS=(
-${PROGS[@]:-}
+PROGS+=(
 partprobe
 fdisk
 cfdisk
@@ -18,8 +16,7 @@ sfdisk
 )
 
 # progs to take along
-PROGS=(
-${PROGS[@]:-}
+PROGS+=(
 rpc.statd
 rpcbind
 mknod
@@ -72,6 +69,7 @@ ping
 netstat
 free
 traceroute
+xxd
 vi
 pico
 nano
@@ -170,8 +168,7 @@ clear
 
 # the lib* serves to cover both 32bit and 64bit libraries!
 #
-LIBS=(
-${LIBS[@]:-}
+LIBS+=(
 
 ### needed for username lookups
 /lib*/libnss_dns*
@@ -208,7 +205,7 @@ ${LIBS[@]:-}
 /usr/lib*/libnssdbm3.so*
 )
 
-COPY_AS_IS=( ${COPY_AS_IS[@]:-} /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/termcap /etc/terminfo /lib*/terminfo /usr/share/terminfo /etc/netconfig /etc/mke2fs.conf /etc/*-release /etc/localtime /etc/magic /usr/share/misc/magic /etc/dracut.conf /etc/dracut.conf.d /usr/lib/dracut /sbin/modprobe.ksplice-orig /etc/sysctl.conf /etc/sysctl.d /etc/e2fsck.conf )
+COPY_AS_IS+=( /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/termcap /etc/terminfo /lib*/terminfo /usr/share/terminfo /etc/netconfig /etc/mke2fs.conf /etc/*-release /etc/localtime /etc/magic /usr/share/misc/magic /etc/dracut.conf /etc/dracut.conf.d /usr/lib/dracut /sbin/modprobe.ksplice-orig /etc/sysctl.conf /etc/sysctl.d /etc/e2fsck.conf )
 # Required by curl with https:
 # There are stored the distribution provided certificates
 # installed from packages, nothing confidential.
@@ -220,15 +217,16 @@ COPY_AS_IS=( ${COPY_AS_IS[@]:-} /dev /etc/inputr[c] /etc/protocols /etc/services
 # but somehow that does not work in practice, see also https://github.com/rear/rear/pull/1971
 # so that /etc/ca-certificates/* is added in the old "known to somehow work" style
 # that had been used before, cf. https://github.com/rear/rear/pull/1402
-COPY_AS_IS=( "${COPY_AS_IS[@]}" '/etc/ssl/certs/*' '/etc/pki/*' '/usr/lib/ssl/*' '/usr/share/ca-certificates/*' '/etc/ca-certificates/*' )
+COPY_AS_IS+=( '/etc/ssl/certs/*' '/etc/pki/*' '/usr/lib/ssl/*' '/usr/share/ca-certificates/*' '/etc/ca-certificates/*' )
 
 # exclude /dev/shm/*, due to the way we use tar the leading / should be omitted
-COPY_AS_IS_EXCLUDE=( ${COPY_AS_IS_EXCLUDE[@]:-} dev/shm/\* )
+COPY_AS_IS_EXCLUDE+=( dev/shm/\* )
 # Exclude private keys: /etc/pki/tls/private /etc/pki/CA/private /etc/pki/nssdb/key*.db and /usr/lib/ssl/private (cf. above):
-COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" '/etc/pki/tls/private' '/etc/pki/CA/private' '/etc/pki/nssdb/key*.db' '/usr/lib/ssl/private' )
+COPY_AS_IS_EXCLUDE+=( '/etc/pki/tls/private' '/etc/pki/CA/private' '/etc/pki/nssdb/key*.db' '/usr/lib/ssl/private' )
 
-# some stuff for the Linux command line
-KERNEL_CMDLINE="$KERNEL_CMDLINE selinux=0"
+# some stuff for the Linux command line (the leading blank is needed to add it as a separated word to the KERNEL_CMDLINE string):
+KERNEL_CMDLINE+=" selinux=0"
+
 # common users and groups
 CLONE_USERS+=( daemon rpc usbmuxd usbmux vcsa nobody dbus )
 CLONE_GROUPS+=( tty usbmuxd usbmux fuse kvm oinstall dbus )

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -693,7 +693,16 @@ is_disk_a_pv() {
 }
 
 function is_multipath_path {
-    [ "$1" ] && type multipath &>/dev/null && multipath -c /dev/$1 &>/dev/null
+    # Return 'false' if there is no device as argument:
+    test "$1" || return 1
+    # Return 'false' if there is no multipath command:
+    type multipath &>/dev/null || return 1
+    # Return 'false' if multipath is not used.
+    # Because "multipath -l" always returns zero exit code we check if it has real output
+    # and we do this via "grep -q" so that no "multipath -l" output appears in the log:
+    multipath -l | grep -q '[[:alnum:]]' || return 1
+    # Check if a block device should be a path in a multipath device:
+    multipath -c /dev/$1 &>/dev/null
 }
 
 # retry_command () is binded with REAR_SLEEP_DELAY and REAR_MAX_RETRIES.

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -697,9 +697,11 @@ function is_multipath_path {
     test "$1" || return 1
     # Return 'false' if there is no multipath command:
     type multipath &>/dev/null || return 1
-    # Return 'false' if multipath is not used.
-    # Because "multipath -l" always returns zero exit code we check if it has real output
-    # and we do this via "grep -q" so that no "multipath -l" output appears in the log:
+    # Return 'false' if multipath is not used, see https://github.com/rear/rear/issues/2298
+    # Because "multipath -l" always returns zero exit code we check if it has real output via grep -q '[[:alnum:]]'
+    # so that no "multipath -l" output could clutter the log (the "multipath -l" output is irrelevant here)
+    # in contrast to e.g. test "$( multipath -l )" that would falsely succeed with blank output
+    # and the output would appear in the log in 'set -x' debugscript mode:
     multipath -l | grep -q '[[:alnum:]]' || return 1
     # Check if a block device should be a path in a multipath device:
     multipath -c /dev/$1 &>/dev/null


### PR DESCRIPTION
* Type: **Bug Fix** / **Cleanup**

* Impact: **High**
In my case disklayout.conf became totally useless.
If the '/dev/sda' entries were only commented out
the bad disklayout.conf could still be manually adapted
but without any '/dev/sda' entries it is useless in practice
(I cannot guess during "rear recover" what right values could be).

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2298

* How was this pull request tested?
Currently untested preliminary initial state.
"rear mkrescue" looks goot to me with that changes
but I need to test "rear recover" (hopefully tomorrow).

* Brief description of the changes in this pull request:

Better (i.e. hopefully more fail safe) `is_multipath_path` function, cf.
https://github.com/rear/rear/issues/2298#issuecomment-564590474

Have `lsblk` output as disklayout.conf header comments
so that it is easier to make sense of the values in the subsequent entries.

Some TODO comments added in layout/prepare/default/010_prepare_files.sh
because I wonder about how some things therein are meant to work.

Added `xdd` (belongs to vi) to the PROGS array because also
a tool to display binary files is needed in the recovery system.
