### PR TITLE
default.conf change ISO_VOLID="RELAXRECOVER" to ISO_VOLID="REAR-ISO"

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -662,10 +662,10 @@ ISO_DIR=$VAR_DIR/output
 # the first ISO 'rear-HOSTNAME.iso' has the label $ISO_VOLID
 # and subsequent ISOs 'rear-HOSTNAME_01.iso' 'rear-HOSTNAME_02.iso' ...
 # get the labels ${ISO_VOLID}_01 ${ISO_VOLID}_02 ... respectively.
-# The ISO_VOLID default value REAR_ISO has 8 characters so that
-# the first ISO 'rear-HOSTNAME.iso' has the label REAR_ISO
+# The ISO_VOLID default value REAR-ISO has 8 characters so that
+# the first ISO 'rear-HOSTNAME.iso' has the label REAR-ISO
 # and subsequent ISOs 'rear-HOSTNAME_01.iso' 'rear-HOSTNAME_02.iso' ...
-# get the labels REAR_ISO_01 REAR_ISO_02 ... respectively
+# get the labels REAR-ISO_01 REAR-ISO_02 ... respectively
 # that have 11 characters which is the maximum length for FAT volume names
 # ("man mkfs.fat" tells that a "volume name can be up to 11 characters long")
 # so things work when the ISO image is used to create a FAT bootable USB stick
@@ -675,7 +675,7 @@ ISO_DIR=$VAR_DIR/output
 # ("man mkfs.xfs" tells "XFS filesystem labels can be at most 12 characters long" so it's ok)
 # the ISO_VOLID value would have to be appropriately specified in /etc/rear/local.conf
 # so that $ISO_VOLID plus the trailing '_NN' does not exceed the maximum label length.
-ISO_VOLID="REAR_ISO"
+ISO_VOLID="REAR-ISO"
 #
 # How to find isolinux.bin.
 # Possible values are "" (meaning search for it) or "/path/to/isolinux.bin"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -662,13 +662,20 @@ ISO_DIR=$VAR_DIR/output
 # the first ISO 'rear-HOSTNAME.iso' has the label $ISO_VOLID
 # and subsequent ISOs 'rear-HOSTNAME_01.iso' 'rear-HOSTNAME_02.iso' ...
 # get the labels ${ISO_VOLID}_01 ${ISO_VOLID}_02 ... respectively.
-# The default value RELAXRECOVER is too long to fit a FAT32 volume label
-# so that the actual FAT32 volume label on the medium is truncated
-# which lets 'rear recover' fail because ReaR cannot mount it with
-# the RELAXRECOVER volume label so that in case of FAT32 or any other
-# filesystem that only support short volume labels the ISO_VOLID value
-# must be appropriately specified in /etc/rear/local.conf
-ISO_VOLID="RELAXRECOVER"
+# The ISO_VOLID default value REAR_ISO has 8 characters so that
+# the first ISO 'rear-HOSTNAME.iso' has the label REAR_ISO
+# and subsequent ISOs 'rear-HOSTNAME_01.iso' 'rear-HOSTNAME_02.iso' ...
+# get the labels REAR_ISO_01 REAR_ISO_02 ... respectively
+# that have 11 characters which is the maximum length for FAT volume names
+# ("man mkfs.fat" tells that a "volume name can be up to 11 characters long")
+# so things work when the ISO image is used to create a FAT bootable USB stick
+# cf. https://github.com/rear/rear/issues/1565
+# and https://github.com/rear/rear/issues/2456
+# In case of special filesystems that only support labels with even less than 11 characters
+# ("man mkfs.xfs" tells "XFS filesystem labels can be at most 12 characters long" so it's ok)
+# the ISO_VOLID value would have to be appropriately specified in /etc/rear/local.conf
+# so that $ISO_VOLID plus the trailing '_NN' does not exceed the maximum label length.
+ISO_VOLID="REAR_ISO"
 #
 # How to find isolinux.bin.
 # Possible values are "" (meaning search for it) or "/path/to/isolinux.bin"


### PR DESCRIPTION
* Type: **Enhancement** / **Possibly backward incompatible change**

* Impact: **High**
High impact because of possibly backward incompatible change,
cf. https://github.com/rear/rear/issues/1565#issuecomment-342449263

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1565
and
https://github.com/rear/rear/issues/2456
in particular
https://github.com/rear/rear/issues/1565#issuecomment-342449263

* How was this pull request tested?
Not at all tested by me.

* Brief description of the changes in this pull request:

In default.conf change `ISO_VOLID="RELAXRECOVER"` to
```
ISO_VOLID="REAR-ISO"
```
so the first ISO has the label REAR-ISO (8 characters) and subsequent ISOs
get the labels REAR-ISO_01 REAR-ISO_02 ... respectively
that have 11 characters which is the maximum length for FAT volume names
so things work by default when the ISO image is used
to (manually) create a FAT bootable USB stick.

Using ISO_VOLID="REAR-ISO" (e.g. instead of ISO_VOLID="REAR_ISO")
because the REAR-... syntax matches better the ISO file name
syntax rear-HOSTNAME.iso and also it matches better the other
label syntax USB_DEVICE_FILESYSTEM_LABEL='REAR-000'
