### PR TITLE
Also parse SSH Include files in 501_check_ssh_keys.sh

### DIFF
--- a/usr/share/rear/build/default/501_check_ssh_keys.sh
+++ b/usr/share/rear/build/default/501_check_ssh_keys.sh
@@ -37,11 +37,11 @@ if is_false "$SSH_UNPROTECTED_PRIVATE_KEYS" ; then
     # where the leading slashes will get removed below in the "for key_file" loop.
     # The "find ./etc/ssh" ensures that SSH 'Include' config files e.g. in /etc/ssh/ssh_config.d/
     # are also parsed, cf. https://github.com/rear/rear/issues/2421
-    local host_identity_files=( $( find ./etc/ssh -type f | xargs grep -ih '^[^#]*IdentityFile.*' | tr -d ' "=' | sed -e 's/identityfile//I' -e "s#~#$ROOT_HOME_DIR#g" ) )
+    local host_identity_files=( $( find ./etc/ssh -type f | xargs grep -ih '^[^#]*IdentityFile' | tr -d ' "=' | sed -e 's/identityfile//I' -e "s#~#$ROOT_HOME_DIR#g" ) )
     # If $ROOTFS_DIR/root/.ssh/config exists parse it for IdentityFile values in the same way as above:
     local root_identity_files=()
     local root_ssh_config="./$ROOT_HOME_DIR/.ssh/config"
-    test -s $root_ssh_config && root_identity_files=( $( grep -i '^[^#]*IdentityFile.*' $root_ssh_config | tr -d ' "=' | sed -e 's/identityfile//I' -e "s#~#$ROOT_HOME_DIR#g" ) )
+    test -s $root_ssh_config && root_identity_files=( $( grep -i '^[^#]*IdentityFile' $root_ssh_config | tr -d ' "=' | sed -e 's/identityfile//I' -e "s#~#$ROOT_HOME_DIR#g" ) )
     # Combine the found key files:
     key_files=( $( echo "${host_key_files[@]}" "${root_key_files[@]}" "${host_identity_files[@]}" "${root_identity_files[@]}" | tr -s '[:space:]' '\n' | sort -u ) )
 else


### PR DESCRIPTION
* Type: **Enhancement** **Cleanup**

* Impact: **Normal**
At most "normal" impact because the
SSH_UNPROTECTED_PRIVATE_KEYS
functionality is only meant to work to some usual extent
but not for each and every special cases,
see its description in default.conf
```
# But SSH_UNPROTECTED_PRIVATE_KEYS="no" is not at all any guarantee
# to not have any kind of unprotected SSH key in the recovery system.
# In general to check if there are unwanted files in the recovery system
# use KEEP_BUILD_DIR="yes" and inspect the recovery system content
# in $TMPDIR/rear.XXXXXXXXXXXXXXX/rootfs/ and use COPY_AS_IS_EXCLUDE
# to exclude unwanted files from the recovery system.
SSH_UNPROTECTED_PRIVATE_KEYS='no'
```

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2421

* How was this pull request tested?
A quick "rear mkrescue" test on my openSUSE Leap 15.1 system
with this in /etc/ssh/ssh_config
```
#   IdentityFile ~/.ssh/id_rsa
IdentityFile    ~/.ssh/id_dsa
 IdentityFile = ~/.ssh/id_ecdsa
  identityfile "~/.ssh/id_ed25519"
```
and that (dummy stuff) in /root/.ssh/config
```
#   IdentityFile ~/.ssh/id_rsaqq
IdentityFile    ~/.ssh/id_dsaqq
 IdentityFile = ~/.ssh/id_ecdsaqq
  identityfile "~/.ssh/id_ed25519qq"
```

* Brief description of the changes in this pull request:

Overhauled how SSH config files are parsed for IdentityFile values
to find (and remove) unprotected SSH keys in the recovery system.
Now "find ./etc/ssh" ensures that SSH 'Include' config files
e.g. in /etc/ssh/ssh_config.d/ are also parsed
