### PR TITLE
Redirect stdout and stderr to the log only in debug mode - normally they go to /dev/null (issue 2416)

### DIFF
--- a/doc/rear-presentation.adoc
+++ b/doc/rear-presentation.adoc
@@ -278,13 +278,13 @@ Usage: $PROGRAM [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c D
 Available options:
  -h --help           usage information
  -c DIR              alternative config directory; instead of /etc/rear
- -d                  debug mode; log debug messages
- -D                  debugscript mode; log every function call (via 'set -x')
+ -d                  debug mode; run many commands verbosely with debug messages in log file (also sets -v)
+ -D                  debugscript mode; log executed commands via 'set -x' (also sets -v and -d)
  --debugscripts SET  same as -d -v -D but debugscript mode with 'set -SET'
- -r KERNEL           kernel version to use; current: '$KERNEL_VERSION'
- -s                  simulation mode; show what scripts rear would include
+ -r KERNEL           kernel version to use; currently '4.12.13-123.45.67-default'
+ -s                  simulation mode; show what scripts are run (without executing them)
  -S                  step-by-step mode; acknowledge each script individually
- -v                  verbose mode; show more output
+ -v                  verbose mode; show messages what Relax-and-Recover is doing on the terminal
  -V --version        version information
 
 -snip-

--- a/doc/rear.8
+++ b/doc/rear.8
@@ -34,7 +34,7 @@ rear \- bare metal disaster recovery and system migration tool
 \fBrear\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-dsSv\fR] [\fB\-D\fR|\fB\-\-debugscripts\fR \fISET\fR] [\fB\-c\fR \fIDIR\fR] [\fB\-C\fR \fICONFIG\fR] [\fB\-r\fR \fIKERNEL\fR] [\-\-] \fICOMMAND\fR [\fIARGS\fR\&...]
 .SH "DESCRIPTION"
 .sp
-Relax\-and\-Recover is the leading Open Source disaster recovery solution\&. It is a modular framework with many ready\-to\-go workflows for common situations\&.
+Relax\-and\-Recover (abbreviated ReaR) is the leading Open Source disaster recovery solution\&. It is a modular framework with many ready\-to\-go workflows for common situations\&.
 .sp
 Relax\-and\-Recover produces a bootable image\&. This image can repartition the system\&. Once that is done it initiates a restore from backup\&. Restores to different hardware are possible\&. Relax\-and\-Recover can therefore be used as a migration tool as well\&.
 .sp
@@ -68,7 +68,7 @@ additional config file; absolute path or relative to config directory
 \-d
 .RS 4
 \fBdebug mode\fR
-(log debug messages to log file \- also sets \-v)
+(run many commands verbosely with debug messages in log file \- also sets \-v)
 .RE
 .PP
 \-D
@@ -107,7 +107,7 @@ kernel version to use (by default use running kernel)
 \-v
 .RS 4
 \fBverbose mode\fR
-(show more output and run many commands in verbose mode)
+(show messages what ReaR is doing on the terminal)
 .RE
 .PP
 \-V \-\-version

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -16,8 +16,8 @@ rear - bare metal disaster recovery and system migration tool
 
 
 == DESCRIPTION
-Relax-and-Recover is the leading Open Source disaster recovery solution. It
-is a modular framework with many ready-to-go workflows for common situations.
+Relax-and-Recover (abbreviated ReaR) is the leading Open Source disaster recovery solution.
+It is a modular framework with many ready-to-go workflows for common situations.
 
 Relax-and-Recover produces a bootable image. This image can repartition the
 system. Once that is done it initiates a restore from backup. Restores to
@@ -63,7 +63,7 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
     additional config file; absolute path or relative to config directory
 
 -d::
-    *debug mode* (log debug messages to log file - also sets -v)
+    *debug mode* (run many commands verbosely with debug messages in log file - also sets -v)
 
 -D::
     *debugscript mode* (log executed commands via 'set -x' - also sets -v and -d)
@@ -81,7 +81,7 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
     *step-by-step mode* (acknowledge each script individually)
 
 -v::
