### PR TITLE
Have 'cd WORKING_DIR' in Source() function

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -100,6 +100,12 @@ CONFIG_DIR="$REAR_DIR_PREFIX/etc/rear"
 VAR_DIR="$REAR_DIR_PREFIX/var/lib/rear"
 LOG_DIR="$REAR_DIR_PREFIX/var/log/rear"
 
+# The current working directory when this script (usr/sbin/rear) is launched
+# is also the working directory of all the other scripts and config files
+# that get sourced via the Source() function in lib/framework-functions.sh
+# cf. https://github.com/rear/rear/issues/2461
+readonly WORKING_DIR="$( pwd )"
+
 # Generic global variables that are not meant to be configured by the user
 # (i.e. that do not belong into usr/share/rear/conf/default.conf),
 # see https://github.com/rear/rear/issues/678

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -46,14 +46,6 @@ function Source () {
         local saved_bash_flags_and_options_commands="$( get_bash_flags_and_options_commands )"
         set -$DEBUGSCRIPTS_ARGUMENT
     fi
-    # The working directory WORKING_DIR="$( pwd )" when usr/sbin/rear was launched
-    # is also the working directory of all other sourced scripts and config files
-    # cf. https://github.com/rear/rear/issues/2461
-    # Quoting "$WORKING_DIR" is needed to make it behave fail-safe if WORKING_DIR is empty
-    # because cd "" succeeds without changing the current directory
-    # in contrast to plain cd which changes to the home directory (usually /root)
-    # cf. https://github.com/rear/rear/pull/2478#issuecomment-673500099
-    cd "$WORKING_DIR" || LogPrintError "Failed to 'cd $WORKING_DIR'"
     # The actual work (source the source file):
     # Do not error out here when 'source' fails (i.e. when 'source' returns a non-zero exit code)
     # because scripts usually return the exit code of their last command
@@ -64,6 +56,14 @@ function Source () {
     source "$source_file"
     source_return_code=$?
     test "0" -eq "$source_return_code" || Debug "Source function: 'source $source_file' returns $source_return_code"
+    # Ensure that after each sourced file we are back in ReaR's usual working directory
+    # that is WORKING_DIR="$( pwd )" when usr/sbin/rear was launched
+    # cf. https://github.com/rear/rear/issues/2461
+    # Quoting "$WORKING_DIR" is needed to make it behave fail-safe if WORKING_DIR is empty
+    # because cd "" succeeds without changing the current directory
+    # in contrast to plain cd which changes to the home directory (usually /root)
+    # cf. https://github.com/rear/rear/pull/2478#issuecomment-673500099
+    cd "$WORKING_DIR" || LogPrintError "Failed to 'cd $WORKING_DIR'"
     # Undo DEBUGSCRIPTS mode settings:
     if test "$DEBUGSCRIPTS" ; then
         Debug "Leaving debugscript mode (back to previous bash flags and options settings)."

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -49,6 +49,10 @@ function Source () {
     # The working directory WORKING_DIR="$( pwd )" when usr/sbin/rear was launched
     # is also the working directory of all other sourced scripts and config files
     # cf. https://github.com/rear/rear/issues/2461
+    # Quoting "$WORKING_DIR" is needed to make it behave fail-safe if WORKING_DIR is empty
+    # because cd "" succeeds without changing the current directory
+    # in contrast to plain cd which changes to the home directory (usually /root)
+    # cf. https://github.com/rear/rear/pull/2478#issuecomment-673500099
     cd "$WORKING_DIR" || LogPrintError "Failed to 'cd $WORKING_DIR'"
     # The actual work (source the source file):
     # Do not error out here when 'source' fails (i.e. when 'source' returns a non-zero exit code)

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -46,6 +46,10 @@ function Source () {
         local saved_bash_flags_and_options_commands="$( get_bash_flags_and_options_commands )"
         set -$DEBUGSCRIPTS_ARGUMENT
     fi
+    # The working directory WORKING_DIR="$( pwd )" when usr/sbin/rear was launched
+    # is also the working directory of all other sourced scripts and config files
+    # cf. https://github.com/rear/rear/issues/2461
+    cd "$WORKING_DIR" || LogPrintError "Failed to 'cd $WORKING_DIR'"
     # The actual work (source the source file):
     # Do not error out here when 'source' fails (i.e. when 'source' returns a non-zero exit code)
     # because scripts usually return the exit code of their last command


### PR DESCRIPTION

* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2461

* How was this pull request tested?
Both "rear mkbackup" and "!rear recover" worked well for me
with BACKUP=NETFS on SLES12-SP5

* Brief description of the changes in this pull request:

The current working directory when usr/sbin/rear is launched
is also the working directory of all the other scripts and config files
that get sourced via the Source() function in lib/framework-functions.sh
