### PR TITLE
Fix #2425: OPALPBA: Reboot after SED-unlocking may hang on UEFI systems

### DIFF
--- a/usr/share/rear/prep/default/380_include_opal_tools.sh
+++ b/usr/share/rear/prep/default/380_include_opal_tools.sh
@@ -2,7 +2,7 @@
 
 has_binary sedutil-cli || return 0
 
-PROGS+=( sedutil-cli lsblk )
+PROGS+=( sedutil-cli lsblk efibootmgr )
 KERNEL_CMDLINE+=" libata.allow_tpm=1"
 
 # Exclude specific udev rules producing error messages when sedutil-cli accesses disks.

--- a/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
+++ b/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
@@ -206,7 +206,7 @@ while (( attempt < max_authentications )); do
             # Symptom: Boot hangs when Grub hands over control to the Linux kernel. Seen on an HPE ML10Gen9 server.
             # Cf. https://github.com/rear/rear/issues/2425
             read -r field_name current_boot_number field_junk <<<"$(efibootmgr 2>/dev/null | grep 'BootCurrent:')"
-            if [[ "$current_boot_number" =~ ^[0-9a-zA-Z]+$ ]]; then
+            if [[ "$current_boot_number" =~ ^[0-9a-fA-F]+$ ]]; then
                 # Set the current boot number as the boot entry for the next boot. This does not make much sense,
                 # except that we can be sure that we're setting a valid boot entry which we can then remove.
                 efibootmgr --bootnext "$current_boot_number" --quiet

--- a/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
+++ b/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
@@ -201,6 +201,20 @@ while (( attempt < max_authentications )); do
         else
             display_message "$unlocked_device_count of $device_count disks unlocked, rebooting..."
         fi
+        if type -p efibootmgr &>/dev/null; then
+            # Workaround for EFI firmware glitch which prevents booting the real OS after unlocking SEDs.
+            # Symptom: Boot hangs when Grub hands over control to the Linux kernel. Seen on an HPE ML10Gen9 server.
+            # Cf. https://github.com/rear/rear/issues/2425
+            read -r field_name current_boot_number field_junk <<<"$(efibootmgr 2>/dev/null | grep 'BootCurrent:')"
+            if [[ "$current_boot_number" =~ ^[0-9]+$ ]]; then
+                # Set the current boot number as the boot entry for the next boot. This does not make much sense,
+                # except that we can be sure that we're setting a valid boot entry which we can then remove.
+                efibootmgr --bootnext "$current_boot_number" --quiet
+                # Remove the next boot entry. This should convince the firmware to use the boot order to determine
+                # the effective boot entry for the next boot.
+                efibootmgr --delete-bootnext --quiet
+            fi
+        fi
         sleep 1
         instant_reboot
     else

--- a/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
+++ b/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
@@ -88,7 +88,7 @@ See history for useful commands. Exit the shell to shut down the system.
 
     if [[ -s "$error_log" ]]; then
         {
-            echo "The following errors occured when executing $0:"
+            echo "The following errors occurred when executing $0:"
             cat "$error_log"
             echo ""
         } >> /etc/motd

--- a/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
+++ b/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
@@ -206,7 +206,7 @@ while (( attempt < max_authentications )); do
             # Symptom: Boot hangs when Grub hands over control to the Linux kernel. Seen on an HPE ML10Gen9 server.
             # Cf. https://github.com/rear/rear/issues/2425
             read -r field_name current_boot_number field_junk <<<"$(efibootmgr 2>/dev/null | grep 'BootCurrent:')"
-            if [[ "$current_boot_number" =~ ^[0-9]+$ ]]; then
+            if [[ "$current_boot_number" =~ ^[0-9a-zA-Z]+$ ]]; then
                 # Set the current boot number as the boot entry for the next boot. This does not make much sense,
                 # except that we can be sure that we're setting a valid boot entry which we can then remove.
                 efibootmgr --bootnext "$current_boot_number" --quiet


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): #2425

* How was this pull request tested? On Ubuntu 20.04 LTS on two UEFI systems (one HPE ML10Gen9 server with problematic firmware, one other)

* Brief description of the changes in this pull request:
    * OPALPBA: Add and remove a UEFI 'next boot' entry (essentially a no-op)
