### PR TITLE
Create destination directory schema when using lftp

### DIFF
--- a/usr/share/rear/output/PXE/default/820_copy_to_net.sh
+++ b/usr/share/rear/output/PXE/default/820_copy_to_net.sh
@@ -6,7 +6,7 @@ test "$OUTPUT_URL" || return 0
 
 local scheme=$( url_scheme $OUTPUT_URL )
 local result_file=""
-local dest_dir=""
+local path=""
 
 case "$scheme" in
     (nfs|cifs|usb|tape|file|davfs)
@@ -16,18 +16,13 @@ case "$scheme" in
     (fish|ftp|ftps|hftp|http|https|sftp)
         LogPrint "Transferring PXE files to $OUTPUT_URL"
         for result_file in "${RESULT_FILES[@]}" ; do
-            # OUTPUT_URL for lftp transfers will look something like:
-            # "<fish|ftp|ftps|hftp|http|https|sftp>://<host_name>/<destination_directory>"
-            # Using `cut' for printing 4th field with "/" delimiter (.. | cut -d/ -f4-),
-            # will strip leading "<protocol>://<hostname>/" from OUTPUT_URL
-            # and by prefixing "/" we will get absolute path to destination directory.
-            dest_dir="/$(echo $OUTPUT_URL | cut -d/ -f4-)"
+            path=$(url_path $OUTPUT_URL)
 
             # Make sure that destination directory exists, otherwise lftp would copy
             # RESULT_FILES into last available directory in the path.
             # e.g. OUTPUT_URL=sftp://<host_name>/iso/server1 and have "/iso/server1"
             # directory missing, would upload RESULT_FILES into sftp://<host_name>/iso/
-            lftp -c "open $OUTPUT_URL; mkdir -fp ${dest_dir}"
+            lftp -c "open $OUTPUT_URL; mkdir -fp ${path}"
 
             LogPrint "Transferring file: $result_file"
             lftp -c "open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput $result_file" || Error "lftp failed to transfer '$result_file' to '$OUTPUT_URL' (lftp exit code: $?)"

--- a/usr/share/rear/output/PXE/default/820_copy_to_net.sh
+++ b/usr/share/rear/output/PXE/default/820_copy_to_net.sh
@@ -6,6 +6,7 @@ test "$OUTPUT_URL" || return 0
 
 local scheme=$( url_scheme $OUTPUT_URL )
 local result_file=""
+local dest_dir=""
 
 case "$scheme" in
     (nfs|cifs|usb|tape|file|davfs)
@@ -20,7 +21,7 @@ case "$scheme" in
             # Using `cut' for printing 4th field with "/" delimiter (.. | cut -d/ -f4-),
             # will strip leading "<protocol>://<hostname>/" from OUTPUT_URL
             # and by prefixing "/" we will get absolute path to destination directory.
-            local dest_dir="/$(echo $OUTPUT_URL | cut -d/ -f4-)"
+            dest_dir="/$(echo $OUTPUT_URL | cut -d/ -f4-)"
 
             # Make sure that destination directory exists, otherwise lftp would copy
             # RESULT_FILES into last available directory in the path.

--- a/usr/share/rear/output/PXE/default/820_copy_to_net.sh
+++ b/usr/share/rear/output/PXE/default/820_copy_to_net.sh
@@ -15,6 +15,19 @@ case "$scheme" in
     (fish|ftp|ftps|hftp|http|https|sftp)
         LogPrint "Transferring PXE files to $OUTPUT_URL"
         for result_file in "${RESULT_FILES[@]}" ; do
+            # OUTPUT_URL for lftp transfers will look something like:
+            # "<fish|ftp|ftps|hftp|http|https|sftp>://<host_name>/<destination_directory>"
+            # Using `cut' for printing 4th field with "/" delimiter (.. | cut -d/ -f4-),
+            # will strip leading "<protocol>://<hostname>/" from OUTPUT_URL
+            # and by prefixing "/" we will get absolute path to destination directory.
+            local dest_dir="/$(echo $OUTPUT_URL | cut -d/ -f4-)"
+
+            # Make sure that destination directory exists, otherwise lftp would copy
+            # RESULT_FILES into last available directory in the path.
+            # e.g. OUTPUT_URL=sftp://<host_name>/iso/server1 and have "/iso/server1"
+            # directory missing, would upload RESULT_FILES into sftp://<host_name>/iso/
+            lftp -c "open $OUTPUT_URL; mkdir -fp ${dest_dir}"
+
             LogPrint "Transferring file: $result_file"
             lftp -c "open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput $result_file" || Error "lftp failed to transfer '$result_file' to '$OUTPUT_URL' (lftp exit code: $?)"
         done

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -98,11 +98,9 @@ case "$scheme" in
     (fish|ftp|ftps|hftp|http|https|sftp)
         # FIXME: Verify if usage of $array[*] instead of "${array[@]}" is actually intended here
         # see https://github.com/rear/rear/issues/1068
-
         LogPrint "Copying result files '${RESULT_FILES[*]}' to $scheme location"
         Log "lftp -c open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput ${RESULT_FILES[*]}"
 
-        local path=$(url_path $OUTPUT_URL)
         # Make sure that destination directory exists, otherwise lftp would copy
         # RESULT_FILES into last available directory in the path.
         # e.g. OUTPUT_URL=sftp://<host_name>/iso/server1 and have "/iso/server1"

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -98,9 +98,22 @@ case "$scheme" in
     (fish|ftp|ftps|hftp|http|https|sftp)
         # FIXME: Verify if usage of $array[*] instead of "${array[@]}" is actually intended here
         # see https://github.com/rear/rear/issues/1068
