### PR TITLE
Allow to boot original system from Grub menu (UEFI)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -685,7 +685,7 @@ ISO_PREFIX="rear-$HOSTNAME"
 # usually ISOLINUX is used for booting from CD-ROM which is usually not the first disk
 # so that the original first disk still is the first disk when booting the ISO from CD-ROM.
 # In case of EXTLINUX "boothd" would mean to boot from the second disk 'boothd1' because
-# usually when EXTLINUX is used the device with the ISO would be the first disk 
+# usually when EXTLINUX is used the device with the ISO would be the first disk
 # and the original first disk would become the second disk (cf. USB_BIOS_BOOT_DEFAULT below).
 # ISO_DEFAULT="boothd0" boots from the first disk.
 # ISO_DEFAULT="boothd1" boots from the second disk.
@@ -2773,6 +2773,22 @@ GRUB2_MODULES_LOAD=()
 # (install all modules in the standalone image ramdisk)
 # This variable currently applies in the same scenarios as GRUB2_MODULES_LOAD.
 GRUB2_MODULES=()
+
+##
+# GRUB2_DEFAULT_BOOT
+#
+# Set default entry to boot, when creating ReaR rescue system boot loader.
+# This variable currently applies when building Grub2 boot loader for UEFI in following scenarios:
+# 1. UEFI boot with OUTPUT=NETFS without secure boot (SECURE_BOOT_BOOTLOADER="")
+# 2. UEFI boot with OUTPUT=USB
+#
+# Valid values are:
+# 0 - Relax-and-Recover (no Secure Boot)
+# 1 - Relax-and-Recover (Secure Boot)
+# 2 - Boot original system
+# 3 - Reboot
+# 4 - Exit
+GRUB2_DEFAULT_BOOT="0"
 
 ##
 # USING_UEFI_BOOTLOADER

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -493,10 +493,16 @@ function get_root_disk_UUID {
 
 # Create configuration grub
 function create_grub2_cfg {
-root_uuid=$(get_root_disk_UUID)
+    root_uuid=$(get_root_disk_UUID)
 
-cat << EOF
-set default="0"
+    local esp_kernel="$1"
+    local esp_initrd="$2"
+
+    test $esp_kernel || esp_kernel="/isolinux/kernel"
+    test $esp_initrd || esp_initrd="/isolinux/$REAR_INITRD_FILENAME"
+
+    cat << EOF
+set default="$GRUB2_DEFAULT_BOOT"
 
 insmod efi_gop
 insmod efi_uga
@@ -512,20 +518,25 @@ insmod ext2
 set timeout=5
 
 search --no-floppy --file /boot/efiboot.img --set
-#set root=(cd0)
+$grub2_set_usb_root
 
 menuentry "Relax-and-Recover (no Secure Boot)"  --class gnu-linux --class gnu --class os {
      echo 'Loading kernel ...'
-     linux /isolinux/kernel root=UUID=$root_uuid $KERNEL_CMDLINE
+     linux $esp_kernel root=UUID=$root_uuid $KERNEL_CMDLINE
      echo 'Loading initial ramdisk ...'
-     initrd /isolinux/$REAR_INITRD_FILENAME
+     initrd $esp_initrd
 }
 
 menuentry "Relax-and-Recover (Secure Boot)"  --class gnu-linux --class gnu --class os {
      echo 'Loading kernel ...'
-     linuxefi /isolinux/kernel root=UUID=$root_uuid $KERNEL_CMDLINE
+     linuxefi $esp_kernel root=UUID=$root_uuid $KERNEL_CMDLINE
      echo 'Loading initial ramdisk ...'
-     initrdefi /isolinux/$REAR_INITRD_FILENAME
+     initrdefi $esp_initrd
+}
+
+menuentry "Boot original system" {
+    search --fs-uuid --no-floppy --set=esp $esp_disk_uuid
+    chainloader (\$esp)$esp_relative_bootloader
 }
 
 menuentry "Reboot" {

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -165,6 +165,11 @@ if is_true $USING_UEFI_BOOTLOADER ; then
         echo "          echo 'Loading initrd $boot_initrd_file (may take a while) ...'"
         echo "          initrd $grub_boot_dir/$boot_initrd_name"
         echo "}"
+        echo ""
+        echo "menuentry 'Boot original system' {"
+        echo "          search --fs-uuid --no-floppy --set=esp $esp_disk_uuid"
+        echo "          chainloader (\$esp)$esp_relative_bootloader"
+        echo "}"
     ) > $grub_config_dir/rear.cfg
 
     # Create rear.efi at UEFI default boot directory location.

--- a/usr/share/rear/rescue/default/860_set_uefi_vars.sh
+++ b/usr/share/rear/rescue/default/860_set_uefi_vars.sh
@@ -1,0 +1,11 @@
+# USING_UEFI_BOOTLOADER empty or no explicit 'true' value means NO UEFI:
+is_true $USING_UEFI_BOOTLOADER || return 0
+
+# Don't do any guess work for boot loader, we will use systemd-bootx64.efi.
+is_true $EFI_STUB && return 0
+
+esp_info=$(df $UEFI_BOOTLOADER | tail -n 1)
+esp_mpt=$(echo $esp_info | awk '{print $NF}')
+esp_disk=$(echo $esp_info | awk '{print $1}')
+esp_relative_bootloader=$(echo ${UEFI_BOOTLOADER#$esp_mpt})
+esp_disk_uuid=$(echo $(lsblk --noheadings --output uuid $esp_disk))


### PR DESCRIPTION
* Type: **New Feature** / **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): #2276 

* How was this pull request tested? 
ReaR rescue system boot with:
OUTPUT=USB and OUTPUT=NETFS
on
 \- SLES12-SP2
 \- Fedora29
 \- Centos 7

* Brief description of the changes in this pull request:
**This patch adds following:**
   \- Possibility to boot original system for UEFI boot with OUTPUT=NETFS
   and OUTPUT=USB (similarly to non UEFI ReaR rescue system).

   \- Introduces couple of new variables that could be later beneficial for other UEFI code:
     - esp_mpt - mount-point of ESP (e.g. /boot/efi)
     - esp_disk - disk device holding ESP (e.g. /dev/sda1)
     - esp_relative_bootloader - relative path to UEFI_BOOTLOADER (e.g. /EFI/BOOT/BOOTX64.EFI)
     - esp_disk_uuid - UUID of disk holding ESP

   \- Replaces grub-mkimage for building of Grub2 boot image for OUTPUT=USB
   with build_bootx86_efi() (grub-mkstandalone).
   \- Replaces separate Grub configuration for OUTPUT=USB with
   create_grub2_cfg()

   Using [build_bootx86_efi()](https://github.com/rear/rear/blob/master/usr/share/rear/lib/uefi-functions.sh#L39) and [create_grub2_cfg()](https://github.com/rear/rear/blob/master/usr/share/rear/lib/bootloader-functions.sh#L495) in OUTPUT=USB will
   unify process of Grub boot image creation with OUTPUT=NETFS.
