### PR TITLE
#2152: make bacula aware of different location of config files

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1947,7 +1947,15 @@ COPY_AS_IS_EXCLUDE_SESAM=()
 ##
 # BACKUP=BACULA stuff (www.bacula.org stuff)
 ##
-COPY_AS_IS_BACULA=( /etc/bacula /var/spool/bacula )
+# If empty BACULA_CONF_DIR and BACULA_BIN_DIR
+# are automatically set in prep/BACULA/default/400_prep_bacula.sh
+# Usually BACULA_CONF_DIR is "/etc/bacula"
+# but for bacula-enterprise-client it is "/opt/bacula/etc"
+# Usually BACULA_BIN_DIR is "/usr/sbin"
+# but for bacula-enterprise-client it is "/opt/bacula/bin"
+BACULA_CONF_DIR=""
+BACULA_BIN_DIR=""
+COPY_AS_IS_BACULA=( /var/spool/bacula )
 COPY_AS_IS_EXCLUDE_BACULA=( /var/lib/bacula )
 PROGS_BACULA=( bacula-fd bconsole bacula-console bextract bls bscan btape smartctl )
 # Provide the (possible) volume labels to restore from using bextract.

--- a/usr/share/rear/prep/BACULA/default/400_prep_bacula.sh
+++ b/usr/share/rear/prep/BACULA/default/400_prep_bacula.sh
@@ -2,7 +2,7 @@
 if ! test -d "$BACULA_CONF_DIR" ; then
     test -d "/etc/bacula" && BACULA_CONF_DIR="/etc/bacula"
     # bacula-enterprise-client uses /opt/bacula/etc
-    test -d "/opt/bacula/etc" && BACULA_CONFIG_DIR="/opt/bacula/etc"
+    test -d "/opt/bacula/etc" && BACULA_CONF_DIR="/opt/bacula/etc"
 fi
 test -d "$BACULA_CONF_DIR" || Error "No BACULA_CONF_DIR"
 if ! test -d "$BACULA_BIN_DIR" ; then

--- a/usr/share/rear/prep/BACULA/default/400_prep_bacula.sh
+++ b/usr/share/rear/prep/BACULA/default/400_prep_bacula.sh
@@ -11,9 +11,9 @@ if ! test -d "$BACULA_BIN_DIR" ; then
     test -d "/opt/bacula/bin" && BACULA_BIN_DIR="/opt/bacula/bin"
 fi
 export PATH=$PATH:$BACULA_BIN_DIR
-CLONE_GROUPS+=( bacula )
-COPY_AS_IS+=( "${COPY_AS_IS_BACULA[@]}" )
+CLONE_GROUPS+=( bacula ) # default CLONE_ALL_USERS_GROUPS="true" in default.conf, but just in case...
 COPY_AS_IS_BACULA+=( $BACULA_CONF_DIR )
+COPY_AS_IS+=( "${COPY_AS_IS_BACULA[@]}" )
 COPY_AS_IS_EXCLUDE+=( "${COPY_AS_IS_EXCLUDE_BACULA[@]}" )
 PROGS+=( "${PROGS_BACULA[@]}" )
 

--- a/usr/share/rear/prep/BACULA/default/400_prep_bacula.sh
+++ b/usr/share/rear/prep/BACULA/default/400_prep_bacula.sh
@@ -1,6 +1,19 @@
 ### prepare stuff for BACULA
+if ! test -d "$BACULA_CONF_DIR" ; then
+    test -d "/etc/bacula" && BACULA_CONF_DIR="/etc/bacula"
+    # bacula-enterprise-client uses /opt/bacula/etc
+    test -d "/opt/bacula/etc" && BACULA_CONFIG_DIR="/opt/bacula/etc"
+fi
+test -d "$BACULA_CONF_DIR" || Error "No BACULA_CONF_DIR"
+if ! test -d "$BACULA_BIN_DIR" ; then
+    BACULA_BIN_DIR="/usr/sbin"
+    # bacula-enterprise-client uses /opt/bacula/bin
+    test -d "/opt/bacula/bin" && BACULA_BIN_DIR="/opt/bacula/bin"
+fi
+export PATH=$PATH:$BACULA_BIN_DIR
 CLONE_GROUPS+=( bacula )
 COPY_AS_IS+=( "${COPY_AS_IS_BACULA[@]}" )
