### PR TITLE
Update 010_merge_skeletons.sh

### DIFF
--- a/usr/share/rear/rescue/default/010_merge_skeletons.sh
+++ b/usr/share/rear/rescue/default/010_merge_skeletons.sh
@@ -15,26 +15,23 @@ for skel_dir in default "$ARCH" "$OS" \
         "$OS_MASTER_VENDOR/default" "$OS_MASTER_VENDOR_ARCH" "$OS_MASTER_VENDOR_VERSION" \
         "$OS_VENDOR/default" "$OS_VENDOR_ARCH" "$OS_VENDOR_VERSION" \
         "$BACKUP" "$OUTPUT" ; do
-    # Skip empty $skel_dir (e.g. if $OS_MASTER_* is empty):
+    # Silently skip when $skel_dir is empty (e.g. when $OS_MASTER_* is empty):
     test "$skel_dir" || continue
-    # If a $skel_dir.tar.gz exists (e.g. usr/share/rear/skel/Debian/default.tar.gz)
-    # use only that (i.e. there cannot be also usr/share/rear/skel/Debian/default/).
-    # FIXME: Explain what the reason behind is why there cannot be both.
+    # Skip if there is neither a $skel_dir directory nor a $skel_dir.tar.gz:
+    if ! test -d "$skel_dir" -o -s "$skel_dir.tar.gz" ; then
+        Debug "Neither a '$skel_path/$skel_dir' directory nor a '$skel_path/$skel_dir.tar.gz'"
+        continue   
+    fi
+    # When $skel_dir is a directory (e.g. usr/share/rear/skel/default/) copy all its contents:
+    if test -d "$skel_dir" ; then
+        Log "Copying '$skel_path/$skel_dir' contents to $ROOTFS_DIR"
+        tar -C "$skel_dir" -c . | tar -C $ROOTFS_DIR -x || Error "Failed to copy '$skel_path/$skel_dir' contents to $ROOTFS_DIR"
+    fi
+    # If $skel_dir.tar.gz exists (e.g. usr/share/rear/skel/Debian/default.tar.gz) extract it:
     if test -s "$skel_dir.tar.gz" ; then
         Log "Extracting '$skel_path/$skel_dir.tar.gz' into $ROOTFS_DIR"
         tar -C $ROOTFS_DIR -xzf "$skel_dir.tar.gz" || Error "Failed to extract '$skel_path/$skel_dir.tar.gz' into $ROOTFS_DIR"
-        test -d "$skel_dir" && Log "Skip copying '$skel_path/$skel_dir' contents to $ROOTFS_DIR"
-        continue
     fi
-    # When $skel_dir is a directory copy it with all its contents:
-	if test -d "$skel_dir" ; then
-		Log "Copying '$skel_path/$skel_dir' contents to $ROOTFS_DIR"
-		tar -C "$skel_dir" -c . | tar -C $ROOTFS_DIR -x || Error "Failed to copy '$skel_path/$skel_dir' contents to $ROOTFS_DIR"
-        continue
-	fi
-    # It is no error when there is neither a $skel_dir directory nor a $skel_dir.tar.gz
-    # FIXME: Explain what the reason behind is why that is no error.
-    Debug "Neither a '$skel_path/$skel_dir' directory nor a '$skel_path/$skel_dir.tar.gz'"
 done
 popd >/dev/null
 

--- a/usr/share/rear/rescue/default/010_merge_skeletons.sh
+++ b/usr/share/rear/rescue/default/010_merge_skeletons.sh
@@ -1,30 +1,42 @@
-# 010_merge_skeletons.sh
+# rescue/default/010_merge_skeletons.sh
 #
