### PR TITLE
Support for systemd and parallel restore with Data Protector (BACKUP=DP)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1832,7 +1832,18 @@ PROGS_AVA=( )
 ##
 # BACKUP=DP stuff (Micro Focus Data Protector)
 ##
-#
+# With COPY_AS_IS_DP=( ... /etc/opt/omni/client ) in particular the client certificate files
+# localhost_cert.pem and localhost_key.pem in the /etc/opt/omni/client/sscertificates/ directory
+# that are needed to restore the backup when Data Protector Secure Communication is configured
+# get copied into the ReaR rescue/recovery system initramfs/initrd so that in particular
+# ReaR ISO images and ReaR recovery media must be protected against unwanted access.
+# In general to check if there are unwanted files in the recovery system use KEEP_BUILD_DIR="yes"
+# and inspect the recovery system content in $TMPDIR/rear.XXXXXXXXXXXXXXX/rootfs/ and use
+# COPY_AS_IS_EXCLUDE or COPY_AS_IS_EXCLUDE_DP to exclude unwanted files from the recovery system.
+# The client certificate is excluded from a Data Protector backup due to security concerns
+# so it is not restored with Data Protector. During "rear recover" the client certificate files
+# are copied from the ReaR recovery system into the recovered/recreated target system.
+# For details see the usr/share/rear/finalize/DP/default/500_restore_ssc.sh script.
 COPY_AS_IS_DP=( /opt/omni /etc/opt/omni/client )
 COPY_AS_IS_EXCLUDE_DP=( /opt/omni/bin/telemetry /opt/omni/Depot /opt/omni/databases /opt/omni/jre /opt/omni/newconfig /opt/omni/bin/drim )
 

--- a/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
+++ b/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
@@ -12,7 +12,7 @@ local keyfile=$sscpath/localhost_key.pem
 test -s $TARGET_FS_ROOT/$certfile -a -s $TARGET_FS_ROOT/$keyfile && return 0
 
 # Tell what will be done so that subsequent (error) messages make sense for the user:
-LogPrint "Restoring Data Protector client certificate:
+LogPrint "Restoring Data Protector client certificate:"
 LogPrint "- $certfile"
 LogPrint "- $keyfile"
 

--- a/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
+++ b/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
@@ -1,7 +1,15 @@
 # 500_restore_ssc.sh
-# Purpose: Make Secure Socket Communication useable after restoring the client system
+# Purpose:
+# Make Secure Socket Communication useable after restoring the client system.
+# Reasoning:
+# The client certificate is currently excluded from a Data Protector backup due to security concerns.
+# This means it is not restored using BACKUP=DP. This might change within Data Protector (in the future).
+# The current implementation in ReaR will get the required files from the running client,
+# use it during "rear recover" and place it on the recovered/recreated system (if not found there).
+# This allows to resume backup and restore operation without manual intervention.
+# The current implementation will not replace the certificate if it gets restored using BACKUP=DP (in the future).
 
-# Only needed for Data Protector 10.x and later with Secure Communication is configured
+# Only needed for Data Protector 10.x and later when Secure Communication is configured:
 test -s /etc/opt/omni/client/ssconfig || return 0
 
 local sscpath=/etc/opt/omni/client/sscertificates

--- a/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
+++ b/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
@@ -9,18 +9,20 @@ local certfile=$sscpath/localhost_cert.pem
 local keyfile=$sscpath/localhost_key.pem
 
 # Nothing to do when the certificate files already exist in the recreated system:
-test -s $TARGET_FS_ROOT/$certfile -a -s $TARGET_FS_ROOT/$keyfile && return
+test -s $TARGET_FS_ROOT/$certfile -a -s $TARGET_FS_ROOT/$keyfile && return 0
 
 # Tell what will be done so that subsequent (error) messages make sense for the user:
-LogPrint "Restoring Data Protector client certificate ($certfile $keyfile)"
+LogPrint "Restoring Data Protector client certificate:
+LogPrint "- $certfile"
+LogPrint "- $keyfile"
 
 # Inform the user but do not error out here at this late state of "rear recover"
 # when it failed to copy specific files into the recreated system:
 cp $v $certfile $TARGET_FS_ROOT/$certfile || LogPrintError "Failed to copy $certfile"
-cp $v $keyfileS $TARGET_FS_ROOT/$keyfile || LogPrintError "Failed to copy $keyfile"
+cp $v $keyfile  $TARGET_FS_ROOT/$keyfile  || LogPrintError "Failed to copy $keyfile"
 
 # All is done when the certificate files exist now in the recreated system:
