### PR TITLE
Use "dd ... bs=1M" in backup/NETFS/default/500_make_backup.sh

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -50,8 +50,12 @@ while read -r backup_exclude_item ; do
 done < $TMP_DIR/backup-exclude.txt
 
 # Check if the backup needs to be splitted or not (on multiple ISOs).
-# Dummy split command when the backup is not splitted (the default case):
-SPLIT_COMMAND="dd of=$backuparchive"
+# Dummy split command when the backup is not splitted (the default case).
+# Let 'dd' read and write up to 1M=1024*1024 bytes at a time to speed up things
+# for example from only 500KiB/s (with the 'dd' default of 512 bytes)
+# via a 100MBit network connection to about its full capacity
+# cf. https://github.com/rear/rear/issues/2369
+SPLIT_COMMAND="dd of=$backuparchive bs=1M"
 if test $ISO_MAX_SIZE ; then
     is_positive_integer $ISO_MAX_SIZE || Error "ISO_MAX_SIZE must be a positive integer value"
     # Tell the user when ISO_MAX_SIZE is less than 600MiB because then things will likely not work


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2369

* How was this pull request tested?
By ReaR user @dsamx

* Brief description of the changes in this pull request:
In backup/NETFS/default/500_make_backup.sh add "bs=1M" to
`SPLIT_COMMAND="dd of=$backuparchive bs=1M"`
to let 'dd' read and write up to 1MiB at a time to speed up things
for example from only 500KiB/s (with the 'dd' default of 512 bytes)
via a 100MBit network connection to about its full capacity
