### PR TITLE
Make recreating LUKS volumes work with optional cryptsetup options

### DIFF
--- a/doc/user-guide/06-layout-configuration.adoc
+++ b/doc/user-guide/06-layout-configuration.adoc
@@ -630,7 +630,7 @@ lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]
 
 === LUKS Devices ===
 ----------------------------------
-crypt /dev/mapper/<name> <device> type=<type> [cipher=<cipher>] [key_size=<key size>] [hash=<hash function>] uuid=<uuid> [keyfile=<keyfile>] [password=<password>]
+crypt /dev/mapper/<name> <device> [type=<type>] [cipher=<cipher>] [key_size=<key size>] [hash=<hash function>] [uuid=<uuid>] [keyfile=<keyfile>] [password=<password>]
 ----------------------------------
 
 === DRBD ===

--- a/doc/user-guide/06-layout-configuration.adoc
+++ b/doc/user-guide/06-layout-configuration.adoc
@@ -630,7 +630,7 @@ lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]
 
 === LUKS Devices ===
 ----------------------------------
-crypt /dev/mapper/<name> <device> [type=<type>] [cipher=<cipher>] [key_size=<key size>] [hash=<hash function>] [uuid=<uuid>] [keyfile=<keyfile>] [password=<password>]
+crypt /dev/mapper/<name> <device> type=<type> [cipher=<cipher>] [key_size=<key size>] [hash=<hash function>] uuid=<uuid> [keyfile=<keyfile>] [password=<password>]
 ----------------------------------
 
 === DRBD ===

