### PR TITLE
NBKDC: Fix ReaR backup and restore with NovaStor DataCenter 8.0 and higher

### DIFF
--- a/doc/rear-release-notes.txt
+++ b/doc/rear-release-notes.txt
@@ -99,7 +99,7 @@ functionality:
       - EMC Avamar (BACKUP=AVA)
       - SEP Sesam (BACKUP=SESAM)
       - FDR/Upstream (BACKUP=FDRUPSTREAM)
-      - Novastor NovaBACKUP DC (BACKUP=NBKDC)
+      - NovaStor DataCenter (BACKUP=NBKDC)
       - Borg Backup (BACKUP=BORG)
       - Rubrik Cloud Data Management (BACKUP=CDM) (New)
   o Integrates with Disaster Recovery Linux Manager (DRLM)

--- a/doc/rear.8
+++ b/doc/rear.8
@@ -38,7 +38,7 @@ Relax\-and\-Recover (abbreviated ReaR) is the leading Open Source disaster recov
 .sp
 Relax\-and\-Recover produces a bootable image\&. This image can repartition the system\&. Once that is done it initiates a restore from backup\&. Restores to different hardware are possible\&. Relax\-and\-Recover can therefore be used as a migration tool as well\&.
 .sp
-Currently Relax\-and\-Recover supports various boot media (incl\&. ISO, PXE, OBDR tape, USB or eSATA storage), a variety of network protocols (incl\&. sftp, ftp, http, nfs, cifs) for storage and backup as well as a multitude of backup strategies (incl\&. IBM Tivoli Storage Manager, MircoFocus Data Protector, Symantec NetBackup, EMC NetWorker, EMC Avamar, FDR/Upstream, NovaBACKUP DC, Rubrik Cloud Data Management (CDM), Bareos, Bacula, rsync, rbme, Borg)\&. This results in a bootable image that is capable of booting via PXE, DVD/CD, bootable tape or virtual provisioning\&.
+Currently Relax\-and\-Recover supports various boot media (incl\&. ISO, PXE, OBDR tape, USB or eSATA storage), a variety of network protocols (incl\&. sftp, ftp, http, nfs, cifs) for storage and backup as well as a multitude of backup strategies (incl\&. IBM Tivoli Storage Manager, MircoFocus Data Protector, Symantec NetBackup, EMC NetWorker, EMC Avamar, FDR/Upstream, NovaStor DC, Rubrik Cloud Data Management (CDM), Bareos, Bacula, rsync, rbme, Borg)\&. This results in a bootable image that is capable of booting via PXE, DVD/CD, bootable tape or virtual provisioning\&.
 .sp
 Relax\-and\-Recover was designed to be easy to set up, requires no maintenance and is there to assist when disaster strikes\&. Its setup\-and\-forget nature removes any excuses for not having a disaster recovery solution implemented\&.
 .sp
@@ -518,7 +518,7 @@ Using SEP Sesam to restore the data\&.
 .PP
 BACKUP=\fBNBKDC\fR
 .RS 4
-Using Novastor NovaBACKUP DC to restore the data\&.
+Using NovaStor DC to restore the data\&.
 .RE
 .PP
 BACKUP=\fBCDM\fR

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -28,7 +28,7 @@ Currently Relax-and-Recover supports various boot media (incl. ISO, PXE,
 OBDR tape, USB or eSATA storage), a variety of network protocols (incl.
 sftp, ftp, http, nfs, cifs) for storage and backup as well as a multitude
 of backup strategies (incl.  IBM Tivoli Storage Manager, MircoFocus Data Protector,
-Symantec NetBackup, EMC NetWorker, EMC Avamar, FDR/Upstream, NovaBACKUP DC, Rubrik Cloud Data Management (CDM),
+Symantec NetBackup, EMC NetWorker, EMC Avamar, FDR/Upstream, NovaStor DC, Rubrik Cloud Data Management (CDM),
 Bareos, Bacula, rsync, rbme, Borg). This results in a bootable image that is capable of
 booting via PXE, DVD/CD, bootable tape or virtual provisioning.
 
@@ -343,7 +343,7 @@ BACKUP=*SESAM*::
 Using SEP Sesam to restore the data.
 
 BACKUP=*NBKDC*::
-Using Novastor NovaBACKUP DC to restore the data.
+Using NovaStor DC to restore the data.
 
 BACKUP=*CDM*::
 Using Rubrik Cloud Data Management (CDM) to restore the data.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1749,10 +1749,10 @@ PROGS_FDRUPSTREAM=()
 ##
 # BACKUP=NBKDC stuff
 ##
