### PR TITLE
create data path for s390 FDR backups if !exists

### DIFF
--- a/usr/share/rear/layout/save/FDRUPSTREAM/Linux-s390/990_copy_disklayout_file.sh
+++ b/usr/share/rear/layout/save/FDRUPSTREAM/Linux-s390/990_copy_disklayout_file.sh
@@ -24,6 +24,7 @@ opath=$( output_path $scheme $path )
 if [[ "$ZVM_NAMING" == "Y" && "$ARCH" == "Linux-s390" ]] ; then 
       VM_UID=$(vmcp q userid |awk '{ print $1 }')
       LogPrint "s390 dislayout.conf will be saved as $(opath)/$VM_UID.disklayout.conf"
+      mkdir -p ${opath}/"$VM_UID"
       cp $v $DISKLAYOUT_FILE ${opath}/"$VM_UID".disklayout.conf || Error "Failed to copy disklayout.conf ($DISKLAYOUT_FILE) to ${opath}/"$VM_UID".disklayout.conf"
 fi
 

--- a/usr/share/rear/layout/save/FDRUPSTREAM/Linux-s390/990_copy_disklayout_file.sh
+++ b/usr/share/rear/layout/save/FDRUPSTREAM/Linux-s390/990_copy_disklayout_file.sh
@@ -23,13 +23,12 @@ opath=$( output_path $scheme $path )
 
 if [[ "$ZVM_NAMING" == "Y" && "$ARCH" == "Linux-s390" ]] ; then 
       VM_UID=$(vmcp q userid |awk '{ print $1 }')
+	
       if [[ -z $VM_UID ]] ; then
-            LogPrint "VM UID is not set, VM UID is set from call to vmcp.  Please make sure vmcp is available and 'vmcp q userid' returns the vm login id"
-            LogPrint "VM UID for disklayout.conf will be set to 'DEFAULT'"
-            VM_UID="DEFAULT"
+            Error "VM UID is not set, VM UID is set from call to vmcp.  Please make sure vmcp is available and 'vmcp q userid' returns the vm login id"
       fi
       if [[ -z $opath ]] ; then
-            LogPrint "Warning: output path is not set, please check OUTPUT_URL in local.conf."
+            Error "Output path is not set, please check OUTPUT_URL in local.conf."
       fi
 
       LogPrint "s390 disklayout.conf will be saved as $opath/$VM_UID.disklayout.conf"

--- a/usr/share/rear/layout/save/FDRUPSTREAM/Linux-s390/990_copy_disklayout_file.sh
+++ b/usr/share/rear/layout/save/FDRUPSTREAM/Linux-s390/990_copy_disklayout_file.sh
@@ -23,8 +23,17 @@ opath=$( output_path $scheme $path )
 
 if [[ "$ZVM_NAMING" == "Y" && "$ARCH" == "Linux-s390" ]] ; then 
       VM_UID=$(vmcp q userid |awk '{ print $1 }')
-      LogPrint "s390 dislayout.conf will be saved as $(opath)/$VM_UID.disklayout.conf"
-      mkdir -p ${opath}/"$VM_UID"
-      cp $v $DISKLAYOUT_FILE ${opath}/"$VM_UID".disklayout.conf || Error "Failed to copy disklayout.conf ($DISKLAYOUT_FILE) to ${opath}/"$VM_UID".disklayout.conf"
+      if [[ -z $VM_UID ]] ; then
+            LogPrint "VM UID is not set, VM UID is set from call to vmcp.  Please make sure vmcp is available and 'vmcp q userid' returns the vm login id"
+            LogPrint "VM UID for disklayout.conf will be set to 'DEFAULT'"
+            VM_UID="DEFAULT"
+      fi
+      if [[ -z $opath ]] ; then
+            LogPrint "Warning: output path is not set, please check OUTPUT_URL in local.conf."
+      fi
+
+      LogPrint "s390 disklayout.conf will be saved as $opath/$VM_UID.disklayout.conf"
+      mkdir -pv $opath
+      cp $v $DISKLAYOUT_FILE $opath/$VM_UID.disklayout.conf || Error "Failed to copy disklayout.conf ($DISKLAYOUT_FILE) to opath/$VM_UID.disklayout.conf"
 fi
 

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -75,16 +75,14 @@ case "$scheme" in
 
             if [[ "$ZVM_NAMING" == "Y" && "$ARCH" == "Linux-s390" ]] ; then 
                if [[ -z $opath ]] ; then
