### PR TITLE
Fix #2474: add AMD firmware to OPAL PBA if necessary

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -236,5 +236,5 @@ CLONE_GROUPS+=( tty usbmuxd usbmux fuse kvm oinstall dbus )
 # lspci output is expected to look similar to this:
 #   00:01.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Device 98e4 (rev 81)
 if type -p lspci >/dev/null && lspci | grep --quiet ' VGA .*AMD'; then
-    OPAL_PBA_FIRMWARE_FILES+=( amdgpu )
+    OPAL_PBA_FIRMWARE_FILES+=( '*/amdgpu/*' )
 fi

--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -231,3 +231,10 @@ KERNEL_CMDLINE+=" selinux=0"
 CLONE_USERS+=( daemon rpc usbmuxd usbmux vcsa nobody dbus )
 CLONE_GROUPS+=( tty usbmuxd usbmux fuse kvm oinstall dbus )
 
+# Add firmware file for AMD graphics hardware (if present) on TCG Opal pre-boot authentication (PBA) images
+# Cf. https://github.com/rear/rear/issues/2474
+# lspci output is expected to look similar to this:
+#   00:01.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Device 98e4 (rev 81)
+if type -p lspci >/dev/null && lspci | grep --quiet ' VGA .*AMD'; then
+    OPAL_PBA_FIRMWARE_FILES+=( amdgpu )
+fi

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -549,6 +549,8 @@ OPAL_PBA_PROGS=()
 OPAL_PBA_COPY_AS_IS=()
 OPAL_PBA_LIBS=()
 OPAL_PBA_KERNEL_CMDLINE=""
+# The following variable, if non-empty, overrides FIRMWARE_FILES for the PBA system.
+OPAL_PBA_FIRMWARE_FILES=()
 # The following variable sets USE_SERIAL_CONSOLE for the PBA system.
 OPAL_PBA_USE_SERIAL_CONSOLE=""
 #

--- a/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
+++ b/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
@@ -9,7 +9,14 @@ KERNEL_CMDLINE+=" quiet splash systemd.volatile=yes systemd.unit=sysinit-opalpba
 USE_SERIAL_CONSOLE="$OPAL_PBA_USE_SERIAL_CONSOLE"
 
 # Strip kernel files to a reasonable minimum
-FIRMWARE_FILES=( 'no' )
+if (( ${#OPAL_PBA_FIRMWARE_FILES[@]} > 0 )); then
+    # Prefer OPAL_PBA_FIRMWARE_FILES if non-empty.
+    FIRMWARE_FILES=( "${OPAL_PBA_FIRMWARE_FILES[@]}" )
+elif [[ -z "${FIRMWARE_FILES[*]}" ]] || is_true "$FIRMWARE_FILES"; then
+    # Always override an empty or 'yes'-like setting for FIRMWARE_FILES
+    # as this will make the PBA exceed its allowable size.
+    FIRMWARE_FILES=( 'no' )
+fi
 MODULES=( 'loaded_modules' )
 local exclude_modules='kvm.*|nvidia.*|vbox.*'
 EXCLUDE_MODULES+=( $(lsmod | tail -n +2 | cut -d ' ' -f 1 | while read m; do modprobe -R $m; done | grep -E '^('"$exclude_modules"'$)' ) )


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): #2474

* How was this pull request tested?

    As AMD graphics hardware was not available on the test system, tests were run by mocking as follows:

    * Add these lines in `usr/share/rear/lib/mkopalpba-workflow.sh` after `SourceStage "prep"`:
        ```bash
            LogPrintError "FIRMWARE_FILES=<${FIRMWARE_FILES[*]}>"
            exit
        ```

    * Run `usr/sbin/rear mkopalpba` with default configuration (Intel graphics), expect result: `FIRMWARE_FILES=<no>`.
    * In `default.conf` use these single-line configuration changes:
        * `FIRMWARE_FILES=( yes )`, expect result: `FIRMWARE_FILES=<no>`.
        * `FIRMWARE_FILES=( a b c )`, expect result: `FIRMWARE_FILES=<a b c>`.
        * `OPAL_PBA_FIRMWARE_FILES=( one two )`, expect result: `FIRMWARE_FILES=<one two>`.
    * In `usr/share/rear/conf/GNU/Linux.conf`, change grep expression `AMD` to `Intel`, expect result: `FIRMWARE_FILES=<amdgpu>`.

* Brief description of the changes in this pull request:

    OPAL PBA images only:
    * Add a required firmware file when AMD graphics hardware is present.
    * Allow setting a PBA-specific firmware configuration via the `OPAL_PBA_FIRMWARE_FILES` configuration variable.

    The issue report #2474 indicates that a single firmware file is all that is required to make a PBA boot with AMD graphics hardware. If field testing shows that more changes are necessary,  this PR's solution should be easy to extend.