### PR TITLE
Home directory of root user is not hard-coded any more.

### DIFF
--- a/doc/user-guide/04-scenarios.adoc
+++ b/doc/user-guide/04-scenarios.adoc
@@ -137,7 +137,7 @@ BORGBACKUP_COMPRESSION="lzma,6"     # Slowest backup, best compression
 # (https://borgbackup.readthedocs.io/en/stable/usage/init.html)
 BORGBACKUP_ENC_TYPE="keyfile"
 export BORG_PASSPHRASE='S3cr37_P455w0rD'
-COPY_AS_IS_BORG=( "/root/.config/borg/keys/" )
+COPY_AS_IS_BORG=( "$ROOT_HOME_DIR/.config/borg/keys/" )
 
 # Borg environment variables
 # (https://borgbackup.readthedocs.io/en/stable/usage/general.html#environment-variables)
@@ -167,7 +167,7 @@ export BORG_RELOCATED_REPO_ACCESS_IS_OK="yes"
 export BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK="yes"
 
 COPY_AS_IS_EXCLUDE=( "${COPY_AS_IS_EXCLUDE[@]}" )
-COPY_AS_IS_BORG=( '/root/.config/borg/keys/' )
+COPY_AS_IS_BORG=( "$ROOT_HOME_DIR/.config/borg/keys/" )
 
 SSH_UNPROTECTED_PRIVATE_KEYS="yes"
 SSH_FILES="yes"
@@ -177,7 +177,7 @@ SSH_FILES="yes"
 
 IMPORTANT: If using BORGBACKUP_ENC_TYPE="keyfile", don't forget to make your
            encryption key available for case of restore!
-           (using `COPY_AS_IS_BORG=( "/root/.config/borg/keys/" )` is a option to consider).
+           (using `COPY_AS_IS_BORG=( "$ROOT_HOME_DIR/.config/borg/keys/" )` is a option to consider).
            Be sure to read https://borgbackup.readthedocs.io/en/stable/usage/init.html,
            and make your self familiar how encryption in Borg works.
 
@@ -1343,16 +1343,16 @@ Once booted on your recovery image, the `mountonly` workflow will:
 
 * offer to decrypt any LUKS-encrypted filesystem that may be present
 