-    *verbose mode* (show more output and run many commands in verbose mode)
+    *verbose mode* (show messages what ReaR is doing on the terminal)
 
 -V --version::
     version information

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -396,19 +396,41 @@ test -r "$RUNTIME_LOGFILE" && mv -f "$RUNTIME_LOGFILE" "$RUNTIME_LOGFILE".old 2>
 # Start logging:
 mkdir -p $LOG_DIR || echo "ERROR: Could not create $LOG_DIR" >&2
 cat /dev/null >"$RUNTIME_LOGFILE"
-# Redirect both STDOUT and STDERR into the log file.
-# To be more on the safe side append to the log file '>>' instead of plain writing to it '>'
-# because when a program (bash in this case) is plain writing to the log file it can overwrite
-# output of a possibly simultaneously running process that likes to append to the log file
-# (e.g. when a background process runs that also uses the ReaR log file for logging):
-exec 2>>"$RUNTIME_LOGFILE"
-# Make stdout the same what stderr already is.
-# This keeps strict ordering of stdout and stderr outputs
-# because now both stdout and stderr use one same file descriptor.
-# The redirection of stdout into the log file was postponed for ReaR v2.2
-# see https://github.com/rear/rear/issues/1398#issuecomment-315318878
-# for ReaR v2.3 redirection of stdout into the log file is re-enabled:
-exec 1>&2
+# In "normal operation" mode stdout and stderr are redirected to /dev/null.
+# In verbose mode stderr is /dev/null but stdout is redirected to the log.
+# In debug modes stdout and stderr are redirected to the log.
+# Cf. https://github.com/rear/rear/issues/2416
+if test "$DEBUG" ; then
+    # To be on the safe side append to the log file '>>' instead of plain writing to it '>'
+    # because when a program (bash in this case) is plain writing to the log file it can overwrite
+    # output of a possibly simultaneously running process that likes to append to the log file
+    # (e.g. when a background process runs that also uses the ReaR log file for logging).
+    exec 2>>"$RUNTIME_LOGFILE"
+    # Make stdout the same what stderr already is.
+    # This keeps strict ordering of stdout and stderr outputs
+    # because now both stdout and stderr use one same file descriptor.
+    # The redirection of stdout into the log file was postponed for ReaR v2.2
+    # see https://github.com/rear/rear/issues/1398#issuecomment-315318878
+    # for ReaR v2.3 redirection of stdout into the log file is re-enabled:
+    exec 1>&2
+else
+    # The debug modes are automatically also verbose
+    # so verbose mode means "verbose mode but not a debug mode".
+    if test "$VERBOSE" ; then
+        # In verbose mode stderr is /dev/null but stdout is redirected to the log
+        # to be in compliance with our $v and $verbose usage (see above)
+        # because it seems command verbose output happens usually on stdout
+        # and "man rear" reads "verbose mode (show more output and run many commands in verbose mode)"
+        # cf. https://github.com/rear/rear/issues/2416#issue-629800799
+        exec 2>/dev/null
+        # To be on the safe side append to the log file '>>' instead of plain writing to it '>'
+        exec 1>>"$RUNTIME_LOGFILE"
+    else
+        # Finally "normal operation" mode means neither a debug mode nor verbose:
+        exec 2>/dev/null
+        exec 1>/dev/null
+    fi
+fi
 
 # Include functions after RUNTIME_LOGFILE is set and readonly
 # so that functions can use a fixed RUNTIME_LOGFILE value:

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -412,9 +412,6 @@ if test "$DEBUG" ; then
     # Make stdout the same what stderr already is.
     # This keeps strict ordering of stdout and stderr outputs
     # because now both stdout and stderr use one same file descriptor.
-    # The redirection of stdout into the log file was postponed for ReaR v2.2
-    # see https://github.com/rear/rear/issues/1398#issuecomment-315318878
-    # for ReaR v2.3 redirection of stdout into the log file is re-enabled:
     exec 1>&2
 else
     exec 2>/dev/null

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -257,10 +257,14 @@ esac
 
 # Set the variables v and verbose to be used in called programs
 # that support the '-v' or '--verbose' options like