-# merge skeleton directories for Relax-and-Recover
+# Merge the skeleton directories for Relax-and-Recover.
 #
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-LogPrint "Creating root filesystem layout"
-pushd $SHARE_DIR/skel >/dev/null
-for dir in default "$ARCH" "$OS" \
-		"$OS_MASTER_VENDOR/default" "$OS_MASTER_VENDOR_ARCH" "$OS_MASTER_VENDOR_VERSION" \
-		"$OS_VENDOR/default" "$OS_VENDOR_ARCH" "$OS_VENDOR_VERSION" \
-		"$BACKUP" "$OUTPUT" ; do
-	if test -z "$dir" ; then
-		# silently skip if $dir it empty, e.g. if OS_MASTER_* is empty
-		continue
-	elif test -s "$dir".tar.gz ; then
-		Log "Adding '$dir.tar.gz'"
-		tar -C $ROOTFS_DIR -xvzf "$dir".tar.gz >/dev/null
-	elif test -d "$dir" ; then
-		Log "Adding '$dir'"
-		tar -C "$dir" -c . | tar -C $ROOTFS_DIR -xv >/dev/null
-	else
-		Debug "No '$dir' or '$dir.tar.gz' found"
+local skel_path="$SHARE_DIR/skel"
+local skel_dir
+
+LogPrint "Creating recovery system root filesystem skeleton layout"
+
+pushd $skel_path >/dev/null
+for skel_dir in default "$ARCH" "$OS" \
+        "$OS_MASTER_VENDOR/default" "$OS_MASTER_VENDOR_ARCH" "$OS_MASTER_VENDOR_VERSION" \
+        "$OS_VENDOR/default" "$OS_VENDOR_ARCH" "$OS_VENDOR_VERSION" \
+        "$BACKUP" "$OUTPUT" ; do
+    # Skip empty $skel_dir (e.g. if $OS_MASTER_* is empty):
+    test "$skel_dir" || continue
+    # If a $skel_dir.tar.gz exists (e.g. usr/share/rear/skel/Debian/default.tar.gz)
+    # use only that (i.e. there cannot be also usr/share/rear/skel/Debian/default/).
+    # FIXME: Explain what the reason behind is why there cannot be both.
+    if test -s "$skel_dir.tar.gz" ; then
+        Log "Extracting '$skel_path/$skel_dir.tar.gz' into $ROOTFS_DIR"
+        tar -C $ROOTFS_DIR -xzf "$skel_dir.tar.gz" || Error "Failed to extract '$skel_path/$skel_dir.tar.gz' into $ROOTFS_DIR"
+        test -d "$skel_dir" && Log "Skip copying '$skel_path/$skel_dir' contents to $ROOTFS_DIR"
+        continue
+    fi
+    # When $skel_dir is a directory copy it with all its contents:
+	if test -d "$skel_dir" ; then
+		Log "Copying '$skel_path/$skel_dir' contents to $ROOTFS_DIR"
+		tar -C "$skel_dir" -c . | tar -C $ROOTFS_DIR -x || Error "Failed to copy '$skel_path/$skel_dir' contents to $ROOTFS_DIR"
+        continue
 	fi
+    # It is no error when there is neither a $skel_dir directory nor a $skel_dir.tar.gz
+    # FIXME: Explain what the reason behind is why that is no error.
+    Debug "Neither a '$skel_path/$skel_dir' directory nor a '$skel_path/$skel_dir.tar.gz'"
 done
 popd >/dev/null
 
-# make sure the owner is root if running from checkout
-chown -R root:root $ROOTFS_DIR
+# Ensure the owner is root (e.g. when running from checkout):
+chown -R root:root $ROOTFS_DIR || Error "Failed to 'chown root' $ROOTFS_DIR contents"


### PR DESCRIPTION
Overhauled rescue/default/010_merge_skeletons.sh
triggered by https://github.com/rear/rear/issues/2307

* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2307

* How was this pull request tested?

Works much better for me with my tests.

* Brief description of the changes in this pull request:

Make rescue/default/010_merge_skeletons.sh
behave more reliably and more fail safe.

Now it errors out when things really went wrong.

Now is is also supported that both a `$skel_dir` directory
(e.g. `usr/share/rear/skel/default/`) plus a `$skel_dir.tar.gz`
(e.g. `usr/share/rear/skel/default.tar.gz`) exist
and then both get copied into the recovery system,
first the directory and then the tar.gz so that via the tar.gz
existing files could be overwritten if needed.
