### PR TITLE
Update 950_check_missing_programs.sh

### DIFF
--- a/usr/share/rear/init/default/950_check_missing_programs.sh
+++ b/usr/share/rear/init/default/950_check_missing_programs.sh
@@ -18,7 +18,15 @@ local missing_progs=()
 
 # Check for required binaries:
 for prog in "${REQUIRED_PROGS[@]}" ; do
-    has_binary "$prog" || missing_progs+=( "$prog" )
+    # When required programs are specified with absolute path like
+    # REQUIRED_PROGS+=( /special/path/myprogam )
+    # the test "has_binary /special/path/myprogam" works during "rear mkrescue/mkbackup"
+    # but that program appears in the ReaR recovery system as /bin/myprogram
+    # so "has_binary /special/path/myprogam" fails inside the recovery system
+    # which would let "rear recover" falsely error out here
+    # cf. https://github.com/rear/rear/issues/2206
+    # so we also test "has_binary myprogam" which works inside the recovery system:
+    has_binary "$prog" || has_binary "$( basename "$prog" )" || missing_progs+=( "$prog" )
 done
 
 # Have all array members as a single word like "${arr[*]}" because it should detect

--- a/usr/share/rear/init/default/950_check_missing_programs.sh
+++ b/usr/share/rear/init/default/950_check_missing_programs.sh
@@ -33,3 +33,5 @@ done
 # when there is any non-empty array member (not necessarily the first one):
 contains_visible_char "${missing_progs[*]}" && Error "Cannot find required programs: ${missing_progs[@]}"
 
+# Finish successfully:
+return 0


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2206

* How was this pull request tested?
Works well for me.

* Brief description of the changes in this pull request:
When checking for required programs also test for "basename program"
because when required programs are specified with absolute path
those programs appears in the ReaR recovery system in /bin/
so testing their original path would falsely fail during "rear recover"
