### PR TITLE
Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -723,9 +723,15 @@ ISO_MAX_SIZE=
 # Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO.
 # There is a limit of the ISO 9660 file system that is 2GiB or 4GiB according to
 # https://en.wikipedia.org/wiki/ISO_9660#The_2/4_GiB_file_size_limit
-# To be on the safe side we use by default a 2GiB limit.
-# 2GiB is at least the actual limit when ebiso is used, cf.
-# https://github.com/gozora/ebiso/issues/12
+# Usually 'mkisofs' is called with '-udf -allow-limited-size'
+# cf. usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
+# but only if the '--help' output of ISO_MKISOFS_BIN shows '-allow-limited-size'
+# so there are cases where ISO 9660 level 1 or 2 is used that has a 2GiB file size limit.
+# For example when 'ebiso' is used there is a 2GiB file size limit
+# cf. https://github.com/gozora/ebiso/issues/12
+# but also other tools that are specified by ISO_MKISOFS_BIN could have that limit.
+# Accordingly to be by default on the safe side we use by default a 2GiB limit
+# cf. https://github.com/rear/rear/pull/2525
 # Under normal circumstances files greater or equal 2GiB should not appear in the ISO.
 # An exception is when the backup is included in the ISO with BACKUP_URL=iso://
 # where the backup archive file (e.g. backup.tar.gz) could be greater or equal 2GiB.
@@ -733,10 +739,14 @@ ISO_MAX_SIZE=
 # actually works in his particular environment even when there are files in his ISO
 # (in particular backup.tar.gz) that are actually greater than the default 2GiB limit.
 # When there is a 2GiB file size limit a backup.tar.gz that is greater than 2GiB
-# will get corrupted in the ISO so backup restore via "rear recover" would fail.
+# will get corrupted in the ISO so backup restore via "rear recover" would fail
+# which is a dead end because the backup in the ISO got corrupted which is a severe error.
 # Also the ReaR recovery system initrd could become greater or equal 2GiB
-# (e.g. because of accidentally too much in COPY_AS_IS) which is very likely an error
-# so we error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO.
+# (e.g. because of accidentally too much in COPY_AS_IS) which is likely an error
+# that could let booting or running the recovery system fail because
+# a recovery system in a 2GiB or bigger compressed initrd will need
+# more memory space when uncompressed and running in the ramdisk.
+# So we error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO.
 # 2 GiB =  2 * 1024 * 1024 * 1024 bytes = 2147483648 bytes:
 ISO_FILE_SIZE_LIMIT=2147483648
 #

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -720,6 +720,26 @@ ISO_ISOLINUX_BIN=""
 # to be on the safe side to not possibly destroy an existing backup.
 ISO_MAX_SIZE=
 #
+# Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO.
+# There is a limit of the ISO 9660 file system that is 2GiB or 4GiB according to
+# https://en.wikipedia.org/wiki/ISO_9660#The_2/4_GiB_file_size_limit
+# To be on the safe side we use by default a 2GiB limit.
+# 2GiB is at least the actual limit when ebiso is used, cf.
+# https://github.com/gozora/ebiso/issues/12
+# Under normal circumstances files greater or equal 2GiB should not appear in the ISO.
+# An exception is when the backup is included in the ISO with BACKUP_URL=iso://
+# where the backup archive file (e.g. backup.tar.gz) could be greater or equal 2GiB.
+# The user might adapt ISO_FILE_SIZE_LIMIT provided he verified that "rear recover"
+# actually works in his particular environment even when there are files in his ISO
+# (in particular backup.tar.gz) that are actually greater than the default 2GiB limit.
+# When there is a 2GiB file size limit a backup.tar.gz that is greater than 2GiB
+# will get corrupted in the ISO so backup restore via "rear recover" would fail.
+# Also the ReaR recovery system initrd could become greater or equal 2GiB
+# (e.g. because of accidentally too much in COPY_AS_IS) which is very likely an error
+# so we error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO.
+# 2 GiB =  2 * 1024 * 1024 * 1024 bytes = 2147483648 bytes:
+ISO_FILE_SIZE_LIMIT=2147483648
+#
 # How to find mkisofs:
 # Guess the common names mkisofs or genisoimage
 # script in prep stage will verify this and complain if not found

