### PR TITLE
Filter out duplicates in COPY_AS_IS and copy_as_is_filelist_file

### DIFF
--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -5,6 +5,55 @@
 # add them to the LIBS list if they are not yet included in the copied files.
 
 LogPrint "Copying files and directories"
+
+# Filter out duplicate entries in COPY_AS_IS but keep the ordering of the elements
+# (i.e. only the first occurrence of an element is kept)
+# cf. https://github.com/rear/rear/issues/2377
+local copy_as_is_without_duplicates=()
+# The basic deduplication algorithm that is used here is to 'printf' each COPY_AS_IS element
+# on a separated line (i.e. this algorithm fails when elements contain newline characters)
+# and then filter those lines by 'awk' that outputs only the first occurrence of a line.
+# To remove duplicate lines and keep the ordering one could use ... | cat -n | sort -uk2 | sort -nk1 | cut -f2-
+# cf. https://stackoverflow.com/questions/11532157/remove-duplicate-lines-without-sorting/11532197#11532197
+# that also explains an awk command that prints each line provided the line was not seen before.
+# The awk variable $0 holds an entire line and square brackets is associative array access in awk.
+# For each line the node of the associative array 'seen' is incremented and the line is printed
+# if the content of that node was not '!' previously set (i.e. if the line was not previously seen)
+# cf. https://www.thegeekstuff.com/2010/03/awk-arrays-explained-with-5-practical-examples/
+{ while read line ; do
+    # A new temporary array is used to store the deduplicated elements for two reasons:
+    # I <jsmeix@suse.de> found no way how to do rewrite COPY_AS_IS in one command
+    # that also works reliably with spaces or special characters in the elements and
+    # the intermediate array is used to test if the deduplication result looks right:
+    copy_as_is_without_duplicates+=( "$line" )
+  done < <( printf '%s\n' "${COPY_AS_IS[@]}" | awk '!seen[$0]++' )
+} 2>>/dev/$DISPENSABLE_OUTPUT_DEV
+# If the deduplication result does not looks reasonable keep using the unchanged COPY_AS_IS
+# also keep using the unchanged COPY_AS_IS when there was no duplicate element
+# which avoids a useless copy of the copy_as_is_without_duplicates array to COPY_AS_IS.
+# The hardcoded condition that copy_as_is_without_duplicates contains more than 100 elements
+# is based on the finding that usually COPY_AS_IS has about 130 elements without duplicates
+# cf. https://github.com/rear/rear/issues/2377#issuecomment-618301702
+# so if deduplication results less than 100 elements things look fishy (possibly falsely removed elements)
+# and then we fall back using the original COPY_AS_IS because things still work
+# when we let 'tar' needlessly copy duplicated things several times:
+if test ${#copy_as_is_without_duplicates[@]} -gt 100 -a ${#COPY_AS_IS[@]} -gt ${#copy_as_is_without_duplicates[@]} ; then
+    Log "COPY_AS_IS has ${#COPY_AS_IS[@]} elements with duplicates"
+    # The simplest way to copy a non-associative array in bash is COPY=( "$ARRAY[@]" )
+    # but it will compress a sparse array and re-index an array with non-contiguous indices e.g.
+    #   # arr=( zero one two three )
+    #   # unset arr[0] arr[2]
+    #   # declare -p arr
+    #   declare -a arr=([1]="one" [3]="three")
+    #   # arr2=( "${arr[@]}" )
+    #   # declare -p arr2
+    #   declare -a arr2=([0]="one" [1]="three")
+    # which is even an advantage when COPY_AS_IS gets re-indexed (without changing its ordering)
+    # cf. https://stackoverflow.com/questions/19417015/how-to-copy-an-array-in-bash
+    COPY_AS_IS=( "${copy_as_is_without_duplicates[@]}" )
+    Log "COPY_AS_IS has ${#COPY_AS_IS[@]} elements without duplicates"
+fi
+
 Log "Files being copied: ${COPY_AS_IS[@]}"
 Log "Files being excluded: ${COPY_AS_IS_EXCLUDE[@]}"
 
@@ -51,7 +100,7 @@ while read -r copy_as_is_file ; do
     test -L "$copy_as_is_file" && continue
     # Remember actual regular files that are executable:
     test -x "$copy_as_is_file" && copy_as_is_executables+=( "$copy_as_is_file" )
-done <$copy_as_is_filelist_file 2>>/dev/$DISPENSABLE_OUTPUT_DEV
+done < <( sort -u $copy_as_is_filelist_file ) 2>>/dev/$DISPENSABLE_OUTPUT_DEV
 Log "copy_as_is_executables = ${copy_as_is_executables[@]}"
 
 # Check for library dependencies of executables in all the copied files and

--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -92,6 +92,15 @@ Log "Finished copying files and directories in COPY_AS_IS minus COPY_AS_IS_EXCLU
 # Build an array of the actual regular files that are executable in all the copied files:
 local copy_as_is_executables=()
 local copy_as_is_file=""
+# Remove duplicates in the copy_as_is_filelist_file
+# with 'sort -u' because here the ordering does not matter.
+# Duplicates in the copy_as_is_filelist_file can happen
+# even if there are no duplicates in COPY_AS_IS
+# e.g. when COPY_AS_IS contains
+#   /path/to/somedir ... /path/to/somedir/subdir
+# then 'tar' copies things in /path/to/somedir/subdir two times
+# and reports them twice in the copy_as_is_filelist_file
+# cf. https://github.com/rear/rear/pull/2378
 # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_input-output-functions.sh):
 while read -r copy_as_is_file ; do
     # Skip non-regular files like directories, device files, and 'tar' error messages (e.g. in case of non-existent files, see above):

--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -28,7 +28,7 @@ local copy_as_is_without_duplicates=()
     copy_as_is_without_duplicates+=( "$line" )
   done < <( printf '%s\n' "${COPY_AS_IS[@]}" | awk '!seen[$0]++' )
 } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
-# If the deduplication result does not looks reasonable keep using the unchanged COPY_AS_IS
+# If the deduplication result does not look reasonable keep using the unchanged COPY_AS_IS
 # also keep using the unchanged COPY_AS_IS when there was no duplicate element
 # which avoids a useless copy of the copy_as_is_without_duplicates array to COPY_AS_IS.
 # The hardcoded condition that copy_as_is_without_duplicates contains more than 100 elements


### PR DESCRIPTION
* Type: **Enhancement** / **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2377

* How was this pull request tested?

With
```
# cp -vp /usr/sbin/parted /usr/local/bin
# cp -vp /usr/sbin/partprobe /usr/local/bin
```
and in etc/rear/local.conf
```
COPY_AS_IS+=( /usr/local/bin /usr/local/bin /usr/share/man/man8/partprobe.8.gz /usr/share/man/man8/partprobe.8.gz )
```
I get same files in /tmp/rear.XXXX/rootfs
with and without deduplication.

* Brief description of the changes in this pull request:

Filter out duplicate entries in COPY_AS_IS
but keep the ordering of the elements
i.e. only the first occurrence of an element is kept.

Also remove duplicates in the copy_as_is_filelist_file
with 'sort -u' because here the ordering does not matter.

Duplicates in the copy_as_is_filelist_file can happen
even if there are no duplicates in COPY_AS_IS
e.g. when COPY_AS_IS contains
```
/path/to/somedir ... /path/to/somedir/subdir
```
then `tar` copies things in `/path/to/somedir/subdir` two times
and reports them twice in the copy_as_is_filelist_file
