### PR TITLE
Evaluate OUTPUT_LFTP_OPTIONS at the beginning of lftp operations.

### DIFF
--- a/usr/share/rear/output/PXE/default/820_copy_to_net.sh
+++ b/usr/share/rear/output/PXE/default/820_copy_to_net.sh
@@ -22,10 +22,10 @@ case "$scheme" in
             # RESULT_FILES into last available directory in the path.
             # e.g. OUTPUT_URL=sftp://<host_name>/iso/server1 and have "/iso/server1"
             # directory missing, would upload RESULT_FILES into sftp://<host_name>/iso/
-            lftp -c "open $OUTPUT_URL; mkdir -fp ${path}"
+            lftp -c "$OUTPUT_LFTP_OPTIONS; open $OUTPUT_URL; mkdir -fp ${path}"
 
             LogPrint "Transferring file: $result_file"
-            lftp -c "open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput $result_file" || Error "lftp failed to transfer '$result_file' to '$OUTPUT_URL' (lftp exit code: $?)"
+            lftp -c "$OUTPUT_LFTP_OPTIONS; open $OUTPUT_URL; mput $result_file" || Error "lftp failed to transfer '$result_file' to '$OUTPUT_URL' (lftp exit code: $?)"
         done
         ;;
     (rsync)

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -99,14 +99,14 @@ case "$scheme" in
         # FIXME: Verify if usage of $array[*] instead of "${array[@]}" is actually intended here
         # see https://github.com/rear/rear/issues/1068
         LogPrint "Copying result files '${RESULT_FILES[*]}' to $scheme location"
-        Log "lftp -c open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput ${RESULT_FILES[*]}"
+        Log "lftp -c $OUTPUT_LFTP_OPTIONS; open $OUTPUT_URL; mput ${RESULT_FILES[*]}"
 
         # Make sure that destination directory exists, otherwise lftp would copy
         # RESULT_FILES into last available directory in the path.
         # e.g. OUTPUT_URL=sftp://<host_name>/iso/server1 and have "/iso/server1"
         # directory missing, would upload RESULT_FILES into sftp://<host_name>/iso/
-        lftp -c "open $OUTPUT_URL; mkdir -fp ${path}"
-        lftp -c "open $OUTPUT_URL; $OUTPUT_LFTP_OPTIONS mput ${RESULT_FILES[*]}" || Error "lftp failed to transfer '${RESULT_FILES[*]}' to '$OUTPUT_URL' (lftp exit code: $?)"
+        lftp -c "$OUTPUT_LFTP_OPTIONS; open $OUTPUT_URL; mkdir -fp ${path}"
+        lftp -c "$OUTPUT_LFTP_OPTIONS; open $OUTPUT_URL; mput ${RESULT_FILES[*]}" || Error "lftp failed to transfer '${RESULT_FILES[*]}' to '$OUTPUT_URL' (lftp exit code: $?)"
         ;;
     (rsync)
         # If BACKUP = RSYNC output/RSYNC/default/900_copy_result_files.sh took care of it:


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix** / **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/2406

* How was this pull request tested?
With executing `rear mkbackup` with configured lftp. 

* Brief description of the changes in this pull request:
Currently OUTPUT_LFTP_OPTIONS are evaluated after connection to
destination host is established. This avoids using of
OUTPUT_LFTP_OPTIONS for connection specific settings.
This patch moves OUTPUT_LFTP_OPTIONS to the beginning of lftp command
before any other command is executed.