+COPY_AS_IS_BACULA+=( $BACULA_CONF_DIR )
 COPY_AS_IS_EXCLUDE+=( "${COPY_AS_IS_EXCLUDE_BACULA[@]}" )
 PROGS+=( "${PROGS_BACULA[@]}" )
 

--- a/usr/share/rear/prep/BACULA/default/450_check_BACULA_client_configured.sh
+++ b/usr/share/rear/prep/BACULA/default/450_check_BACULA_client_configured.sh
@@ -7,7 +7,7 @@ if [ "$BEXTRACT_DEVICE" -o "$BEXTRACT_VOLUME" ]; then
    has_binary bextract
    StopIfError "Bacula bextract is missing"
 
-   [ -s /etc/bacula/bacula-sd.conf ]
+   [ -s $BACULA_CONF_DIR/bacula-sd.conf ]
    StopIfError "Bacula configuration file (bacula-sd.conf) missing"
 
 else
@@ -16,13 +16,13 @@ else
    has_binary bacula-fd
    StopIfError "Bacula File Daemon is missing"
 
-   [ -s /etc/bacula/bacula-fd.conf ]
+   [ -s $BACULA_CONF_DIR/bacula-fd.conf ]
    StopIfError "Bacula configuration file (bacula-fd.conf) missing"
 
    has_binary bconsole
    StopIfError "Bacula console executable is missing"
 
-   [ -s /etc/bacula/bconsole.conf ]
+   [ -s $BACULA_CONF_DIR/bconsole.conf ]
    StopIfError "Bacula configuration file (bconsole.conf) missing"
 
 fi

--- a/usr/share/rear/prep/BACULA/default/450_check_BACULA_client_configured.sh
+++ b/usr/share/rear/prep/BACULA/default/450_check_BACULA_client_configured.sh
@@ -4,25 +4,19 @@
 if [ "$BEXTRACT_DEVICE" -o "$BEXTRACT_VOLUME" ]; then
 
    ### Bacula support using bextract
-   has_binary bextract
-   StopIfError "Bacula bextract is missing"
+   has_binary bextract || Error "Bacula bextract is missing"
 
-   [ -s $BACULA_CONF_DIR/bacula-sd.conf ]
-   StopIfError "Bacula configuration file (bacula-sd.conf) missing"
+   [ -s $BACULA_CONF_DIR/bacula-sd.conf ] || Error "Bacula configuration file (bacula-sd.conf) missing"
 
 else
 
    ### Bacula support using bconsole
-   has_binary bacula-fd
-   StopIfError "Bacula File Daemon is missing"
+   has_binary bacula-fd || Error "Bacula File Daemon is missing"
 
-   [ -s $BACULA_CONF_DIR/bacula-fd.conf ]
-   StopIfError "Bacula configuration file (bacula-fd.conf) missing"
+   [ -s $BACULA_CONF_DIR/bacula-fd.conf ] || Error "Bacula configuration file (bacula-fd.conf) missing"
 
-   has_binary bconsole
-   StopIfError "Bacula console executable is missing"
+   has_binary bconsole || Error "Bacula console executable is missing"
 
-   [ -s $BACULA_CONF_DIR/bconsole.conf ]
-   StopIfError "Bacula configuration file (bconsole.conf) missing"
+   [ -s $BACULA_CONF_DIR/bconsole.conf ] || Error "Bacula configuration file (bconsole.conf) missing"
 
 fi

--- a/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
+++ b/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
@@ -15,12 +15,6 @@ fi
 BACULA_DIRECTOR=$(grep -i address $BACULA_CONF_DIR/bconsole.conf | awk '{ print $3 }')
 [ "${BACULA_DIRECTOR}" ] || Error "Director not defined in $BACULA_CONF_DIR/bconsole.conf"
 
-if test "$PING"; then
-	ping -c 2 -q  $BACULA_DIRECTOR >/dev/null || Error "Backup host [$BACULA_DIRECTOR] not reachable."
-else
-	Log "Skipping ping test"
-fi
-
 # does the director allow connections from this client? bconsole knows!
 #
 # We want these two lines to show that we can connect to the director

--- a/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
+++ b/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
@@ -29,11 +29,11 @@ fi
 # and that the director can connect to the file daemon on this system.
 # "Connecting to Director 'director_name-fd:9101'"
 # "Connecting to Client 'bacula_client_name-fd at FQDN:9102"