+
         LogPrint "Copying result files '${RESULT_FILES[*]}' to $scheme location"
         Log "lftp -c open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput ${RESULT_FILES[*]}"
-        lftp -c "open $OUTPUT_URL; mkdir -fp /$(echo $OUTPUT_URL | cut -d"/" -f4-)"
+
+        # OUTPUT_URL for lftp transfers will look something like:
+        # "<fish|ftp|ftps|hftp|http|https|sftp>://<host_name>/<destination_directory>"
+        # Using `cut' for printing 4th field with "/" delimiter (.. | cut -d/ -f4-),
+        # will strip leading "<protocol>://<hostname>/" from OUTPUT_URL
+        # and by prefixing "/" we will get absolute path to destination directory.
+        local dest_dir="/$(echo $OUTPUT_URL | cut -d/ -f4-)"
+
+        # Make sure that destination directory exists, otherwise lftp would copy
+        # RESULT_FILES into last available directory in the path.
+        # e.g. OUTPUT_URL=sftp://<host_name>/iso/server1 and have "/iso/server1"
+        # directory missing, would upload RESULT_FILES into sftp://<host_name>/iso/
+        lftp -c "open $OUTPUT_URL; mkdir -fp ${dest_dir}"
         lftp -c "open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput ${RESULT_FILES[*]}" || Error "lftp failed to transfer '${RESULT_FILES[*]}' to '$OUTPUT_URL' (lftp exit code: $?)"
         ;;
     (rsync)

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -102,18 +102,12 @@ case "$scheme" in
         LogPrint "Copying result files '${RESULT_FILES[*]}' to $scheme location"
         Log "lftp -c open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput ${RESULT_FILES[*]}"
 
-        # OUTPUT_URL for lftp transfers will look something like:
-        # "<fish|ftp|ftps|hftp|http|https|sftp>://<host_name>/<destination_directory>"
-        # Using `cut' for printing 4th field with "/" delimiter (.. | cut -d/ -f4-),
-        # will strip leading "<protocol>://<hostname>/" from OUTPUT_URL
-        # and by prefixing "/" we will get absolute path to destination directory.
-        local dest_dir="/$(echo $OUTPUT_URL | cut -d/ -f4-)"
-
+        local path=$(url_path $OUTPUT_URL)
         # Make sure that destination directory exists, otherwise lftp would copy
         # RESULT_FILES into last available directory in the path.
         # e.g. OUTPUT_URL=sftp://<host_name>/iso/server1 and have "/iso/server1"
         # directory missing, would upload RESULT_FILES into sftp://<host_name>/iso/
-        lftp -c "open $OUTPUT_URL; mkdir -fp ${dest_dir}"
+        lftp -c "open $OUTPUT_URL; mkdir -fp ${path}"
         lftp -c "open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput ${RESULT_FILES[*]}" || Error "lftp failed to transfer '${RESULT_FILES[*]}' to '$OUTPUT_URL' (lftp exit code: $?)"
         ;;
     (rsync)

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -68,22 +68,22 @@ case "$scheme" in
             # ZVM_NAMING      - set in local.conf, if Y then enable naming override
             # ZVM_KERNEL_NAME - keeps track of kernel name in results array
             # ARCH            - override only if ARCH is Linux-s390
-            # 
+            #
             # initrd name override is handled in 900_create_initramfs.sh
             # kernel name override is handled in 400_guess_kernel.sh
             # kernel name override is handled in 950_copy_result_files.sh
 
-            if [[ "$ZVM_NAMING" == "Y" && "$ARCH" == "Linux-s390" ]] ; then 
+            if [[ "$ZVM_NAMING" == "Y" && "$ARCH" == "Linux-s390" ]] ; then
                if [[ -z $opath ]] ; then
                   Error "Output path is not set, please check OUTPUT_URL in local.conf."
-               fi  
+               fi
 
                if [ "$ZVM_KERNEL_NAME" == "$result_file" ] ; then
                   VM_UID=$(vmcp q userid |awk '{ print $1 }')
 
                   if [[ -z $VM_UID ]] ; then
                      Error "VM UID is not set, VM UID is set from call to vmcp.  Please make sure vmcp is available and 'vmcp q userid' returns VM ID"
-                  fi      
+                  fi
 
                   LogPrint "s390 kernel naming override: $result_file will be written as $VM_UID.kernel"
                   cp $v "$result_file" $opath/$VM_UID.kernel || Error "Could not copy result file $result_file to $opath/$VM_UID.kernel at $scheme location"
@@ -100,6 +100,7 @@ case "$scheme" in
         # see https://github.com/rear/rear/issues/1068
         LogPrint "Copying result files '${RESULT_FILES[*]}' to $scheme location"
         Log "lftp -c open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput ${RESULT_FILES[*]}"
+        lftp -c "open $OUTPUT_URL; mkdir -fp /$(echo $OUTPUT_URL | cut -d"/" -f4-)"
         lftp -c "open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput ${RESULT_FILES[*]}" || Error "lftp failed to transfer '${RESULT_FILES[*]}' to '$OUTPUT_URL' (lftp exit code: $?)"
         ;;
     (rsync)


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): **N/A**

* How was this pull request tested?
Run `rear mkrescue` with and without destination directory schema created.

* Brief description of the changes in this pull request:
When transferring ReaR recovery system ISO, create also destination directory structure (including parents). This is useful because when destination directory structure does not exist (or is incomplete), Lftp puts files into last available directory in OUTPUT_URL scheme.