-# (Novastor NovaBACKUP DataCenter: http://www.novastor.com)
+# (NovaStor DataCenter: http://www.novastor.com)
 # Agent installation will be detected automatically in:
 #  prep/NBKDC/default/400_prep_nbkdc.sh
-# ReaR will not perform the backup, this will be triggered by NBK DataCenter
+# ReaR will not perform the backup, this will be triggered by NovaStor DataCenter
 ##
 NBKDC_DIR=/opt/NovaStor/DataCenter
 COPY_AS_IS_NBKDC=()

--- a/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
+++ b/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
@@ -42,6 +42,7 @@ while CDV== read key value ; do
         "&tapedir:") NBKDC_HIBTAP_DIR="$value" ;;
         "&msgdir:") NBKDC_HIBMSG_DIR="$value" ;;
         "&logdir:") NBKDC_HIBLOG_DIR="$value" ;;
+        "&ssl-enabled:") NBKDC_HIBSSL_ENABLED="$value" ;;
     esac
 done <"$COND"
 
@@ -55,6 +56,7 @@ NBKDC_HIB_TPD=$NBKDC_HIBTPD_DIR
 NBKDC_HIB_TAP=$NBKDC_HIBTAP_DIR
 NBKDC_HIB_MSG=$NBKDC_HIBMSG_DIR
 NBKDC_HIB_LOG=$NBKDC_HIBLOG_DIR
+NBKDC_HIB_SSL_ENABLED=$NBKDC_HIBSSL_ENABLED
 EOF
 
 

