### PR TITLE
TCG Opal Improvements

### DIFF
--- a/doc/user-guide/13-tcg-opal-support.adoc
+++ b/doc/user-guide/13-tcg-opal-support.adoc
@@ -161,6 +161,10 @@ or on the rescue system.
 
 * Unlock disk(s): `rear opaladmin unlock`
 
+* Persistently deactivate the locking mechanism on disk(s): `rear opaladmin deactivate`
+
+* Reactivate the locking mechanism on disk(s): `rear opaladmin reactivate`
+
 * For help: `rear opaladmin help`
 
 === Erasing a Self-Encrypting Disk

--- a/usr/share/rear/build/OPALPBA/Linux-i386/095_exclude_non_essential_files.sh
+++ b/usr/share/rear/build/OPALPBA/Linux-i386/095_exclude_non_essential_files.sh
@@ -13,7 +13,7 @@ COPY_AS_IS_EXCLUDE+=( /lib/systemd/systemd-{cryptsetup,logind,networkd*,resolved
 # SSL
 COPY_AS_IS_EXCLUDE+=( /etc/pki /etc/ssl /usr/lib/ssl /usr/share/ca-certificates)
 # ReaR
-COPY_AS_IS_EXCLUDE+=( "$REAR_DIR_PREFIX" )
+COPY_AS_IS_EXCLUDE+=( "$SHARE_DIR" "$VAR_DIR" "$LOG_DIR" )
 
 local progs_to_exclude=()
 # networking

--- a/usr/share/rear/build/OPALPBA/Linux-i386/106_remove_files_copied_unconditionally.sh
+++ b/usr/share/rear/build/OPALPBA/Linux-i386/106_remove_files_copied_unconditionally.sh
@@ -1,0 +1,18 @@
+# Remove files which have been copied unconditionally
+
+# Safety check - avoid removing files in the wrong place
+[[ -n "$ROOTFS_DIR" && -d "$ROOTFS_DIR" ]] || BugError "ROOTFS_DIR='$ROOTFS_DIR' does not specify a valid directory"
+
+# Remove symlinks whose targets have been excluded on the PBA system
+local symlinks_to_remove=(
+    bin/vim
+    var/lib/rear
+)
+
+local symlink_to_remove
+for symlink_to_remove in "${symlinks_to_remove[@]}"; do
+    [[ -h "$ROOTFS_DIR/$symlink_to_remove" ]] && rm "$ROOTFS_DIR/$symlink_to_remove"
+done
+
+# Remove ReaR configuration (may contain sensitive information)
+rm -r "$ROOTFS_DIR/etc/rear"

--- a/usr/share/rear/conf/Ubuntu.conf
+++ b/usr/share/rear/conf/Ubuntu.conf
@@ -1,5 +1,8 @@
 PROGS+=( initctl MAKEDEV )
 
+# Exclude paths which will trigger warnings about non-existing symlink targets
+COPY_AS_IS_EXCLUDE+=( /usr/share/misc/magic )
+
 #####
 # TCG Opal 2 PBA system only: Include Plymouth graphical boot animation
 

--- a/usr/share/rear/conf/Ubuntu.conf
+++ b/usr/share/rear/conf/Ubuntu.conf
@@ -14,12 +14,13 @@ OPAL_PBA_COPY_AS_IS+=( /etc/alternatives/*plymouth* /usr/lib/x86_64-linux-gnu/pl
 # but fails to consider shared libraries (*.so) from COPY_AS_IS. Adding those to LIBS gets them covered.
 OPAL_PBA_LIBS+=( /usr/lib/x86_64-linux-gnu/plymouth/*.so /usr/lib/x86_64-linux-gnu/plymouth/renderers/*.so )
 
-if grep --quiet 'vt.handoff=1' /proc/cmdline; then
-    # vt.handoff=1 triggers an Ubuntu-specifc mechanism to ensure a smooth boot splash transition
+vt_handoff="$(grep --extended-regexp --only-matching 'vt.handoff=[0-9]+' /proc/cmdline)"
+if [[ -n "$vt_handoff" ]]; then
+    # vt.handoff triggers an Ubuntu-specifc mechanism to ensure a smooth boot splash transition
     # Cf. https://help.ubuntu.com/community/vt.handoff
     # Only do this on systems where it was originally enabled, otherwise the PBA might boot into a black screen.
     # (In case of the latter, pressing ESC helps).
-    OPAL_PBA_KERNEL_CMDLINE+=" vt.handoff=1"
+    OPAL_PBA_KERNEL_CMDLINE+=" $vt_handoff"
 fi
 
 OPAL_PBA_USE_SERIAL_CONSOLE="No"

--- a/usr/share/rear/layout/save/GNU/Linux/190_opaldisk_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/190_opaldisk_layout.sh
@@ -10,7 +10,7 @@ for device in "${devices[@]}"; do
     [[ "${attributes[setup]}" == "y" ]] || continue
 
     if [[ "${attributes[locked]}" == "y" ]]; then
-        LogPrintError "TCG Opal 2 self-encrypting disk \"$device\" is locked: excluding from layout."
+        LogPrintError "TCG Opal 2 self-encrypting disk '$device' is locked: excluding from layout."
         continue
     fi
 

--- a/usr/share/rear/lib/opal-functions.sh
+++ b/usr/share/rear/lib/opal-functions.sh
@@ -201,6 +201,26 @@ function opal_device_unlock() {
     sedutil-cli --setLockingRange 0 RW "$password" "$device" && opal_device_hide_mbr "$device" "$password"
 }
 
+function opal_device_deactivate_locking() {
+    local device="${1:?}"
+    local password="${2:?}"
+    # attempts to permanently deactivate the locking mechanism (locking range 0 spanning the entire disk) on device
+    # and disable the MBR.
+    # Returns 0 on success.
+
+    sedutil-cli --disableLockingRange 0 "$password" "$device" && opal_device_disable_mbr "$device" "$password"
+}
+
+function opal_device_reactivate_locking() {
+    local device="${1:?}"
+    local password="${2:?}"
+    # attempts to permanently reactivate the locking mechanism (locking range 0 spanning the entire disk) on device
+    # and re-enable the MBR.
+    # Returns 0 on success.
+
+    sedutil-cli --enableLockingRange 0 "$password" "$device" && opal_device_enable_mbr "$device" "$password"
+}
+
 function opal_disk_partition_information() {
     local device="${1:?}"
     # prints disk and partition information.

--- a/usr/share/rear/lib/opal-functions.sh
+++ b/usr/share/rear/lib/opal-functions.sh
@@ -85,7 +85,7 @@ function opal_device_identification() {
     local device="${1:?}"
     # prints identification information for an Opal device.
 
-    echo "\"$device\" ($(opal_device_attribute "$device" "model"))"
+    echo "'$device' ($(opal_device_attribute "$device" "model"))"
 }
 
 function opal_device_information() {
@@ -260,7 +260,7 @@ function opal_check_pba_image() {
     # generates an error if the PBA image is larger than the guaranteed MBR capacity.
     # REQUIRES ReaR.
 
-    [[ -f "$pba_image_file" ]] || Error "\"$pba_image_file\" is not a regular file, thus cannot be used as TCG Opal 2 PBA image."
+    [[ -f "$pba_image_file" ]] || Error "'$pba_image_file' is not a regular file, thus cannot be used as TCG Opal 2 PBA image."
 
     local -i file_size=$(stat --printf="%s\n" "$pba_image_file")
     local -i mbr_size_limit=$((128 * 1024 * 1024))  # guaranteed minimum MBR size: 128 MiB (Opal 2 spec, section 4.3.5.4)
@@ -268,7 +268,7 @@ function opal_check_pba_image() {
     if (( file_size > mbr_size_limit )); then
         local file_size_MiB="$(opal_bytes_to_mib $file_size) MiB"
         local mbr_size_limit_MiB="$(opal_bytes_to_mib $mbr_size_limit) MiB"
-        Error "TCG Opal 2 PBA image file \"$pba_image_file\" is $file_size_MiB in size, allowed maximum is $mbr_size_limit_MiB."
+        Error "TCG Opal 2 PBA image file '$pba_image_file' is $file_size_MiB in size, allowed maximum is $mbr_size_limit_MiB."
     fi
 }
 
@@ -364,12 +364,11 @@ function opal_device_recreate_setup() {
         Log "Opal 2 disk $device reset to factory defaults, data erased."
     fi
 
-    opal_device_setup "$device" "$password"
-    StopIfError "Could not set up $device."
+    opal_device_setup "$device" "$password" || Error "Could not set up $device."
     Log "Opal 2 disk $device set up."
 
-    opal_device_regenerate_dek_ERASING_ALL_DATA "$device" "$password"
-    StopIfError "Could not reset data encryption key (DEK) of Opal 2 disk $device."
+    opal_device_regenerate_dek_ERASING_ALL_DATA "$device" "$password" ||
+        Error "Could not reset data encryption key (DEK) of Opal 2 disk $device."
     Log "Data encryption key (DEK) of Opal 2 disk $device reset, data erased."
 }
 
@@ -380,9 +379,9 @@ function opal_device_recreate_boot_support() {
     # prepares the device for booting.
     # REQUIRES ReaR.
 
-    opal_device_enable_mbr "$device" "$password"
-    StopIfError "Could not enable the shadow MBR on Opal 2 disk $device."
-    opal_device_load_pba_image "$device" "$password" "$pba_image_file"
-    StopIfError "Could not upload the PBA image \"$pba_image_file\" to Opal 2 disk $device."
+    opal_device_enable_mbr "$device" "$password" ||
+        Error "Could not enable the shadow MBR on Opal 2 disk $device."
+    opal_device_load_pba_image "$device" "$password" "$pba_image_file" ||
+        Error "Could not upload the PBA image '$pba_image_file' to Opal 2 disk $device."
     Log "Opal 2 disk $device: Shadow MBR enabled and PBA uploaded."
 }

--- a/usr/share/rear/lib/opaladmin-workflow.sh
+++ b/usr/share/rear/lib/opaladmin-workflow.sh
@@ -70,7 +70,7 @@ function WORKFLOW_opaladmin() {
             action="$1"
             shift
             if (($# < 1)); then
-                PrintError "Missing required DEVICE argument for action \"$action\"."
+                PrintError "Missing required DEVICE argument for action '$action'."
                 opaladmin_usage_error
             fi
             ;;
@@ -83,7 +83,7 @@ function WORKFLOW_opaladmin() {
             opaladmin_usage_error
             ;;
         (*)
-            PrintError "Unknown action \"$1\"."
+            PrintError "Unknown action '$1'."
             opaladmin_usage_error
             ;;
     esac
@@ -105,7 +105,7 @@ function WORKFLOW_opaladmin() {
                 break
                 ;;
             (*)
-                Error "Internal error during option processing (\"$1\")."
+                Error "Internal error during option processing ('$1')."
                 ;;
         esac
     done
@@ -123,7 +123,7 @@ function WORKFLOW_opaladmin() {
                 set -- "${OPALADMIN_DEVICES[@]}"
                 break
             elif ! IsInArray "$device" "${OPALADMIN_DEVICES[@]}"; then
-                Error "Device \"$device\" is not a TCG Opal 2-compliant self-encrypting disk."
+                Error "Device '$device' is not a TCG Opal 2-compliant self-encrypting disk."
             fi
         done
 
@@ -178,14 +178,14 @@ function opaladmin_setupERASE_action() {
             if [[ "${attributes[setup]}" == "y" ]]; then
                 LogUserOutput "Opal locking on device $(opal_device_identification "$device") has already been enabled."
 
-                opaladmin_device_unlock_if_locked "$device" "\"$device\""
+                opaladmin_device_unlock_if_locked "$device" "'$device'"
             else
                 LogUserOutput "Setting up Opal locking on device $(opal_device_identification "$device")..."
 
                 local enable_boot_unlocking="n"
 
                 if [[ -n "$OPALADMIN_IMAGE_FILE" ]]; then
-                    local prompt="Shall device \"$device\" act as a boot device for disk unlocking (y/n)? "
+                    local prompt="Shall device '$device' act as a boot device for disk unlocking (y/n)? "
                     enable_boot_unlocking="$(opal_choice_input "OPALADMIN_SETUP_BOOT_$device_number" "$prompt" "y" "n")"
                 fi
 
@@ -194,17 +194,16 @@ function opaladmin_setupERASE_action() {
                     OPAL_DISK_PASSWORD="$(opal_checked_password_input "OPAL_DISK_PASSWORD" "disk password")"
                 fi
 
-                opal_device_setup "$device" "$OPAL_DISK_PASSWORD"
-                StopIfError "Could not set up device \"$device\"."
+                opal_device_setup "$device" "$OPAL_DISK_PASSWORD" || Error "Could not set up device '$device'."
                 LogUserOutput "Initial setup successful."
 
                 if [[ "$enable_boot_unlocking" == "y" ]]; then
                     opaladmin_use_image_file
-                    LogUserOutput "Enabling shadow MBR and uploading the PBA to device \"$device\"..."
-                    opal_device_enable_mbr "$device" "$OPAL_DISK_PASSWORD"
-                    StopIfError "Could not enable the shadow MBR on device \"$device\"."
-                    opal_device_load_pba_image "$device" "$OPAL_DISK_PASSWORD" "$OPALADMIN_IMAGE_FILE"
-                    StopIfError "Could not upload the PBA image to device \"$device\"."
+                    LogUserOutput "Enabling shadow MBR and uploading the PBA to device '$device'..."
+                    opal_device_enable_mbr "$device" "$OPAL_DISK_PASSWORD" ||
+                        Error "Could not enable the shadow MBR on device '$device'."
+                    opal_device_load_pba_image "$device" "$OPAL_DISK_PASSWORD" "$OPALADMIN_IMAGE_FILE" ||
+                        Error "Could not upload the PBA image to device '$device'."
                     LogUserOutput "Shadow MBR enabled and PBA uploaded."
                 else
                     opal_device_disable_mbr "$device" "$OPAL_DISK_PASSWORD"
@@ -265,8 +264,8 @@ function opaladmin_uploadPBA_action() {
                 opaladmin_use_image_file
                 LogUserOutput "Uploading the PBA to device $(opal_device_identification "$device")..."
                 opaladmin_get_disk_password
-                opal_device_load_pba_image "$device" "$OPAL_DISK_PASSWORD" "$OPALADMIN_IMAGE_FILE"
-                StopIfError "Could not upload the PBA image to device \"$device\"."
+                opal_device_load_pba_image "$device" "$OPAL_DISK_PASSWORD" "$OPALADMIN_IMAGE_FILE" ||
+                    Error "Could not upload the PBA image to device '$device'."
                 LogUserOutput "PBA uploaded."
             else
                 LogUserOutput "Device $(opal_device_identification "$device") is not a boot device, skipping PBA upload."
@@ -345,7 +344,7 @@ function opaladmin_resetDEK_action() {
             # Unlock before checking device contents
             opaladmin_device_unlock_if_locked "$device" "$(opal_device_identification "$device")"
 
-            local confirmation="$(opaladmin_erase_confirmation "$device" "Reset data encryption key (DEK) of device \"$device\"")"
+            local confirmation="$(opaladmin_erase_confirmation "$device" "Reset data encryption key (DEK) of device '$device'")"
 
             if [[ "$confirmation" == "YesERASE" ]]; then
                 LogUserOutput "About to reset the data encryption key (DEK) of device $(opal_device_identification "$device")..."
@@ -354,7 +353,7 @@ function opaladmin_resetDEK_action() {
                 if (( $? == 0 )); then
                     LogUserOutput "Data encryption key (DEK) reset, data erased."
                 else
-                    LogUserOutput "WARNING: Could not reset data encryption key (DEK) of device \"$device\"."
+                    LogUserOutput "WARNING: Could not reset data encryption key (DEK) of device '$device'."
                 fi
             else
                 LogUserOutput "SKIPPING: Data encryption key (DEK) of device $(opal_device_identification "$device") left untouched."
@@ -378,13 +377,13 @@ function opaladmin_factoryRESET_action() {
             # Unlock before checking device contents
             opaladmin_device_unlock_if_locked "$device" "$(opal_device_identification "$device")"
 
-            local confirmation="$(opaladmin_erase_confirmation "$device" "Factory-reset device \"$device\"")"
+            local confirmation="$(opaladmin_erase_confirmation "$device" "Factory-reset device '$device'")"
 
             if [[ "$confirmation" == "YesERASE" ]]; then
                 LogUserOutput "About to reset device $(opal_device_identification "$device") to factory defaults..."
                 opaladmin_get_disk_password
-                opal_device_factory_reset_ERASING_ALL_DATA "$device" "$OPAL_DISK_PASSWORD"
-                StopIfError "Could not reset device \"$device\" to factory defaults."
+                opal_device_factory_reset_ERASING_ALL_DATA "$device" "$OPAL_DISK_PASSWORD" ||
+                    Error "Could not reset device '$device' to factory defaults."
                 LogUserOutput "Device reset to factory defaults, data erased."
             else
                 LogUserOutput "SKIPPING: Device $(opal_device_identification "$device") left untouched."
@@ -403,8 +402,7 @@ function opaladmin_device_unlock_if_locked() {
     if [[ "$(opal_device_attribute "$device" "locked")" == "y" ]]; then
         LogUserOutput "Unlocking device $identification..."
         opaladmin_get_disk_password
-        opal_device_unlock "$device" "$OPAL_DISK_PASSWORD"
-        StopIfError "Could not unlock device \"$device\"."
+        opal_device_unlock "$device" "$OPAL_DISK_PASSWORD" || Error "Could not unlock device '$device'."
         LogUserOutput "Device unlocked."
     fi
 }
@@ -416,8 +414,8 @@ function opaladmin_deactivate_locking() {
 
     LogUserOutput "Persistently deactivating the locking mechanism on device $identification..."
     opaladmin_get_disk_password
-    opal_device_deactivate_locking "$device" "$OPAL_DISK_PASSWORD"
-    StopIfError "Could not deactivate locking on device \"$device\"."
+    opal_device_deactivate_locking "$device" "$OPAL_DISK_PASSWORD" ||
+        Error "Could not deactivate locking on device '$device'."
     LogUserOutput "Locking deactivated."
 }
 
@@ -428,8 +426,8 @@ function opaladmin_reactivate_locking() {
 
     LogUserOutput "Reactivate the locking mechanism on device $identification..."
     opaladmin_get_disk_password
-    opal_device_reactivate_locking "$device" "$OPAL_DISK_PASSWORD"
-    StopIfError "Could not reactivate locking on device \"$device\"."
+    opal_device_reactivate_locking "$device" "$OPAL_DISK_PASSWORD" ||
+        Error "Could not reactivate locking on device '$device'."
     LogUserOutput "Locking reactivated."
 }
 
@@ -440,7 +438,7 @@ function opaladmin_erase_confirmation() {
 
     local confirmation="No"
 
-    [[ "$(opal_device_attribute "$device" "locked")" == "n" ]] || BugError "Cannot safety-check contents of locked device \"$device\""
+    [[ "$(opal_device_attribute "$device" "locked")" == "n" ]] || BugError "Cannot safety-check contents of locked device '$device'"
 
     if opal_disk_has_partitions "$device"; then
         if opal_disk_has_mounted_partitions "$device"; then
@@ -472,5 +470,5 @@ function opaladmin_use_image_file() {
     # ensures that $OPALADMIN_IMAGE_FILE is non-empty or exits with an error.
 
     [[ -n "$OPALADMIN_IMAGE_FILE" ]] || Error "Could not find a PBA image file."
-    LogPrint "Using PBA image file \"$OPALADMIN_IMAGE_FILE\"."
+    LogPrint "Using PBA image file '$OPALADMIN_IMAGE_FILE'."
 }

--- a/usr/share/rear/prep/default/380_include_opal_tools.sh
+++ b/usr/share/rear/prep/default/380_include_opal_tools.sh
@@ -12,6 +12,6 @@ if [[ "$WORKFLOW" == "mkrescue" ]]; then
     local pba_image_file="$(opal_local_pba_image_file)"
     if [[ -n "$pba_image_file" ]]; then
         COPY_AS_IS+=( "$pba_image_file" )
-        LogPrint "Using local PBA image file \"$pba_image_file\""
+        LogPrint "Using local PBA image file '$pba_image_file'"
     fi
 fi

--- a/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
+++ b/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
@@ -21,6 +21,11 @@ function quit_plymouth() {
     use_plymouth && plymouth quit
 }
 
+function enter_plymouth_shutdown_mode() {
+    # puts plymouth into shutdown mode, if in use.
+    use_plymouth && plymouth change-mode --shutdown
+}
+
 function display_message() {
     local message="${1:?}"
 
@@ -106,7 +111,7 @@ function stop_error_handling() {
 }
 
 function instant_reboot() {
-    quit_plymouth
+    enter_plymouth_shutdown_mode
     stop_error_handling
 
     # Force immediate hardware reboot via Magic SysRq key
@@ -119,7 +124,7 @@ function instant_reboot() {
 }
 
 function instant_poweroff() {
-    quit_plymouth
+    enter_plymouth_shutdown_mode
     stop_error_handling
 
     # Force immediate hardware poweroff via Magic SysRq key


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): #2436

* How was this pull request tested? On Ubuntu 20.04 LTS

* Brief description of the changes in this pull request:
    * OPALPBA, Ubuntu: Fix incomplete file exclusions
        * Fixes omissions reported in #2436.
        * Uses COPY_AS_IS_EXCLUDE where possible.
        * Removes files from the PBA system's staging directory where _not copying_ could not be configured.
    * OPALPBA: Improve boot splash on Ubuntu 20.04
        * Takes into account a change from VT1 to VT7 to hide log messages during the boot process.
        * Improves Plymouth boot splash usage to hide log messages during the reboot after unlocking disks.
    * opaladmin: Add sub-commands 'deactivate', 'reactivate'
        * Makes turning on and off hardware encryption easier on provisioned drives.