-test -s $TARGET_FS_ROOT/$certfile -a -s $TARGET_FS_ROOT/$keyfile && return
+test -s $TARGET_FS_ROOT/$certfile -a -s $TARGET_FS_ROOT/$keyfile && return 0
 
 LogPrint "Client certificate not properly restored. A new certificate will be generated now"
 local omnicc=/opt/omni/bin/omnicc
@@ -35,4 +37,4 @@ if ! chroot $TARGET_FS_ROOT $omnicc -secure_comm -get_fingerprint ; then
     return 1
 fi
 LogPrint "Generated new Data Protector client certificate"
-LogPrint "Run 'omnicc -secure_comm -configure_peer <Client>' on the Cell Manager after rebooting the client system"
+LogPrint "Run 'omnicc -secure_comm -configure_peer <Client>' on the Cell Manager after rebooting the client"

--- a/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
+++ b/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
@@ -13,8 +13,8 @@ test -s $TARGET_FS_ROOT/$certfile -a -s $TARGET_FS_ROOT/$keyfile && return 0
 
 # Tell what will be done so that subsequent (error) messages make sense for the user:
 LogPrint "Restoring Data Protector client certificate:"
-LogPrint "- $certfile"
-LogPrint "- $keyfile"
+LogPrint "$certfile"
+LogPrint "$keyfile"
 
 # Inform the user but do not error out here at this late state of "rear recover"
 # when it failed to copy specific files into the recreated system:
@@ -36,5 +36,5 @@ if ! chroot $TARGET_FS_ROOT $omnicc -secure_comm -get_fingerprint ; then
     LogPrintError "Failed to get fingerprint"
     return 1
 fi
-LogPrint "Generated new Data Protector client certificate"
+LogPrint "Generated a new Data Protector client certificate"
 LogPrint "Run 'omnicc -secure_comm -configure_peer <Client>' on the Cell Manager after rebooting the client"

--- a/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
+++ b/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
@@ -1,0 +1,24 @@
+# 500_restore_ssc.sh
+# Purpose: Make Secure Socket Communication useable after restoring the client system
+
+SSCPATH=/etc/opt/omni/client/sscertificates
+OMNICC=/opt/omni/bin/omnicc
+
+# Only needed for Data Protector 10.x and later with Secure Communication is configured
+if test -s /etc/opt/omni/client/ssconfig; then
+
+    cp $v ${SSCPATH}/localhost_cert.pem /mnt/local/${SSCPATH}/localhost_cert.pem || Error "Could not copy localhost_cert.pem"
+    cp $v ${SSCPATH}/localhost_key.pem  /mnt/local/${SSCPATH}/localhost_key.pem  || Error "Could not copy localhost_key.pem"
+
+    if test -s /mnt/local/${SSCPATH}/localhost_cert.pem -a -s /mnt/local/${SSCPATH}/localhost_key.pem
+	    
+        LogPrint "Client certificate properly restored."
+	  
+    else
+
+        LogPrint "Client certificate not properly restored. A new certificate will be generated now."
+        chroot /mnt/local ${OMNICC} -secure_comm -regenerate_cert
+	chroot /mnt/local ${OMNICC} -secure_comm -get_fingerprint
+        LogPrint "Run omnicc -secure_comm -configure_peer <Client> on the Cell Manager after rebooting the client system"
+
+fi

--- a/usr/share/rear/output/DP/default/950_dp_save_result_files.sh
+++ b/usr/share/rear/output/DP/default/950_dp_save_result_files.sh
@@ -1,8 +1,7 @@
 # 950_dp_save_result_files.sh
 # Saving result files via Data Protector
 
