### PR TITLE
No longer load video_bochs and video_cirrus by the create_grub2_cfg function

### DIFF
--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -506,8 +506,6 @@ set default="$GRUB2_DEFAULT_BOOT"
 
 insmod efi_gop
 insmod efi_uga
-insmod video_bochs
-insmod video_cirrus
 insmod all_video
 
 set gfxpayload=keep


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2388

* How was this pull request tested?
the change in this pull request was tested by the affected user, see
https://github.com/rear/rear/issues/2388#issuecomment-625147460

* Brief description of the changes in this pull request:

In the `create_grub2_cfg` function in usr/share/rear/lib/bootloader-functions.sh
that is used in case of UEFI to set up GRUB2 as bootloader for the recovery system
do no longer let GRUB2 load the modules `video_bochs` and `video_cirrus`
because those are not available as GRUB2 modules in case of UEFI (`x86_64-efi`)
and the generic `insmod all_video` that is still there should be sufficient for GRUB2
cf. https://github.com/rear/rear/issues/2388#issuecomment-625105141
