### PR TITLE
Updated generated locale filename from "rear.UTF-8" to "en_US.UTF-8" (BACKUP=BORG)

### DIFF
--- a/usr/share/rear/lib/borg-functions.sh
+++ b/usr/share/rear/lib/borg-functions.sh
@@ -148,7 +148,7 @@ on ${BORGBACKUP_HOST:-USB}"
 
     # Has to be $verbose, not "$verbose", since it's used as option.
     # shellcheck disable=SC2086
-    LC_ALL=rear.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
     borg extract $verbose --sparse "${borg_additional_options[@]}" \
     "${BORGBACKUP_OPT_REMOTE_PATH[@]}" \
     "${borg_dst_dev}${BORGBACKUP_REPO}::$BORGBACKUP_ARCHIVE"

--- a/usr/share/rear/prep/BORG/default/200_prep_borg.sh
+++ b/usr/share/rear/prep/BORG/default/200_prep_borg.sh
@@ -16,7 +16,7 @@ fi
 
 # Create our own locales, used only for Borg restore.
 mkdir -p "$ROOTFS_DIR/usr/lib/locale"
-localedef -f UTF-8 -i en_US "$ROOTFS_DIR/usr/lib/locale/rear.UTF-8"
+localedef -f UTF-8 -i en_US "$ROOTFS_DIR/usr/lib/locale/en_US.UTF-8"
 StopIfError "Could not create locales"
 
 # Activate $COPY_AS_IS_BORG from default.conf.


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): **N/A**

* How was this pull request tested?
Full backup/restore

* Brief description of the changes in this pull request:
During restore with `BACKUP=BORG` messages as follow could be observed:
```
=== Borg archives list ===
Location:   backup
Repository: /mnt/rear/borg/node1

[1] HAEnode1_1 	Thu, 2020-05-21 10:40:15

[2] Exit

Choose archive to recover from
(timeout 300 seconds)
1
Recovering from backup archive /mnt/rear/borg/node1::HAEnode1_1 on backup
Remote: bash: warning: setlocale: LC_ALL: cannot change locale (rear.UTF-8)
...
```
`Remote: bash: warning: setlocale: LC_ALL: cannot change locale (rear.UTF-8)` message is shown when server site does not have `rear.UTF-8` available.
Changing locale name to standard `en_US.UTF-8` will fix this problem.

One can workaround this message by generating `rear.UTF-8` locales on destination host running Borg.
```
# localedef -f UTF-8 -i en_US "/usr/lib/locale/rear.UTF-8"
```