### PR TITLE
Makefile: fix warning "jobserver unavailable: using -j1"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ Relax-and-Recover make variables (optional):\n\
 clean:
 	rm -Rf dist build
 	rm -f build-stamp
-	make -C doc clean
+	$(MAKE) -C doc clean
 
 ### You can call 'make validate' directly from your .git/hooks/pre-commit script
 validate:
@@ -107,11 +107,11 @@ validate:
 
 man:
 	@echo -e "\033[1m== Prepare manual ==\033[0;0m"
-	make -C doc man
+	$(MAKE) -C doc man
 
 doc:
 	@echo -e "\033[1m== Prepare documentation ==\033[0;0m"
-	make -C doc docs
+	$(MAKE) -C doc docs
 
 install-config:
 	@echo -e "\033[1m== Installing configuration ==\033[0;0m"
@@ -144,7 +144,7 @@ install-var:
 
 install-doc:
 	@echo -e "\033[1m== Installing documentation ==\033[0;0m"
-	make -C doc install
+	$(MAKE) -C doc install
 	sed -i -e 's,/etc,$(sysconfdir),' \
 		-e 's,/usr/sbin,$(sbindir),' \
 		-e 's,/usr/share,$(datadir),' \


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**
* Impact: **Normal**

* Reference to related issue (URL):
N/A

* How was this pull request tested?
The issue occurred when creating a gentoo ebuild for the 2.6 release

* Brief description of the changes in this pull request:
when running "make install" make throws warnings
`make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.`
Fix: do not call "make" inside a Makefile, use "$(MAKE)" instead
For reference, see
https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html