### PR TITLE
Have '-iso-level 3' option also for ppc64le

### DIFF
--- a/usr/share/rear/output/ISO/Linux-ppc64le/820_create_iso_image.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64le/820_create_iso_image.sh
@@ -17,8 +17,12 @@ else
     chrp_boot_option="-chrp-boot"
 fi
 
+# Have a hardcoded '-iso-level 3' option also here because it is
+# also hardcoded in output/ISO/Linux-i386/820_create_iso_image.sh
+# and it seems to also work in general on POWER architecture
+# cf. https://github.com/rear/rear/issues/2344#issuecomment-601949828
 $ISO_MKISOFS_BIN $v $ISO_MKISOFS_OPTS -o "$ISO_DIR/$ISO_PREFIX.iso" \
-    -U $chrp_boot_option -R -J -volid "$ISO_VOLID" -v -graft-points \
+    -U $chrp_boot_option -R -J -volid "$ISO_VOLID" -v -iso-level 3 -graft-points \
     "${ISO_FILES[@]}" >&2
 
 StopIfError "Could not create ISO image (with $ISO_MKISOFS_BIN)"


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2344#issuecomment-601949828

* How was this pull request tested?
By @mmetts in https://github.com/rear/rear/issues/2344

* Brief description of the changes in this pull request:

Have a hardcoded '-iso-level 3' option
in output/ISO/Linux-ppc64le/820_create_iso_image.sh
because it is also hardcoded
in output/ISO/Linux-i386/820_create_iso_image.sh
and it seems to also work in general on PPC64LE architecture.