-* mount all the target filesystems (including the most important virtual 
+* mount all the target filesystems (including the most important virtual
   ones) below `/mnt/local`
 
 thereby making it possible for you to explore your system at will,
-correcting any configuration mistake that may have prevented its startup, 
-or allowing you to simply `chroot` into it and further repair it using its 
+correcting any configuration mistake that may have prevented its startup,
+or allowing you to simply `chroot` into it and further repair it using its
 own administrative tools.
 
-One important point to remember is that the `mountonly` workflow on its own 
-won't modify the target system in any way. Of course, once the target 
+One important point to remember is that the `mountonly` workflow on its own
+won't modify the target system in any way. Of course, once the target
 filesystems are mounted you, as the administrator, may decide to do so
 manually.
 
@@ -1364,19 +1364,19 @@ layout description file generated during the run of the `mkrescue` or
 Here are the steps you would typically follow:
 
 === Create your recovery image
-Using any of the techniques described in the other scenarios, create a 
-ReaR recovery image for your system (through `rear mkrescue` or `rear 
-mkbackup`). If you only take the `mountonly` workflow into consideration, it 
-doesn't matter whether you also make a backup of your system or not 
-(obviously, you'd better cover all your bases and make sure you'd be able to 
+Using any of the techniques described in the other scenarios, create a
+ReaR recovery image for your system (through `rear mkrescue` or `rear
+mkbackup`). If you only take the `mountonly` workflow into consideration, it
+doesn't matter whether you also make a backup of your system or not
+(obviously, you'd better cover all your bases and make sure you'd be able to
 perform a full `recover` as well should the need occur).
 
-Please note, that by default ReaR only includes in the recovery image the 
-tools it will need to recover the system. If you anticipate the need for 
-some extra tools in the context of a repair operation (e.g. tools that you 
-might need in the event `chroot`ing into the target system doesn't work), you 
-should make sure to include them in your recovery image by adding to the 
-`PROGS` or `REQUIRED_PROGS` configuration variables (please refer to the 
+Please note, that by default ReaR only includes in the recovery image the
+tools it will need to recover the system. If you anticipate the need for
+some extra tools in the context of a repair operation (e.g. tools that you
+might need in the event `chroot`ing into the target system doesn't work), you
+should make sure to include them in your recovery image by adding to the
+`PROGS` or `REQUIRED_PROGS` configuration variables (please refer to the
 comments in `default.conf` for the exact meaning of each).
 
 === Booting on the recovery image
@@ -1384,7 +1384,7 @@ Arrange for the target system to boot on your recovery image as you would in
 any of the other scenarios.
 
 === Launching the "mount only" workflow
-Issue the `rear mountonly` command to launch the workflow (that one is always 
+Issue the `rear mountonly` command to launch the workflow (that one is always
 verbose):
 
 ----
@@ -1405,7 +1405,7 @@ Mounting filesystem /
 Mounting filesystem /home
 Mounting filesystem /boot/efi
 Please enter the password for LUKS device cr_vg00-lvol4 (/dev/mapper/vg00-lvol4):
-Enter passphrase for /dev/mapper/vg00-lvol4: 
+Enter passphrase for /dev/mapper/vg00-lvol4:
 Mounting filesystem /products
 Disk layout processed.
 Finished 'mountonly'. The target system is mounted at '/mnt/local'.
@@ -1413,25 +1413,25 @@ Exiting rear mountonly (PID 625) and its descendant processes ...
 Running exit tasks
 ----
 
-As you can see in the output above, you will first be asked to confirm 
-running the workflow (`Proceed with 'mountonly'`) -- simply press return. 
-All the target filesystems should now be mounted below `/mnt/local` (including 
-LUKS-encrypted ones if present and all needed virtual ones). In case any of 
-them fails to mount, you will be offered to review the mount script and to 
+As you can see in the output above, you will first be asked to confirm
+running the workflow (`Proceed with 'mountonly'`) -- simply press return.
+All the target filesystems should now be mounted below `/mnt/local` (including
+LUKS-encrypted ones if present and all needed virtual ones). In case any of
+them fails to mount, you will be offered to review the mount script and to
 re-execute it if needed.
 
 Once the system is in the desired state, you can start exploring it, correcting
-any configuration mistake or filesystem corruption that prevented it from 
-booting properly. In this state, the only tools at your disposal are those 
+any configuration mistake or filesystem corruption that prevented it from
+booting properly. In this state, the only tools at your disposal are those
 included by default in ReaR recovery image, or those you saw fit to add
 yourself (see above).
 
 If this is not enough and you need to run the native administrative tools
-hosted inside your target system (such as YaST in the case of SUSE 
-distributions), you are now in a position where you can `chroot` inside 
+hosted inside your target system (such as YaST in the case of SUSE
+distributions), you are now in a position where you can `chroot` inside
 your system to reach them (`chroot /mnt/local`).
 
 === Closing the session
-Once done, don't forget to leave the `chroot` environment if applicable 
-(Ctrl-D), then issue the `shutdown` command. This will ensure that all the 
+Once done, don't forget to leave the `chroot` environment if applicable
+(Ctrl-D), then issue the `shutdown` command. This will ensure that all the
 target filesystems will be cleanly unmounted before the system is restarted.

--- a/usr/share/rear/build/GNU/Linux/130_create_dotfiles.sh
+++ b/usr/share/rear/build/GNU/Linux/130_create_dotfiles.sh
@@ -9,7 +9,7 @@
 # use this ruler to make sure the comments stay in a single line:
 # the bash prompt is: 'RESCUE $HOSTNAME:~ #
 # -----------------------------------------------------80-|
-cat <<EOF > $ROOTFS_DIR/root/.bash_history
+cat <<EOF > $ROOTFS_DIR/$ROOT_HOME_DIR/.bash_history
 : # no more predefined ReaR entries in the bash history
 systemctl start sshd.service              # start SSH daemon
 ip -4 addr                                # get IPv4 address
@@ -24,6 +24,6 @@ rear recover                              # recover system
 : # there are some predefined entries in the bash history
 EOF
 
-chmod $v 0644 $ROOTFS_DIR/root/.bash_history >&2
+chmod $v 0644 $ROOTFS_DIR/$ROOT_HOME_DIR/.bash_history >&2
 
 # any other dot files should be listed below

--- a/usr/share/rear/build/default/501_check_ssh_keys.sh
+++ b/usr/share/rear/build/default/501_check_ssh_keys.sh
@@ -20,13 +20,13 @@ if is_false "$SSH_UNPROTECTED_PRIVATE_KEYS" ; then
     # When SSH_UNPROTECTED_PRIVATE_KEYS is false let ReaR find SSH key files:
     local host_key_files=( etc/ssh/ssh_host_* )
     # Caveat: This code will only detect SSH key files for root, not for other users.
-    local root_key_files=( root/.ssh/identi[t]y root/.ssh/id_* )
+    local root_key_files=( ./$ROOT_HOME_DIR/.ssh/identi[t]y ./$ROOT_HOME_DIR/.ssh/id_* )
     # Parse etc/ssh/ssh_config and root/.ssh/config (if exists) to find more key files
     # that could be specified via (not commented) IdentityFile entries (if exists)
     # and replace '~' in things like '~/.ssh/id_rsa' with 'root/.ssh/id_rsa':
     local more_key_files="$( sed -n -e "s#~#root#g" \
                                     -e '/^[^#]*identityfile/Is/^.*identityfile[ ]\+\([^ ]\+\).*$/\1/ip' \
-                                 etc/ssh/ssh_co[n]fig root/.ssh/co[n]fig </dev/null )"
+                                 etc/ssh/ssh_co[n]fig ./$ROOT_HOME_DIR/.ssh/co[n]fig </dev/null )"
     # Combine the found key files:
     key_files=( $( echo "${host_key_files[@]}" "${root_key_files[@]}" "${more_key_files[@]}" | tr -s '[:space:]' '\n' | sort -u ) )
 else

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -57,6 +57,17 @@
 # would not work in compliance with the Linux/Unix standards regarding TMPDIR
 # see https://github.com/rear/rear/issues/968
 
+##
+# ROOT_HOME_DIR
+#
+# According to the Filesystem Hierarchy Standard
+# the home directory for the root user has to be '/root'
+# cf. https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
+# but you may set it as needed like ROOT_HOME_DIR=~root
+# ~root is not included into double (or single) quotes so it can be
+# later expanded to actual root home directory.
+ROOT_HOME_DIR=~root
+
 # You can override autodetection and specify the kernel for the rescue/recovery system:
 KERNEL_FILE=""
 # The kernel configuration is used to collect the kernel binary and modules.

--- a/usr/share/rear/conf/examples/borg-example.conf
+++ b/usr/share/rear/conf/examples/borg-example.conf
@@ -20,7 +20,7 @@ BORGBACKUP_COMPRESSION="zlib,9"
 ## Borg repository encryption
 BORGBACKUP_ENC_TYPE="keyfile"
 # Change directory for storing repository keys
-export BORG_KEYS_DIR="/root/keys"
+export BORG_KEYS_DIR=~root/keys
 # Password for key encryption
 export BORG_PASSPHRASE="S3cr37_P455w0rD"
 # Copy encryption keys to Relax-and-Recover rescue/recovery system

--- a/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
+++ b/usr/share/rear/finalize/GNU/Linux/310_migrate_udev_rules.sh
@@ -40,7 +40,7 @@ for rule in "${UDEV_NET_MAC_RULE_FILES[@]}" ; do
     cmp -s "$rule" "$TARGET_FS_ROOT/$rule" && continue
     # Save the one that was restored from the backup:
     rulefile="$( basename "$rule" )"
-    cp $v "$TARGET_FS_ROOT/$rule" $TARGET_FS_ROOT/root/rear-"$rulefile".old
+    cp $v "$TARGET_FS_ROOT/$rule" $TARGET_FS_ROOT/$ROOT_HOME_DIR/rear-"$rulefile".old
     # Overwrite the one that was restored from the backup with the one from the rescue system:
     LogPrint "Replacing restored udev rule '$TARGET_FS_ROOT/$rule' with the one from the ReaR rescue system"
     cp $v "$rule" "$TARGET_FS_ROOT/$rule" || LogPrintError "Failed to copy '$rule' to '$TARGET_FS_ROOT/$rule'"

--- a/usr/share/rear/finalize/NBU/default/990_copy_bplogrestorelog.sh
+++ b/usr/share/rear/finalize/NBU/default/990_copy_bplogrestorelog.sh
@@ -1,5 +1,5 @@
 # 990_copy_bprestorelog.sh
 # copy the logfile to the recovered system, at least the part that has been written till now.
 
-mkdir -p $TARGET_FS_ROOT/root
-cp -f $TMP_DIR/bplog.restore* $TARGET_FS_ROOT/root/
+mkdir -p $TARGET_FS_ROOT/$ROOT_HOME_DIR
+cp -f $TMP_DIR/bplog.restore* $TARGET_FS_ROOT/$ROOT_HOME_DIR/

--- a/usr/share/rear/prep/DUPLICITY/default/050_prep_duplicity.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/050_prep_duplicity.sh
@@ -24,9 +24,9 @@ COPY_AS_IS=(
 /etc/python
 /etc/python2.6
 /etc/python2.7
-/root/.duply
-/root/.duplicity
-/root/.gnupg
+$ROOT_HOME_DIR/.duply
+$ROOT_HOME_DIR/.duplicity
+$ROOT_HOME_DIR/.gnupg
 /usr/lib/pymodules
 /usr/lib/pyshared
 /usr/lib/python2.6

--- a/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
@@ -40,7 +40,7 @@ if [ "$BACKUP_PROG" = "duplicity" ] && has_binary duply; then
     # we found the duply program; check if we can find a profile defined in ReaR config file
     if [[ -z "$DUPLY_PROFILE" ]]; then
         # no profile pre-set in local.conf; let's try to find one
-        DUPLY_PROFILE=$( find /etc/duply /root/.duply -name conf 2>&1)
+        DUPLY_PROFILE=$( find /etc/duply $ROOT_HOME_DIR/.duply -name conf 2>&1)
         # above result could contain more than one profile
         [[ -z "$DUPLY_PROFILE" ]] && return
         find_duply_profile "$DUPLY_PROFILE"
@@ -50,7 +50,7 @@ if [ "$BACKUP_PROG" = "duplicity" ] && has_binary duply; then
     [[ -z "$DUPLY_PROFILE" ]] && return
 
     # retrieve the real path of DUPLY_PROFILE in case DUPLY_PROFILE was defined local.conf
-    DUPLY_PROFILE_FILE=$( ls /etc/duply/$DUPLY_PROFILE/conf /root/.duply/$DUPLY_PROFILE/conf 2>/dev/null )
+    DUPLY_PROFILE_FILE=$( ls /etc/duply/$DUPLY_PROFILE/conf $ROOT_HOME_DIR/.duply/$DUPLY_PROFILE/conf 2>/dev/null )
     # Assuming we have a duply configuration we must have a path, right?
     [[ -z "$DUPLY_PROFILE_FILE" ]] && return
     find_duply_profile "$DUPLY_PROFILE_FILE"

--- a/usr/share/rear/rescue/default/300_patch_root_home.sh
+++ b/usr/share/rear/rescue/default/300_patch_root_home.sh
@@ -1,0 +1,11 @@
+# Update root home directory
+
+# When home directory or root user is moved away from default "/root"
+# we will move it in ReaR recovery system as well. This will help to keep
+# recovery system similar to original as much as possible.
+# When root home directory is in default "/root" action in this file will be
+# skipped.
+test $ROOT_HOME_DIR = "/root" && return
+
+sed -i s#export\ HOME=/root\$#export\ HOME=${ROOT_HOME_DIR}#g $ROOTFS_DIR/bin/login
+sed -i s#root::0:0:root:/root:#root::0:0:root:${ROOT_HOME_DIR}:#g $ROOTFS_DIR/etc/passwd

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -23,17 +23,17 @@ if is_true "$SSH_FILES" ; then
     # into the recovery system to make remote access "just work" in the recovery system
     # (provided SSH_UNPROTECTED_PRIVATE_KEYS is not false - otherwise unprotected keys get excluded)
     # cf. https://github.com/rear/rear/issues/1512 and https://github.com/rear/rear/issues/1511
-    copy_as_is_ssh_files=( /etc/s[s]h /root/.s[s]h /root/.shos[t]s )
+    copy_as_is_ssh_files=( /etc/s[s]h $ROOT_HOME_DIR/.s[s]h $ROOT_HOME_DIR/.shos[t]s )
 else
     # Use a reasonably secure fallback if SSH_FILES is not set or empty:
     contains_visible_char "${SSH_FILES[*]}" || SSH_FILES="avoid_sensitive_files"
     if test "avoid_sensitive_files" = "$SSH_FILES" ; then
         # Avoid copying sensitive SSH files:
         # From /etc/ssh copy only moduli ssh_config sshd_config ssh_known_hosts
-        # and from /root/.ssh copy only authorized_keys known_hosts (if exists)
+        # and from $ROOT_HOME_DIR/.ssh copy only authorized_keys known_hosts (if exists)
         # cf. https://github.com/rear/rear/issues/1512#issuecomment-331638066
         copy_as_is_ssh_files=( /etc/ssh/modu[l]i /etc/ssh/ssh_co[n]fig /etc/ssh/sshd_co[n]fig /etc/ssh/ssh_known_hos[t]s )
-        copy_as_is_ssh_files=( "${copy_as_is_ssh_files[@]}" /root/.ssh/authorized_ke[y]s /root/.ssh/known_hos[t]s )
+        copy_as_is_ssh_files=( "${copy_as_is_ssh_files[@]}" $ROOT_HOME_DIR/.ssh/authorized_ke[y]s $ROOT_HOME_DIR/.ssh/known_hos[t]s )
     else
         # Copy exactly what is specified:
         copy_as_is_ssh_files=( "${SSH_FILES[@]}" )
@@ -85,8 +85,8 @@ fi
 echo "ssh:23:respawn:/etc/scripts/run-sshd" >>$ROOTFS_DIR/etc/inittab
 
 # Print an info if there is no authorized_keys file for root and no SSH_ROOT_PASSWORD set:
-if ! test -f "/root/.ssh/authorized_keys" -o "$SSH_ROOT_PASSWORD" ; then
-    LogPrintError "To log into the recovery system via ssh set up /root/.ssh/authorized_keys or specify SSH_ROOT_PASSWORD"
+if ! test -f "$ROOT_HOME_DIR/.ssh/authorized_keys" -o "$SSH_ROOT_PASSWORD" ; then
+    LogPrintError "To log into the recovery system via ssh set up $ROOT_HOME_DIR/.ssh/authorized_keys or specify SSH_ROOT_PASSWORD"
 fi
 
 # Set the SSH root password; if pw is encrypted just copy it otherwise use openssl (for backward compatibility)

--- a/usr/share/rear/restore/DUPLICITY/default/110_check_temp_dir_with_duply.sh
+++ b/usr/share/rear/restore/DUPLICITY/default/110_check_temp_dir_with_duply.sh
@@ -10,7 +10,7 @@
 # if DUPLY_PROFILE="" then we have nonsense defined in our ReaR configuration
 [[ -z "$DUPLY_PROFILE" ]] && return
 
-DUPLY_PROFILE_FILE=$( ls /etc/duply/$DUPLY_PROFILE/conf /root/.duply/$DUPLY_PROFILE/conf 2>/dev/null )
+DUPLY_PROFILE_FILE=$( ls /etc/duply/$DUPLY_PROFILE/conf $ROOT_HOME_DIR/.duply/$DUPLY_PROFILE/conf 2>/dev/null )
 # Assuming we have a duply configuration we must have a path, right?
 [[ -z "$DUPLY_PROFILE_FILE" ]] && return
 find_duply_profile "$DUPLY_PROFILE_FILE"

--- a/usr/share/rear/restore/RSYNC/default/800_copy_restore_log.sh
+++ b/usr/share/rear/restore/RSYNC/default/800_copy_restore_log.sh
@@ -1,12 +1,12 @@
 # copy the restore log to restored system $TARGET_FS_ROOT/root/ with a timestamp
 
-if ! test -d $TARGET_FS_ROOT/root ; then
-	mkdir -p $TARGET_FS_ROOT/root
-	chmod 0700 $TARGET_FS_ROOT/root
+if ! test -d $TARGET_FS_ROOT/$ROOT_HOME_DIR ; then
+	mkdir -p $TARGET_FS_ROOT/$ROOT_HOME_DIR
+	chmod 0700 $TARGET_FS_ROOT/$ROOT_HOME_DIR
 fi
 
-cp "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log" $TARGET_FS_ROOT/root/restore-$(date +%Y%m%d.%H%M).log
-StopIfError "Could not copy ${BACKUP_PROG_ARCHIVE}-restore.log to $TARGET_FS_ROOT/root"
-gzip "$TARGET_FS_ROOT/root/restore-$(date +%Y%m%d.)*.log"
+cp "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log" $TARGET_FS_ROOT/$ROOT_HOME_DIR/restore-$(date +%Y%m%d.%H%M).log
+StopIfError "Could not copy ${BACKUP_PROG_ARCHIVE}-restore.log to $TARGET_FS_ROOT/$ROOT_HOME_DIR"
+gzip "$TARGET_FS_ROOT/$ROOT_HOME_DIR/restore-$(date +%Y%m%d.)*.log"
 
 # the rear.log file will be copied later (by wrapup/default/990_copy_logfile.sh)

--- a/usr/share/rear/setup/default/005_ssh_agent_start.sh
+++ b/usr/share/rear/setup/default/005_ssh_agent_start.sh
@@ -13,5 +13,5 @@ if has_binary ssh-agent && has_binary ssh && grep -iq AddKeysToAgent "$(type -P 
     AddExitTask "ssh-agent -k >/dev/null"
     eval "$(ssh-agent -s)"
 
-    echo -e "\nHost *\nAddKeysToAgent yes\n" >> /root/.ssh/config
+    echo -e "\nHost *\nAddKeysToAgent yes\n" >> $ROOT_HOME_DIR/.ssh/config
 fi

--- a/usr/share/rear/wrapup/default/990_copy_logfile.sh
+++ b/usr/share/rear/wrapup/default/990_copy_logfile.sh
@@ -25,7 +25,7 @@ copy_log_file_exit_task="mkdir -p -m 0700 $recovery_system_recover_log_dir && cp
 # To be backward compatible with where to the logfile was copied before
 # have it as a symbolic link that points to where the logfile actually is:
 # ( "roots" in recovery_system_roots_home_dir means root's but ' in a variable name is not so good ;-)
-recovery_system_roots_home_dir=$TARGET_FS_ROOT/root
+recovery_system_roots_home_dir=$TARGET_FS_ROOT/$ROOT_HOME_DIR
 test -d $recovery_system_roots_home_dir || mkdir $verbose -m 0700 $recovery_system_roots_home_dir
 log_file_symlink_target=$recover_log_dir/$final_logfile_name
 # Remove existing and now outdated symlinks that would falsely point to the same target cf. https://github.com/rear/rear/issues/2301


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): #2331

* How was this pull request tested?
Full backup/restore with:
  - root home directory set to _/root_
  - root home directory set to _/root/home/root_

* Brief description of the changes in this pull request:
This patch removes hard-coded location of root home directory (/root) from ReaR code, and replaces it with global configuration variable **ROOT_HOME_DIR**. This allows to correctly track home directory of root user even when a non-default location is used.

