### PR TITLE
Add missing but required NFS users for proper rpcbind startup

### DIFF
--- a/usr/share/rear/prep/NETFS/default/100_check_nfs_version.sh
+++ b/usr/share/rear/prep/NETFS/default/100_check_nfs_version.sh
@@ -9,9 +9,9 @@ for module in $(lsmod|grep nfs|awk '{print $1}') ; do
 done
 
 # add any nfs related user to the rescue environment
-# rpcuser   : Default
-# rpc       : Added for RHEL7.x
-# _rpc      : Debian 10
+# rpcuser  : default
+# rpc      : used in for RHEL7.x
+# _rpc     : used in Debian 10
 CLONE_USERS=( ${CLONE_USERS[@]} rpcuser rpc _rpc )
 
 # copy nfs related configuration files

--- a/usr/share/rear/prep/NETFS/default/100_check_nfs_version.sh
+++ b/usr/share/rear/prep/NETFS/default/100_check_nfs_version.sh
@@ -10,7 +10,7 @@ done
 
 # add any nfs related user to the rescue environment
 # rpcuser  : default
-# rpc      : used in for RHEL7.x
+# rpc      : used in RHEL7.x
 # _rpc     : used in Debian 10
 CLONE_USERS=( ${CLONE_USERS[@]} rpcuser rpc _rpc )
 

--- a/usr/share/rear/prep/NETFS/default/100_check_nfs_version.sh
+++ b/usr/share/rear/prep/NETFS/default/100_check_nfs_version.sh
@@ -9,7 +9,10 @@ for module in $(lsmod|grep nfs|awk '{print $1}') ; do
 done
 
 # add any nfs related user to the rescue environment
-CLONE_USERS=( ${CLONE_USERS[@]} rpcuser )
+# rpcuser   : Default
+# rpc       : Added for RHEL7.x
+# _rpc      : Debian 10
+CLONE_USERS=( ${CLONE_USERS[@]} rpcuser rpc _rpc )
 
 # copy nfs related configuration files
 COPY_AS_IS=( ${COPY_AS_IS[@]} /etc/nfsmount.conf /etc/sysconfig/nfs )

--- a/usr/share/rear/prep/NETFS/default/100_check_nfs_version.sh
+++ b/usr/share/rear/prep/NETFS/default/100_check_nfs_version.sh
@@ -5,17 +5,17 @@ mount | grep nfs > "$TMP_DIR/nfs.mount.info"
 
 # make sure we have the nfs related kernel on-board
 for module in $(lsmod|grep nfs|awk '{print $1}') ; do
-    MODULES=( ${MODULES[@]} $module )
+    MODULES+=( $module )
 done
 
 # add any nfs related user to the rescue environment
 # rpcuser  : default
 # rpc      : used in RHEL7.x
 # _rpc     : used in Debian 10
-CLONE_USERS=( ${CLONE_USERS[@]} rpcuser rpc _rpc )
+CLONE_USERS+=( rpcuser rpc _rpc )
 
 # copy nfs related configuration files
-COPY_AS_IS=( ${COPY_AS_IS[@]} /etc/nfsmount.conf /etc/sysconfig/nfs )
+COPY_AS_IS+=( /etc/nfsmount.conf /etc/sysconfig/nfs )
 
 # create the required nfs related directories found under /var/lib/nfs
 # in $ROOTFS_DIR
@@ -25,13 +25,13 @@ done
 
 # verify is we require more nfsv4 related daemons
 if grep -q nfs4 "$TMP_DIR/nfs.mount.info" ; then
-    COPY_AS_IS=( ${COPY_AS_IS[@]} /etc/idmapd.conf )
-    PROGS=( ${PROGS[@]} nfsidmap nfsdcltrack nfsstat rpc.mountd rpc.idmapd )
-    COPY_AS_IS=( ${COPY_AS_IS[@]} "/lib64/libnfsidmap/*" )
+    COPY_AS_IS+=( /etc/idmapd.conf )
+    PROGS+=( nfsidmap nfsdcltrack nfsstat rpc.mountd rpc.idmapd )
+    COPY_AS_IS+=( "/lib64/libnfsidmap/*" )
 
     if grep -q "sys=krb" "$TMP_DIR/nfs.mount.info" ; then
         # Kerberos used with nfsv4
-        COPY_AS_IS=( ${COPY_AS_IS[@]} "/etc/request-key.d/*" /etc/request-key.conf /etc/gss /etc/gssproxy )
-        PROGS=( ${PROGS[@]} rpc.gssd request-key keyctl gssproxy gss_destroy_creds gss_clnt_send_err )
+        COPY_AS_IS+=( "/etc/request-key.d/*" /etc/request-key.conf /etc/gss /etc/gssproxy )
+        PROGS+=( rpc.gssd request-key keyctl gssproxy gss_destroy_creds gss_clnt_send_err )
     fi
 fi


### PR DESCRIPTION
* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?**
**Bug Fix**
* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent**
**Low**
* Reference to related issue (URL):
#2341 and #2250 
* How was this pull request tested?
- Under RHEL7.6: On a  HPE DL360 Gen10.
- Under Debian 10: -

* Brief description of the changes in this pull request:
This pull request adds the missing but required NFS users for RHEL7.x and Debian 10 to let `rpcbind `start successfully during recovery.
