### PR TITLE
ppc64 support for BACKUP=DP

### DIFF
--- a/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
+++ b/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
@@ -1,6 +1,8 @@
 # 450_check_dp_client_configured.sh
 # this script has a simple goal: check if this client system has been properly
 # configured on the Cell Manager and backed up at least once - no more no less
+# Required Data Protector User Interface only available on i386, x86_64 and ia64
+# Make this work on ppc64 without the User Interface installed
 
 OMNIDB=/opt/omni/bin/omnidb
 OMNIR=/opt/omni/bin/omnir
@@ -10,9 +12,14 @@ Log "Backup method is DP: check Data Protector requirements"
 test -x $VBDA || Error "Cannot execute $VBDA
 Install Data Protector Disk Agent (DA component) on the client."
 
-test -x $OMNIR || Error "Cannot execute $OMNIR
-Install Data Protector User Interface (CC component) on the client."
+if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-x86_64" ] || [ $ARCH == "Linux-ia64" ]; then
+    test -x $OMNIR || Error "Cannot execute $OMNIR
+    Install Data Protector User Interface (CC component) on the client."
 
-$OMNIDB -filesystem | grep $( hostname ) || Error "Data Protector check failed, error code $?.
-Check if the user root is configured in Data Protector UserList and if backups for this client exist in the IDB.
-See $RUNTIME_LOGFILE for more details."
+    $OMNIDB -filesystem | grep $( hostname ) || Error "Data Protector check failed, error code $?.
+    Check if the user root is configured in Data Protector UserList and backups for this client exist in the IDB.
+    See $RUNTIME_LOGFILE for more details."
+else
+    LogPrint "Data Protector User Interface (CC component) not supported on $ARCH."
+    LogPrint "Additional checks skipped. Restore can be done using Data Protector GUI only."
+fi

--- a/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
+++ b/usr/share/rear/prep/DP/default/450_check_dp_client_configured.sh
@@ -12,7 +12,7 @@ Log "Backup method is DP: check Data Protector requirements"
 test -x $VBDA || Error "Cannot execute $VBDA
 Install Data Protector Disk Agent (DA component) on the client."
 
-if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-x86_64" ] || [ $ARCH == "Linux-ia64" ]; then
+if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-ia64" ]; then
     test -x $OMNIR || Error "Cannot execute $OMNIR
     Install Data Protector User Interface (CC component) on the client."
 

--- a/usr/share/rear/restore/DP/default/450_restore_via_gui.sh
+++ b/usr/share/rear/restore/DP/default/450_restore_via_gui.sh
@@ -8,7 +8,7 @@ Log "Request for a manual restore via the GUI"
 LogUserOutput "
 **********************************************************************
 * The Data Protector client is available on the network. Restore a
-* backup from the Data Protector GUI. Make sure you select \"overwrite\"
+* backup from the Data Protector GUI. Make sure you select 'Overwrite'
 * from Destination tab and $TARGET_FS_ROOT as destination.
 *
 * When the restore is complete press ANY key to continue!

--- a/usr/share/rear/restore/DP/default/450_restore_via_gui.sh
+++ b/usr/share/rear/restore/DP/default/450_restore_via_gui.sh
@@ -7,13 +7,13 @@ Log "Request for a manual restore via the GUI"
 
 LogUserOutput "
 **********************************************************************
-**  Please try to restore the backup from Data Protector GUI!
-**  Make sure you select \"overwrite\" (destination tab) and make the
-**  new destination $TARGET_FS_ROOT.
-**  When the restore is complete press ANY key to continue!
+* The Data Protector client is available on the network. Restore a
+* backup from the Data Protector GUI. Make sure you select \"overwrite\"
+* from Destination tab and $TARGET_FS_ROOT as destination.
+*
+* When the restore is complete press ANY key to continue!
 **********************************************************************
 "
 # Use the original STDIN STDOUT and STDERR when 'rear' was launched by the user
 # because 'read' outputs non-error stuff also to STDERR (e.g. its prompt):
 read answer 0<&6 1>&7 2>&8
-

--- a/usr/share/rear/verify/DP/default/400_verify_dp.sh
+++ b/usr/share/rear/verify/DP/default/400_verify_dp.sh
@@ -8,7 +8,7 @@ CELL_SERVER="$( cat /etc/opt/omni/client/cell_server )"
 
 OMNICHECK=/opt/omni/bin/omnicheck
 
-if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-x86_64" ] || [ $ARCH == "Linux-ia64" ]; then
+if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-ia64" ]; then
     # check that the Cell Manager is responding on the INET port
     ${OMNICHECK} -patches -host ${CELL_SERVER} || Error "Data Protector Cell Manager is not responding, error code $?.
     See $RUNTIME_LOGFILE for more details."