--- a/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
+++ b/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
@@ -61,6 +61,7 @@ EOF
 # include DataCenter executables and configuration files 
 COPY_AS_IS+=(
     "${COPY_AS_IS_NBKDC[@]}" 
+    $NBKDC_DIR/etc/ssl
     $NBKDC_DIR/conf
     $NBKDC_DIR/log
     $NBKDC_DIR/rcmd-executor 

--- a/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
+++ b/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
@@ -2,15 +2,9 @@
 # prepare stuff for NovaStor DataCenter
 #
 
-# Note: unlike in C/C++, in bash `if function param..` uses the then branch, if
-# the function returns 0
 function is_nbkdc_dir() {
   local candidate="$1"
-  if [ -x $candidate/rcmd-executor/rcmd-executor ]; then
-    return 0
-  else
-    return 1
-  fi
+  test -x $candidate/rcmd-executor/rcmd-executor
 }
 
 function find_nbkdc_dir() {

--- a/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
+++ b/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
@@ -44,7 +44,7 @@ fi
 
 
 COND=$NBKDC_HIB_DIR/CONDEV
-[[ ! -r "$COND" ]] && Error "CONDEV file '$COND' can not be read"
+[[ -r "$COND" ]] || Error "CONDEV file '$COND' can not be read"
 
 while CDV== read key value ; do
     case "$key" in

--- a/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
+++ b/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
@@ -1,5 +1,5 @@
 #
-# prepare stuff for NovaBACKUP DataCenter
+# prepare stuff for NovaStor DataCenter
 #
 
 # Note: unlike in C/C++, in bash `if function param..` uses the then branch, if
@@ -30,7 +30,7 @@ function find_nbkdc_dir() {
 if find_nbkdc_dir; then
   Log "Detected NovaStor DC Installation in $NBKDC_DIR"
 else
-  LogPrintError "No NovaBACKUP DataCenter Software installed"
+  LogPrintError "No NovaStor DataCenter Software installed"
   Error "No NBKDC found, exiting NBKDC prep"
 fi
 

--- a/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
+++ b/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
@@ -98,6 +98,8 @@ COPY_AS_IS_EXCLUDE+=(
     $NBKDC_HIBTMP_DIR 
     $NBKDC_HIBLIS_DIR 
     $NBKDC_HIBTPD_DIR/*.tpd
+    $NBKDC_HIB_DIR/db2
+    $NBKDC_HIB_DIR/onbar
     $NBKDC_HIB_DIR/ora* 
     $NBKDC_HIB_DIR/ndmp 
     $NBKDC_HIB_DIR/mm 

--- a/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
+++ b/usr/share/rear/prep/NBKDC/default/400_prep_nbkdc.sh
@@ -108,3 +108,9 @@ COPY_AS_IS_EXCLUDE+=(
     $NBKDC_HIB_DIR/svm
     /var/run/rcmd-executor.pid
 )
+
+# The files of NovaStor DataCenter installation belong to 'novastor'
+TRUSTED_FILE_OWNERS+=(
+    "${TRUSTED_FILE_OWNERS[@]}"
+    novastor
+)

--- a/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
@@ -1,6 +1,36 @@
 
 source $VAR_DIR/recovery/nbkdc_settings
 
+function print_hiback_encryption_help {
+  local condev_ssl_enabled_setting="$1"
+
+  if [ -z "$condev_ssl_enabled_setting" ]; then
+    LogUserOutput "
+It seems this restore image contains a Hiback without encrypted network
+support. If you have updated your NovaStor Datacenter backup server to
+8.0 or higher, and encounter failed connections to it, you may have to
+disable encryption on the backup server temporarily. Ask NovaStor support
+for further info.
+"
+  else
+    local ssl_setting_natural_language
+    local opposite_ssl_setting
+    if [ "false" = "$condev_ssl_enabled_setting" ]; then
+      ssl_setting_natural_language="disabled"
+      opposite_ssl_setting="true"
+    else
+      ssl_setting_natural_language="enabled"
+      opposite_ssl_setting="false"
+    fi
+    LogUserOutput "
+At the time of creating this restore image Hiback network encryption was
+$ssl_setting_natural_language. If you encounter problems to connect to the
+backup server, change the setting '&ssl-enabled:' in $NBKDC_HIB_DIR/CONDEV on
+this live environment to the opposite '$opposite_ssl_setting'.
+"
+  fi
+}
+
 procpid=$(ps -e | grep rcmd-executor | grep -v grep | awk -F\  '{print $1}')
 rcmdpid=$(cat /var/run/rcmd-executor.pid)
 
@@ -28,7 +58,11 @@ to restore - typically it will be a full backup.
 
 Attention!
 The restore target must be set to '$TARGET_FS_ROOT'.
+"
 
+print_hiback_encryption_help "$NBKDC_HIB_SSL_ENABLED"
+
+LogUserOutput "
 For further documentation see the following link:
 https://support.novastor.com/hc/en-us/
 

--- a/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
@@ -30,21 +30,10 @@ Attention!
 The restore target must be set to '$TARGET_FS_ROOT'.
 
 For further documentation see the following link:
-http://www.novastor.com/help-html/dc/en-US/index.html
+https://support.novastor.com/hc/en-us/
 
 Verify that the backup has been restored correctly to '$TARGET_FS_ROOT'.
 "
-
-#When finished, type 'exit' to continue recovery.
-#"
-
-# Suppress the motd, as it is only confusing at this stage
-#mv /etc/motd ~/.hushlogin
-
-#rear_shell "Did you restore the backup to $TARGET_FS_ROOT ? Are you ready to continue recovery ?"
-
-# Now we can make the motd available for further use
-#mv ~/.hushlogin /etc/motd
 
 user_input_prompt="
 Have you successfully restored the backup to $TARGET_FS_ROOT ?

--- a/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
@@ -37,9 +37,9 @@ rcmdpid=$(cat /var/run/rcmd-executor.pid)
 if [ -e /var/run/rcmd-executor.pid ]; then
     if [ $procpid = $rcmdpid ]; then
         LogPrint "
-NovaBACKUP DataCenter Agent started ..."
+NovaStor DataCenter Agent started ..."
     else
-        Error "NovaBACKUP DataCenter Agent rcmd-executor is NOT running ...
+        Error "NovaStor DataCenter Agent rcmd-executor is NOT running ...
         Please check check the logfiles
         $NBKDC_DIR/log/rcmd-executor.log and
         $NBKDC_DIR/log/rcmd-executor.service.log
@@ -52,7 +52,7 @@ fi
 LogUserOutput "
 The System is now ready for restore.
 Start the restore task from the
-NovaBACKUP DataCenter Central Management.
+NovaStor DataCenter Central Management.
 It is assumed that you know what is necessary
 to restore - typically it will be a full backup.
 

--- a/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NBKDC/default/400_restore_backup.sh
@@ -33,10 +33,7 @@ this live environment to the opposite '$opposite_ssl_setting'.
 
 function rcmd_executor_is_running {
   local procpid=$(ps -e | grep rcmd-executor | grep -v grep | awk -F\  '{print $1}')
-  if [ -n "$procpid" ]; then
-    return 0
-  fi
-  return 1
+  test -n "$procpid" 
 }
 
 function make_sure_rcmd_executor_is_running {


### PR DESCRIPTION
* Type: Bug Fix

Fixes #2518 

* Impact: Normal

* Reference to related issue (URL): https://github.com/rear/rear/issues/2518

* How was this pull request tested?
 + NovaStor development team internal code Review.
 + Developer (me) tested backup and restore of Fedora Workstation 32 and Ubuntu 20.04 VM.
 + NovaStor QA team tested backup and restore of CentOS 7 VM.

* Brief description of the changes in this pull request:

This PR allows ReaR restore with NovaStor DataCenter 8.0 or higher. The NBKDC scripts before, are working only with DataCenter 7.x.

The commit messages contain brief description, what they change.