-[ ${#RESULT_FILES[@]} -gt 0 ]
-StopIfError "No files to copy (RESULT_FILES is empty)"
+[ ${#RESULT_FILES[@]} -gt 0 ] || Error "No files to copy (RESULT_FILES is empty)"
 
 LogPrint "Saving result files with Data Protector"
 #DP_RESULT_FILES=()
@@ -11,9 +10,7 @@ LogPrint "Saving result files with Data Protector"
 test -z "$DP_RESULT_FILES_PATH" && DP_RESULT_FILES_PATH="$VAR_DIR/rescue"
 
 if ! test -d "$DP_RESULT_FILES_PATH" ; then
-	mkdir -p $v "$DP_RESULT_FILES_PATH" >&2
-	StopIfError "Could not create '$DP_RESULT_FILES_PATH'"
+	mkdir -p $v "$DP_RESULT_FILES_PATH" || Error "Could not create '$DP_RESULT_FILES_PATH'"
 fi
 
-cp -r $v "$VAR_DIR/recovery" "$DP_RESULT_FILES_PATH" >&2
-StopIfError "Could not save result files with Data Protector"
+cp -r $v "$VAR_DIR/recovery" "$DP_RESULT_FILES_PATH" || Error "Could not save result files with Data Protector"

--- a/usr/share/rear/output/DP/default/950_dp_save_result_files.sh
+++ b/usr/share/rear/output/DP/default/950_dp_save_result_files.sh
@@ -1,10 +1,10 @@
-#
-# saving result files via DP
+# 950_dp_save_result_files.sh
+# Saving result files via Data Protector
 
 [ ${#RESULT_FILES[@]} -gt 0 ]
 StopIfError "No files to copy (RESULT_FILES is empty)"
 
-LogPrint "Saving result files with DP"
+LogPrint "Saving result files with Data Protector"
 #DP_RESULT_FILES=()
 
 # if DP_RESULT_FILES_PATH is unset, then save the result files where they are
@@ -16,4 +16,4 @@ if ! test -d "$DP_RESULT_FILES_PATH" ; then
 fi
 
 cp -r $v "$VAR_DIR/recovery" "$DP_RESULT_FILES_PATH" >&2
-StopIfError "Could not save result files with dataprotector"
+StopIfError "Could not save result files with Data Protector"

--- a/usr/share/rear/prep/DP/default/400_prep_dp.sh
+++ b/usr/share/rear/prep/DP/default/400_prep_dp.sh
@@ -1,6 +1,5 @@
-#
-# prepare stuff for DP
-#
+# 400_prep_dp.sh
+# Prepare stuff for Data Protector
 
 COPY_AS_IS+=( "${COPY_AS_IS_DP[@]}" )
 COPY_AS_IS_EXCLUDE+=( "${COPY_AS_IS_EXCLUDE_DP[@]}" )

--- a/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
+++ b/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
@@ -1,15 +1,18 @@
 # 450_check_dp_client_configured.sh
 # this script has a simple goal: check if this client system has been properly
-# defined on the DP cell server and that a backup specification has been
-# made for this client - no more no less
+# configured on the Cell Manager and backed up at least once - no more no less
 
 OMNIDB=/opt/omni/bin/omnidb
 OMNIR=/opt/omni/bin/omnir
 
 Log "Backup method is DP: check Data Protector requirements"
+[ -x ${VBDA} ]
+StopIfError "Please install Data Protector Disk Agent (DA component) on the client."
+
 [ -x ${OMNIR} ]
-StopIfError "Please install Data Protector User Interface (cc component) on the client."
+StopIfError "Please install Data Protector User Interface (CC component) on the client."
 
 ${OMNIDB} -filesystem | grep $(hostname) >/dev/null
-StopIfError "Data Protector check failed with error code $? (no filesystem backup found).
+StopIfError "Data Protector check failed with error code $?.
+Check if root is configured in Data Protector UserList and if backups for this client exist in the IDB.
 See $RUNTIME_LOGFILE for more details."

--- a/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
+++ b/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
@@ -4,6 +4,7 @@
 
 OMNIDB=/opt/omni/bin/omnidb
 OMNIR=/opt/omni/bin/omnir
+VBDA=/opt/omni/lbin/vbda
 
 Log "Backup method is DP: check Data Protector requirements"
 [ -x ${VBDA} ]
@@ -12,7 +13,7 @@ StopIfError "Please install Data Protector Disk Agent (DA component) on the clie
 [ -x ${OMNIR} ]
 StopIfError "Please install Data Protector User Interface (CC component) on the client."
 
-${OMNIDB} -filesystem | grep $(hostname) >/dev/null
-StopIfError "Data Protector check failed with error code $?.
-Check if root is configured in Data Protector UserList and if backups for this client exist in the IDB.
+${OMNIDB} -filesystem | grep $(hostname}
+StopIfError "Data Protector check failed, error code $?.
+Check if the root user is configured in Data Protector UserList and if backups for this client exist in the IDB.
 See $RUNTIME_LOGFILE for more details."

--- a/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
+++ b/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
@@ -13,7 +13,7 @@ StopIfError "Please install Data Protector Disk Agent (DA component) on the clie
 [ -x ${OMNIR} ]
 StopIfError "Please install Data Protector User Interface (CC component) on the client."
 
-${OMNIDB} -filesystem | grep $(hostname}
+${OMNIDB} -filesystem | grep $(hostname)
 StopIfError "Data Protector check failed, error code $?.
-Check if the root user is configured in Data Protector UserList and if backups for this client exist in the IDB.
+Check if the user root is configured in Data Protector UserList and if backups for this client exist in the IDB.
 See $RUNTIME_LOGFILE for more details."

--- a/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
+++ b/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
@@ -7,13 +7,12 @@ OMNIR=/opt/omni/bin/omnir
 VBDA=/opt/omni/lbin/vbda
 
 Log "Backup method is DP: check Data Protector requirements"
-[ -x ${VBDA} ]
-StopIfError "Please install Data Protector Disk Agent (DA component) on the client."
+test -x $VBDA || Error "Cannot execute $VBDA
+Install Data Protector Disk Agent (DA component) on the client."
 
-[ -x ${OMNIR} ]
-StopIfError "Please install Data Protector User Interface (CC component) on the client."
+test -x $OMNIR || Error "Cannot execute $OMNIR
+Install Data Protector User Interface (CC component) on the client."
 
-${OMNIDB} -filesystem | grep $(hostname)
-StopIfError "Data Protector check failed, error code $?.
+$OMNIDB -filesystem | grep $( hostname ) || Error "Data Protector check failed, error code $?.
 Check if the user root is configured in Data Protector UserList and if backups for this client exist in the IDB.
 See $RUNTIME_LOGFILE for more details."

--- a/usr/share/rear/rescue/DP/default/450_prepare_omni_systemd.sh
+++ b/usr/share/rear/rescue/DP/default/450_prepare_omni_systemd.sh
@@ -1,0 +1,17 @@
+# 450_prepare_omni_systemd.sh
+# Make sure Data Protector INET gets included in the rescue image (if systemd is used)
+
+if [ -r "/usr/lib/systemd/system/omni.socket" ]; then
+
+PROGS+=( systemd )
+COPY_AS_IS+=( /usr/lib/systemd/system/omni.socket /usr/lib/systemd/system/omni@.service /etc/systemd/system/sockets.target.wants/omni.socket )
+
+cat >$ROOTFS_DIR/etc/scripts/system-setup.d/90-omni.sh <<-EOF
+echo "Starting Data Protector daemon using systemd..."
+systemctl start omni.socket
+EOF
+
+chmod +x $ROOTFS_DIR/etc/scripts/system-setup.d/90-omni.sh
+Log "Created the Data Protector start-up script (90-omni.sh) for ReaR using systemd"
+
+fi

--- a/usr/share/rear/rescue/DP/default/450_prepare_omni_systemd.sh
+++ b/usr/share/rear/rescue/DP/default/450_prepare_omni_systemd.sh
@@ -1,7 +1,8 @@
 # 450_prepare_omni_systemd.sh
 # Make sure Data Protector INET gets included in the rescue image (if systemd is used)
 
-if [ -r "/usr/lib/systemd/system/omni.socket" ]; then
+# Nothing to do when systemd is not used
+test -r "/usr/lib/systemd/system/omni.socket" || return 0
 
 PROGS+=( systemd )
 COPY_AS_IS+=( /usr/lib/systemd/system/omni.socket /usr/lib/systemd/system/omni@.service /etc/systemd/system/sockets.target.wants/omni.socket )
@@ -13,5 +14,3 @@ EOF
 
 chmod +x $ROOTFS_DIR/etc/scripts/system-setup.d/90-omni.sh
 Log "Created the Data Protector start-up script (90-omni.sh) for ReaR using systemd"
-
-fi

--- a/usr/share/rear/rescue/DP/default/450_prepare_omni_xinetd.sh
+++ b/usr/share/rear/rescue/DP/default/450_prepare_omni_xinetd.sh
@@ -1,8 +1,15 @@
+# 450_prepare_omni_systemd.sh
+# Make sure Data Protector INET gets included in the rescue image (if xinetd is used)
+
+if [ -r "/etc/xinetd.d/omni" ]; then
+
 PROGS+=( xinetd )
 COPY_AS_IS+=( /etc/xinetd.conf /etc/xinetd.d/omni )
 cat >$ROOTFS_DIR/etc/scripts/system-setup.d/90-xinetd.sh <<-EOF
-# Data Protector needs omni service to be started from xinetd
-echo "Starting a minimal xinetd daemon ..."
+echo "Starting Data Protector daemon using xinetd ..."
 xinetd
 EOF
 chmod $v +x $ROOTFS_DIR/etc/scripts/system-setup.d/90-xinetd.sh
+Log "Created the Data Protector start-up script (90-omni.sh) for ReaR using xinetd"
+
+fi

--- a/usr/share/rear/rescue/DP/default/450_prepare_omni_xinetd.sh
+++ b/usr/share/rear/rescue/DP/default/450_prepare_omni_xinetd.sh
@@ -1,7 +1,8 @@
 # 450_prepare_omni_systemd.sh
 # Make sure Data Protector INET gets included in the rescue image (if xinetd is used)
 
-if [ -r "/etc/xinetd.d/omni" ]; then
+# Nothing to do when xinetd is not used
+test -r "/etc/xinetd.d/omni" || return 0
 
 PROGS+=( xinetd )
 COPY_AS_IS+=( /etc/xinetd.conf /etc/xinetd.d/omni )
@@ -11,5 +12,3 @@ xinetd
 EOF
 chmod $v +x $ROOTFS_DIR/etc/scripts/system-setup.d/90-xinetd.sh
 Log "Created the Data Protector start-up script (90-omni.sh) for ReaR using xinetd"
-
-fi

--- a/usr/share/rear/restore/DP/default/300_create_dp_restore_fs_list.sh
+++ b/usr/share/rear/restore/DP/default/300_create_dp_restore_fs_list.sh
@@ -9,8 +9,7 @@
 OMNIDB=/opt/omni/bin/omnidb
 
 ${OMNIDB} -session $(cat $TMP_DIR/dp_recovery_session) | grep `cat $TMP_DIR/dp_recovery_host` | cut -d"'" -f -2 > $TMP_DIR/list_of_fs_objects
-[ -s $TMP_DIR/list_of_fs_objects ]
-StopIfError "Data Protector did not find any file system objects for $(hostname)"
+test -s $TMP_DIR/list_of_fs_objects || Error "Data Protector did not find any file system objects for $(hostname)"
 
 # check if we need to exclude a file system - exclude fs list =  $VAR_DIR/recovery/exclude_mountpoints
 if [ -f $VAR_DIR/recovery/exclude_mountpoints ]; then

--- a/usr/share/rear/restore/DP/default/400_restore_with_dp.sh
+++ b/usr/share/rear/restore/DP/default/400_restore_with_dp.sh
@@ -44,7 +44,7 @@ done
 # parallel restore of all objects previously collected
 LogPrint "Parallel restore of backup objects started. See Data Protector GUI for restore progress."
 chmod 755 ${TMP_DIR}/restore_cmd
-${TMP_DIR}/restore_cmd > /dev/null
+${TMP_DIR}/restore_cmd
 
 case $? in
 	0)  LogPrint "Restore was successful." ;;

--- a/usr/share/rear/restore/DP/default/400_restore_with_dp.sh
+++ b/usr/share/rear/restore/DP/default/400_restore_with_dp.sh
@@ -18,31 +18,38 @@
 #	Backup ID          : n/a
 #	Copy ID            : 20 (Orig)
 
-# The list of file systems to restore is listed in file $TMP_DIR/list_of_fs_objects
+# The list of file systems to restore is listed in file ${TMP_DIR}/list_of_fs_objects
 # per line we have something like: test.internal.it3.be:/ '/'
 
-[ -f $TMP_DIR/DP_GUI_RESTORE ] && return # GUI restore explicetely requested
+[ -f ${TMP_DIR}/DP_GUI_RESTORE ] && return # GUI restore explicetely requested
 
 OMNIR=/opt/omni/bin/omnir
+echo -n ${OMNIR} > ${TMP_DIR}/restore_cmd
 
-# we will loop over all objects listed in $TMP_DIR/list_of_fs_objects
-cat $TMP_DIR/list_of_fs_objects | while read object
+# we will loop over all objects listed in ${TMP_DIR}/list_of_fs_objects
+cat ${TMP_DIR}/list_of_fs_objects | while read object
 do
 	host_fs=`echo ${object} | awk '{print $1}'`
 	fs=`echo ${object} | awk '{print $1}' | cut -d: -f 2`
 	label=`echo "${object}" | cut -d"'" -f 2`
 	# only retain the latest backup which was completed successfully
 	if grep -q "^${fs} " ${VAR_DIR}/recovery/mountpoint_device; then
-		LogPrint "Restore filesystem ${object}"
-		SessionID=`cat $TMP_DIR/dp_recovery_session`
-		${OMNIR} -filesystem ${host_fs} "${label}" -session ${SessionID} -full -omit_unrequired_object_versions -no_resumable -overwrite -tree ${fs} -into $TARGET_FS_ROOT -sparse -target `hostname` >/dev/null
-		case $? in
-			0)  Log "Restore of ${fs} was successful." ;;
-			10) Log "Restore of ${fs} finished with warnings." ;;
-			*)  LogPrint "Restore of ${fs} failed."
-				> $TMP_DIR/DP_GUI_RESTORE
-				break # get out of the loop
-				;;
-		esac
-	fi # if grep "^${fs}
+		LogPrint "Filesystem ${object} added to restore command"
+		SessionID=`cat ${TMP_DIR}/dp_recovery_session`
+		# append objects to restore command
+		echo -n " -filesystem ${host_fs} '${label}' -session ${SessionID} -full -omit_unrequired_object_versions -no_resumable -overwrite -tree ${fs} -into $TARGET_FS_ROOT -sparse -target `hostname`" >> ${TMP_DIR}/restore_cmd
+	fi
 done
+
+# parallel restore of all objects previously collected
+LogPrint "Parallel restore of backup objects started. See Data Protector GUI for restore progress."
+chmod 755 ${TMP_DIR}/restore_cmd
+${TMP_DIR}/restore_cmd > /dev/null
+
+case $? in
+	0)  LogPrint "Restore was successful." ;;
+	10) LogPrint "Restore finished with warnings." ;;
+	*)  LogPrint "Restore failed."
+		> ${TMP_DIR}/DP_GUI_RESTORE
+		;;
+esac

