### PR TITLE
Error out for unsupported workflow in any case

### DIFF
--- a/usr/share/rear/init/default/050_check_rear_recover_mode.sh
+++ b/usr/share/rear/init/default/050_check_rear_recover_mode.sh
@@ -3,16 +3,33 @@
 # - 'mountonly'
 # - 'opaladmin'
 # - 'help'
-# cf. https://github.com/rear/rear/issues/987
+# cf. https://github.com/rear/rear/issues/719
+# and https://github.com/rear/rear/issues/987
 # and https://github.com/rear/rear/issues/1088
 # and https://github.com/rear/rear/issues/1901
+# In particular in the normal/original system the workflows
+# recover layoutonly restoreonly finalizeonly and mountonly
+# must not run because they can destroy the original system
+# cf. https://github.com/rear/rear/issues/2387#issuecomment-626303944
 # In the ReaR rescue/recovery system /etc/rear-release is unique (it does not exist otherwise):
-test -f /etc/rear-release || return 0
-case "$WORKFLOW" in
-    (recover|layoutonly|restoreonly|finalizeonly|mountonly|opaladmin|help)
-        LogPrint "Running workflow $WORKFLOW within the ReaR rescue/recovery system"
-        ;;
-    (*)
-        Error "The workflow $WORKFLOW is not supported in the ReaR rescue/recovery system"
-        ;;
-esac
+if test -f /etc/rear-release ; then
+    # We are in the ReaR rescue/recovery system:
+    case "$WORKFLOW" in
+        (recover|layoutonly|restoreonly|finalizeonly|mountonly|opaladmin|help)
+            LogPrint "Running workflow $WORKFLOW within the ReaR rescue/recovery system"
+            ;;
+        (*)
+            Error "The workflow $WORKFLOW is not supported in the ReaR rescue/recovery system"
+            ;;
+    esac
+else
+    # We are in the normal/original system:
+    case "$WORKFLOW" in
+        (recover|layoutonly|restoreonly|finalizeonly|mountonly)
+            Error "The workflow $WORKFLOW is only supported in the ReaR rescue/recovery system"
+            ;;
+        (*)
+            LogPrint "Running workflow $WORKFLOW on the normal/original system"
+            ;;
+    esac
+fi


### PR DESCRIPTION

* Type: **Bug Fix**

* Impact: **Critical**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2387#issuecomment-626303944

* How was this pull request tested?
Tested by me on my SLES15 test system

* Brief description of the changes in this pull request:

Before init/default/050_check_rear_recover_mode.sh did only error out
when in the recovery system an unsupported workflow should be run.
Now it also errors out when on the normal/original system
an unsupported workflow should be run.

Rear 2.6 should not be released without that critical bug fix => "blocker".