-BACULA_CLIENT=`grep $(hostname -s) $BACULA_CONF_DIR/bacula-fd.conf | grep "\-fd" | awk '{print $3}' | sed -e "s/-fd//g"`
+BACULA_CLIENT=$(grep $(hostname -s) $BACULA_CONF_DIR/bacula-fd.conf | grep "\-fd" | awk '{print $3}' | sed -e "s/-fd//g")
 [ "${BACULA_CLIENT}" ]
 StopIfError "Client $(hostname -s) not defined in $BACULA_CONF_DIR/bacula-fd.conf"
 
-BACULA_RESULT=( `echo -e " status client=${BACULA_CLIENT}-fd" | bconsole | grep Connect ` )
+BACULA_RESULT=( $(echo -e " status client=${BACULA_CLIENT}-fd" | bconsole | grep Connect) )
 
 director=${BACULA_RESULT[3]}
 client=${BACULA_RESULT[9]}

--- a/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
+++ b/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
@@ -13,12 +13,10 @@ fi
 #
 # is the director server present? Fetch from $BACULA_CONF_DIR/bconsole.conf file
 BACULA_DIRECTOR=$(grep -i address $BACULA_CONF_DIR/bconsole.conf | awk '{ print $3 }')
-[ "${BACULA_DIRECTOR}" ]
-StopIfError "Director not defined in $BACULA_CONF_DIR/bconsole.conf"
+[ "${BACULA_DIRECTOR}" ] || Error "Director not defined in $BACULA_CONF_DIR/bconsole.conf"
 
 if test "$PING"; then
-	ping -c 2 -q  $BACULA_DIRECTOR >/dev/null
-	StopIfError "Backup host [$BACULA_DIRECTOR] not reachable."
+	ping -c 2 -q  $BACULA_DIRECTOR >/dev/null || Error "Backup host [$BACULA_DIRECTOR] not reachable."
 else
 	Log "Skipping ping test"
 fi
@@ -30,18 +28,15 @@ fi
 # "Connecting to Director 'director_name-fd:9101'"
 # "Connecting to Client 'bacula_client_name-fd at FQDN:9102"
 BACULA_CLIENT=$(grep $(hostname -s) $BACULA_CONF_DIR/bacula-fd.conf | grep "\-fd" | awk '{print $3}' | sed -e "s/-fd//g")
-[ "${BACULA_CLIENT}" ]
-StopIfError "Client $(hostname -s) not defined in $BACULA_CONF_DIR/bacula-fd.conf"
+[ "${BACULA_CLIENT}" ] || Error "Client $(hostname -s) not defined in $BACULA_CONF_DIR/bacula-fd.conf"
 
 BACULA_RESULT=( $(echo -e " status client=${BACULA_CLIENT}-fd" | bconsole | grep Connect) )
 
 director=${BACULA_RESULT[3]}
 client=${BACULA_RESULT[9]}
 
-[ "$director" ]
-StopIfError "Bacula director not reachable."
+[ "$director" ] || Error "Bacula director not reachable."
 
-[ "$client" ]
-StopIfError "Bacula client status unknown on director."
+[ "$client" ] || Error "Bacula client status unknown on director."
 
 Log "Bacula director = $director, client = $client"

--- a/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
+++ b/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
@@ -15,6 +15,12 @@ fi
 BACULA_DIRECTOR=$(grep -i address $BACULA_CONF_DIR/bconsole.conf | awk '{ print $3 }')
 [ "${BACULA_DIRECTOR}" ] || Error "Director not defined in $BACULA_CONF_DIR/bconsole.conf"
 
+# check if the director is responding?
+if has_binary nc; then
+   DIRECTOR_RESULT=$(nc -vz "${BACULA_DIRECTOR}" 9101 2>&1 | grep -i connected | wc -l)
+   [[ $DIRECTOR_RESULT -eq 0 ]] && Error "Bacula director ${BACULA_DIRECTOR} is not responding."
+fi
+
 # does the director allow connections from this client? bconsole knows!
 #
 # We want these two lines to show that we can connect to the director

--- a/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
+++ b/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
@@ -11,10 +11,10 @@ fi
 #
 # See if we can ping the director
 #