--- a/usr/share/rear/restore/DP/default/450_restore_via_gui.sh
+++ b/usr/share/rear/restore/DP/default/450_restore_via_gui.sh
@@ -1,5 +1,5 @@
 # 450_restore_via_gui.sh
-# id the automatic restore failed give the end-user the option to execute a retsore via GUI
+# If the automatic restore failes give the user the option to execute a restore via GUI
 
 [ ! -f $TMP_DIR/DP_GUI_RESTORE ] && return   # restore was OK - skip this option
 
@@ -7,7 +7,7 @@ Log "Request for a manual restore via the GUI"
 
 LogUserOutput "
 **********************************************************************
-**  Please try to push the backups of the latest session from DP GUI
+**  Please try to restore the backup from Data Protector GUI!
 **  Make sure you select \"overwrite\" (destination tab) and make the
 **  new destination $TARGET_FS_ROOT.
 **  When the restore is complete press ANY key to continue!

--- a/usr/share/rear/restore/DP/default/460_press_y_to_continue.sh
+++ b/usr/share/rear/restore/DP/default/460_press_y_to_continue.sh
@@ -1,5 +1,4 @@
-
-# restore/DP/default/460_press_y_to_continue.sh
+# 460_press_y_to_continue.sh
 
 unset REPLY
 while true ; do