--- a/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
@@ -68,9 +68,9 @@ create_crypt() {
         echo "echo \"$password\" | cryptsetup luksFormat --batch-mode $cryptsetup_options $source_device"
         echo "echo \"$password\" | cryptsetup luksOpen $source_device $target_name"
     else
-        echo "LogPrint \"Enter the password for LUKS device $target_name (for 'cryptsetup luksFormat' on $source_device):\""
+        echo "LogPrint \"Set the password for LUKS device $target_name (for 'cryptsetup luksFormat' on $source_device):\""
         echo "cryptsetup luksFormat --batch-mode $cryptsetup_options $source_device"
-        echo "LogPrint \"Again enter the password for LUKS device $target_name (for 'cryptsetup luksOpen' on $source_device):\""
+        echo "LogPrint \"Enter the password for LUKS device $target_name (for 'cryptsetup luksOpen' on $source_device):\""
         echo "cryptsetup luksOpen $source_device $target_name"
     fi
     echo ""

--- a/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
@@ -1,30 +1,49 @@
+
 # Code to recreate and/or open LUKS volumes.
 
 create_crypt() {
     # See the create_device() function in lib/layout-functions.sh what "device type" means:
     local device_type="$1"
     if ! grep -q "^crypt $device_type " "$LAYOUT_FILE" ; then
-        LogPrintError "Skip recreating LUKS device $device_type (no 'crypt $device_type' entry in $LAYOUT_FILE)"
+        LogPrintError "Skip recreating LUKS volume $device_type (no 'crypt $device_type' entry in $LAYOUT_FILE)"
         # FIXME: The return code is ignored in the create_device() function in lib/layout-functions.sh:
         return 1
     fi
     
     local crypt target_device source_device options
-    read crypt target_device source_device options < <( grep "^crypt $device_type " "$LAYOUT_FILE" )
-    local target_name=${target_device#/dev/mapper/}
+    local mapping_name option key value
     local cryptsetup_options="" keyfile="" password=""
-    local option key value
+
+    read crypt target_device source_device options < <( grep "^crypt $device_type " "$LAYOUT_FILE" )
+
+    if ! test -b "$source_device" ; then
+        LogPrintError "Skip recreating LUKS volume $device_type on device '$source_device' that is no block device (see the 'crypt $device_type' entry in $LAYOUT_FILE)"
+        # FIXME: The return code is ignored in the create_device() function in lib/layout-functions.sh:
+        return 1
+    fi
+
+    mapping_name=${target_device#/dev/mapper/}
+    if ! test $mapping_name ; then
+        LogPrintError "Skip recreating LUKS volume $device_type: No /dev/mapper/... mapping name (see the 'crypt $device_type' entry in $LAYOUT_FILE)"
+        # FIXME: The return code is ignored in the create_device() function in lib/layout-functions.sh:
+        return 1
+    fi
+
     for option in $options ; do
-        key=${option%=*}
+        # $option is of the form keyword=value and
+        # we assume keyword has no '=' character but value could be anything that may have a '=' character
+        # so we split keyword=value at the leftmost '=' character so that
+        # e.g. keyword=foo=bar gets split into key="keyword" and value="foo=bar":
+        key=${option%%=*}
         value=${option#*=}
-        # The "cryptseup luksFormat" command does not require any of the cipher, key-size, hash option values
-        # because if omitted a cryptseup default value is used so treat those values as optional.
+        # The "cryptseup luksFormat" command does not require any of the type, cipher, key-size, hash, uuid option values
+        # because if omitted a cryptseup default value is used so we treat those values as optional.
         # Using plain test to ensure the value is a single non empty and non blank word
         # without quoting because test " " would return zero exit code
         # cf. "Beware of the emptiness" in https://github.com/rear/rear/wiki/Coding-Style
         case "$key" in
             (type)
-                cryptsetup_options+=" --type $value"
+                test $value && cryptsetup_options+=" --type $value"
                 ;;
             (cipher)
                 test $value && cryptsetup_options+=" --cipher $value"
@@ -36,13 +55,13 @@ create_crypt() {
                 test $value && cryptsetup_options+=" --hash $value"
                 ;;
             (uuid)
-                cryptsetup_options+=" --uuid $value"
+                test $value && cryptsetup_options+=" --uuid $value"
                 ;;
             (keyfile)
-                keyfile=$value
+                test $value && keyfile=$value
                 ;;
             (password)
-                password=$value
+                test $value && password=$value
                 ;;
             (*)
                 LogPrintError "Skipping unsupported LUKS cryptsetup option '$key' in 'crypt $target_device $source_device' entry in $LAYOUT_FILE"
@@ -53,25 +72,25 @@ create_crypt() {
     cryptsetup_options+=" $LUKS_CRYPTSETUP_OPTIONS"
 
     (
-    echo "Log \"Creating LUKS device $target_name on $source_device\""
+    echo "LogPrint \"Creating LUKS volume $mapping_name on $source_device\""
     if [ -n "$keyfile" ] ; then
         # Assign a temporary keyfile at this stage so that original keyfiles do not leak onto the rescue medium.
         # The original keyfile will be restored from the backup and then re-assigned to the LUKS device in the
         # 'finalize' stage.
         # The scheme for generating a temporary keyfile path must be the same here and in the 'finalize' stage.
-        keyfile="$TMP_DIR/LUKS-keyfile-$target_name"
+        keyfile="$TMP_DIR/LUKS-keyfile-$mapping_name"
         dd bs=512 count=4 if=/dev/urandom of="$keyfile"
         chmod u=rw,go=- "$keyfile"
         echo "cryptsetup luksFormat --batch-mode $cryptsetup_options $source_device $keyfile"
-        echo "cryptsetup luksOpen --key-file $keyfile $source_device $target_name"
+        echo "cryptsetup luksOpen --key-file $keyfile $source_device $mapping_name"
     elif [ -n "$password" ] ; then
         echo "echo \"$password\" | cryptsetup luksFormat --batch-mode $cryptsetup_options $source_device"
-        echo "echo \"$password\" | cryptsetup luksOpen $source_device $target_name"
+        echo "echo \"$password\" | cryptsetup luksOpen $source_device $mapping_name"
     else
-        echo "LogPrint \"Set the password for LUKS device $target_name (for 'cryptsetup luksFormat' on $source_device):\""
+        echo "LogUserOutput \"Set the password for LUKS volume $mapping_name (for 'cryptsetup luksFormat' on $source_device):\""
         echo "cryptsetup luksFormat --batch-mode $cryptsetup_options $source_device"
-        echo "LogPrint \"Enter the password for LUKS device $target_name (for 'cryptsetup luksOpen' on $source_device):\""
-        echo "cryptsetup luksOpen $source_device $target_name"
+        echo "LogUserOutput \"Enter the password for LUKS volume $mapping_name (for 'cryptsetup luksOpen' on $source_device):\""
+        echo "cryptsetup luksOpen $source_device $mapping_name"
     fi
     echo ""
     ) >> "$LAYOUT_CODE"
@@ -79,37 +98,61 @@ create_crypt() {
 
 # Function open_crypt() is meant to be used by the 'mountonly' workflow
 open_crypt() {
+    # See the do_mount_device() function in lib/layout-functions.sh what "device type" means:
+    local device_type="$1"
+    if ! grep -q "^crypt $device_type " "$LAYOUT_FILE" ; then
+        LogPrintError "Skip opening LUKS volume $device_type (no 'crypt $device_type' entry in $LAYOUT_FILE)"
+        # FIXME: The return code is ignored in the do_mount_device() function in lib/layout-functions.sh:
+        return 1
+    fi
+
     local crypt target_device source_device options
-    read crypt target_device source_device options < <(grep "^crypt $1 " "$LAYOUT_FILE")
-
-    local target_name=${target_device#/dev/mapper/}
-
+    local mapping_name option key value
     local cryptsetup_options="" keyfile="" password=""
-    local option key value
+
+    read crypt target_device source_device options < <( grep "^crypt $device_type " "$LAYOUT_FILE" )
+
+    if ! test -b "$source_device" ; then
+        LogPrintError "Skip opening LUKS volume $device_type on device '$source_device' that is no block device (see the 'crypt $device_type' entry in $LAYOUT_FILE)"
+        # FIXME: The return code is ignored in the do_mount_device() function in lib/layout-functions.sh:
+        return 1
+    fi
+
+    mapping_name=${target_device#/dev/mapper/}
+    if ! test $mapping_name ; then
+        LogPrintError "Skip opening LUKS volume $device_type: No /dev/mapper/... mapping name (see the 'crypt $device_type' entry in $LAYOUT_FILE)"
+        # FIXME: The return code is ignored in the do_mount_device() function in lib/layout-functions.sh:
+        return 1
+    fi
+
     for option in $options ; do
-        key=${option%=*}
+        # $option is of the form keyword=value and
+        # we assume keyword has no '=' character but value could be anything that may have a '=' character
+        # so we split keyword=value at the leftmost '=' character so that
+        # e.g. keyword=foo=bar gets split into key="keyword" and value="foo=bar":
+        key=${option%%=*}
         value=${option#*=}
         case "$key" in
             (keyfile)
-                keyfile=$value
+                test $value && keyfile=$value
                 ;;
             (password)
-                password=$value
+                test $value && password=$value
                 ;;
         esac
     done
 
     (
-    echo "Log \"Opening LUKS device $target_name on $source_device\""
+    echo "LogPrint \"Opening LUKS volume $mapping_name on $source_device\""
     if [ -n "$keyfile" ] ; then
         # During a 'mountonly' workflow, the original keyfile is supposed to be
         # available at this point.
-        echo "cryptsetup luksOpen --key-file $keyfile $source_device $target_name"
+        echo "cryptsetup luksOpen --key-file $keyfile $source_device $mapping_name"
     elif [ -n "$password" ] ; then
-        echo "echo \"$password\" | cryptsetup luksOpen $source_device $target_name"
+        echo "echo \"$password\" | cryptsetup luksOpen $source_device $mapping_name"
     else
-        echo "LogPrint \"Enter the password for LUKS device $target_name (for 'cryptsetup luksOpen' on $source_device):\""
-        echo "cryptsetup luksOpen $source_device $target_name"
+        echo "LogUserOutput \"Enter the password for LUKS volume $mapping_name (for 'cryptsetup luksOpen' on $source_device):\""
+        echo "cryptsetup luksOpen $source_device $mapping_name"
     fi
     echo ""
     ) >> "$LAYOUT_CODE"

--- a/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
@@ -1,38 +1,51 @@
 # Code to recreate and/or open LUKS volumes.
 
 create_crypt() {
+    # See the create_device() function in lib/layout-functions.sh what "device type" means:
+    local device_type="$1"
+    if ! grep -q "^crypt $device_type " "$LAYOUT_FILE" ; then
+        LogPrintError "Skip recreating LUKS device $device_type (no 'crypt $device_type' entry in $LAYOUT_FILE)"
+        # FIXME: The return code is ignored in the create_device() function in lib/layout-functions.sh:
+        return 1
+    fi
+    
     local crypt target_device source_device options
-    read crypt target_device source_device options < <(grep "^crypt $1 " "$LAYOUT_FILE")
-
+    read crypt target_device source_device options < <( grep "^crypt $device_type " "$LAYOUT_FILE" )
     local target_name=${target_device#/dev/mapper/}
-
     local cryptsetup_options="" keyfile="" password=""
     local option key value
     for option in $options ; do
         key=${option%=*}
         value=${option#*=}
-
+        # The "cryptseup luksFormat" command does not require any of the cipher, key-size, hash option values
+        # because if omitted a cryptseup default value is used so treat those values as optional.
+        # Using plain test to ensure the value is a single non empty and non blank word
+        # without quoting because test " " would return zero exit code
+        # cf. "Beware of the emptiness" in https://github.com/rear/rear/wiki/Coding-Style
         case "$key" in
-            type)
+            (type)
                 cryptsetup_options+=" --type $value"
                 ;;
-            cipher)
-                cryptsetup_options+=" --cipher $value"
+            (cipher)
+                test $value && cryptsetup_options+=" --cipher $value"
                 ;;
-            key_size)
-                cryptsetup_options+=" --key-size $value"
+            (key_size)
+                test $value && cryptsetup_options+=" --key-size $value"
                 ;;
-            hash)
-                cryptsetup_options+=" --hash $value"
+            (hash)
+                test $value && cryptsetup_options+=" --hash $value"
                 ;;
-            uuid)
+            (uuid)
                 cryptsetup_options+=" --uuid $value"
                 ;;
-            keyfile)
+            (keyfile)
                 keyfile=$value
                 ;;
-            password)
+            (password)
                 password=$value
+                ;;
+            (*)
+                LogPrintError "Skipping unsupported LUKS cryptsetup option '$key' in 'crypt $target_device $source_device' entry in $LAYOUT_FILE"
                 ;;
         esac
     done
@@ -49,16 +62,15 @@ create_crypt() {
         keyfile="$TMP_DIR/LUKS-keyfile-$target_name"
         dd bs=512 count=4 if=/dev/urandom of="$keyfile"
         chmod u=rw,go=- "$keyfile"
-
         echo "cryptsetup luksFormat --batch-mode $cryptsetup_options $source_device $keyfile"
         echo "cryptsetup luksOpen --key-file $keyfile $source_device $target_name"
     elif [ -n "$password" ] ; then
         echo "echo \"$password\" | cryptsetup luksFormat --batch-mode $cryptsetup_options $source_device"
         echo "echo \"$password\" | cryptsetup luksOpen $source_device $target_name"
     else
-        echo "LogPrint \"Please enter the password for LUKS device $target_name ($source_device):\""
+        echo "LogPrint \"Enter the password for LUKS device $target_name (for 'cryptsetup luksFormat' on $source_device):\""
         echo "cryptsetup luksFormat --batch-mode $cryptsetup_options $source_device"
-        echo "LogPrint \"Please re-enter the password for LUKS device $target_name ($source_device):\""
+        echo "LogPrint \"Again enter the password for LUKS device $target_name (for 'cryptsetup luksOpen' on $source_device):\""
         echo "cryptsetup luksOpen $source_device $target_name"
     fi
     echo ""
@@ -77,12 +89,11 @@ open_crypt() {
     for option in $options ; do
         key=${option%=*}
         value=${option#*=}
-
         case "$key" in
-            keyfile)
+            (keyfile)
                 keyfile=$value
                 ;;
-            password)
+            (password)
                 password=$value
                 ;;
         esac
@@ -97,7 +108,7 @@ open_crypt() {
     elif [ -n "$password" ] ; then
         echo "echo \"$password\" | cryptsetup luksOpen $source_device $target_name"
     else
-        echo "LogPrint \"Please enter the password for LUKS device $target_name ($source_device):\""
+        echo "LogPrint \"Enter the password for LUKS device $target_name (for 'cryptsetup luksOpen' on $source_device):\""
         echo "cryptsetup luksOpen $source_device $target_name"
     fi
     echo ""

--- a/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
@@ -48,44 +48,19 @@ create_crypt() {
         # cf. "Beware of the emptiness" in https://github.com/rear/rear/wiki/Coding-Style
         case "$key" in
             (type)
-                if test $value ; then
-                    cryptsetup_options+=" --type $value"
-                else
-                    LogPrint "No 'type' value for recreating LUKS volume $mapping_name on $source_device (using 'cryptsetup' default)"
-                fi
+                test $value && cryptsetup_options+=" --type $value"
                 ;;
             (cipher)
-                if test $value ; then
-                    cryptsetup_options+=" --cipher $value"
-                else
-                    LogPrint "No 'cipher' value for recreating LUKS volume $mapping_name on $source_device (using 'cryptsetup' default)"
-                fi
+                test $value && cryptsetup_options+=" --cipher $value"
                 ;;
             (key_size)
-                if test $value ; then
-                    cryptsetup_options+=" --key-size $value"
-                else
-                    LogPrint "No 'key_size' value for recreating LUKS volume $mapping_name on $source_device (using 'cryptsetup' default)"
-                fi 
+                test $value && cryptsetup_options+=" --key-size $value"
                 ;;
             (hash)
-                if test $value ; then
-                    cryptsetup_options+=" --hash $value"
-                else
-                    LogPrint "No 'hash' value for recreating LUKS volume $mapping_name on $source_device (using 'cryptsetup' default)"
-                fi
+                test $value && cryptsetup_options+=" --hash $value"
                 ;;
             (uuid)
-                if test $value ; then
-                    cryptsetup_options+=" --uuid $value"
-                else
-                    # Report a missig uuid value as an error to have the user informed
-                    # but do not error out here because things can be fixed manually during "rear recover"
-                    # cf. https://github.com/rear/rear/pull/2506#issuecomment-721757810
-                    # and https://github.com/rear/rear/pull/2506#issuecomment-722315498
-                    # and https://github.com/rear/rear/issues/2509
-                    LogPrintError "Error: No 'uuid' value for recreating LUKS volume $mapping_name on $source_device (mounting it or booting the recreated system may fail)"
-                fi
+                test $value && cryptsetup_options+=" --uuid $value"
                 ;;
             (keyfile)
                 test $value && keyfile=$value

--- a/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
@@ -74,6 +74,11 @@ create_crypt() {
                 if test $value ; then
                     cryptsetup_options+=" --uuid $value"
                 else
+                    # Report a missig uuid value as an error to have the user informed
+                    # but do not error out here because things can be fixed manually during "rear recover"
+                    # cf. https://github.com/rear/rear/pull/2506#issuecomment-721757810
+                    # and https://github.com/rear/rear/pull/2506#issuecomment-722315498
+                    # and https://github.com/rear/rear/issues/2509
                     LogPrintError "Error: No 'uuid' value for recreating LUKS volume $mapping_name on $source_device (mounting it or booting the recreated system may fail)"
                 fi
                 ;;

--- a/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
@@ -24,7 +24,7 @@ create_crypt() {
 
     mapping_name=${target_device#/dev/mapper/}
     if ! test $mapping_name ; then
-        LogPrintError "Skip recreating LUKS volume $device_type: No /dev/mapper/... mapping name (see the 'crypt $device_type' entry in $LAYOUT_FILE)"
+        LogPrintError "Skip recreating LUKS volume $device_type on $source_device: No /dev/mapper/... mapping name (see the 'crypt $device_type' entry in $LAYOUT_FILE)"
         # FIXME: The return code is ignored in the create_device() function in lib/layout-functions.sh:
         return 1
     fi
@@ -43,19 +43,39 @@ create_crypt() {
         # cf. "Beware of the emptiness" in https://github.com/rear/rear/wiki/Coding-Style
         case "$key" in
             (type)
-                test $value && cryptsetup_options+=" --type $value"
+                if test $value ; then
+                    cryptsetup_options+=" --type $value"
+                else
+                    LogPrint "No 'type' value for recreating LUKS volume $mapping_name on $source_device (using 'cryptsetup' default)"
+                fi
                 ;;
             (cipher)
-                test $value && cryptsetup_options+=" --cipher $value"
+                if test $value ; then
+                    cryptsetup_options+=" --cipher $value"
+                else
+                    LogPrint "No 'cipher' value for recreating LUKS volume $mapping_name on $source_device (using 'cryptsetup' default)"
+                fi
                 ;;
             (key_size)
-                test $value && cryptsetup_options+=" --key-size $value"
+                if test $value ; then
+                    cryptsetup_options+=" --key-size $value"
+                else
+                    LogPrint "No 'key_size' value for recreating LUKS volume $mapping_name on $source_device (using 'cryptsetup' default)"
+                fi 
                 ;;
             (hash)
-                test $value && cryptsetup_options+=" --hash $value"
+                if test $value ; then
+                    cryptsetup_options+=" --hash $value"
+                else
+                    LogPrint "No 'hash' value for recreating LUKS volume $mapping_name on $source_device (using 'cryptsetup' default)"
+                fi
                 ;;
             (uuid)
-                test $value && cryptsetup_options+=" --uuid $value"
+                if test $value ; then
+                    cryptsetup_options+=" --uuid $value"
+                else
+                    LogPrintError "Error: No 'uuid' value for recreating LUKS volume $mapping_name on $source_device (mounting it or booting the recreated system may fail)"
+                fi
                 ;;
             (keyfile)
                 test $value && keyfile=$value
@@ -120,7 +140,7 @@ open_crypt() {
 
     mapping_name=${target_device#/dev/mapper/}
     if ! test $mapping_name ; then
-        LogPrintError "Skip opening LUKS volume $device_type: No /dev/mapper/... mapping name (see the 'crypt $device_type' entry in $LAYOUT_FILE)"
+        LogPrintError "Skip opening LUKS volume $device_type on $source_device: No /dev/mapper/... mapping name (see the 'crypt $device_type' entry in $LAYOUT_FILE)"
         # FIXME: The return code is ignored in the do_mount_device() function in lib/layout-functions.sh:
         return 1
     fi

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -76,8 +76,15 @@ while read target_name junk ; do
         hash=$( grep "Hash spec" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
     elif test $luks_type = "luks2" ; then
         cipher=$( grep "cipher:" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
-        # More than one keyslot may be defined - use key_size from the first slot
-        key_size=$( grep -m 1 "Key:" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+) bits$/\1/' )
+        # More than one keyslot may be defined - use key_size from the first slot.
+        # Depending on the version the "cryptsetup luksDump" command outputs the key_size value
+        # as a line like
+        #         Key:        512 bits
+        # and/or as a line like
+        #         Cipher key: 512 bits
+        # cf. https://github.com/rear/rear/pull/2504#issuecomment-718729198 and subsequent comments
+        # so we grep for both lines but use only the first match from the first slot:
+        key_size=$( egrep -m 1 "Key:|Cipher key:" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+) bits$/\1/' )
         hash=$( grep "Hash" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
     fi
 

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -109,18 +109,19 @@ while read target_name junk ; do
     fi
     if test $key_size ; then
         if ! is_positive_integer $key_size ; then
-            LogPrintError "Error: 'key_size=$key_size' is no positive integer for LUKS$version volume $target_name in $source_device" 
+            LogPrintError "Error: 'key_size=$key_size' is no positive integer for LUKS$version volume $target_name in $source_device"
             invalid_cryptsetup_option_value="yes"
         fi
     else
-        LogPrint "No 'key_size' value for LUKS$version volume $target_name in $source_device"   
+        LogPrint "No 'key_size' value for LUKS$version volume $target_name in $source_device"
     fi
     if ! test $hash ; then
         LogPrint "No 'hash' value for LUKS$version volume $target_name in $source_device"
     fi
     if ! test $uuid ; then
-        LogPrintError "Error: No 'uuid' value for LUKS$version volume $target_name in $source_device" 
-        invalid_cryptsetup_option_value="yes"
+        # Report missig uuid value as an error but do not error out because of it
+        # cf. https://github.com/rear/rear/pull/2506#issuecomment-721757810
+        LogPrintError "Error: No 'uuid' value for LUKS$version volume $target_name in $source_device (mounting it may fail)"
     fi
 
     echo "crypt /dev/mapper/$target_name $source_device type=$luks_type cipher=$cipher key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -119,9 +119,11 @@ while read target_name junk ; do
         LogPrint "No 'hash' value for LUKS$version volume $target_name in $source_device"
     fi
     if ! test $uuid ; then
-        # Report missig uuid value as an error but do not error out because of it
+        # Report a missig uuid value as an error to have the user informed
+        # but do not error out here because things can be fixed manually during "rear recover"
         # cf. https://github.com/rear/rear/pull/2506#issuecomment-721757810
-        LogPrintError "Error: No 'uuid' value for LUKS$version volume $target_name in $source_device (mounting it may fail)"
+        # and https://github.com/rear/rear/pull/2506#issuecomment-722315498
+        LogPrintError "Error: No 'uuid' value for LUKS$version volume $target_name in $source_device (mounting it or booting the recreated system may fail)"
     fi
 
     echo "crypt /dev/mapper/$target_name $source_device type=$luks_type cipher=$cipher key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -13,7 +13,7 @@ Log "Saving Encrypted volumes"
 REQUIRED_PROGS+=( cryptsetup dmsetup )
 COPY_AS_IS+=( /usr/share/cracklib/\* /etc/security/pwquality.conf )
 
-local missing_cryptsetup_option_value="no"
+local invalid_cryptsetup_option_value="no"
 
 while read target_name junk ; do
 
@@ -83,9 +83,9 @@ while read target_name junk ; do
 
     # Basic checks that the cipher key_size hash uuid values exist
     # cf. https://github.com/rear/rear/pull/2504#issuecomment-718729198
-    # because all values are needed (i.e. none can be empty) during "rear recover"
+    # because some values are needed during "rear recover"
     # to set cryptsetup options in layout/prepare/GNU/Linux/160_include_luks_code.sh
-    # and it seems cryptsetup fails when such values are empty
+    # and it seems cryptsetup fails when options with empty values are specified
     # cf. https://github.com/rear/rear/pull/2504#issuecomment-719479724
     # For example a LUKS1 crypt entry in disklayout.conf looks like
     # crypt /dev/mapper/luks1test /dev/sda7 type=luks1 cipher=aes-xts-plain64 key_size=256 hash=sha256 uuid=1b4198c9-d9b0-4c57-b9a3-3433e391e706 
@@ -95,27 +95,29 @@ while read target_name junk ; do
     # Using plain test to ensure a value is a single non empty and non blank word
     # without quoting because test " " would return zero exit code
     # cf. "Beware of the emptiness" in https://github.com/rear/rear/wiki/Coding-Style
-    # Do not error out instantly here but only report errors here so the user can see all missing values
-    # and actually error out at the end of this script if there was one missing value:
+    # Do not error out instantly here but only report errors here so the user can see all messages
+    # and actually error out at the end of this script if there was one actually invalid value:
     if ! test $cipher ; then
-        LogPrintError "Error: No 'cipher' value for LUKS$version volume $target_name in $source_device"
-        missing_cryptsetup_option_value="yes"
+        LogPrint "No 'cipher' value for LUKS$version volume $target_name in $source_device"
     fi
-    if ! test $key_size ; then
-        LogPrintError "Error: No 'key_size' value for LUKS$version volume $target_name in $source_device"
-        missing_cryptsetup_option_value="yes"
+    if test $key_size ; then
+        if ! is_positive_integer $key_size ; then
+            LogPrintError "Error: 'key_size=$key_size' is no positive integer for LUKS$version volume $target_name in $source_device" 
+            invalid_cryptsetup_option_value="yes"
+        fi
+    else
+        LogPrint "No 'key_size' value for LUKS$version volume $target_name in $source_device"   
     fi
     if ! test $hash ; then
-        LogPrintError "Error: No 'hash' value for LUKS$version volume $target_name in $source_device"
-        missing_cryptsetup_option_value="yes"
+        LogPrint "No 'hash' value for LUKS$version volume $target_name in $source_device"
     fi
     if ! test $uuid ; then
         LogPrintError "Error: No 'uuid' value for LUKS$version volume $target_name in $source_device" 
-        missing_cryptsetup_option_value="yes"
+        invalid_cryptsetup_option_value="yes"
     fi
 
     echo "crypt /dev/mapper/$target_name $source_device type=$luks_type cipher=$cipher key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE
 
 done < <( dmsetup ls --target crypt )
 
-is_true $missing_cryptsetup_option_value && Error "Missing LUKS cryptsetup option value(s) in $DISKLAYOUT_FILE"
+is_true $invalid_cryptsetup_option_value && Error "Invalid or empty LUKS cryptsetup option value(s) in $DISKLAYOUT_FILE"

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -123,6 +123,7 @@ while read target_name junk ; do
         # but do not error out here because things can be fixed manually during "rear recover"
         # cf. https://github.com/rear/rear/pull/2506#issuecomment-721757810
         # and https://github.com/rear/rear/pull/2506#issuecomment-722315498
+        # and https://github.com/rear/rear/issues/2509
         LogPrintError "Error: No 'uuid' value for LUKS$version volume $target_name in $source_device (mounting it or booting the recreated system may fail)"
     fi
 

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -131,4 +131,5 @@ while read target_name junk ; do
 
 done < <( dmsetup ls --target crypt )
 
-is_true $invalid_cryptsetup_option_value && Error "Invalid or empty LUKS cryptsetup option value(s) in $DISKLAYOUT_FILE"
+# Let this script return successfully when invalid_cryptsetup_option_value is not true:
+is_true $invalid_cryptsetup_option_value && Error "Invalid or empty LUKS cryptsetup option value(s) in $DISKLAYOUT_FILE" || true


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2504

* How was this pull request tested?
Not yet tested by me.

* Brief description of the changes in this pull request:

The "cryptseup luksFormat" command does not require
any of the cipher, key-size, hash option values
because if omitted a cryptseup default value is used, cf.
https://github.com/rear/rear/pull/2504#issuecomment-720341023
