### PR TITLE
More verbose messages when components are excluded

### DIFF
--- a/usr/share/rear/layout/save/default/310_include_exclude.sh
+++ b/usr/share/rear/layout/save/default/310_include_exclude.sh
@@ -15,7 +15,7 @@
 # If you somehow need this functionality, it's advised to exclude the
 # device or volume group
 #for mountpoint in "${EXCLUDE_MOUNTPOINTS[@]}" ; do
-#    LogPrint "Excluding mountpoint $mountpoint"
+#    LogPrint "Excluding mountpoint $mountpoint in EXCLUDE_MOUNTPOINTS"
 #    mark_as_done "fs:$mountpoint"
 #    mark_tree_as_done "fs:$mountpoint"
 #done
@@ -25,7 +25,7 @@
 if [ "${MANUAL_INCLUDE:-NO}" == "YES" ] ; then
     while read fs device mountpoint junk ; do
         if ! IsInArray "$mountpoint" "${BACKUP_PROG_INCLUDE[@]}" ; then
-            LogPrint "Excluding mountpoint $mountpoint (MANUAL_INCLUDE mode)"
+            LogPrint "Excluding mountpoint $mountpoint not in BACKUP_PROG_INCLUDE (MANUAL_INCLUDE mode)"
             mark_as_done "fs:$mountpoint"
             mark_tree_as_done "fs:$mountpoint"
         fi
@@ -33,13 +33,13 @@ if [ "${MANUAL_INCLUDE:-NO}" == "YES" ] ; then
 fi
 
 for md in "${EXCLUDE_MD[@]}" ; do
-    LogPrint "Excluding RAID $md"
+    LogPrint "Excluding RAID $md in EXCLUDE_MD"
     mark_as_done "/dev/$md"
     mark_tree_as_done "/dev/$md"
 done
 
 for vg in "${EXCLUDE_VG[@]}" ; do
-    LogPrint "Excluding Volume Group $vg"
+    LogPrint "Excluding Volume Group $vg in EXCLUDE_VG"
     mark_as_done "/dev/$vg"
     mark_tree_as_done "/dev/$vg"
 done