--- a/usr/share/rear/verify/DP/default/400_verify_dp.sh
+++ b/usr/share/rear/verify/DP/default/400_verify_dp.sh
@@ -5,8 +5,8 @@ CELL_SERVER="$( cat /etc/opt/omni/client/cell_server )"
 OMNICHECK=/opt/omni/bin/omnicheck
 
 # the Cell Manager must be configured on the client
-# TODO: the above comment and the error message do not match the test (does not actually test TCPSERVERADDRESS)
-[ "${CELL_SERVER}" ] || Error "Data Protector Cell Manager TCPSERVERADDRESS not set in /etc/opt/omni/client/cell_server"
+# if /etc/opt/omni/client/cell_server exists and contains something, we're good
+test -s "${CELL_SERVER}" || Error "Data Protector Cell Manager not configured in /etc/opt/omni/client/cell_server"
 
 # check that the Cell Manager is responding on the INET port
 ${OMNICHECK} -patches -host ${CELL_SERVER} || Error "Data Protector Cell Manager is not responding, error code $?.

--- a/usr/share/rear/verify/DP/default/400_verify_dp.sh
+++ b/usr/share/rear/verify/DP/default/400_verify_dp.sh
@@ -1,14 +1,13 @@
 # 400_verify_dp.sh
 # read Data Protector vars from config file
 
