### PR TITLE
Inform the user about unsupported LUKS2 volumes but do not error out

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -11,7 +11,7 @@ Log "Saving Encrypted volumes"
 # so we include things in any case so that the user could do a manual setup if needed
 # cf. https://github.com/rear/rear/issues/2491
 # See the create_crypt function in layout/prepare/GNU/Linux/160_include_luks_code.sh
-# what program calls are written to diskrestore.sh abd
+# what program calls are written to diskrestore.sh and
 # see also https://github.com/rear/rear/issues/1963
 REQUIRED_PROGS+=( cryptsetup dmsetup )
 COPY_AS_IS+=( /usr/share/cracklib/\* /etc/security/pwquality.conf )

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -1,46 +1,62 @@
 # Describe LUKS devices
 # We use /etc/crypttab and cryptsetup for information
 
-if ! has_binary cryptsetup; then
-    return
-fi
+# Skip when not needed:
+has_binary cryptsetup || return 0
 
-Log "Saving Encrypted volumes."
+Log "Saving Encrypted volumes"
+
+# cryptsetup is required in the recovery system if disklayout.conf contains at least one 'crypt' entry
+# but also in case of an incomplete commented '#crypt' entry from a LUKS2 volume
+# so we include things in any case so that the user could do a manual setup if needed
+# cf. https://github.com/rear/rear/issues/2491
+# See the create_crypt function in layout/prepare/GNU/Linux/160_include_luks_code.sh
+# what program calls are written to diskrestore.sh abd
+# see also https://github.com/rear/rear/issues/1963
 REQUIRED_PROGS+=( cryptsetup dmsetup )
 COPY_AS_IS+=( /usr/share/cracklib/\* /etc/security/pwquality.conf )
 
 while read target_name junk ; do
-    # find the target device we're mapping
-    if ! [ -e /dev/mapper/$target_name ] ; then
-        Log "Device Mapper name $target_name not found in /dev/mapper."
+
+    if ! test -e /dev/mapper/$target_name ; then
+        Log "Skipping $target_name (there is no /dev/mapper/$target_name)"
         continue
     fi
 
-    sysfs_device=$(get_sysfs_name /dev/mapper/$target_name)
-    if [ -z "$sysfs_device" ] ; then
-        Log "Could not find device $target_name in sysfs."
+    sysfs_device=$( get_sysfs_name /dev/mapper/$target_name )
+    if ! test "$sysfs_device" ; then
+        Log "Skipping $target_name (could not find device for $target_name in /sys/block/)"
         continue
     fi
 
     source_device=""
     for slave in /sys/block/$sysfs_device/slaves/* ; do
-        if ! [ -z "$source_device" ] ; then
-            BugError "Multiple Device Mapper slaves for crypt $target_name detected."
+        if test "$source_device" ; then
+            BugError "Crypt $target_name has multiple device mapper slaves in /sys/block/$sysfs_device/slaves/"
         fi
-        source_device="$(get_device_name ${slave##*/})"
+        source_device="$( get_device_name ${slave##*/} )"
     done
-
-    if ! cryptsetup isLuks $source_device >/dev/null 2>&1; then
+    if ! test "$source_device" ; then
+        Log "Skipping $target_name (could not get its device in /sys/block/$sysfs_device/slaves/)"
+        continue
+    fi
+    
+    if ! cryptsetup isLuks $source_device ; then
+        Log "Skipping $target_name (its $source_device is not a LUKS device)"
         continue
     fi
 
