### PR TITLE
Supply default value for root in grub in UEFI ISO

### DIFF
--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -502,6 +502,7 @@ function create_grub2_cfg {
     test $esp_initrd || esp_initrd="/isolinux/$REAR_INITRD_FILENAME"
 
     cat << EOF
+${grub2_set_root:+"set root=$grub2_set_root"}
 set default="$GRUB2_DEFAULT_BOOT"
 
 insmod all_video

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -62,7 +62,14 @@ title Relax-and-Recover (no Secure Boot)
 
 EOF
 else
-    # create a grub.cfg
+    # Create a grub.cfg:
+    # Sometimes the search command in GRUB2 used in UEFI ISO does not find the root device.
+    # This was seen at least in Debian Buster running in Qemu
+    # (VirtualBox works fine, RHEL/CentOS in Qemu works fine as well).
+    # The GRUB2 image created by grub-mkstandalone has 'root' set to memdisk, which can't work.
+    # To make ReaR work in this case, set 'root' to a sensible value 'cd0' before trying search
+    # (via ${grub2_set_root:+"set root=$grub2_set_root"} in the create_grub2_cfg function)
+    # cf. https://github.com/rear/rear/issues/2434 and https://github.com/rear/rear/pull/2453
     grub2_set_root=cd0
     create_grub2_cfg > $efi_boot_tmp_dir/grub.cfg
 fi

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -63,6 +63,7 @@ title Relax-and-Recover (no Secure Boot)
 EOF
 else
     # create a grub.cfg
+    grub2_set_root=cd0
     create_grub2_cfg > $efi_boot_tmp_dir/grub.cfg
 fi
 


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):

Fixes #2434. (problem introduced in PR #2293).

* How was this pull request tested?

Success was reported by @yontalcar in #2434 (for RHEL 7 and RHEL 8 only though).

* Brief description of the changes in this pull request:

Sometimes the search command in GRUB2 used in UEFI ISO does not find the root device. This was seen at least in Debian Buster running in Qemu (VirtualBox works fine, RHEL/CentOS in Qemu works fine as well).

To make ReaR work in this case, set $root to a sensible value before trying `search`. The GRUB2 image created by grub-mkstandalone has $root set to memdisk, which can't work.

This essentially matches how it used to work before PR #2293. 