### PR TITLE
500_make_backup.sh: filter informational tar messages from output

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -292,7 +292,7 @@ case "$(basename $BACKUP_PROG)" in
             if (( $backup_prog_rc == 1 )); then
                 LogUserOutput "WARNING: $prog ended with return code 1 and below output:
   ---snip---
-$(grep '^tar: ' "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log" | sed -e 's/^/  /' | tail -n3)
+$(sed -n -e '/^tar: .*\(socket ignored\|Removing leading\)/d;/^'"$prog"':/s/^/  /p' "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log" | tail -n3)
   ----------
 This means that files have been modified during the archiving
 process. As a result the backup may not be completely consistent
@@ -304,7 +304,7 @@ backup in order to be sure to safely recover this system.
                 rc=$(cat $FAILING_BACKUP_PROG_RC_FILE)
                 Error "$prog failed with return code $rc and below output:
   ---snip---
-$(grep "^$prog: " "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log" | sed -e 's/^/  /' | tail -n3)
+$(sed -n -e '/^tar: .*\(socket ignored\|Removing leading\)/d;/^'"$prog"':/s/^/  /p' "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log" | tail -n3)
   ----------
 This means that the archiving process ended prematurely, or did
 not even start. As a result it is unlikely you can recover this

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -289,10 +289,19 @@ case "$(basename $BACKUP_PROG)" in
     (tar)
         if (( $backup_prog_rc != 0 )); then
             prog="$(cat $FAILING_BACKUP_PROG_FILE)"
+            # Suppress purely informational tar messages from output like
+            #   tar: Removing leading / from member names
+            #   tar: Removing leading / from hard link targets
+            #   tar: /var/spool/postfix/private/discard: socket ignored
+            # but keep actual tar error or warning messages like
+            #    tar: /etc/grub.d/README: file changed as we read it
+            # and show only messages that are prefixed with "$prog:" (like 'tar:' or 'dd:')
+            # which works when 'tar' or 'dd' fail but falsely suppresses messages from 'openssl'
+            # FIXME see https://github.com/rear/rear/pull/2466#discussion_r466347471
             if (( $backup_prog_rc == 1 )); then
-                LogUserOutput "WARNING: $prog ended with return code 1 and below output:
+                LogUserOutput "WARNING: $prog ended with return code 1 and below output (last 5 lines):
   ---snip---
-$(sed -n -e '/^tar: .*\(socket ignored\|Removing leading\)/d;/^'"$prog"':/s/^/  /p' "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log" | tail -n3)
+$( sed -n -e '/^tar: .*\(socket ignored\|Removing leading\)/d;/^'"$prog"':/s/^/  /p' "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log" | tail -n5 )
   ----------
 This means that files have been modified during the archiving
 process. As a result the backup may not be completely consistent
@@ -302,9 +311,9 @@ backup in order to be sure to safely recover this system.
 "
             else
                 rc=$(cat $FAILING_BACKUP_PROG_RC_FILE)
-                Error "$prog failed with return code $rc and below output:
+                Error "$prog failed with return code $rc and below output (last 5 lines):
   ---snip---
-$(sed -n -e '/^tar: .*\(socket ignored\|Removing leading\)/d;/^'"$prog"':/s/^/  /p' "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log" | tail -n3)
+$( sed -n -e '/^tar: .*\(socket ignored\|Removing leading\)/d;/^'"$prog"':/s/^/  /p' "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log" | tail -n5 )
   ----------
 This means that the archiving process ended prematurely, or did
 not even start. As a result it is unlikely you can recover this


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): #2465

* How was this pull request tested? See steps to reproduce in issue #2465 

* Brief description of the changes in this pull request:
```
When tar exits with status greater than zero rear copies the last three
tar messages from backup.log to its own log. Those lines are also shown
to the user when rear is invoked with the "-v" option.

Some tar messages, however, are purely informational, e.g.

    tar: Removing leading `/' from member names
    tar: Removing leading `/' from hard link targets
    tar: /var/spool/postfix/private/discard: socket ignored

Strip the informational messages and show only actual errors, e.g.

    tar: /etc/grub.d/README: file changed as we read it

Fixes: issue #2465
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1865697

Signed-off-by: Carlos Santos <casantos@redhat.com>
```