-CELL_SERVER="`cat /etc/opt/omni/client/cell_server`"
+CELL_SERVER="$( cat /etc/opt/omni/client/cell_server )"
 OMNICHECK=/opt/omni/bin/omnicheck
 
 # the Cell Manager must be configured on the client
-[ "${CELL_SERVER}" ]
-StopIfError "Data Protector Cell Manager TCPSERVERADDRESS not set in /etc/opt/omni/client/cell_server"
+# TODO: the above comment and the error message do not match the test (does not actually test TCPSERVERADDRESS)
+[ "${CELL_SERVER}" ] || Error "Data Protector Cell Manager TCPSERVERADDRESS not set in /etc/opt/omni/client/cell_server"
 
 # check that the Cell Manager is responding on the INET port
-${OMNICHECK} -patches -host ${CELL_SERVER}
-StopIfError "Data Protector Cell Manager is not responding, error code $?.
+${OMNICHECK} -patches -host ${CELL_SERVER} || Error "Data Protector Cell Manager is not responding, error code $?.
 See $RUNTIME_LOGFILE for more details."

--- a/usr/share/rear/verify/DP/default/400_verify_dp.sh
+++ b/usr/share/rear/verify/DP/default/400_verify_dp.sh
@@ -1,5 +1,6 @@
 # 400_verify_dp.sh
