### PR TITLE
Support OPAL 2 self-encrypting NVMe disk drives (fix #2475)

### DIFF
--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -221,7 +221,9 @@ generate_layout_dependencies() {
             opaldisk)
                 dev=$(echo "$remainder" | cut -d " " -f "1")
                 add_component "opaldisk:$dev" "opaldisk"
-                add_dependency "$dev" "opaldisk:$dev"
+                for disk in $(opal_device_disks "$dev"); do
+                    add_dependency "$disk" "opaldisk:$dev"
+                done
                 ;;
         esac
     done < $LAYOUT_FILE

--- a/usr/share/rear/lib/opal-functions.sh
+++ b/usr/share/rear/lib/opal-functions.sh
@@ -34,7 +34,8 @@ function opal_device_disks() {
 
     case "$device" in
         (*/nvme*)
-            echo "$device"n[0-9]  # consider all namespace block devices (NOTE: relies on nullglob)
+            # consider all namespace block devices
+            echo "$device"n[1-9] "$device"n[1-9][0-9]  # cover namespace IDs 1..99  (NOTE: relies on nullglob)
             ;;
         (*)
             echo "$device"

--- a/usr/share/rear/lib/opal-functions.sh
+++ b/usr/share/rear/lib/opal-functions.sh
@@ -34,8 +34,7 @@ function opal_device_disks() {
 
     case "$device" in
         (*/nvme*)
-            # consider all namespace block devices
-            echo "$device"n[1-9] "$device"n[1-9][0-9]  # cover namespace IDs 1..99  (NOTE: relies on nullglob)
+            echo "$device"n+([0-9])  # consider all namespace block devices (NOTE: relies on nullglob extglob)
             ;;
         (*)
             echo "$device"

--- a/usr/share/rear/lib/opal-functions.sh
+++ b/usr/share/rear/lib/opal-functions.sh
@@ -18,6 +18,7 @@
 #
 # Functions in this section are meant to be used independently from ReaR. They do not rely on any external
 # script code unless stated otherwise. Return codes must be checked by the caller.
+# Before using these functions ensure that pattern matching extensions are enabled : 'shopt -s nullglob extglob'.
 #
 
 function opal_devices() {

--- a/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
+++ b/usr/share/rear/skel/default/etc/scripts/unlock-opal-disks
@@ -7,6 +7,7 @@
 # To avoid delays, this script will perform a hard reset or power-off instead of a regular
 # system shutdown.
 
+shopt -s nullglob extglob  # Enable pattern matching extensions required for 'opal-functions.sh'
 source /usr/share/rear/lib/opal-functions.sh
 [[ -f /.OPAL_PBA_SETTINGS.sh ]] && source /.OPAL_PBA_SETTINGS.sh
 


### PR DESCRIPTION
This patch enables support for OPAL 2 self-encrypting NVMe disk drives.

I will amend this PR and/or propose merging it as soon as testing results come in (cf. progress in #2475).