@@ -47,7 +47,7 @@ done
 if [ ${#ONLY_INCLUDE_VG[@]} -gt 0 ] ; then
     while read lvmgrp name junk ; do
         if ! IsInArray "${name#/dev/}" "${ONLY_INCLUDE_VG[@]}" ; then
-            LogPrint "Excluding Volume Group ${name#/dev/}"
+            LogPrint "Excluding Volume Group ${name#/dev/} not in ONLY_INCLUDE_VG"
             mark_as_done "$name"
             mark_tree_as_done "$name"
         fi
@@ -55,13 +55,13 @@ if [ ${#ONLY_INCLUDE_VG[@]} -gt 0 ] ; then
 fi
 
 for component in "${EXCLUDE_COMPONENTS[@]}" ; do
-    LogPrint "Excluding component $component"
+    LogPrint "Excluding component $component in EXCLUDE_COMPONENTS"
     mark_as_done "$component"
     mark_tree_as_done "$component"
 done
 
 for component in "${EXCLUDE_RECREATE[@]}" ; do
-    LogPrint "Excluding component $component"
+    LogPrint "Excluding component $component in EXCLUDE_RECREATE"
     mark_as_done "$component"
     mark_tree_as_done "$component"
 done

--- a/usr/share/rear/layout/save/default/320_autoexclude.sh
+++ b/usr/share/rear/layout/save/default/320_autoexclude.sh
@@ -1,7 +1,7 @@
 # Automatically exclude multipath devices
 if is_true $AUTOEXCLUDE_MULTIPATH ; then
     while read multipath device devices junk ; do
-        Log "Automatically excluding multipath device $device"
+        DebugPrint "Automatically excluding multipath device $device"
         mark_as_done "$device"
         mark_tree_as_done "$device"
     done < <(grep ^multipath $LAYOUT_FILE)
@@ -15,7 +15,7 @@ if [[ "$AUTOEXCLUDE_PATH" ]] ; then
     for exclude in "${AUTOEXCLUDE_PATH[@]}" ; do
         while read fs device mountpoint junk ; do
             if [[ "${mountpoint#${exclude%/}/}" != "$mountpoint" ]] ; then
-                Log "Automatically excluding filesystem $mountpoint"
+                DebugPrint "Automatically excluding filesystem $mountpoint"
                 mark_as_done "fs:$mountpoint"
                 mark_tree_as_done "fs:$mountpoint"
                 ### by excluding the filesystem, the device will be excluded by the
@@ -30,7 +30,7 @@ if [[ "$AUTOEXCLUDE_USB_PATH" ]] ; then
     for exclude in "${AUTOEXCLUDE_USB_PATH[@]}" ; do
         while read fs device mountpoint junk ; do
             if [[ "$exclude" = "$mountpoint" ]] ; then
-                Log "Automatically excluding filesystem $mountpoint (USB device $device)"
+                DebugPrint "Automatically excluding filesystem $mountpoint (USB device $device)"
                 mark_as_done "fs:$mountpoint"
                 mark_tree_as_done "fs:$mountpoint"
                 ### by excluding the filesystem, the device will also be excluded
@@ -87,9 +87,10 @@ if is_true "$AUTOEXCLUDE_DISKS" ; then
     # Find out which disks were not in the list and remove them.
     while read disk name junk ; do
         if ! IsInArray "$name" "${used_disks[@]}" ; then
-            Log "Disk $name is not used by any mounted filesystem. Excluding."
+            DebugPrint "Automatically excluding disk $name (not used by any mounted filesystem)"
             mark_as_done "$name"
             # If this was a self-encrypting disk, remove its entry, too.
+            Debug "Also automatically excluding opaldisk $name if exists"
             mark_as_done "opaldisk:$name"
             mark_tree_as_done "$name"
         fi
@@ -110,11 +111,12 @@ while read multipath device dm_size label slaves junk ; do
     IFS=$OIFS
 
     for slave in "${devices[@]}" ; do
-        Log "Excluding multipath slave $slave"
+        DebugPrint "Automatically excluding multipath slave $slave"
         mark_as_done "$slave"
         ### the slave can have partitions, also exclude them
         while read child parent junk ; do
             if [[ "$child" != "$device" ]] ; then
+                DebugPrint "Automatically excluding multipath child $child"
                 mark_as_done "$child"
             fi
         done < <(grep "$slave$" $LAYOUT_DEPS)
@@ -124,6 +126,7 @@ done < <(grep ^multipath $LAYOUT_FILE)
 ### Automatically exclude autofs devices
 if [[ -n "$AUTOEXCLUDE_AUTOFS" ]] ; then
     while read name mountpoint junk ; do
+        DebugPrint "Automatically excluding autofs filesystem $mountpoint"
         BACKUP_PROG_EXCLUDE+=( "$mountpoint" )
     done < <(grep " autofs " /proc/mounts)
 fi

--- a/usr/share/rear/layout/save/default/330_remove_exclusions.sh
+++ b/usr/share/rear/layout/save/default/330_remove_exclusions.sh
@@ -1,56 +1,94 @@
-# Remove the excluded components from the disklayout file.
-# Excluded components are marked as DONE in the disktodo file.
 
-if ! [ -s "$LAYOUT_TODO" ] ; then
-    return 0
-fi
+# Disable excluded components in var/lib/rear/layout/disklayout.conf
+# Excluded components have been marked as 'done ...' in var/lib/rear/layout/disktodo.conf
 
-# Component in position 2.
-remove_component() {
+test -s "$LAYOUT_TODO" || return 0
+
+# Below there is a (perhaps oversophisticated?) distinction what messages should appear
+# - only in the log file in debug '-d' mode via 'Debug'
+# - in the log file and on the user's terminal in debug '-d' mode via 'DebugPrint'
+# - in the log file and on the user's terminal in verbose '-v' mode via 'LogPrint'
+# so that the info that is shown on the user's terminal (hopefully) looks consistent.
+# This distinction matches the same kind of distinction in the
+# mark_as_done and mark_tree_as_done functions in lib/layout-functions.sh
+
+DebugPrint "Disabling excluded components in $LAYOUT_FILE"
+
+# Disable component $1 $2 in disklayout.conf
+# where $1 is the component keyword/type that is always at the first position
+# and the component value/name $2 is at the second position:
+disable_component_at_second_position() {
+    # The trailing blank in "... $2 " is crucial to not match wrong components
+    # for example the component "part /dev/sda1" must not match accidentally
+    # other components like "part /dev/sda12" in var/lib/rear/layout/disklayout.conf
+    if grep -q "#$1 $2 " $LAYOUT_FILE ; then
+        DebugPrint "Component '$1 $2' is disabled in $LAYOUT_FILE"
+        return 0
+    fi
+    if ! grep -q "^$1 $2 " $LAYOUT_FILE ; then
+        Debug "Cannot disable component because there is no '^$1 $2 ' in $LAYOUT_FILE"
+        return 1
+    fi
+    LogPrint "Disabling component '$1 $2' in $LAYOUT_FILE"
     sed -i "s|^$1 $2 |\#$1 $2 |" "$LAYOUT_FILE"
 }
 
-# Component in position 3.
-remove_second_component() {
+# Disable component $1 ... $2 in disklayout.conf
+# where $1 is the component keyword/type that is always at the first position
+# and the component value/name $2 is at the third position:
+disable_component_at_third_position() {
+    # The trailing blank in "... $2 " is crucial to not match wrong components
+    # for example the component "part /dev/sda1" must not match accidentally
+    # other components like "part /dev/sda12" in var/lib/rear/layout/disklayout.conf
+    if grep -q "#$1 [^ ][^ ]* $2 " $LAYOUT_FILE ; then
+        DebugPrint "Component '$1 ... $2' is disabled in $LAYOUT_FILE"
+        return 0
+    fi
+    if ! grep -q "^$1 [^ ][^ ]* $2 " $LAYOUT_FILE ; then
+        Debug "Cannot disable component because there is no '^$1 ... $2 ' in $LAYOUT_FILE"
+        return 1
+    fi
+    LogPrint "Disabling component '$1 ... $2' in $LAYOUT_FILE"
     sed -i -r "s|^$1 ([^ ]+) $2 |\#$1 \1 $2 |" "$LAYOUT_FILE"
 }
 
-# Remove lines in the LAYOUT_FILE.
+# In disktodo.conf the component status ('todo'/'done') is always at the first position
+# and the component value/name is always at the second position
+# and the component keyword/type is always at the third position:
 while read status name type junk ; do
     case "$type" in
-        part)
-            ### find the immediate parent
-            name=$(grep "^$name " "$LAYOUT_DEPS" | cut -d " " -f 2)
-            remove_component "$type" "$name"
+        (part)
+            # find the immediate parent
+            name=$( grep "^$name " "$LAYOUT_DEPS" | cut -d " " -f 2 )
+            disable_component_at_second_position "$type" "$name"
             ;;
-        lvmvol)
+        (lvmvol)
             name=${name#/dev/mapper/}
-            ### split between vg and lv is single dash
-            ### Device mapper doubles dashes in vg and lv
-            vg=$(sed "s/\([^-]\)-[^-].*/\1/;s/--/-/g" <<< "$name")
-            lv=$(sed "s/.*[^-]-\([^-]\)/\1/;s/--/-/g" <<< "$name")
-
+            # split between vg and lv is single dash
+            # Device mapper doubles dashes in vg and lv
+            vg=$( sed "s/\([^-]\)-[^-].*/\1/;s/--/-/g" <<< "$name" )
+            lv=$( sed "s/.*[^-]-\([^-]\)/\1/;s/--/-/g" <<< "$name" )
             sed -i -r "s|^($type /dev/$vg $lv )|\#\1|" "$LAYOUT_FILE"
             ;;
-        fs|btrfsmountedsubvol|lvmdev)
+        (fs|btrfsmountedsubvol|lvmdev)
             name=${name#$type:}
-            remove_second_component "$type" "$name"
+            disable_component_at_third_position "$type" "$name"
             ;;
-        opaldisk)
+        (opaldisk)
             name=${name#$type:}
-            remove_component "$type" "$name"
+            disable_component_at_second_position "$type" "$name"
             ;;
-        swap)
+        (swap)
             name=${name#swap:}
-            remove_component "$type" "$name"
+            disable_component_at_second_position "$type" "$name"
             ;;
-        *)
-            remove_component "$type" "$name"
+        (*)
+            disable_component_at_second_position "$type" "$name"
             ;;
     esac
-done < <(grep "^done" "$LAYOUT_TODO")
+done < <( grep "^done" "$LAYOUT_TODO" )
 
-# Remove all LVM PVs of excluded VGs.
+# Disable all LVM PVs of excluded VGs:
 while read status name junk ; do
-    remove_component "lvmdev" "$name"
-done < <(grep -E "^done [^ ]+ lvmgrp" "$LAYOUT_TODO")
+    disable_component_at_second_position "lvmdev" "$name"
+done < <( grep -E "^done [^ ]+ lvmgrp" "$LAYOUT_TODO" )

--- a/usr/share/rear/layout/save/default/335_remove_excluded_multipath_vgs.sh
+++ b/usr/share/rear/layout/save/default/335_remove_excluded_multipath_vgs.sh
@@ -22,7 +22,7 @@ while read lvmdev name mpdev junk ; do
         # Now we need to comment all lines that contain "$devices" in the LAYOUT_FILE
         sed -i "s|^$LINE|\#$LINE|" "$LAYOUT_FILE"
     done < <(grep "$device" $LAYOUT_FILE | grep -v "^#")
-    Log "Excluding multipath device $device"
+    DebugPrint "Disabling multipath device $device belonging to disabled 'lvmdev $name' in $LAYOUT_FILE"
 done < <(grep "^#lvmdev" $LAYOUT_FILE)
 
 # Double check if we did not leave unused multipath devices uncommented
@@ -35,7 +35,6 @@ while read LINE ; do
     if [ $num -lt 2 ] ; then
         # If the $device is only seen once (in a uncommented line) then the multipath is not in use
         sed -i "s|^$LINE|\#$LINE|" "$LAYOUT_FILE"
-        Log "Excluding multipath device $device"
+        DebugPrint "Disabling multipath device $device only seen once in $LAYOUT_FILE"
     fi
 done < <(grep "^multipath" $LAYOUT_FILE)
-

--- a/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
+++ b/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
@@ -14,7 +14,7 @@
 # BYTES ONLY.
 #
 
-LogPrint "Verifying that the entries in $DISKLAYOUT_FILE are correct ..."
+LogPrint "Verifying that the entries in $DISKLAYOUT_FILE are correct"
 local keyword dummy junk
 
 Log "Verifying that the 'disk' entries in $DISKLAYOUT_FILE are correct"
@@ -256,6 +256,9 @@ is_true "$disklayout_file_is_broken" && BugError "Entries in $DISKLAYOUT_FILE ar
 # It is not a BugError when non consecutive partitions are not supported
 # but an Error because the used parted is insufficient:
 is_true "$non_consecutive_partitions" && Error "There are non consecutive partitions ('rear recover' would fail)"
+
+# Matching message to "Creating disk layout" in layout/save/GNU/Linux/100_create_layout_file.sh
+LogPrint "Created disk layout (check the results in $DISKLAYOUT_FILE)"
 
 # Finish this script successfully in the normal case (i.e. when both 'is_true' above result non zero return code):
 true

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -268,7 +268,7 @@ mark_as_done() {
 # Mark all components that depend on component $1 as done.
 mark_tree_as_done() {
     for component in $( get_child_components "$1" ) ; do
-        DebugPrint "Marking dependant $component as done because it is a child of component $1"
+        DebugPrint "Dependant component $component is a child of component $1"
         mark_as_done "$component"
     done
 }

--- a/usr/share/rear/prep/NETFS/default/400_automatic_exclude_recreate.sh
+++ b/usr/share/rear/prep/NETFS/default/400_automatic_exclude_recreate.sh
@@ -32,6 +32,7 @@ case $scheme in
         test "/" = "$backup_directory_mountpoint" && Error "URL '$BACKUP_URL' has the backup directory '$backup_directory' in the '/' filesystem which is forbidden."
         # When the mountpoint of the backup directory is not yet excluded add its mountpoint to the EXCLUDE_RECREATE array:
         if ! grep -q "$backup_directory_mountpoint" <<< $( echo ${EXCLUDE_RECREATE[@]} ) ; then
+            DebugPrint "Adding backup directory mountpoint 'fs:$backup_directory_mountpoint' to EXCLUDE_RECREATE"
             EXCLUDE_RECREATE+=( "fs:$backup_directory_mountpoint" )
         fi
         ;;


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* How was this pull request tested?

Tested on my home-office laptop while working on
https://github.com/rear/rear/pull/2493

* Brief description of the changes in this pull request:

More verbose messages when components are excluded
so that is is easier for the user to see what the actual results are
when he specified to exclude components in his etc/rear/local.conf
and what components are automatically excluded by ReaR.

There is a (perhaps oversophisticated?) distinction what messages should appear

- only in the log file in debug '-d' mode via 'Debug'
- in the log file and on the user's terminal in debug '-d' mode via 'DebugPrint'
- in the log file and on the user's terminal in verbose '-v' mode via 'LogPrint'

so that the info that is shown on the user's terminal (hopefully) looks consistent.