-# read DP vars from config file
+# read Data Protector vars from config file
+
 CELL_SERVER="`cat /etc/opt/omni/client/cell_server`"
 
 # check that cell server is actually available (ping)
@@ -8,9 +9,9 @@ StopIfError "Data Protector Cell Manager not set in /etc/opt/omni/client/cell_se
 
 if test "$PING" ; then
 	ping -c 1 "${CELL_SERVER}" >/dev/null 2>&1
-	StopIfError "Sorry, but cannot reach Data Protector Cell Manager ${CELL_SERVER}"
+	StopIfError "Data Protector Cell Manager ${CELL_SERVER} not responding to ping."
 
-	Log "Data Protector Cell Manager ${CELL_SERVER} seems to be up and running."
+	Log "Data Protector Cell Manager ${CELL_SERVER} seems to be reachable."
 else
 	Log "Skipping ping test"
 fi

--- a/usr/share/rear/verify/DP/default/400_verify_dp.sh
+++ b/usr/share/rear/verify/DP/default/400_verify_dp.sh
@@ -2,17 +2,13 @@
 # read Data Protector vars from config file
 
 CELL_SERVER="`cat /etc/opt/omni/client/cell_server`"
+OMNICHECK=/opt/omni/bin/omnicheck
 
-# check that cell server is actually available (ping)
+# the Cell Manager must be configured on the client
 [ "${CELL_SERVER}" ]
-StopIfError "Data Protector Cell Manager not set in /etc/opt/omni/client/cell_server (TCPSERVERADDRESS) !"
+StopIfError "Data Protector Cell Manager TCPSERVERADDRESS not set in /etc/opt/omni/client/cell_server"
 
-if test "$PING" ; then
-	ping -c 1 "${CELL_SERVER}" >/dev/null 2>&1
-	StopIfError "Data Protector Cell Manager ${CELL_SERVER} not responding to ping."
-
-	Log "Data Protector Cell Manager ${CELL_SERVER} seems to be reachable."
-else
-	Log "Skipping ping test"
-fi
-
+# check that the Cell Manager is responding on the INET port
+${OMNICHECK} -patches -host ${CELL_SERVER}
+StopIfError "Data Protector Cell Manager is not responding, error code $?.
+See $RUNTIME_LOGFILE for more details."

--- a/usr/share/rear/verify/DP/default/400_verify_dp.sh
+++ b/usr/share/rear/verify/DP/default/400_verify_dp.sh
@@ -1,13 +1,12 @@
 # 400_verify_dp.sh
 # read Data Protector vars from config file
 
-CELL_SERVER="$( cat /etc/opt/omni/client/cell_server )"
-OMNICHECK=/opt/omni/bin/omnicheck
-
 # the Cell Manager must be configured on the client
 # if /etc/opt/omni/client/cell_server exists and contains something, we're good
-test -s "${CELL_SERVER}" || Error "Data Protector Cell Manager not configured in /etc/opt/omni/client/cell_server"
+test -s /etc/opt/omni/client/cell_server || Error "Data Protector Cell Manager not configured in /etc/opt/omni/client/cell_server"
+CELL_SERVER="$( cat /etc/opt/omni/client/cell_server )"
 