-# "cp $v ..." or "rm $verbose ..." and so on:
+# "cp $v ..." or "rm $verbose ..." and so on.
+# Normally stdout and stderr are redirected to /dev/null (see below).
+# In debug modes stdout and stderr are redirected to the log
+# so setting that variables only makes sense in debug modes.
+# Cf. https://github.com/rear/rear/issues/2416
 v=""
 verbose=""
-if test "$VERBOSE" ; then
+if test "$DEBUG" ; then
     v="-v"
     verbose="--verbose"
 fi
@@ -396,8 +400,7 @@ test -r "$RUNTIME_LOGFILE" && mv -f "$RUNTIME_LOGFILE" "$RUNTIME_LOGFILE".old 2>
 # Start logging:
 mkdir -p $LOG_DIR || echo "ERROR: Could not create $LOG_DIR" >&2
 cat /dev/null >"$RUNTIME_LOGFILE"
-# In "normal operation" mode stdout and stderr are redirected to /dev/null.
-# In verbose mode stderr is /dev/null but stdout is redirected to the log.
+# Normally stdout and stderr are redirected to /dev/null.
 # In debug modes stdout and stderr are redirected to the log.
 # Cf. https://github.com/rear/rear/issues/2416
 if test "$DEBUG" ; then
@@ -414,22 +417,8 @@ if test "$DEBUG" ; then
     # for ReaR v2.3 redirection of stdout into the log file is re-enabled:
     exec 1>&2
 else
-    # The debug modes are automatically also verbose
-    # so verbose mode means "verbose mode but not a debug mode".
-    if test "$VERBOSE" ; then
-        # In verbose mode stderr is /dev/null but stdout is redirected to the log
-        # to be in compliance with our $v and $verbose usage (see above)
-        # because it seems command verbose output happens usually on stdout
-        # and "man rear" reads "verbose mode (show more output and run many commands in verbose mode)"
-        # cf. https://github.com/rear/rear/issues/2416#issue-629800799
-        exec 2>/dev/null
-        # To be on the safe side append to the log file '>>' instead of plain writing to it '>'
-        exec 1>>"$RUNTIME_LOGFILE"
-    else
-        # Finally "normal operation" mode means neither a debug mode nor verbose:
-        exec 2>/dev/null
-        exec 1>/dev/null
-    fi
+    exec 2>/dev/null
+    exec 1>/dev/null
 fi
 
 # Include functions after RUNTIME_LOGFILE is set and readonly

--- a/usr/share/rear/lib/help-workflow.sh
+++ b/usr/share/rear/lib/help-workflow.sh
@@ -24,15 +24,15 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 Available options:
  -h --help           usage information (this text)
- -c DIR              alternative config directory; instead of /etc/rear
+ -c DIR              alternative config directory; instead of $CONFIG_DIR
  -C CONFIG           additional config file; absolute path or relative to config directory
- -d                  debug mode; log debug messages (also sets -v verbose mode)
- -D                  debugscript mode (implies -v -d); log executed commands (via 'set -x')
+ -d                  debug mode; run many commands verbosely with debug messages in log file (also sets -v)
+ -D                  debugscript mode; log executed commands via 'set -x' (also sets -v and -d)
  --debugscripts SET  same as -d -v -D but debugscript mode with 'set -SET'
- -r KERNEL           kernel version to use; current: '$KERNEL_VERSION'
+ -r KERNEL           kernel version to use; currently '$KERNEL_VERSION'
  -s                  simulation mode; show what scripts are run (without executing them)
  -S                  step-by-step mode; acknowledge each script individually
- -v                  verbose mode; show more output (and run many commands in verbose mode)
+ -v                  verbose mode; show messages what $PRODUCT is doing on the terminal
  -V --version        version information
 
 List of commands:


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2416

* How was this pull request tested?
I tested `rear mkrescue` `rear -v mkrescue` `rear -d mkrescue` `rear -D mkrescue`
on my homeoffice laptop and I think the content in the log is now less confusing
for the user in particular in normal modes (i.e. `rear mkrescue` `rear -v mkrescue`).

* Brief description of the changes in this pull request:
Normally stdout and stderr are redirected to /dev/null.
Only in debug modes stdout and stderr are redirected to the log.
Cf. https://github.com/rear/rear/issues/2416#issuecomment-702142588