### PR TITLE
Add DHCP auto-configuration for Network Manager (Ubuntu 20.04 Desktop)

### DIFF
--- a/usr/share/rear/prep/GNU/Linux/210_include_dhclient.sh
+++ b/usr/share/rear/prep/GNU/Linux/210_include_dhclient.sh
@@ -73,6 +73,8 @@ function dhcp_client_is_active() {
     fi
 
     # Strategy 3: Check if Network Manager has been used for DHCP client setup
+    # This auto-detection tests for an nmcli command which supports the '--get-values' option. It will silently
+    # skip the test otherwise.
     if type nmcli &>/dev/null; then
         local conn_name
         while read -r conn_name; do
@@ -85,7 +87,7 @@ function dhcp_client_is_active() {
                     return 0
                 fi
             fi
-        done <<<"$(nmcli --get-values NAME connection show --active)"
+        done <<<"$(nmcli --get-values NAME connection show --active 2>/dev/null)"  # ignore if '--get-values' is not supported
     fi
 
     return 1


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **High**
Personally I ( @jsmeix ) consider such kind of additional auto-detection
functionality in ReaR as **Low** impact - provided there is a config variable
where the user can specify what he wants and ReaR obeys.

* How was this pull request tested? On Ubuntu 20.04 LTS Desktop,
cf. https://github.com/rear/rear/issues/2368#issuecomment-644663685

* Brief description of the changes in this pull request:

While ReaR already does DHCP auto-detection during `mkrescue` for a number of configurations, the Network Manager flavor on Ubuntu 20.04 Desktop is not supported. This leads to DHCP not being auto-enabled and usually a rescue system which is not accessible remotely.

This patch adds the required Network Manager auto-detection:
```
2020-06-16 10:18:24.532781411 Including prep/GNU/Linux/210_include_dhclient.sh
2020-06-16 10:18:24.572542776 Detected an active Network Manager connection 'Wired connection 1' set up via DHCPv4
2020-06-16 10:18:24.573677590 Auto-enabling DHCP on the rescue system
```

It is an isolated section which has been tested on two different Ubuntu 20.04 bare-metal installations, one of them on a notebook with wireless and wired interfaces.