### PR TITLE
ISO_FILE_SIZE_LIMIT: provide final power to the user to skip the ISO_FILE_SIZE_LIMIT test

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -746,8 +746,10 @@ ISO_MAX_SIZE=
 # that could let booting or running the recovery system fail because
 # a recovery system in a 2GiB or bigger compressed initrd will need
 # more memory space when uncompressed and running in the ramdisk.
-# So we error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO.
-# 2 GiB =  2 * 1024 * 1024 * 1024 bytes = 2147483648 bytes:
+# By default we error out when files greater or equal ISO_FILE_SIZE_LIMIT should be
+# included in the ISO but if really needed this ISO_FILE_SIZE_LIMIT test
+# can be skipped with ISO_FILE_SIZE_LIMIT=0 in etc/rear/local.conf
+# (2 GiB =  2 * 1024 * 1024 * 1024 bytes = 2147483648 bytes):
 ISO_FILE_SIZE_LIMIT=2147483648
 #
 # How to find mkisofs:

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -723,10 +723,9 @@ ISO_MAX_SIZE=
 # Error out when files greater or equal ISO_FILE_SIZE_LIMIT should be included in the ISO.
 # There is a limit of the ISO 9660 file system that is 2GiB or 4GiB according to
 # https://en.wikipedia.org/wiki/ISO_9660#The_2/4_GiB_file_size_limit
-# Usually 'mkisofs' is called with '-udf -allow-limited-size'
+# Usually 'mkisofs' is called with '-iso-level 3'
 # cf. usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
-# but only if the '--help' output of ISO_MKISOFS_BIN shows '-allow-limited-size'
-# so there are cases where ISO 9660 level 1 or 2 is used that has a 2GiB file size limit.
+# but there are cases where ISO 9660 level 1 or 2 is used that has a 2GiB file size limit.
 # For example when 'ebiso' is used there is a 2GiB file size limit
 # cf. https://github.com/gozora/ebiso/issues/12
 # but also other tools that are specified by ISO_MKISOFS_BIN could have that limit.

