### PR TITLE
Error out when LUKS version 2 is used (issue #2204)

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -42,6 +42,11 @@ while read target_name junk ; do
     uuid=$(cryptsetup luksDump $source_device | grep "UUID" | sed -r 's/^.+:\s*(.+)$/\1/')
     keyfile_option=$([ -f /etc/crypttab ] && awk '$1 == "'"$target_name"'" && $3 != "none" && $3 != "-" && $3 != "" { print "keyfile=" $3; }' /etc/crypttab)
 
+    # LUKS version 2 is not yet suppported, see https://github.com/rear/rear/issues/2204
+    # When LUKS version 2 is used the above code fails at least to determine the hash value
+    # so we use an empty hash value as a simple test if gathering crypt information was successful:
+    test "$hash" || Error "No hash value for LUKS device /dev/mapper/$target_name at $source_device (only LUKS version 1 is supported)"
+
     echo "crypt /dev/mapper/$target_name $source_device cipher=$cipher-$mode key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE
 done < <( dmsetup ls --target crypt )
 

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -45,7 +45,7 @@ while read target_name junk ; do
     # LUKS version 2 is not yet suppported, see https://github.com/rear/rear/issues/2204
     # When LUKS version 2 is used the above code fails at least to determine the hash value
     # so we use an empty hash value as a simple test if gathering crypt information was successful:
-    test "$hash" || Error "No hash value for LUKS device /dev/mapper/$target_name at $source_device (only LUKS version 1 is supported)"
+    test "$hash" || Error "No hash value for LUKS device '$target_name' at '$source_device' (only LUKS version 1 is supported)"
 
     echo "crypt /dev/mapper/$target_name $source_device cipher=$cipher-$mode key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE
 done < <( dmsetup ls --target crypt )


### PR DESCRIPTION
* Type: **Minor Bug Fix**
It is a minor bug when "rear mkrescue/mkbackup" does not error out
when things have actually failed.
In this case when gathering crypt information was not successful
the code blindly proceeds resulting wrong (incomplete) entries
in disklayout.conf that let later (when it is too late) "rear recover" fail.

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2204

* How was this pull request tested?
By me on my current homeoffice laptop that uses LUKS 1.
I get still same 'crypt' entries in disklayout conf.

* Brief description of the changes in this pull request:
Error out during "rear mkrescue/mkbackup" when LUKS version 2 is used
because currently LUKS version 2 is not suppported.
When LUKS version 2 is used it fails at least to determine the hash value cf.
https://github.com/rear/rear/issues/2204#issuecomment-520254591
so we use an empty hash value as a simple test if gathering crypt information
was successful and error out if not.