-# is the director server present? Fetch from /etc/bacula/bconsole.conf file
-BACULA_DIRECTOR=$(grep -i address /etc/bacula/bconsole.conf | awk '{ print $3 }')
+# is the director server present? Fetch from $BACULA_CONF_DIR/bconsole.conf file
+BACULA_DIRECTOR=$(grep -i address $BACULA_CONF_DIR/bconsole.conf | awk '{ print $3 }')
 [ "${BACULA_DIRECTOR}" ]
-StopIfError "Director not defined in /etc/bacula/bconsole.conf"
+StopIfError "Director not defined in $BACULA_CONF_DIR/bconsole.conf"
 
 if test "$PING"; then
 	ping -c 2 -q  $BACULA_DIRECTOR >/dev/null
@@ -29,11 +29,11 @@ fi
 # and that the director can connect to the file daemon on this system.
 # "Connecting to Director 'director_name-fd:9101'"
 # "Connecting to Client 'bacula_client_name-fd at FQDN:9102"
-BACULA_CLIENT=`grep $(hostname -s) /etc/bacula/bacula-fd.conf | grep "\-fd" | awk '{print $3}' | sed -e "s/-fd//g"`
+BACULA_CLIENT=`grep $(hostname -s) $BACULA_CONF_DIR/bacula-fd.conf | grep "\-fd" | awk '{print $3}' | sed -e "s/-fd//g"`
 [ "${BACULA_CLIENT}" ]
-StopIfError "Client $(hostname -s) not defined in /etc/bacula/bacula-fd.conf"
+StopIfError "Client $(hostname -s) not defined in $BACULA_CONF_DIR/bacula-fd.conf"
 
-BACULA_RESULT=( `echo -e " status client=${BACULA_CLIENT}-fd" | bconsole |grep Connect ` )
+BACULA_RESULT=( `echo -e " status client=${BACULA_CLIENT}-fd" | bconsole | grep Connect ` )
 
 director=${BACULA_RESULT[3]}
 client=${BACULA_RESULT[9]}

--- a/usr/share/rear/prep/OBDR/BACULA/default/030_bextract_tape_device.sh
+++ b/usr/share/rear/prep/OBDR/BACULA/default/030_bextract_tape_device.sh
@@ -13,6 +13,5 @@ if [[ -z "$TAPE_DEVICE" && "$BEXTRACT_DEVICE" ]]; then
 
     TAPE_DEVICE="$(echo cap | btape $BEXTRACT_DEVICE | awk '/^Device name/ { print $3 }')"
 
-    [[ "$TAPE_DEVICE" ]]
-    StopIfError "Either tape device $BEXTRACT_DEVICE is missing, or it has no tape inserted."
+    [[ "$TAPE_DEVICE" ]] || Error "Either tape device $BEXTRACT_DEVICE is missing, or it has no tape inserted."
 fi

--- a/usr/share/rear/verify/BACULA/default/050_check_requirements.sh
+++ b/usr/share/rear/verify/BACULA/default/050_check_requirements.sh
@@ -10,25 +10,19 @@ if [ "$BEXTRACT_DEVICE" -o "$BEXTRACT_VOLUME" ]; then
       BEXTRACT_VOLUME=*
    fi
 
-   [ -x $BACULA_BIN_DIR/bextract ]
-   StopIfError "Bacula executable (bextract) missing or not executable"
+   [ -x $BACULA_BIN_DIR/bextract ] || Error "Bacula executable (bextract) missing or not executable"
 
-   [ -s $BACULA_CONF_DIR/bacula-sd.conf ]
-   StopIfError "Bacula configuration file (bacula-sd.conf) missing"
+   [ -s $BACULA_CONF_DIR/bacula-sd.conf ] || Error "Bacula configuration file (bacula-sd.conf) missing"
 
 else
 
    ### Bacula support using bconsole
-   [ -x $BACULA_BIN_DIR/bacula-fd ]
-   StopIfError "Bacula executable (bacula-fd) missing or not executable"
+   [ -x $BACULA_BIN_DIR/bacula-fd ] || Error "Bacula executable (bacula-fd) missing or not executable"
 
-   [ -s $BACULA_CONF_DIR/bacula-fd.conf ]
-   StopIfError "Bacula configuration file (bacula-fd.conf) missing"
+   [ -s $BACULA_CONF_DIR/bacula-fd.conf ] || Error "Bacula configuration file (bacula-fd.conf) missing"
 