--- a/usr/share/rear/lib/output-functions.sh
+++ b/usr/share/rear/lib/output-functions.sh
@@ -37,7 +37,7 @@ function FindUsbDevices () {
 # It errors out for the first file that is greater or equal ISO_FILE_SIZE_LIMIT and shows only this one to the user
 # so if there are also other files greater or equal ISO_FILE_SIZE_LIMIT they are not shown. At least for now
 # this should be sufficient because more than one file greater or equal ISO_FILE_SIZE_LIMIT is not expected
-# and the "assert" meaning is that this error exit is there only as safeguard for a very exceptional case.
+# and the "assert" meaning is that this error exit is there only as safeguard for exceptional cases.
 function assert_ISO_FILE_SIZE_LIMIT () {
     # Use fallback ISO_FILE_SIZE_LIMIT 2GiB (2147483648 bytes) if not set (cf. default.conf):
     is_positive_integer $ISO_FILE_SIZE_LIMIT || ISO_FILE_SIZE_LIMIT=2147483648

--- a/usr/share/rear/lib/output-functions.sh
+++ b/usr/share/rear/lib/output-functions.sh
@@ -1,27 +1,54 @@
-# functions required for output related stuff
 
-#
+# Functions required for output related stuff
+
 # OUT: a valid usb device in /dev
-#
-FindUsbDevices () {
-	# we use the model to find USB devices
-	for d in $(ls /sys/block/*/device/model) ; do
-		grep -q -i -E 'usb|FlashDisk' $d || continue
-		#echo "**** Analyzing $d"
+function FindUsbDevices () {
+    local d sysfspath device
+    # we use the model to find USB devices
+    for d in $( ls /sys/block/*/device/model ) ; do
+        grep -q -i -E 'usb|FlashDisk' $d || continue
+        # analyzing $d
+        # /sys/block/sdb
+        sysfspath="$( dirname $( dirname "$d" ) )"
+        # bare device name
+        # sdb
+        device="$( basename "$sysfspath" )"
+        # still need to check if device contains a partition?
+        # if USB device has no partition table we skip this device
+        if [ -f $sysfspath/${device}1/partition ] ; then
+            # find a device node matching this device in /dev
+            DeviceNameToNode "$device" || return 1
+            Log "USB device $device selected."
+        else
+            Log "USB device /dev/$device does not contain a valid partition table - skip device."
+        fi
+    done
+}
 
-		sysfspath="$(dirname $(dirname "$d"))"		# /sys/block/sdb
-		# bare device name
-		device="$(basename "$sysfspath")"	# sdb
-
-		# still need to check if device contains a partition?
-		# if USB device has no partition table we skip this device
-		if [ -f $sysfspath/${device}1/partition ]; then
-			# find a device node matching this device in /dev
-			DeviceNameToNode "$device" || return 1
-			Log "USB device $device selected."
-		else
-			Log "USB device /dev/$device does not contain a valid partition table - skip device."
-		fi
-
-	done
+# Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO (cf. default.conf)
+# for files passed as arguments e.g: assert_ISO_FILE_SIZE_LIMIT file1 relative/path/file2 /absolute/path/file3 ...
+# Normally there should be no error exit inside a function but a function should return non-zero exit code
+# and leave it to its caller what to do depending on the callers environment. But this function is an exception.
+# It is meant like the "assert" macro in C that outputs a message on stderr and then exits with abort().
+# Furthermore it is less duplicated code to implement the error exit inside this function
+# than to let this function return non-zero exit code and implement the error exit in each caller
+# when the meaning of this function is to always exit for files greater or equal ISO_FILE_SIZE_LIMIT
+# (for the reasoning why "always exit" for such files see default.conf).
+# It errors out for the first file that is greater or equal ISO_FILE_SIZE_LIMIT and shows only this one to the user
+# so if there are also other files greater or equal ISO_FILE_SIZE_LIMIT they are not shown. At least for now
+# this should be sufficient because more than one file greater or equal ISO_FILE_SIZE_LIMIT is not expected
+# and the "assert" meaning is that this error exit is there only as safeguard for a very exceptional case.
+function assert_ISO_FILE_SIZE_LIMIT () {
+    # Use fallback ISO_FILE_SIZE_LIMIT 2GiB (2147483648 bytes) if not set (cf. default.conf):
+    is_positive_integer $ISO_FILE_SIZE_LIMIT || ISO_FILE_SIZE_LIMIT=2147483648
+    local file_for_iso file_for_iso_size
+    for file_for_iso in $@ ; do
+        file_for_iso_size=$( stat -L -c '%s' $file_for_iso )
+        # Continue "bona fide" with testing the next one if size could not be determined (assume the current one is OK):
+        is_positive_integer $file_for_iso_size || continue
+        # Continue testing the next one when this one is below the file size limit:
+        test $file_for_iso_size -lt $ISO_FILE_SIZE_LIMIT && continue
+        # Show only basename to avoid the meaningless ReaR-internal path where files for the ISO are (temporarily) located:
+        Error "File for ISO $( basename $file_for_iso ) size $file_for_iso_size greater or equal ISO_FILE_SIZE_LIMIT=$ISO_FILE_SIZE_LIMIT"
+    done
 }

--- a/usr/share/rear/output/ISO/Linux-i386/810_prepare_multiple_iso.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/810_prepare_multiple_iso.sh
@@ -71,6 +71,9 @@ for iso_number in $( seq -f '%02g' 1 $(( $number_of_ISOs - 1 )) ) ; do
     mkdir -p $TEMP_BACKUP_DIR
     mv $BACKUP_NAME $TEMP_BACKUP_DIR
     pushd $TEMP_ISO_DIR 1>/dev/null
+    # Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO (cf. default.conf).
+    # Consider all regular files and follow symbolic links to also get regular files where symlinks point to:
+    assert_ISO_FILE_SIZE_LIMIT $( find -L . -type f )
     if ! $ISO_MKISOFS_BIN $v $ISO_MKISOFS_OPTS -o "$ISO_OUTPUT_PATH" -R -J -volid "${ISO_VOLID}_$iso_number" -v -iso-level 3 . 1>/dev/null ; then
         Error "Failed to create ISO image $ISO_NAME (with $ISO_MKISOFS_BIN)"
     fi

--- a/usr/share/rear/output/ISO/Linux-i386/820_create_iso_image.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/820_create_iso_image.sh
@@ -19,18 +19,9 @@ fi
 
 pushd $TMP_DIR/isofs >/dev/null
 
-# Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO (cf. default.conf):
-is_positive_integer $ISO_FILE_SIZE_LIMIT || ISO_FILE_SIZE_LIMIT=2147483648
-local file_for_iso file_for_iso_size
+# Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO (cf. default.conf).
 # Consider all regular files and follow symbolic links to also get regular files where symlinks point to:
-for file_for_iso in $( find -L . -type f ) ; do
-    file_for_iso_size=$( stat -L -c '%s' $file_for_iso )
-    # Continue "bona fide" with testing the next one if size could not be determined (assume the current one is OK):
-    is_positive_integer $file_for_iso_size || continue
-    # Continue testing the next one when this one is below the file size limit:
-    test $file_for_iso_size -lt $ISO_FILE_SIZE_LIMIT && continue
-    Error "File for ISO $( basename $file_for_iso ) size $file_for_iso_size greater or equal ISO_FILE_SIZE_LIMIT=$ISO_FILE_SIZE_LIMIT"
-done
+assert_ISO_FILE_SIZE_LIMIT $( find -L . -type f )
 
 # ebiso uses different command line options and parameters:
 if test "ebiso" = $( basename $ISO_MKISOFS_BIN ) ; then

--- a/usr/share/rear/output/ISO/Linux-i386/820_create_iso_image.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/820_create_iso_image.sh
@@ -18,6 +18,20 @@ else
 fi
 
 pushd $TMP_DIR/isofs >/dev/null
+
+# Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO (cf. default.conf):
+is_positive_integer $ISO_FILE_SIZE_LIMIT || ISO_FILE_SIZE_LIMIT=2147483648
+local file_for_iso file_for_iso_size
+# Consider all regular files and follow symbolic links to also get regular files where symlinks point to:
+for file_for_iso in $( find -L . -type f ) ; do
+    file_for_iso_size=$( stat -L -c '%s' $file_for_iso )
+    # Continue "bona fide" with testing the next one if size could not be determined (assume the current one is OK):
+    is_positive_integer $file_for_iso_size || continue
+    # Continue testing the next one when this one is below the file size limit:
+    test $file_for_iso_size -lt $ISO_FILE_SIZE_LIMIT && continue
+    Error "File for ISO $file_for_iso size greater or equal ISO_FILE_SIZE_LIMIT=$ISO_FILE_SIZE_LIMIT"
+done
+
 # ebiso uses different command line options and parameters:
 if test "ebiso" = $( basename $ISO_MKISOFS_BIN ) ; then
     # ebiso currently works only with UEFI:

--- a/usr/share/rear/output/ISO/Linux-i386/820_create_iso_image.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/820_create_iso_image.sh
@@ -29,7 +29,7 @@ for file_for_iso in $( find -L . -type f ) ; do
     is_positive_integer $file_for_iso_size || continue
     # Continue testing the next one when this one is below the file size limit:
     test $file_for_iso_size -lt $ISO_FILE_SIZE_LIMIT && continue
-    Error "File for ISO $file_for_iso size greater or equal ISO_FILE_SIZE_LIMIT=$ISO_FILE_SIZE_LIMIT"
+    Error "File for ISO $( basename $file_for_iso ) size $file_for_iso_size greater or equal ISO_FILE_SIZE_LIMIT=$ISO_FILE_SIZE_LIMIT"
 done
 
 # ebiso uses different command line options and parameters:

--- a/usr/share/rear/output/ISO/Linux-i386/830_create_iso_image_EFISTUB.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/830_create_iso_image_EFISTUB.sh
@@ -5,6 +5,10 @@ LogPrint "EFI_STUB: Making ISO image"
 
 pushd $TMP_DIR/isofs >/dev/null
 
+# Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO (cf. default.conf).
+# Consider all regular files and follow symbolic links to also get regular files where symlinks point to:
+assert_ISO_FILE_SIZE_LIMIT $( find -L . -type f )
+
 $ISO_MKISOFS_BIN $v $ISO_MKISOFS_OPTS -o "$ISO_DIR/$ISO_PREFIX.iso" \
     -b isolinux/isolinux.bin -c isolinux/boot.cat \
     -no-emul-boot -boot-load-size 4 -boot-info-table \

--- a/usr/share/rear/output/ISO/Linux-ia64/800_create_isofs.sh
+++ b/usr/share/rear/output/ISO/Linux-ia64/800_create_isofs.sh
@@ -24,6 +24,10 @@ mv -f $v $TMP_DIR/boot.img "$TMP_DIR/isofs/boot"
 # Careful in case of 'return' after 'pushd' (must call the matching 'popd' before 'return'):
 pushd $TMP_DIR/isofs # so that relative paths will work
 
+# Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO (cf. default.conf).
+# Consider all regular files and follow symbolic links to also get regular files where symlinks point to:
+assert_ISO_FILE_SIZE_LIMIT $( find -L . -type f )
+
 $ISO_MKISOFS_BIN $v $ISO_MKISOFS_OPTS -o "$ISO_DIR/$ISO_PREFIX.iso" \
     -b boot/boot.img -c boot/boot.catalog \
     -no-emul-boot -R -T -J -volid "$ISO_VOLID" -v . >/dev/null

--- a/usr/share/rear/output/ISO/Linux-ppc64le/820_create_iso_image.sh
+++ b/usr/share/rear/output/ISO/Linux-ppc64le/820_create_iso_image.sh
@@ -17,6 +17,10 @@ else
     chrp_boot_option="-chrp-boot"
 fi
 
+# Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO (cf. default.conf).
+# Consider all regular files and follow symbolic links to also get regular files where symlinks point to:
+assert_ISO_FILE_SIZE_LIMIT "${ISO_FILES[@]}"
+
 # Have a hardcoded '-iso-level 3' option also here because it is
 # also hardcoded in output/ISO/Linux-i386/820_create_iso_image.sh
 # and it seems to also work in general on POWER architecture

--- a/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
+++ b/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
@@ -6,6 +6,7 @@
 # and mkisofs and genisoimage as second and third option
 # but for UEFI bootable systems 'ISO_MKISOFS_BIN=/usr/bin/ebiso' is used.
 test -x "$ISO_MKISOFS_BIN" || Error "Could not find program to make ISO9660 filesystem. Install 'mkisofs', 'genisoimage' or 'ebiso' or specify ISO_MKISOFS_BIN (currently $ISO_MKISOFS_BIN)"
+DebugPrint "Using '$ISO_MKISOFS_BIN' to create ISO filesystem images"
 
 # Include 'udf' module which is required if backup archive is >= 4GiB and mkisofs/genisoimage is used:
 IsInArray "all_modules" "${MODULES[@]}" || MODULES+=( udf )
@@ -56,7 +57,5 @@ if test "ebiso" = "$( basename $ISO_MKISOFS_BIN )" ; then
     # 2 GiB =  2 * 1024 * 1024 * 1024 bytes = 2147483648 bytes:
     test $ISO_FILE_SIZE_LIMIT -le 2147483648 || Error "ebiso has a 2GiB file size limit but ISO_FILE_SIZE_LIMIT is greater than 2GiB"
 fi
-
-DebugPrint "Using '$ISO_MKISOFS_BIN' to create ISO filesystem images"
 
 # vim: set et ts=4 sw=4:

--- a/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
+++ b/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
@@ -5,8 +5,29 @@
 [ -x "$ISO_MKISOFS_BIN" ]
 StopIfError "Could not find 'mkisofs' compatible program. Please install 'mkisofs', 'genisoimage' or 'ebiso' into your path or manually set ISO_MKISOFS_BIN [$ISO_MKISOFS_BIN]"
 
-# We also include 'udf' module which is required if backup archive is >= 4GiB
-# and mkisofs/genisoimage is used.
+# We also include 'udf' module which is required if backup archive is >= 4GiB and mkisofs/genisoimage is used.
+# "man mkisofs" (at least on SLES12-SP5 for /usr/bin/mkisofs from the cdrkit-cdrtools-compat RPM) reads (excerpts):
+#   -allow-limited-size
+#     When processing files larger than 2GiB which cannot be represented in ISO9660 level 1 or 2,
+#     add them with a shrunk visible file size to ISO9660 and with the correct visible file size to the UDF system.
+#     The result is an inconsistent filesystem and users need to make sure that they really use UDF
+#     rather than ISO9660 driver to read a such disk. Implies enabling -udf. See also -iso-level 3
+#   -udf
+#     Include UDF filesystem support in the generated filesystem image.
+#     UDF support is currently in alpha status and for this reason,
+#     it is not possible to create UDF-only images.
+#     UDF data structures are currently coupled to the Joliet structures,
+#     so there are many pitfalls with the current implementation.
+#     There is no UID/GID support, there is no POSIX permission support, there is no support for  symlinks.
+#   -iso-level level
+#      With level 1, files may only consist of one section and filenames are restricted to 8.3 characters.
+#      With level 2, files may only consist of one section.
+#      With level 3, no restrictions (other than ISO-9660:1988) do apply.
+#      Starting with this level, genisoimage also allows files to be larger than 4 GB
+#      by implementing ISO-9660 multi-extent files.
+#      With all ISO9660 levels from 1 to 3, all filenames are restricted to uppercase letters,
+#      numbers and underscores (_). Filenames are limited to 31 characters,
+#      directory nesting is limited to 8 levels, and pathnames are limited to 255 characters.
 if $ISO_MKISOFS_BIN --help 2>&1 >/dev/null | grep -qw -- -allow-limited-size ; then
     MODULES+=( udf )
     ISO_MKISOFS_OPTS+=" -allow-limited-size"

--- a/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
+++ b/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
@@ -1,11 +1,14 @@
-# verify that we have a working mkisofs
+
+# Verify that we have a working program to make ISO9660 filesystem.
 #
-# default for ISO_MKISOFS_BIN is to check for mkisofs and genisoimage in the path
+# In default.conf ISO_MKISOFS_BIN is to check what there is in the path with
+# xorrisofs used as the preferred method for generating the iso image
+# and mkisofs and genisoimage as second and third option
+# but for UEFI bootable systems 'ISO_MKISOFS_BIN=/usr/bin/ebiso' is used.
+test -x "$ISO_MKISOFS_BIN" || Error "Could not find program to make ISO9660 filesystem. Install 'mkisofs', 'genisoimage' or 'ebiso' or specify ISO_MKISOFS_BIN (currently $ISO_MKISOFS_BIN)"
 
-[ -x "$ISO_MKISOFS_BIN" ]
-StopIfError "Could not find 'mkisofs' compatible program. Please install 'mkisofs', 'genisoimage' or 'ebiso' into your path or manually set ISO_MKISOFS_BIN [$ISO_MKISOFS_BIN]"
-
-# We also include 'udf' module which is required if backup archive is >= 4GiB and mkisofs/genisoimage is used.
+# Include 'udf' module which is required if backup archive is >= 4GiB and mkisofs/genisoimage is used:
+IsInArray "all_modules" "${MODULES[@]}" || MODULES+=( udf )
 # "man mkisofs" (at least on SLES12-SP5 for /usr/bin/mkisofs from the cdrkit-cdrtools-compat RPM) reads (excerpts):
 #   -allow-limited-size
 #     When processing files larger than 2GiB which cannot be represented in ISO9660 level 1 or 2,
@@ -28,11 +31,32 @@ StopIfError "Could not find 'mkisofs' compatible program. Please install 'mkisof
 #      With all ISO9660 levels from 1 to 3, all filenames are restricted to uppercase letters,
 #      numbers and underscores (_). Filenames are limited to 31 characters,
 #      directory nesting is limited to 8 levels, and pathnames are limited to 255 characters.
+# "man mkisofs" on openSUSE Leap 15.1 for /usr/bin/mkisofs from the mkisofs RPM
+# does not mention 'allow-limited-size' neither does 'mkisofs --help' show it
+# but it reads (excerpt):
+#   If you like to have files larger than 2 GB, you need to specify -iso-level 3 or above.
+# The 'output/ISO/...create_iso_image.sh' scripts
+#   output/ISO/Linux-i386/810_prepare_multiple_iso.sh
+#   output/ISO/Linux-i386/820_create_iso_image.sh
+#   output/ISO/Linux-i386/830_create_iso_image_EFISTUB.sh
+#   output/ISO/Linux-ppc64le/820_create_iso_image.sh
+# specify '-iso-level 3' only
+#   output/ISO/Linux-ia64/800_create_isofs.sh
+# does not specify '-iso-level 3'
+# so on IA-64 (Intel Itanium architecture) there is probably a 2GiB file size limit.
+# Also 'ebiso --help' does not mention 'allow-limited-size'.
 if $ISO_MKISOFS_BIN --help 2>&1 >/dev/null | grep -qw -- -allow-limited-size ; then
-    MODULES+=( udf )
     ISO_MKISOFS_OPTS+=" -allow-limited-size"
 fi
 
-Log "Using '$ISO_MKISOFS_BIN' to create ISO images"
+# ebiso has a 2GiB file size limit
+# cf. https://github.com/gozora/ebiso/issues/12
+# so ISO_FILE_SIZE_LIMIT must not be greater than 2GiB
+if test "ebiso" = "$( basename $ISO_MKISOFS_BIN )" ; then
+    # 2 GiB =  2 * 1024 * 1024 * 1024 bytes = 2147483648 bytes:
+    test $ISO_FILE_SIZE_LIMIT -le 2147483648 || Error "ebiso has a 2GiB file size limit but ISO_FILE_SIZE_LIMIT is greater than 2GiB"
+fi
+
+DebugPrint "Using '$ISO_MKISOFS_BIN' to create ISO filesystem images"
 
 # vim: set et ts=4 sw=4:


### PR DESCRIPTION
* Type: **Bug Fix**  / **Enhancement**

* Impact: **Low** / **Critical**

Low impact (actually there should be no impact) under normal circumstances.

In contrast critical when the backup is included in the ISO with BACKUP_URL=iso://
where the backup archive file (e.g. backup.tar.gz) could be greater or equal 2GiB.
When there is a 2GiB file size limit a backup.tar.gz that is greater than 2GiB
will get corrupted in the ISO so backup restore via "rear recover" would fail
but then it is too late and the backup in the ISO is unusable.

Therefore such a test is critical because without such a test
for the user it appears af if everything went OK during "rear mkbackup"
until he finds out later during "rear recover" that his backup got corrupted.

* Reference to related issue (URL):
https://github.com/gozora/ebiso/issues/12

* How was this pull request tested?
"rear mkrescue" still works well for me.
I did not yes test with a file greater or equal 2GiB for the ISO.

* Brief description of the changes in this pull request:

There is a limit of the ISO 9660 file system that is 2GiB or 4GiB according to
https://en.wikipedia.org/wiki/ISO_9660#The_2/4_GiB_file_size_limit

To be on the safe side we use by default a 2GiB limit.
2GiB is at least the actual limit when ebiso is used, cf.
https://github.com/gozora/ebiso/issues/12

Under normal circumstances files greater or equal 2GiB should not appear in the ISO.

An exception is when the backup is included in the ISO with BACKUP_URL=iso://
where the backup archive file (e.g. backup.tar.gz) could be greater or equal 2GiB.

The user might adapt ISO_FILE_SIZE_LIMIT provided he verified that "rear recover"
actually works in his particular environment even when there are files in his ISO
(in particular backup.tar.gz) that are actually greater than the default 2GiB limit.
When there is a 2GiB file size limit a backup.tar.gz that is greater than 2GiB
will get corrupted in the ISO so backup restore via "rear recover" would fail.

Also the ReaR recovery system initrd could become greater or equal 2GiB
(e.g. because of accidentally too much in COPY_AS_IS) which is very likely an error
so we error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO.
