### PR TITLE
Make GRUB2_MODULES variables having UEFI specific names (issue 2392)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2779,7 +2779,7 @@ BOOTLOADER=""
 test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
 
 ##
-# GRUB2_MODULES_LOAD
+# GRUB2_MODULES_UEFI_LOAD
 #
 # WARNING: Incorrect use of this variable can lead to unusable ReaR recovery system!
 #          Whenever you modify this variable, test of ReaR recovery system is advised!
@@ -2789,15 +2789,15 @@ test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
 # (a reasonable set of default modules), and add modules needed to access /boot
 # and /boot/efi, if applicable.
 # More modules can be installed into the Grub2 standalone image ramdisk without
-# being included in the core image, see GRUB2_MODULES.
+# being included in the core image, see GRUB2_MODULES_UEFI.
 # This variable currently applies when building Grub2 boot loader for UEFI in two scenarios:
 # 1. UEFI boot without secure boot (SECURE_BOOT_BOOTLOADER="")
 # and / or
 # 2. UEFI boot with GRUB_RESCUE="y"
-GRUB2_MODULES_LOAD=()
+GRUB2_MODULES_UEFI_LOAD=()
 
 ##
-# GRUB2_MODULES
+# GRUB2_MODULES_UEFI
 #
 # WARNING: Incorrect use of this variable can lead to unusable ReaR recovery system!
 #          Whenever you modify this variable, test of ReaR recovery system is advised!
@@ -2807,8 +2807,8 @@ GRUB2_MODULES_LOAD=()
 # or manual loading via insmod.
 # When empty ReaR will use the defaults of grub-mkstandalone
 # (install all modules in the standalone image ramdisk)
-# This variable currently applies in the same scenarios as GRUB2_MODULES_LOAD.
-GRUB2_MODULES=()
+# This variable currently applies in the same scenarios as GRUB2_MODULES_UEFI_LOAD.
+GRUB2_MODULES_UEFI=()
 
 ##
 # GRUB2_DEFAULT_BOOT

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -43,8 +43,8 @@ function build_bootx86_efi {
     local gprobe=""
     local dirs=()
     # modules is the list of modules to load
-    # If GRUB2_MODULES_LOAD is nonempty, it determines what modules to load
-    local modules=( ${GRUB2_MODULES_LOAD:+"${GRUB2_MODULES_LOAD[@]}"} )
+    # If GRUB2_MODULES_UEFI_LOAD is nonempty, it determines what modules to load
+    local modules=( ${GRUB2_MODULES_UEFI_LOAD:+"${GRUB2_MODULES_UEFI_LOAD[@]}"} )
 
     # Configuration file is optional for image creation.
     shift
@@ -69,7 +69,7 @@ function build_bootx86_efi {
     fi
 
     # Determine what modules need to be loaded in order to access given directories
-    # (if the list of modules is not overriden by GRUB2_MODULES_LOAD)
+    # (if the list of modules is not overriden by GRUB2_MODULES_UEFI_LOAD)
     if (( ${#dirs[@]} )) && ! (( ${#modules[@]} )) ; then
         if has_binary grub-probe ; then
             gprobe=grub-probe
@@ -113,10 +113,10 @@ function build_bootx86_efi {
     # would falsely fail with "bash: test: ... unary operator expected":
     test /usr/*/grub*/x86_64-efi/moddep.lst || LogPrintError "$gmkstandalone may fail to make a bootable EFI image of GRUB2 (no /usr/*/grub*/x86_64-efi/moddep.lst file)"
 
-    (( ${#GRUB2_MODULES[@]} )) && LogPrint "Installing only ${GRUB2_MODULES[*]} modules into $outfile memdisk"
+    (( ${#GRUB2_MODULES_UEFI[@]} )) && LogPrint "Installing only ${GRUB2_MODULES_UEFI[*]} modules into $outfile memdisk"
     (( ${#modules[@]} )) && LogPrint "GRUB2 modules to load: ${modules[*]}"
 
-    if ! $gmkstandalone $v ${GRUB2_MODULES:+"--install-modules=${GRUB2_MODULES[*]}"} ${modules:+"--modules=${modules[*]}"} -O x86_64-efi -o $outfile $embedded_config ; then
+    if ! $gmkstandalone $v ${GRUB2_MODULES_UEFI:+"--install-modules=${GRUB2_MODULES_UEFI[*]}"} ${modules:+"--modules=${modules[*]}"} -O x86_64-efi -o $outfile $embedded_config ; then
         Error "Failed to make bootable EFI image of GRUB2 (error during $gmkstandalone of $outfile)"
     fi
 }


### PR DESCRIPTION
Renamed GRUB2_MODULES and GRUB2_MODULES_LOAD
for installing GRUB2 as recovery system UEFI bootloader into
GRUB2_MODULES_UEFI and GRUB2_MODULES_UEFI_LOAD
cf. https://github.com/rear/rear/issues/2392