-                  LogPrint "Warning: output path is not set, please check OUTPUT_URL in local.conf."
+                  Error "Output path is not set, please check OUTPUT_URL in local.conf."
                fi  
 
                if [ "$ZVM_KERNEL_NAME" == "$result_file" ] ; then
                   VM_UID=$(vmcp q userid |awk '{ print $1 }')
 
                   if [[ -z $VM_UID ]] ; then
-                     LogPrint "VM UID is not set, VM UID is set from call to vmcp.  Please make sure vmcp is available and 'vmcp q userid' returns VM ID"
-                     LogPrint "VM UID for kernel will be set to 'DEFAULT'"
-                     VM_UID="DEFAULT"
+                     Error "VM UID is not set, VM UID is set from call to vmcp.  Please make sure vmcp is available and 'vmcp q userid' returns VM ID"
                   fi      
 
                   LogPrint "s390 kernel naming override: $result_file will be written as $VM_UID.kernel"

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -72,16 +72,28 @@ case "$scheme" in
             # initrd name override is handled in 900_create_initramfs.sh
             # kernel name override is handled in 400_guess_kernel.sh
             # kernel name override is handled in 950_copy_result_files.sh
+
             if [[ "$ZVM_NAMING" == "Y" && "$ARCH" == "Linux-s390" ]] ; then 
+               if [[ -z $opath ]] ; then
+                  LogPrint "Warning: output path is not set, please check OUTPUT_URL in local.conf."
+               fi  
+
                if [ "$ZVM_KERNEL_NAME" == "$result_file" ] ; then
                   VM_UID=$(vmcp q userid |awk '{ print $1 }')
+
+                  if [[ -z $VM_UID ]] ; then
+                     LogPrint "VM UID is not set, VM UID is set from call to vmcp.  Please make sure vmcp is available and 'vmcp q userid' returns VM ID"
+                     LogPrint "VM UID for kernel will be set to 'DEFAULT'"
+                     VM_UID="DEFAULT"
+                  fi      
+
                   LogPrint "s390 kernel naming override: $result_file will be written as $VM_UID.kernel"
-                  cp $v "$result_file" "${opath}/"$VM_UID".kernel" || Error "Could not copy result file $result_file to $opath/$VM_UID.kernel at $scheme location"
+                  cp $v "$result_file" $opath/$VM_UID.kernel || Error "Could not copy result file $result_file to $opath/$VM_UID.kernel at $scheme location"
                else
-                  cp $v "$result_file" "${opath}/" || Error "Could not copy result file $result_file to $opath at $scheme location"
+                  cp $v "$result_file" $opath/ || Error "Could not copy result file $result_file to $opath at $scheme location"
                fi
             else
-               cp $v "$result_file" "${opath}/" || Error "Could not copy result file $result_file to $opath at $scheme location"
+               cp $v "$result_file" $opath/ || Error "Could not copy result file $result_file to $opath at $scheme location"
             fi
         done
         ;;

--- a/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
+++ b/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
@@ -36,9 +36,7 @@ if [ "$ARCH" == "Linux-s390" ] ; then
    VM_UID=$(vmcp q userid |awk '{ print $1 }')
 
    if [[ -z $VM_UID && "$ZVM_NAMING" == "Y" ]] ; then
-      LogPrint "VM UID is not set, VM UID is set from call to vmcp.  Please make sure vmcp is available and 'vmcp q userid' returns VM ID"
-      LogPrint "VM UID for initrd will be set to 'DEFAULT'"
-      VM_UID="DEFAULT"
+      Error "VM UID is not set, VM UID is set from call to vmcp.  Please make sure vmcp is available and 'vmcp q userid' returns VM ID"
    fi      
 fi
 

--- a/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
+++ b/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
@@ -32,9 +32,14 @@
 # kernel name override is handled in 400_guess_kernel.sh
 # kernel name override is handled in 950_copy_result_files.sh
 
-echo $ARCH
 if [ "$ARCH" == "Linux-s390" ] ; then
    VM_UID=$(vmcp q userid |awk '{ print $1 }')
+
+   if [[ -z $VM_UID && "$ZVM_NAMING" == "Y" ]] ; then
+      LogPrint "VM UID is not set, VM UID is set from call to vmcp.  Please make sure vmcp is available and 'vmcp q userid' returns VM ID"
+      LogPrint "VM UID for initrd will be set to 'DEFAULT'"
+      VM_UID="DEFAULT"
+   fi      
 fi
 
 pushd "$ROOTFS_DIR" >/dev/null


### PR DESCRIPTION
   if the path for $FDRUPSTREAM_DATA_PATH does not exist, then create it.
This change is FDR specific for s390 and is only in effect if ZVM_NAMING is "Y"

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: Bug Fix

* Impact:  Normal

Description:
If the data destination dir does not exist, then create it

