### PR TITLE
Cleanup and enhance 320_migrate_network_configuration_files.sh (issue 2310)

### DIFF
--- a/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
+++ b/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
@@ -388,17 +388,17 @@ if test -s $TMP_DIR/mappings/ip_addresses ; then
                 # We have IP-address/CIDR like 192.168.100.101/24 so we use that without a separated netmask setting.
                 # The usual sed 's/regexp/replacement/flags' command delimiter character / is replaced by # here because
                 # the delimiter character must not appear in regexp or replacement but e.g. 192.168.100.101/24 contains it:
-                sed_script="/iface $new_interface/ s/;address [0-9.]*;/;address $new_ip_cidr;/g"
+                sed_script="/iface $new_interface/ s#;address [0-9.]*;#;address $new_ip_cidr;#g"
             else
                 # We have a plain IP-address like 192.168.100.101 without CIDR:
                 if test "$new_netmask" ; then
                     # We also have a netmask so we use the plain IP-address plus a separated netmask setting:
-                    sed_script="/iface $new_interface/ s/;address [0-9.]*;/;address $new_ip;/g ; /iface $new_interface/ s/;netmask [0-9.]*;/;netmask $new_netmask;/g"
+                    sed_script="/iface $new_interface/ s#;address [0-9.]*;#;address $new_ip;#g ; /iface $new_interface/ s#;netmask [0-9.]*;#;netmask $new_netmask;#g"
                 else
                     # We have only a plain IP-address like 192.168.100.101 but no netmask so we can use only the plain IP-address
                     # but only a plain IP-address without netmask is likely insufficient so we tell the user about it:
                     LogPrintError "Only plain IP-address $new_ip without netmask can be set in $network_interfaces_file (likely insufficient)"
-                    sed_script="/iface $new_interface/ s/;address [0-9.]*;/;address $new_ip;/g"
+                    sed_script="/iface $new_interface/ s#;address [0-9.]*;#;address $new_ip;#g"
                 fi
             fi
             linearized_network_interfaces_file="$TMP_DIR/${network_interfaces_file##*/}.linearized"

--- a/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
+++ b/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
@@ -202,7 +202,7 @@ else
         for interface in $( cut -f 1 -d " " $TMP_DIR/mappings/ip_addresses ) ; do
             # /sys/class/net/$interface/address contains the MAC address with lower case hex letters (cf. above):
             current_mac=$( cat /sys/class/net/$interface/address )
-            echo "$mac $mac $interface" >> $TMP_DIR/mappings/mac
+            echo "$current_mac $current_mac $interface" >> $TMP_DIR/mappings/mac
         done
         # Verify we could generate a fallback $TMP_DIR/mappings/mac file with acual content (i.e. non-empty):
         if test -s $TMP_DIR/mappings/mac ; then


### PR DESCRIPTION
* Type: **Bug Fix**  / **Enhancement** / **Cleanup**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2310

* How was this pull request tested?

Just an initial "submit early submit often" part of today.
More will come tomorrow.
Not yet tested at all (only `bash -n` does not show a syntax error).
Currently it is an incomplete first part up to the line
```
# change the ip addresses in the configuration files if a mapping is available
```
of a general cleanup as first step which I do primarily
to get some basic understanding of the code.
Not yet any actual enhancement (that will be the second step).

* Brief description of the changes in this pull request:

Overhaul 320_migrate_network_configuration_files.sh
to make it working sufficiently with nowadays network ifcfg file syntax, cf.
https://github.com/rear/rear/issues/2310#issuecomment-574574414