-    # gather crypt information
-    cipher=$(cryptsetup luksDump $source_device | grep "Cipher name" | sed -r 's/^.+:\s*(.+)$/\1/')
-    mode=$(cryptsetup luksDump $source_device | grep "Cipher mode" | cut -d: -f2- | awk '{printf("%s",$1)};')
-    key_size=$(cryptsetup luksDump $source_device | grep "MK bits" | sed -r 's/^.+:\s*(.+)$/\1/')
-    hash=$(cryptsetup luksDump $source_device | grep "Hash spec" | sed -r 's/^.+:\s*(.+)$/\1/')
-    uuid=$(cryptsetup luksDump $source_device | grep "UUID" | sed -r 's/^.+:\s*(.+)$/\1/')
-    keyfile_option=$([ -f /etc/crypttab ] && awk '$1 == "'"$target_name"'" && $3 != "none" && $3 != "-" && $3 != "" { print "keyfile=" $3; }' /etc/crypttab)
+    # Gather crypt information:
+    if ! cryptsetup luksDump $source_device >$TMP_DIR/cryptsetup.luksDump ; then
+        LogPrintError "Error: Cannot get LUKS values for $target_name ('cryptsetup luksDump $source_device' failed)"
+        continue
+    fi
+    cipher=$( grep "Cipher name" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
+    mode=$( grep "Cipher mode" $TMP_DIR/cryptsetup.luksDump | cut -d: -f2- | awk '{printf("%s",$1)};' )
+    key_size=$( grep "MK bits" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
+    hash=$( grep "Hash spec" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
+    uuid=$( grep "UUID" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
+    keyfile_option=$( [ -f /etc/crypttab ] && awk '$1 == "'"$target_name"'" && $3 != "none" && $3 != "-" && $3 != "" { print "keyfile=" $3; }' /etc/crypttab )
 
     # LUKS version 2 is not yet suppported, see https://github.com/rear/rear/issues/2204
     # When LUKS version 2 is used the above code fails at least to determine the hash value
@@ -62,11 +78,4 @@ while read target_name junk ; do
     echo "crypt /dev/mapper/$target_name $source_device cipher=$cipher-$mode key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE
     
 done < <( dmsetup ls --target crypt )
-
-# cryptsetup is required in the recovery system if disklayout.conf contains at least one 'crypt' entry
-# (also in case of an incomplete commented '#crypt' entry from a LUKS2 volume for manual setup by the user)
-# see the create_crypt function in layout/prepare/GNU/Linux/160_include_luks_code.sh
-# what program calls are written to diskrestore.sh
-# cf. https://github.com/rear/rear/issues/1963
-grep -q '^#*crypt ' $DISKLAYOUT_FILE && REQUIRED_PROGS+=( cryptsetup ) || true
 

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -69,7 +69,7 @@ while read target_name junk ; do
         # The only way to not let "rear mkrescue" process LUKS2 volumes is to 'umount' and 'cryptsetup luksClose' them
         # before "rear mkrescue" is run so that those volumes are no longer listed by 'dmsetup ls --target crypt'
         # cf. https://github.com/rear/rear/issues/2491
-        LogPrintError "Error: Incomplete values for LUKS device '$target_name' at '$source_device' (only LUKS version 1 is supported) see $DISKLAYOUT_FILE"
+        LogPrintError "Incomplete values for LUKS device '$target_name' at '$source_device' (only LUKS version 1 is supported) see $DISKLAYOUT_FILE"
         echo "# Incomplete values for LUKS device '$target_name' at '$source_device' (only LUKS version 1 is supported):" >> $DISKLAYOUT_FILE
         echo "#crypt /dev/mapper/$target_name $source_device cipher=$cipher-$mode key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE
         continue


### PR DESCRIPTION
* Type: **Bug Fix** / **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2491

* How was this pull request tested?

On my home-office laptop I have both LUKS1 and LUKS2 volumes.
`luks2test` is the only LUKS2 volume.

With this changes I get (excerpts):
```
# usr/sbin/rear -D mkrescue
...
Creating disk layout
Overwriting existing disk layout file /root/rear.github.master/var/lib/rear/layout/disklayout.conf
Error: Incomplete values for LUKS device 'luks2test' at '/dev/sda8' (only LUKS version 1 is supported) see /root/rear.github.master/var/lib/rear/layout/disklayout.conf
Excluding component fs:/other
...
```
(The component `fs:/other` gets automatically excluded
because I use `OUTPUT_URL=file:///other` for my tests.)

This is the resulting var/lib/rear/layout/disklayout.conf
```
# Disk layout dated 20200916145825 (YYYYmmddHHMMSS)
# NAME                                                      KNAME     PKNAME    TRAN   TYPE  FSTYPE        SIZE MOUNTPOINT
# /dev/sda                                                  /dev/sda            sata   disk              465.8G 
# |-/dev/sda1                                               /dev/sda1 /dev/sda         part                  8M 
# |-/dev/sda2                                               /dev/sda2 /dev/sda         part  crypto_LUKS     4G 
# | `-/dev/mapper/cr_ata-TOSHIBA_MQ01ABF050_Y2PLP02CT-part2 /dev/dm-0 /dev/sda2        crypt swap            4G [SWAP]
# |-/dev/sda3                                               /dev/sda3 /dev/sda         part  crypto_LUKS   200G 
# | `-/dev/mapper/cr_ata-TOSHIBA_MQ01ABF050_Y2PLP02CT-part3 /dev/dm-1 /dev/sda3        crypt ext4          200G /
# |-/dev/sda4                                               /dev/sda4 /dev/sda         part  ext4          100G /nfs
# |-/dev/sda5                                               /dev/sda5 /dev/sda         part  ext4          150G /var/lib/libvirt
# |-/dev/sda6                                               /dev/sda6 /dev/sda         part  ext2            8G /other
# |-/dev/sda7                                               /dev/sda7 /dev/sda         part  crypto_LUKS     1G 
# | `-/dev/mapper/luks1test                                 /dev/dm-2 /dev/sda7        crypt ext2         1022M /luks1test
# `-/dev/sda8                                               /dev/sda8 /dev/sda         part  crypto_LUKS     1G 
#   `-/dev/mapper/luks2test                                 /dev/dm-3 /dev/sda8        crypt ext2         1020M /luks2test
# /dev/sr0                                                  /dev/sr0            sata   rom                1024M 
# Disk /dev/sda
# Format: disk <devname> <size(bytes)> <partition label type>
disk /dev/sda 500107862016 gpt
# Partitions on /dev/sda
# Format: part <device> <partition size(bytes)> <partition start(bytes)> <partition type|name> <flags> /dev/<partition>
part /dev/sda 8388608 1048576 rear-noname bios_grub /dev/sda1
part /dev/sda 4294967296 9437184 rear-noname swap /dev/sda2
part /dev/sda 214748364800 4304404480 rear-noname legacy_boot /dev/sda3
part /dev/sda 107374182400 219052769280 rear-noname none /dev/sda4
part /dev/sda 161061273600 326426951680 rear-noname none /dev/sda5
part /dev/sda 8589934592 487488225280 other none /dev/sda6
part /dev/sda 1073741824 496078159872 playground none /dev/sda7
part /dev/sda 1073741824 497151901696 playground2 none /dev/sda8
# Filesystems (only ext2,ext3,ext4,vfat,xfs,reiserfs,btrfs are supported).
# Format: fs <device> <mountpoint> <fstype> [uuid=<uuid>] [label=<label>] [<attributes>]
fs /dev/mapper/cr_ata-TOSHIBA_MQ01ABF050_Y2PLP02CT-part3 / ext4 uuid=f05af948-6075-40a3-9191-354b0a0a9afc label= blocksize=4096 reserved_blocks=4% max_mounts=-1 check_interval=0d bytes_per_inode=16383 default_mount_options=user_xattr,acl options=rw,relatime,data=ordered
fs /dev/mapper/luks1test /luks1test ext2 uuid=84e951c1-170d-489d-b1cc-191f95608d97 label= blocksize=4096 reserved_blocks=4% max_mounts=-1 check_interval=0d bytes_per_inode=16384 default_mount_options=user_xattr,acl options=rw,relatime
fs /dev/mapper/luks2test /luks2test ext2 uuid=c1d5b6e6-7760-4b6a-bfe8-70beda9003d7 label= blocksize=4096 reserved_blocks=5% max_mounts=-1 check_interval=0d bytes_per_inode=16384 default_mount_options=user_xattr,acl options=rw,relatime
fs /dev/sda4 /nfs ext4 uuid=4c4a923d-1562-4254-a1fa-4e761278c02f label= blocksize=4096 reserved_blocks=5% max_mounts=-1 check_interval=0d bytes_per_inode=16384 default_mount_options=user_xattr,acl options=rw,relatime,data=ordered
fs /dev/sda5 /var/lib/libvirt ext4 uuid=4a42395e-4f9d-4056-9948-6d5d9d92d990 label= blocksize=4096 reserved_blocks=5% max_mounts=-1 check_interval=0d bytes_per_inode=16384 default_mount_options=user_xattr,acl options=rw,relatime,data=ordered
#fs /dev/sda6 /other ext2 uuid=259dac9c-f2fd-4181-a351-83603398e465 label= blocksize=4096 reserved_blocks=4% max_mounts=-1 check_interval=0d bytes_per_inode=16384 default_mount_options=user_xattr,acl options=rw,relatime
# Swap partitions or swap files
# Format: swap <filename> uuid=<uuid> label=<label>
swap /dev/mapper/cr_ata-TOSHIBA_MQ01ABF050_Y2PLP02CT-part2 uuid=6d8f8998-dd20-412a-bcc2-618eed858662 label=
crypt /dev/mapper/cr_ata-TOSHIBA_MQ01ABF050_Y2PLP02CT-part3 /dev/sda3 cipher=aes-xts-plain64 key_size=256 hash=sha256 uuid=a6dba0d8-5be8-4970-b1e7-a272ae0cafdd 
crypt /dev/mapper/luks1test /dev/sda7 cipher=aes-xts-plain64 key_size=256 hash=sha256 uuid=1b4198c9-d9b0-4c57-b9a3-3433e391e706 
crypt /dev/mapper/cr_ata-TOSHIBA_MQ01ABF050_Y2PLP02CT-part2 /dev/sda2 cipher=aes-xts-plain64 key_size=256 hash=sha256 uuid=54fc77c5-8ec2-457f-b558-9deda3b843b2 
# Incomplete values for LUKS device 'luks2test' at '/dev/sda8' (only LUKS version 1 is supported):
#crypt /dev/mapper/luks2test /dev/sda8 cipher=- key_size= hash= uuid=3e874a28-7415-4f8c-9757-b3f28a96c4d2 
```

* Brief description of the changes in this pull request:

In case of LUKS2 volumes inform the user via LogPrintError
and write the available info as comment to disklayout.conf
but do not error out because there is no simple way
to skip LUKS2 volumes during "rear mkrescue",
see the comments in the code.