--- a/usr/share/rear/verify/DP/default/400_verify_dp.sh
+++ b/usr/share/rear/verify/DP/default/400_verify_dp.sh
@@ -6,9 +6,9 @@
 test -s /etc/opt/omni/client/cell_server || Error "Data Protector Cell Manager not configured in /etc/opt/omni/client/cell_server"
 CELL_SERVER="$( cat /etc/opt/omni/client/cell_server )"
 
-if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-x86_64" ] || [ $ARCH == "Linux-ia64" ]; then
-    OMNICHECK=/opt/omni/bin/omnicheck
+OMNICHECK=/opt/omni/bin/omnicheck
 
+if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-x86_64" ] || [ $ARCH == "Linux-ia64" ]; then
     # check that the Cell Manager is responding on the INET port
     ${OMNICHECK} -patches -host ${CELL_SERVER} || Error "Data Protector Cell Manager is not responding, error code $?.
     See $RUNTIME_LOGFILE for more details."

--- a/usr/share/rear/verify/DP/default/400_verify_dp.sh
+++ b/usr/share/rear/verify/DP/default/400_verify_dp.sh
@@ -6,7 +6,10 @@
 test -s /etc/opt/omni/client/cell_server || Error "Data Protector Cell Manager not configured in /etc/opt/omni/client/cell_server"
 CELL_SERVER="$( cat /etc/opt/omni/client/cell_server )"
 
-OMNICHECK=/opt/omni/bin/omnicheck
-# check that the Cell Manager is responding on the INET port
-${OMNICHECK} -patches -host ${CELL_SERVER} || Error "Data Protector Cell Manager is not responding, error code $?.
-See $RUNTIME_LOGFILE for more details."
+if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-x86_64" ] || [ $ARCH == "Linux-ia64" ]; then
+    OMNICHECK=/opt/omni/bin/omnicheck
+
+    # check that the Cell Manager is responding on the INET port
+    ${OMNICHECK} -patches -host ${CELL_SERVER} || Error "Data Protector Cell Manager is not responding, error code $?.
+    See $RUNTIME_LOGFILE for more details."
+fi

--- a/usr/share/rear/verify/DP/default/450_request_gui_restore.sh
+++ b/usr/share/rear/verify/DP/default/450_request_gui_restore.sh
@@ -6,7 +6,7 @@
 # ensure the flag DP GUI restore request does not exists
 rm -f $TMP_DIR/DP_GUI_RESTORE
 
-if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-x86_64" ] || [ $ARCH == "Linux-ia64" ]; then
+if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-ia64" ]; then
     unset REPLY
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
     # to get input from the user and to show output to the user (cf. _input-output-functions.sh):

--- a/usr/share/rear/verify/DP/default/450_request_gui_restore.sh
+++ b/usr/share/rear/verify/DP/default/450_request_gui_restore.sh
@@ -6,12 +6,18 @@
 # ensure the flag DP GUI restore request does not exists
 rm -f $TMP_DIR/DP_GUI_RESTORE
 
-unset REPLY
-# Use the original STDIN STDOUT and STDERR when rear was launched by the user
-# to get input from the user and to show output to the user (cf. _input-output-functions.sh):
-read -t $WAIT_SECS -r -n 1 -p "press 'G' to fall back to Data Protector GUI-based restore [$WAIT_SECS secs]: " 0<&6 1>&7 2>&8
+if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-x86_64" ] || [ $ARCH == "Linux-ia64" ]; then
+    unset REPLY
+    # Use the original STDIN STDOUT and STDERR when rear was launched by the user
+    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    read -t $WAIT_SECS -r -n 1 -p "press 'G' to fall back to Data Protector GUI-based restore [$WAIT_SECS secs]: " 0<&6 1>&7 2>&8
 
-if test "$REPLY" = "g" -o "$REPLY" = "G" ; then
-    Log "Data Protector GUI restore requested"
+    if test "$REPLY" = "g" -o "$REPLY" = "G" ; then
+        Log "Data Protector GUI restore requested"
+        > $TMP_DIR/DP_GUI_RESTORE
+    fi
+else
+    LogPrint "Data Protector User Interface (CC component) not supported on $ARCH."
+    LogPrint "Additional checks skipped. Restore can be done using Data Protector GUI only."
     > $TMP_DIR/DP_GUI_RESTORE
 fi


### PR DESCRIPTION
Type: Enhancement

Impact: High
Other platforms supporting the Data Protector Disk Agent, but not the Cell Console (GUI), will be supported with REAR and BACKUP=DP. This includes ppc64.

Reference to related issue (URL):
none

How was this pull request tested?
Applied the changes to a SLES15 SP1 system running rear 2.6.1. Created a new ISO, booted the system and ran through various test cases.

Brief description of the changes in this pull request:
Relevant checks unavailable on clients without the Data Protector Cell Console (GUI) are skipped. Restore defaults to external Data Protector GUI restore.