+OMNICHECK=/opt/omni/bin/omnicheck
 # check that the Cell Manager is responding on the INET port
 ${OMNICHECK} -patches -host ${CELL_SERVER} || Error "Data Protector Cell Manager is not responding, error code $?.
 See $RUNTIME_LOGFILE for more details."

--- a/usr/share/rear/verify/DP/default/450_request_gui_restore.sh
+++ b/usr/share/rear/verify/DP/default/450_request_gui_restore.sh
@@ -1,5 +1,4 @@
-##############################################################################
-#
+# 450_request_gui_restore.sh
 # Press [gG] to fall back to GUI restore
 
 #set -e

--- a/usr/share/rear/verify/DP/default/500_select_dp_restore.sh
+++ b/usr/share/rear/verify/DP/default/500_select_dp_restore.sh
@@ -1,5 +1,4 @@
-##############################################################################
-#
+# 500_select_dp_restore.sh
 # Select dataprotector backup to be restored
 #
 # Ends in:
@@ -51,7 +50,7 @@ DPChooseBackup() {
   else
     HOST="`hostname`"
   fi >&2
-  LogPrint "Scanning for DP backups for Host ${HOST}"
+  LogPrint "Scanning for protected backups for client ${HOST}"
   DPGetBackupList $HOST > $TMP_DIR/backup.list
   > $TMP_DIR/backup.list.part
 
@@ -63,9 +62,9 @@ DPChooseBackup() {
 
   while true; do
     LogPrint ""
-    LogPrint "Found DP-Backup:"
+    LogPrint "Found Backup:"
     LogPrint ""
-    LogPrint "  [H] Host........: $HOST"
+    LogPrint "  [C] Client......: $HOST"
     LogPrint "  [D] Datalist....: $DATALIST"
     LogPrint "  [S] Session.....: $SESSION"
     LogPrint "      Device(s)...: $DEVS"
@@ -74,7 +73,7 @@ DPChooseBackup() {
     unset REPLY
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
     # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
-    read -t $WAIT_SECS -r -n 1 -p "press ENTER or choose H,D,S [$WAIT_SECS secs]: " 0<&6 1>&7 2>&8
+    read -t $WAIT_SECS -r -n 1 -p "press ENTER or choose C,D,S [$WAIT_SECS secs]: " 0<&6 1>&7 2>&8
 
     if test -z "${REPLY}"; then
       echo $HOST > $TMP_DIR/dp_recovery_host
@@ -83,7 +82,7 @@ DPChooseBackup() {
       echo $DEVS > $TMP_DIR/dp_recovery_devs
       LogPrint "ok"
       return
-    elif test "${REPLY}" = "h" -o "${REPLY}" = "H"; then
+    elif test "${REPLY}" = "c" -o "${REPLY}" = "C"; then
       DPChangeHost
       return
     elif test "${REPLY}" = "d" -o "${REPLY}" = "D"; then
@@ -117,7 +116,7 @@ DPChangeHost() {
     UserOutput ""
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
     # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
-    read -r -p "Enter host: " 0<&6 1>&7 2>&8
+    read -r -p "Enter client name: " 0<&6 1>&7 2>&8
     if test -z "${REPLY}"; then
       DPChooseBackup
       return
@@ -136,7 +135,7 @@ DPChangeDataList() {
   while test $valid -eq 0; do
     LogPrint ""
     LogPrint ""
-    LogPrint "Available datalists for host:"
+    LogPrint "Available datalists for client:"
     LogPrint ""
     i=0
     cat $TMP_DIR/backup.list | while read s; do echo "$s" | cut -f 2; done | sort -u | while read s; do


### PR DESCRIPTION
Type: Bug Fix and Enhancement

Impact: High
Without those changes the Data Protector 10.70 and later won't be able to use systemd (over xinetd). Restore performance from BACKUP=DP has been increased by doing parallel restores now.

Reference to related issue (URL):
none

How was this pull request tested?
Applied the changes to a SLES15 SP1 system running rear 2.6.1. Created a new ISO, booted the system and ran through various test cases.

Brief description of the changes in this pull request:
Additional changes to Data Protector branding and general script cleanup
Adjustment required to support systemd-only with Data Protector 10.70 and later in addition to xinetd-only deployments
Parallel restore support from BACKUP=DP