### PR TITLE
New 036_valid_output_methods.sh to error out for unsupported OUTPUT methods

### DIFF
--- a/usr/share/rear/prep/default/036_valid_output_methods.sh
+++ b/usr/share/rear/prep/default/036_valid_output_methods.sh
@@ -1,0 +1,13 @@
+
+# For "rear mkbackup/mkrescue/mkbackuponly/mkopalpba"
+# (i.e. for all workflows that run the 'prep' stage)
+# check that the OUTPUT method is actually implemented
+# i.e. check that a usr/share/rear/output/$OUTPUT directory exists
+# and error out when an OUTPUT method seems to be not supported
+# to ensure that the user cannot specify a non-working OUTPUT in /etc/rear/local.conf
+# see https://github.com/rear/rear/issues/2501
+# and cf. usr/share/rear/prep/default/035_valid_backup_methods.sh
+
+if ! test -d "$SHARE_DIR/output/$OUTPUT" ; then
+    Error "The OUTPUT method '$OUTPUT' is not supported (no $SHARE_DIR/output/$OUTPUT directory)"
+fi


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2501

* How was this pull request tested?
Tested with `OUTPUT=iso` versus `OUTPUT=ISO` on my homeoffice laptop.

* Brief description of the changes in this pull request:
For "rear mkbackup/mkrescue/mkbackuponly/mkopalpba"
(i.e. for all workflows that run the 'prep' stage)
check that the OUTPUT method is actually implemented
i.e. check that a usr/share/rear/output/$OUTPUT directory exists
and error out when an OUTPUT method seems to be not supported
to ensure that the user cannot specify a non-working OUTPUT in /etc/rear/local.conf
cf. usr/share/rear/prep/default/035_valid_backup_methods.sh