-   [ -x $BACULA_BIN_DIR/bconsole ]
-   StopIfError "Bacula executable (bconsole) missing or not executable"
+   [ -x $BACULA_BIN_DIR/bconsole ] || Error "Bacula executable (bconsole) missing or not executable"
 
-   [ -s $BACULA_CONF_DIR/bconsole.conf ]
-   StopIfError "Bacula configuration file (bconsole.conf) missing"
+   [ -s $BACULA_CONF_DIR/bconsole.conf ] || Error "Bacula configuration file (bconsole.conf) missing"
 
 fi

--- a/usr/share/rear/verify/BACULA/default/050_check_requirements.sh
+++ b/usr/share/rear/verify/BACULA/default/050_check_requirements.sh
@@ -10,25 +10,25 @@ if [ "$BEXTRACT_DEVICE" -o "$BEXTRACT_VOLUME" ]; then
       BEXTRACT_VOLUME=*
    fi
 
-   [ -x /usr/sbin/bextract ]
+   [ -x $BACULA_BIN_DIR/bextract ]
    StopIfError "Bacula executable (bextract) missing or not executable"
 
-   [ -s /etc/bacula/bacula-sd.conf ]
+   [ -s $BACULA_CONF_DIR/bacula-sd.conf ]
    StopIfError "Bacula configuration file (bacula-sd.conf) missing"
 
 else
 
    ### Bacula support using bconsole
-   [ -x /usr/sbin/bacula-fd ]
+   [ -x $BACULA_BIN_DIR/bacula-fd ]
    StopIfError "Bacula executable (bacula-fd) missing or not executable"
 
-   [ -s /etc/bacula/bacula-fd.conf ]
+   [ -s $BACULA_CONF_DIR/bacula-fd.conf ]
    StopIfError "Bacula configuration file (bacula-fd.conf) missing"
 
-   [ -x /usr/sbin/bconsole ]
+   [ -x $BACULA_BIN_DIR/bconsole ]
    StopIfError "Bacula executable (bconsole) missing or not executable"
 
-   [ -s /etc/bacula/bconsole.conf ]
+   [ -s $BACULA_CONF_DIR/bconsole.conf ]
    StopIfError "Bacula configuration file (bconsole.conf) missing"
 
 fi

--- a/usr/share/rear/verify/BACULA/default/100_start_bacula-fd.sh
+++ b/usr/share/rear/verify/BACULA/default/100_start_bacula-fd.sh
@@ -13,7 +13,7 @@ if [ "$BEXTRACT_DEVICE" -o "$BEXTRACT_VOLUME" ]; then
 else
 
    ### Bacula support using bconsole
-   bacula-fd -u root -g bacula -c /etc/bacula/bacula-fd.conf
+   bacula-fd -u root -g bacula -c $BACULA_CONF_DIR/bacula-fd.conf
    StopIfError "Cannot start bacula-fd file daemon"
 
 fi

--- a/usr/share/rear/verify/BACULA/default/100_start_bacula-fd.sh
+++ b/usr/share/rear/verify/BACULA/default/100_start_bacula-fd.sh
@@ -6,14 +6,12 @@ if [ "$BEXTRACT_DEVICE" -o "$BEXTRACT_VOLUME" ]; then
    ### Bacula support using bextract
    if [ -b "$BEXTRACT_DEVICE" ]; then
       mkdir -p /backup
-      mount $BEXTRACT_DEVICE /backup
-      StopIfError "Could not mount Bacula device $BACULA_DEVICE at /backup"
+      mount $BEXTRACT_DEVICE /backup || Error "Could not mount Bacula device $BACULA_DEVICE at /backup"
    fi
 
 else
 
    ### Bacula support using bconsole
-   bacula-fd -u root -g bacula -c $BACULA_CONF_DIR/bacula-fd.conf
-   StopIfError "Cannot start bacula-fd file daemon"
+   bacula-fd -u root -g bacula -c $BACULA_CONF_DIR/bacula-fd.conf || Error "Cannot start bacula-fd file daemon"
 
 fi


### PR DESCRIPTION
Signed-off-by: Gratien Dhaese <gratien.dhaese@gmail.com>

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): #2152 

* How was this pull request tested? Not yet tested - waiting on Bacula user to do that for us

* Brief description of the changes in this pull request: The Enterprise Bacula uses different locations for keeping the configuration files than the community version of Bacula, hence, the enhancement to detect the correct location via preparation flow.

