### PR TITLE
Migrate XFS configuration files.

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
@@ -143,9 +143,9 @@ function create_fs () {
             # unless the user has explicitly specified XFS filesystem options:
             local xfs_opts
             local xfs_device_basename="$( basename $device )"
-            local xfs_info_filename="$LAYOUT_XFS_OPT_DIR/$xfs_device_basename.xfs"
+            local xfs_info_filename="$LAYOUT_XFS_OPT_DIR_RESTORE/$xfs_device_basename.xfs"
             # Only uppercase letters and digits are used to ensure mkfs_xfs_options_variable_name is a valid bash variable name
-            # even in case of complicated device nodes e.g. things like /dev/mapper/SIBM_2810XIV_78033E7012F-part3 
+            # even in case of complicated device nodes e.g. things like /dev/mapper/SIBM_2810XIV_78033E7012F-part3
             # cf. current_orig_device_basename_alnum_uppercase in layout/prepare/default/300_map_disks.sh
             local xfs_device_basename_alnum_uppercase="$( echo $xfs_device_basename | tr -d -c '[:alnum:]' | tr '[:lower:]' '[:upper:]' )"
             # cf. predefined_input_variable_name in the function UserInput in lib/_input-output-functions.sh

--- a/usr/share/rear/layout/prepare/default/010_prepare_files.sh
+++ b/usr/share/rear/layout/prepare/default/010_prepare_files.sh
@@ -5,6 +5,7 @@ LAYOUT_DEPS="$VAR_DIR/layout/diskdeps.conf"
 LAYOUT_TODO="$VAR_DIR/layout/disktodo.conf"
 LAYOUT_CODE="$VAR_DIR/layout/diskrestore.sh"
 LAYOUT_XFS_OPT_DIR="$VAR_DIR/layout/xfs"
+LAYOUT_XFS_OPT_DIR_RESTORE="$LAYOUT_XFS_OPT_DIR/restore"
 
 FS_UUID_MAP="$VAR_DIR/layout/fs_uuid_mapping"
 LUN_WWID_MAP="$VAR_DIR/layout/lun_wwid_mapping"

--- a/usr/share/rear/layout/prepare/default/319_rename_xfs_configs.sh
+++ b/usr/share/rear/layout/prepare/default/319_rename_xfs_configs.sh
@@ -27,8 +27,9 @@ while read source target junk ; do
         cp "$v" "$LAYOUT_XFS_OPT_DIR/$base_source.xfs" \
          "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_target.xfs"
 
-        # Replace old disk name in XFS configuration file as well.
-        sed -i s#"$base_source"#"$base_target"# \
+        # Replace old device name in meta-data= option in XFS
+        # configuration file as well.
+        sed -i s#"meta-data=${source}\(\s\)"#"meta-data=${target}\1"# \
           "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_target.xfs"
 
         # Mark XFS config file as processed to avoid copying it again later.
@@ -43,13 +44,16 @@ while read source target junk ; do
         if [[ "$source" = "$layout_device" ]]; then
             base_src_layout_partition=$(basename "$layout_partition")
             base_dst_layout_partition=${base_src_layout_partition//$base_source/$base_target}
+            dst_layout_partition=${layout_partition//$base_source/$base_target}
+
             if [ -e "$LAYOUT_XFS_OPT_DIR/$base_src_layout_partition.xfs" ]; then
                 Log "Migrating XFS configuration $base_src_layout_partition.xfs to $base_dst_layout_partition.xfs"
                 cp "$v" "$LAYOUT_XFS_OPT_DIR/$base_src_layout_partition.xfs" \
                  "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_dst_layout_partition.xfs"
 
-                # Replace old disk name in XFS configuration file as well.
-                sed -i s#"$base_src_layout_partition"#"$base_dst_layout_partition"# \
+                # Replace old device name in meta-data= option in XFS
+                # configuration file as well.
+                sed -i s#"meta-data=${layout_partition}\(\s\)"#"meta-data=${dst_layout_partition}\1"# \
                   "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_dst_layout_partition.xfs"
 
                 # Mark XFS config file as processed to avoid copying it again later.

--- a/usr/share/rear/layout/prepare/default/319_rename_xfs_configs.sh
+++ b/usr/share/rear/layout/prepare/default/319_rename_xfs_configs.sh
@@ -1,0 +1,79 @@
+# Cleanup directory which hold XFS configuration file for `rear recover'.
+# This will avoid possible mess in LAYOUT_XFS_OPT_DIR_RESTORE if `rear recover'
+# would be launched multiple times, where user will choose different disk
+# mapping each time.
+# Removing and creating LAYOUT_XFS_OPT_DIR_RESTORE will ensure that ReaR will
+# have only current files available during current session.
+rm -rf "$LAYOUT_XFS_OPT_DIR_RESTORE"
+mkdir -p "$LAYOUT_XFS_OPT_DIR_RESTORE"
+
+local excluded_configs=()
+
+# Read $MAPPING_FILE (disk_mappings) to discover final disk mapping.
+# Once mapping is known, configuration files can be renamed.
+# (e.g. sds2.xfs to sdb2.xfs, ...)
+while read source target junk ; do
+    # Disks in MAPPING_FILE are listed with full device path. Since XFS config
+    # files are created in format e.g. sda2.xfs strip prefixed path to have
+    # only short device name available.
+    base_source=$(basename "$source")
+    base_target=$(basename "$target")
+
+    # Check if XFS configuration file for whole device (unpartitioned)
+    # is available (sda, sdb, ...). If so, rename and copy it to
+    # LAYOUT_XFS_OPT_DIR_RESTORE.
+    if [ -e "$LAYOUT_XFS_OPT_DIR/$base_source.xfs" ]; then
+        Log "Migrating XFS configuration file $base_source.xfs to $base_target.xfs"
+        cp "$v" "$LAYOUT_XFS_OPT_DIR/$base_source.xfs" \
+         "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_target.xfs"
+
+        # Replace old disk name in XFS configuration file as well.
+        sed -i s#"$base_source"#"$base_target"# \
+          "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_target.xfs"
+
+        # Mark XFS config file as processed to avoid copying it again later.
+        # More details on why are configs excluded can be found near the
+        # end of this script (near `tar' command).
+        excluded_configs+=("--exclude=$base_source.xfs")
+    fi
+
+    # Find corresponding partitions to source disk in LAYOUT_FILE
+    # and migrate/rename them too if necessary.
+    while read _ layout_device _ _ _ _ layout_partition; do
+        if [[ "$source" = "$layout_device" ]]; then
+            base_src_layout_partition=$(basename "$layout_partition")
+            base_dst_layout_partition=${base_src_layout_partition//$base_source/$base_target}
+            if [ -e "$LAYOUT_XFS_OPT_DIR/$base_src_layout_partition.xfs" ]; then
+                Log "Migrating XFS configuration $base_src_layout_partition.xfs to $base_dst_layout_partition.xfs"
+                cp "$v" "$LAYOUT_XFS_OPT_DIR/$base_src_layout_partition.xfs" \
+                 "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_dst_layout_partition.xfs"
+
+                # Replace old disk name in XFS configuration file as well.
+                sed -i s#"$base_src_layout_partition"#"$base_dst_layout_partition"# \
+                  "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_dst_layout_partition.xfs"
+
+                # Mark XFS config file as processed to avoid copying it again later.
+                # More details on why are configs excluded can be found near the
+                # end of this script (near `tar' command).
+                excluded_configs+=("--exclude=$base_src_layout_partition.xfs")
+            fi
+        fi
+    done < <( grep -E "^part " "$LAYOUT_FILE" )
+done < <( grep -v '^#' "$MAPPING_FILE" )
+
+pushd "$LAYOUT_XFS_OPT_DIR" >/dev/null
+# Copy remaining files
+# We need to copy remaining files into LAYOUT_XFS_OPT_DIR_RESTORE which will
+# serve as base dictionary where ReaR will look for XFS config files.
+# It is necessary to copy only files that were not previously processed,
+# because in LAYOUT_XFS_OPT_DIR they are still listed with
+# original name and copy to LAYOUT_XFS_OPT_DIR_RESTORE could overwrite
+# XFS configs already migrated.
+# e.g. with following disk mapping situation:
+# /dev/sda2 => /dev/sdb2
+# /dev/sdb2 => /dev/sda2
+# Files in LAYOUT_XFS_OPT_DIR_RESTORE would be overwritten by XFS configs with
+# wrong names.
+# tar is used to take advantage of its exclude feature.
+tar cf - --exclude=restore "${excluded_configs[@]}" . | tar xfp - -C "$LAYOUT_XFS_OPT_DIR_RESTORE"
+popd >/dev/null

--- a/usr/share/rear/layout/save/GNU/Linux/100_create_layout_file.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/100_create_layout_file.sh
@@ -10,6 +10,7 @@ mkdir -p $v $VAR_DIR/layout/config
 # We need directory for XFS options only if XFS is in use:
 if test "$( mount -t xfs )" ; then
     LAYOUT_XFS_OPT_DIR="$VAR_DIR/layout/xfs"
+    rm -rf $LAYOUT_XFS_OPT_DIR
     mkdir -p $v $LAYOUT_XFS_OPT_DIR
 fi
 


### PR DESCRIPTION
* Type: **Bug Fix** / **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/2333

* How was this pull request tested?
Successfully restored VM with following disk layout from VirtualBox to Qemu. (migration from /dev/sd* to /dev/vd*)
```
# lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,SIZE,MOUNTPOINT
NAME                        KNAME     PKNAME    TRAN   TYPE  FSTYPE             SIZE MOUNTPOINT
/dev/sda                    /dev/sda            sata   disk                       8G 
|-/dev/sda1                 /dev/sda1 /dev/sda         part  vfat               200M /boot/efi
|-/dev/sda2                 /dev/sda2 /dev/sda         part  xfs                  1G /boot
`-/dev/sda3                 /dev/sda3 /dev/sda         part  LVM2_member        6.8G 
  |-/dev/mapper/centos-root /dev/dm-0 /dev/sda3        lvm   xfs                  6G /
  `-/dev/mapper/centos-swap /dev/dm-1 /dev/sda3        lvm   swap               820M [SWAP]
/dev/sdb                    /dev/sdb            sata   disk  mpath_member         8G 
`-/dev/mapper/disk_2        /dev/dm-3 /dev/sdb         mpath linux_raid_member    8G 
  `-/dev/md0                /dev/md0  /dev/dm-3        raid1 xfs                  8G /data
/dev/sdc                    /dev/sdc            sata   disk  mpath_member         8G 
`-/dev/mapper/disk_1        /dev/dm-2 /dev/sdc         mpath linux_raid_member    8G 
  `-/dev/md0                /dev/md0  /dev/dm-2        raid1 xfs                  8G /data
/dev/sr0                    /dev/sr0            ata    rom                     1024M 
```

* Brief description of the changes in this pull request:
When in MIGRATION_MODE, migrate/rename XFS configuration files so they follow disk mapping set by user.
