### PR TITLE
Enhanced recovery system BIOS boot default settings for USB and ISO (related to issue 2276

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -604,15 +604,15 @@ RAMDISK_SUFFIX="$HOSTNAME"
 ##
 # OUTPUT=ISO stuff
 ##
-# ISO produces files suitable for booting with isolinux and assumes that the result
-# will be written sequentially to a read-only media with limited size (e.g. optical media)
-
+# OUTPUT=ISO produces files suitable for booting with SYSLINUX/ISOLINUX and assumes that the result
+# will be written sequentially to a read-only medium with limited size (e.g. optical medium like CD-ROM).
+#
 # Default "local" ISO directory (usually /var/lib/rear/output). However, to avoid duplicate ISO images when
 # also using the OUTPUT_URL variable with a file syntax, it is then better only to use ISO_DIR.
 # Keep in mind that ISO_DIR works only with an absolute directory path and does not replace OUTPUT_URL
 # which supports the NETFS syntax (to copy the ISO image across the network).
 ISO_DIR=$VAR_DIR/output
-
+#
 # Default ISO label:
 # When the backup is split on multiple ISOs (cf. ISO_MAX_SIZE below)
 # the first ISO 'rear-HOSTNAME.iso' has the label $ISO_VOLID
@@ -625,11 +625,11 @@ ISO_DIR=$VAR_DIR/output
 # filesystem that only support short volume labels the ISO_VOLID value
 # must be appropriately specified in /etc/rear/local.conf
 ISO_VOLID="RELAXRECOVER"
-
+#
 # How to find isolinux.bin.
 # Possible values are "" (meaning search for it) or "/path/to/isolinux.bin"
 ISO_ISOLINUX_BIN=""
-
+#
 # Maximum size of generated ISO images.
 # Multiple ISO images will be generated if the size exceeds ISO_MAX_SIZE.
 # The ISO_MAX_SIZE value is specified in MiB
@@ -651,7 +651,7 @@ ISO_ISOLINUX_BIN=""
 # Accordingly when ISO_MAX_SIZE is set the mkrescue workflow is forbidden
 # to be on the safe side to not possibly destroy an existing backup.
 ISO_MAX_SIZE=
-
+#
 # How to find mkisofs:
 # Guess the common names mkisofs or genisoimage
 # script in prep stage will verify this and complain if not found
@@ -662,37 +662,58 @@ ISO_MAX_SIZE=
 # xorrisofs is now used as the preferred method for generating the iso image
 # with mkisofs and genisoimage as second and third option
 ISO_MKISOFS_BIN="$( type -p xorrisofs || type -p mkisofs || type -p genisoimage )"
-
+#
 # Additional options passed to the $ISO_MKISOFS_BIN binary
 ISO_MKISOFS_OPTS=""
-
+#
 # Which files to include in the ISO image:
 ISO_FILES=()
-
+#
 # Prefix name for ISO images without the .iso suffix.
 # This might get a number appended (for splitting data onto multiple CDs).
 ISO_PREFIX="rear-$HOSTNAME"
-
-# Default boot option for ISO image. If unset, system will boot from first HD
-# by default. This is useful in almost all cases. If empty "boothd" will be used.
-# Change this only, if you are about to automate things
-# E.g. ISO_DEFAULT=manual
-# This will start the REAR system and you can connect via ssh and issue 'rear recover'
-ISO_DEFAULT=boothd
-
-# The ISO_RECOVER_MODE variable can be set to "" (blank: default), "unattended" (export mode:
-# where rear will not wait for a question, but is only meant for experts and testing purposes),
 #
-ISO_RECOVER_MODE=
+# Default boot option (i.e. what gets booted automatically after some timeout)
+# when SYSLINUX boots the ISO image on BIOS systems.
+# This variable ISO_DEFAULT should be better named ISO_BIOS_BOOT_DEFAULT
+# (cf. USB_BIOS_BOOT_DEFAULT below) but we won't rename existing config variables
+# to avoid regressions for users who use existing config variable names
+# cf. https://github.com/rear/rear/pull/2293#issuecomment-564439509
+# If ISO_DEFAULT is unset or empty or only blanks "boothd" is used by default.
+# ISO_DEFAULT="boothd" is an automatism that intends to boot from the original first disk.
+# In case of ISOLINUX "boothd" means to boot from the first disk 'boothd0' because
+# usually ISOLINUX is used for booting from CD-ROM which is usually not the first disk
+# so that the original first disk still is the first disk when booting the ISO from CD-ROM.
+# In case of EXTLINUX "boothd" would mean to boot from the second disk 'boothd1' because
+# usually when EXTLINUX is used the device with the ISO would be the first disk 
+# and the original first disk would become the second disk (cf. USB_BIOS_BOOT_DEFAULT below).
+# ISO_DEFAULT="boothd0" boots from the first disk.
+# ISO_DEFAULT="boothd1" boots from the second disk.
+# The ISO_DEFAULT values 'boothd' 'boothd0' 'boothd1' are only supported
+# when the SYSLINUX module 'chain.c32' for chain booting is available.
+# ISO_DEFAULT="manual" boots the ReaR recovery system in normal mode
+# where one must manually log in as 'root', manually type "rear recover", and manually reboot.
+# ISO_DEFAULT="automatic" boots the ReaR recovery system with the 'auto_recover' kernel command line option
+# that runs "rear recover" automatically without automated reboot (see "man rear").
+# For details see the make_syslinux_config function in lib/bootloader-functions.sh
+ISO_DEFAULT="boothd"
+#
+# ISO_RECOVER_MODE="unattended" boots the ReaR recovery system with the 'unattended' kernel command line option
+# that runs "rear recover" automatically plus automated reboot after successful rear recover (see "man rear").
+# Together with ISO_DEFAULT="automatic" full-automated recovery happens when the ISO image is booted
+# which could result an endless full-automated recovery cycle when the ISO is booted by default
+# (e.g. when the device with the ISO is the first one in the BIOS boot order list).
+# The default ISO_RECOVER_MODE="" results the normal behaviour:
+ISO_RECOVER_MODE=""
 
 ##
 # OUTPUT=USB stuff
 ##
-# USB produces files suitable for booting with extlinux, USB sticks are just the main use for this
+# OUTPUT=USB produces files suitable for booting with SYSLINUX/EXTLINUX from a disk device.
+# USB sticks and USB disks are the main use case for this.
+# "USB" also means any local block-storage device and includes eSATA and other external disks.
 # The device is also made bootable and a boot loader installed.
 # The device must be partitioned and formatted with an ext* file system.
-#
-# NOTE: "USB" means any local block-storage device and includes also eSATA and other external disks
 #
 # The device to use, set automatically by BACKUP=NETFS and BACKUP_URL=usb:///dev/sdb1
 USB_DEVICE=
@@ -766,6 +787,18 @@ USB_PARTITION_ALIGN_BLOCK_SIZE="8"
 # USB_PARTITION_ALIGN_BLOCK_SIZE chunk:
 USB_UEFI_PART_SIZE="400"
 #
+# Default boot option (i.e. what gets booted automatically after some timeout)
+# when EXTLINUX boots the USB stick or USB disk or other disk device on BIOS systems.
+# USB_BIOS_BOOT_DEFAULT="boothd0" boots from 'boothd0' which is usually the same disk
+# wherefrom currently EXTLINUX is booting so that this results usually a booting loop.
+# The default USB_BIOS_BOOT_DEFAULT="" boots from the second disk 'boothd1'
+# which should be the original first local harddisk because usually when booting
+# from USB stick or USB disk or other disk device this boot device is the first disk
+# and the original first local harddisk disk becomes the second disk.
+# USB_BIOS_BOOT_DEFAULT is only supported when the SYSLINUX module 'chain.c32' for chain booting is available.
+# For details see output/USB/Linux-i386/300_create_extlinux.sh
+USB_BIOS_BOOT_DEFAULT=""
+#
 # Resulting files that should be copied onto the USB stick:
 USB_FILES=()
 #
@@ -790,19 +823,7 @@ USB_SUFFIX=""
 # What is more than USB_RETAIN_BACKUP_NR gets automatically removed.
 # This setting is ignored when USB_SUFFIX is set (see above).
 USB_RETAIN_BACKUP_NR=2
-
-# Define the default WORKFLOW for the udev handler (empty to disable)
-UDEV_WORKFLOW=mkrescue
 #
-# Beep when udev handler has finished
-UDEV_BEEP=y
-#
-# Suspend the (USB) device when udev handler has finished ?
-UDEV_SUSPEND=y
-#
-# Turn the UID led on during udev workflow
-UDEV_UID_LED=y
-
 # Variable will probably be filled automatically
 # if an USB device was manually mounted to avoid recursive backups:
 AUTOEXCLUDE_USB_PATH=()
@@ -1102,6 +1123,21 @@ FULLBACKUPDAY=()
 # By default an existing full backup is considered to be too old
 # when it is older than 7 days ago:
 FULLBACKUP_OUTDATED_DAYS="7"
+
+##
+# UDEV workflow stuff
+##
+# Define the default WORKFLOW for the udev handler (empty to disable)
+UDEV_WORKFLOW=mkrescue
+#
+# Beep when udev handler has finished
+UDEV_BEEP=y
+#
+# Suspend the (USB) device when udev handler has finished ?
+UDEV_SUSPEND=y
+#
+# Turn the UID led on during udev workflow
+UDEV_UID_LED=y
 
 # Program files (as found in PATH) to include in the rescue/recovery system:
 # These progs are optional, if they are missing, nothing happens

--- a/usr/share/rear/conf/templates/rear.help
+++ b/usr/share/rear/conf/templates/rear.help
@@ -1,21 +1,21 @@
-09Relax-and-Recover recovery mode07
-01~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~07
-0fRelax-and-Recover07 is a disaster recovery and system migration tool.
+Relax-and-Recover recovery mode
+===============================
+Relax-and-Recover (ReaR) is a disaster recovery tool.
 
-This help is part of the rescue image, you are here because you plan to recover
-or migrate a previously made backup of your system, including the disk layout
-as it was when the rescue environment was created.
+This help is part of the ReaR rescue image. You are here when you need
+to recover your system by restoring a backup that you had made before
+plus recreating the disk layout (partitions, filesystems) as it was
+when you had made the rescue image (via "rear mkbackup/mkrescue).
 
-The menu gives an overview of the various system rescue environments stored on
-the boot media you used for booting this screen (either USB, PXE or ISO). For
-each of the systems one or more rescue environments are stored, when browsing
-through the images more information is shown below the menu.
+The menu lists the rescue images (or recovery environments) stored
+on this boot medium (USB, PXE, ISO) that is used to boot this menu.
+For each system one or more rescue images can be stored.
+When browsing through them more information is shown.
 
-Once you boot into one of the rescue images, you can start recover the system.
-You can do this by typing: 0erear recover07
+After you booted into a ReaR rescue image, you can recover that system
+by logging in as 'root' and starting the recovery with "rear recover".
 
-cfCAUTION:0f Once you start recovery, it is likely the actions cannot be undone and
-         you may loose anything stored on the physical disks of the system.07
-
+CAUTION: Once you launched the recovery, its actions cannot be undone.
+         It will overwrite all what is stored on the system disk(s).
 
 Press ENTER to return to the menu.

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -306,6 +306,11 @@ function make_syslinux_config {
             echo "default boothd0"
             syslinux_menu "default"
         fi
+        if test "boothd0" = "$ISO_DEFAULT" ; then
+            # the user has explicitly specified to boot via boothd0 by default
+            echo "default boothd0"
+            syslinux_menu "default"
+        fi
         echo "kernel chain.c32"
         echo "append hd0"
         echo ""
@@ -316,6 +321,11 @@ function make_syslinux_config {
         if [[ "$flavour" == "extlinux" ]] && [ "$ISO_DEFAULT" == "boothd" ]; then
             # for extlinux local boot means boot from second disk because the boot disk became the first disk
             # which usually allows us to access the original first disk as second disk
+            echo "default boothd1"
+            syslinux_menu "default"
+        fi
+        if test "boothd1" = "$ISO_DEFAULT" ; then
+            # the user has explicitly specified to boot via boothd1 by default
             echo "default boothd1"
             syslinux_menu "default"
         fi

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -112,12 +112,10 @@ function set_syslinux_features {
     FEATURE_SYSLINUX_MENU_HIDDEN=
     # true if syslinux supports TEXT HELP directive
     FEATURE_SYSLINUX_TEXT_HELP=
-        # true if syslinux supports modules sub-dir (Version > 5.00)
-        FEATURE_SYSLINUX_MODULES=
-    # If ISO_DEFAULT is not set, set it to default 'boothd'
-    if [ -z "$ISO_DEFAULT" ]; then
-        ISO_DEFAULT="boothd"
-    fi
+    # true if syslinux supports modules sub-dir (Version > 5.00)
+    FEATURE_SYSLINUX_MODULES=
+    # If ISO_DEFAULT is not set or empty or only blanks, set it to default 'boothd'
+    test $ISO_DEFAULT || ISO_DEFAULT="boothd"
     # Define the syslinux directory for later usage (since version 5 the bins and c32 are in separate dirs)
     if [[ -z "$SYSLINUX_DIR" ]]; then
         ISOLINUX_BIN=$(find_syslinux_file isolinux.bin)
@@ -261,9 +259,9 @@ function make_syslinux_config {
     echo "kernel kernel"
     echo "append initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE"
     if [ "$ISO_DEFAULT" == "manual" ] ; then
-               echo "default rear"
-               syslinux_menu "default"
-        fi
+        echo "default rear"
+        syslinux_menu "default"
+    fi
     echo ""
 
     echo "say rear - Recover $HOSTNAME"
@@ -275,10 +273,10 @@ function make_syslinux_config {
     echo "append initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover $ISO_RECOVER_MODE"
 
     if [ "$ISO_DEFAULT" == "automatic" ] ; then
-               echo "default rear-automatic"
-               syslinux_menu "default"
-               echo "timeout 50"
-        fi
+        echo "default rear-automatic"
+        syslinux_menu "default"
+        echo "timeout 50"
+    fi
     echo ""
 
     syslinux_menu separator

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -352,7 +352,7 @@ EOF
     if syslinux_has "chain.c32" ; then
         # Boot from boothd0 (which is usually the same USB disk where this syslinux boot menue is currently shown)
         # only as boot default when that was explicitly specified by the user (results usually a boot loop):
-        if test "boothd0" = "$USB_BOOT_DEFAULT" ; then
+        if test "boothd0" = "$USB_BIOS_BOOT_DEFAULT" ; then
             syslinux_write <<EOF
 ontimeout boothd0
 label boothd0
@@ -376,7 +376,7 @@ Usually hd1 is the local harddisk
 
 EOF
         else
-            # Boot from boothd1 (which is usually the local harddisk) by default (i.e. when USB_BOOT_DEFAULT is not boothd0):
+            # Boot from boothd1 (which is usually the local harddisk) by default (i.e. when USB_BIOS_BOOT_DEFAULT is not boothd0):
             syslinux_write <<EOF
 label boothd0
     say boothd0 - boot first local disk

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -214,7 +214,7 @@ EOF
 menu begin $system
     menu label $system
     text help
-Recover backup of $system to this system.
+Recover backup of $system to this system
     endtext
 
 EOF
@@ -341,7 +341,7 @@ EOF
 label help
     menu label ^Help for Relax-and-Recover
     text help
-More information about Relax-and-Recover and the steps for recovering your system
+Information about Relax-and-Recover and steps for recovering your system
     endtext
     menu help rear.help
 
@@ -349,26 +349,70 @@ EOF
     fi
 
     # Use chain booting for booting disk, if chain.c32 is available
-    if syslinux_has "chain.c32"; then
-        syslinux_write <<EOF
+    if syslinux_has "chain.c32" ; then
+        # Boot from boothd0 (which is usually the same USB disk where this syslinux boot menue is currently shown)
+        # only as boot default when that was explicitly specified by the user (results usually a boot loop):
+        if test "boothd0" = "$USB_BOOT_DEFAULT" ; then
+            syslinux_write <<EOF
+ontimeout boothd0
+label boothd0
+    say boothd0 - boot first local disk
+    menu label Boot ^First local disk (hd0)
+    text help
+Usually hd0 is the USB disk wherefrom currently is booted
+    endtext
+    menu default
+    kernel chain.c32
+    append hd0
+
+label boothd1
+    say boothd1 - boot second local disk
+    menu label Boot ^Second local disk (hd1)
+    text help
+Usually hd1 is the local harddisk
+    endtext
+    kernel chain.c32
+    append hd1
+
+EOF
+        else
+            # Boot from boothd1 (which is usually the local harddisk) by default (i.e. when USB_BOOT_DEFAULT is not boothd0):
+            syslinux_write <<EOF
+label boothd0
+    say boothd0 - boot first local disk
+    menu label Boot ^First local disk (hd0)
+    text help
+Usually hd0 is the USB disk wherefrom currently is booted
+    endtext
+    kernel chain.c32
+    append hd0
+
 ontimeout boothd1
 label boothd1
     say boothd1 - boot second local disk
-    menu label Boot ^Local disk (hd1)
+    menu label Boot ^Second local disk (hd1)
+    text help
+Usually hd1 is the local harddisk
+    endtext
     menu default
     kernel chain.c32
     append hd1
 
+EOF
+        fi
+
+        syslinux_write <<EOF
 label bootlocal
     say bootlocal - boot second local bios disk
     menu label Boot ^BIOS disk (0x81)
     text help
-Use this when booting from local disk 0x81 does not work !
+Try this when booting from local disk does not work
     endtext
     localboot 0x81
 
 EOF
     else
+        # Fallback when chain.c32 is not available:
         syslinux_write <<EOF
 ontimeout bootlocal
 label bootlocal
@@ -383,7 +427,7 @@ EOF
 label bootnext
     menu label Boot ^Next device
     text help
-Boot from the next device in the BIOS boot order list.
+Boot from the next device in the BIOS boot order list
     endtext
     localboot -1
 


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2276#issuecomment-554316041

* How was this pull request tested?
Currently I had only tested the USB case.
I need to test the ISO case.

* Brief description of the changes in this pull request:

For `OUTPUT=ISO` the user can now explicitly specify
what to boot by default when booting the ISO on BIOS systems via
`ISO_DEFAULT="boothd0"` to boot from the first disk and
`ISO_DEFAULT="boothd1"` to boot from the second disk.

For `OUTPUT=USB` the user can now explicitly specify
what to boot by default when booting the disk on BIOS systems via
`USB_BIOS_BOOT_DEFAULT="boothd0"` to boot from the first disk.
The default `USB_BIOS_BOOT_DEFAULT=""` boots the second disk.

Those things are now (hopefully correctly) explained in default.conf

Additionally usr/share/rear/conf/templates/rear.help
is now plain ASCII according to "Character encoding" in
https://github.com/rear/rear/wiki/Coding-Style
to avoid that this text may show unexpected when the
SYSLINUX boot stuff is shown to the user on whatever
possibly unusual remote console or on whatever special
system management user interface (I had some personal
"interesting user experience" with some Java based tingy ;-)