--- a/usr/share/rear/lib/output-functions.sh
+++ b/usr/share/rear/lib/output-functions.sh
@@ -39,8 +39,8 @@ function FindUsbDevices () {
 # this should be sufficient because more than one file greater or equal ISO_FILE_SIZE_LIMIT is not expected
 # and the "assert" meaning is that this error exit is there only as safeguard for exceptional cases.
 function assert_ISO_FILE_SIZE_LIMIT () {
-    # Use fallback ISO_FILE_SIZE_LIMIT 2GiB (2147483648 bytes) if not set (cf. default.conf):
-    is_positive_integer $ISO_FILE_SIZE_LIMIT || ISO_FILE_SIZE_LIMIT=2147483648
+    # Skip when there is no usable ISO_FILE_SIZE_LIMIT set:
+    is_positive_integer $ISO_FILE_SIZE_LIMIT || return 0
     local file_for_iso file_for_iso_size
     for file_for_iso in $@ ; do
         file_for_iso_size=$( stat -L -c '%s' $file_for_iso )

--- a/usr/share/rear/lib/output-functions.sh
+++ b/usr/share/rear/lib/output-functions.sh
@@ -39,7 +39,7 @@ function FindUsbDevices () {
 # this should be sufficient because more than one file greater or equal ISO_FILE_SIZE_LIMIT is not expected
 # and the "assert" meaning is that this error exit is there only as safeguard for exceptional cases.
 function assert_ISO_FILE_SIZE_LIMIT () {
-    # Skip when there is no usable ISO_FILE_SIZE_LIMIT set:
+    # Skip when there is no usable ISO_FILE_SIZE_LIMIT set (in particular for ISO_FILE_SIZE_LIMIT=0):
     is_positive_integer $ISO_FILE_SIZE_LIMIT || return 0
     local file_for_iso file_for_iso_size
     for file_for_iso in $@ ; do

--- a/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
+++ b/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
@@ -11,10 +11,11 @@ DebugPrint "Using '$ISO_MKISOFS_BIN' to create ISO filesystem images"
 # Include 'udf' module which is required if backup archive is >= 4GiB and mkisofs/genisoimage is used:
 IsInArray "all_modules" "${MODULES[@]}" || MODULES+=( udf )
 # Enforce 2GiB ISO_FILE_SIZE_LIMIT when the MODULES array contains 'loaded_modules'
-# because MODULES+=( udf ) has no effect in this case unless it is loaded (which normally isn't)
+# because in this case MODULES+=( udf ) has no effect (unless it is loaded which normally isn't)
 # except the user has specified to skip the ISO_FILE_SIZE_LIMIT test with ISO_FILE_SIZE_LIMIT=0
+# but keep what the user has specified if ISO_FILE_SIZE_LIMIT is specified less than 2GiB:
 if IsInArray "loaded_modules" "${MODULES[@]}" ; then
-    if is_positive_integer $ISO_FILE_SIZE_LIMIT ; then
+    if is_positive_integer $ISO_FILE_SIZE_LIMIT && test $ISO_FILE_SIZE_LIMIT -gt 2147483648 ; then
         DebugPrint "Enforcing 2GiB ISO_FILE_SIZE_LIMIT (MODULES contains 'loaded_modules')"
         ISO_FILE_SIZE_LIMIT=2147483648
     fi

--- a/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
+++ b/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
@@ -10,6 +10,15 @@ DebugPrint "Using '$ISO_MKISOFS_BIN' to create ISO filesystem images"
 
 # Include 'udf' module which is required if backup archive is >= 4GiB and mkisofs/genisoimage is used:
 IsInArray "all_modules" "${MODULES[@]}" || MODULES+=( udf )
+# Enforce 2GiB ISO_FILE_SIZE_LIMIT when the MODULES array contains 'loaded_modules'
+# because MODULES+=( udf ) has no effect in this case unless it is loaded (which normally isn't)
+# except the user has specified to skip the ISO_FILE_SIZE_LIMIT test with ISO_FILE_SIZE_LIMIT=0
+if IsInArray "loaded_modules" "${MODULES[@]}" ; then
+    if is_positive_integer $ISO_FILE_SIZE_LIMIT ; then
+        DebugPrint "Enforcing 2GiB ISO_FILE_SIZE_LIMIT (MODULES contains 'loaded_modules')"
+        ISO_FILE_SIZE_LIMIT=2147483648
+    fi
+fi
 # "man mkisofs" (at least on SLES12-SP5 for /usr/bin/mkisofs from the cdrkit-cdrtools-compat RPM) reads (excerpts):
 #   -allow-limited-size
 #     When processing files larger than 2GiB which cannot be represented in ISO9660 level 1 or 2,

--- a/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
+++ b/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
@@ -50,10 +50,13 @@ if $ISO_MKISOFS_BIN --help 2>&1 >/dev/null | grep -qw -- -allow-limited-size ; t
     ISO_MKISOFS_OPTS+=" -allow-limited-size"
 fi
 
-# ebiso has a 2GiB file size limit
-# cf. https://github.com/gozora/ebiso/issues/12
-# so ISO_FILE_SIZE_LIMIT must not be greater than 2GiB
+# ebiso has a 2GiB file size limit cf. https://github.com/gozora/ebiso/issues/12
+# so an actual ISO_FILE_SIZE_LIMIT value must be set that is not greater than 2GiB:
 if test "ebiso" = "$( basename $ISO_MKISOFS_BIN )" ; then
+    # For ebiso the ISO_FILE_SIZE_LIMIT test must not be skipped with ISO_FILE_SIZE_LIMIT=0
+    # because it would be disastrous when e.g. a backup.tar.gz in the ISO becomes bigger than 2GiB
+    # that gets corrupted in the ISO so the backup is lost and restore via "rear recover" cannot work:
+    is_positive_integer $ISO_FILE_SIZE_LIMIT || Error "ebiso has a 2GiB file size limit but ISO_FILE_SIZE_LIMIT is not set accordingly"
     # 2 GiB =  2 * 1024 * 1024 * 1024 bytes = 2147483648 bytes:
     test $ISO_FILE_SIZE_LIMIT -le 2147483648 || Error "ebiso has a 2GiB file size limit but ISO_FILE_SIZE_LIMIT is greater than 2GiB"
 fi

--- a/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
+++ b/usr/share/rear/prep/ISO/GNU/Linux/320_verify_mkisofs.sh
@@ -13,7 +13,10 @@ IsInArray "all_modules" "${MODULES[@]}" || MODULES+=( udf )
 # Enforce 2GiB ISO_FILE_SIZE_LIMIT when the MODULES array contains 'loaded_modules'
 # because in this case MODULES+=( udf ) has no effect (unless it is loaded which normally isn't)
 # except the user has specified to skip the ISO_FILE_SIZE_LIMIT test with ISO_FILE_SIZE_LIMIT=0
-# but keep what the user has specified if ISO_FILE_SIZE_LIMIT is specified less than 2GiB:
+# but keep what the user has specified if ISO_FILE_SIZE_LIMIT is specified less than 2GiB.
+# Do nothing when the MODULES array contains 'no_modules' because that is meant for experts usually
+# when they have all needed modules (they have to know what they need) compiled into their kernel
+# (in default.conf a 2GiB ISO_FILE_SIZE_LIMIT is set so by default things should behave safe):
 if IsInArray "loaded_modules" "${MODULES[@]}" ; then
     if is_positive_integer $ISO_FILE_SIZE_LIMIT && test $ISO_FILE_SIZE_LIMIT -gt 2147483648 ; then
         DebugPrint "Enforcing 2GiB ISO_FILE_SIZE_LIMIT (MODULES contains 'loaded_modules')"


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2525

* How was this pull request tested?
See https://github.com/rear/rear/pull/2533#issuecomment-738034862

* Brief description of the changes in this pull request:

Skip the assert_ISO_FILE_SIZE_LIMIT function
when there is no usable ISO_FILE_SIZE_LIMIT set
so the user could specify `ISO_FILE_SIZE_LIMIT=0`
or `ISO_FILE_SIZE_LIMIT="no"` in his etc/rear/local.conf
if he wants to skip the ISO_FILE_SIZE_LIMIT test.