### PR TITLE
RAWDISK: Add local rescue partition installation capability

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -985,6 +985,16 @@ RAWDISK_BOOT_EXCLUDE_SYSLINUX_LEGACY='no'
 RAWDISK_BOOT_EXCLUDE_SYSLINUX_EFI='no'
 RAWDISK_BOOT_EXCLUDE_GRUB2_EFI='no'
 #
+# Name of local disk GPT partition(s) receiving an UEFI rescue system
+# If this variable is non-empty, 'rear mkrescue' will, in addition to its regular output,
+# install the rescue/recovery system to local GPT partitions with the specified name.
+# (A partition name can be set by sgdisk(8) with its '--change-name' option.)
+# The installation will only proceed with an UEFI bootloader and only on target partitions which
+# (a) are either empty or contain a VFAT file system, and
+# (b) are not currently mounted.
+# It is the user's responsibility to create appropriate boot entries, e.g. via efibootmgr(8).
+RAWDISK_INSTALL_GPT_PARTITION_NAME=''
+#
 # Set RAWDISK_DEBUG to 'yes' to drop into a shell as soon as the boot image is finished.
 # The image's partitions are still mounted at this stage and can be examined. The
 # ReaR workflow continues when exiting the shell.

--- a/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
@@ -197,13 +197,13 @@ if [[ -n "$RAWDISK_BOOT_EFI_STAGING_ROOT" && -n "$RAWDISK_INSTALL_GPT_PARTITION_
     for install_partition in $(lsblk --paths --list --noheadings --output=NAME,PARTLABEL | awk "/ $RAWDISK_INSTALL_GPT_PARTITION_NAME"'$/ { print $1; }'); do
         local cannot_install_partition="Cannot install the EFI rescue system to partition '$install_partition'"
 
-        detected_fs_type="$(lsblk --output FSTYPE --noheadings "$install_partition")"
+        detected_fs_type="$(lsblk --output FSTYPE --noheadings "$install_partition")" || Error "Could not analyze the file system type on '$install_partition'"
         if [[ "$detected_fs_type" != "" && "$detected_fs_type" != "vfat" ]]; then
             LogPrintError "$cannot_install_partition with type '$detected_fs_type' (must be 'vfat' or empty)"
             continue
         fi
 
-        detected_mount_point="$(lsblk --output MOUNTPOINT --noheadings "$install_partition")"
+        detected_mount_point="$(lsblk --output MOUNTPOINT --noheadings "$install_partition")" || Error "Could not detect whether '$install_partition' is mounted"
         if [[ -n "$detected_mount_point" ]]; then
             LogPrintError "$cannot_install_partition as it is currently mounted at '$detected_mount_point'"
             continue

--- a/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
@@ -198,7 +198,7 @@ if [[ -n "$RAWDISK_BOOT_EFI_STAGING_ROOT" && -n "$RAWDISK_INSTALL_GPT_PARTITION_
         fi
 
         LogPrint "Installing the EFI rescue system to partition '$install_partition'"
-        dd if="$boot_partition.x" bs=1024 of="$install_partition" 2>>"$RUNTIME_LOGFILE" || Error "Could not copy the EFI rescue system to partition '$install_partition'"
+        dd if="$boot_partition" bs=1024 of="$install_partition" 2>>"$RUNTIME_LOGFILE" || Error "Could not copy the EFI rescue system to partition '$install_partition'"
         install_partition_count=$((install_partition_count + 1))
     done
 

--- a/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
@@ -185,6 +185,9 @@ if [[ -n "$RAWDISK_BOOT_EFI_STAGING_ROOT" && -n "$RAWDISK_INSTALL_GPT_PARTITION_
     for install_partition in $(lsblk --paths --list --noheadings --output=NAME,PARTLABEL | awk "/ $RAWDISK_INSTALL_GPT_PARTITION_NAME"'$/ { print $1; }'); do
         local cannot_install_partition="Cannot install the EFI rescue system to partition '$install_partition'"
 
+        # The loop device partition we have just created will most probably have the required partition name: Ignore it.
+        [[ "$install_partition" == "$boot_partition" ]] && continue
+
         detected_fs_type="$(lsblk --output FSTYPE --noheadings "$install_partition")" || Error "Could not analyze the file system type on '$install_partition'"
         if [[ "$detected_fs_type" != "" && "$detected_fs_type" != "vfat" ]]; then
             LogPrintError "$cannot_install_partition with type '$detected_fs_type' (must be 'vfat' or empty)"

--- a/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
+++ b/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
@@ -55,3 +55,4 @@ RAWDISK_GPT_PARTITION_NAME="TCG Opal PBA"
 RAWDISK_FAT_VOLUME_LABEL="OPAL PBA"
 RAWDISK_BOOT_GRUB_MENUENTRY_TITLE="TCG Opal pre-boot authentication"
 RAWDISK_BOOT_SYSLINUX_START_INFORMATION="Starting TCG Opal pre-boot authentication..."
+RAWDISK_INSTALL_GPT_PARTITION_NAME=''  # Never install a PBA in a rescue system partition


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **New Feature**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested? On Ubuntu 20.04 LTS Server

* Brief description of the changes in this pull request:

This PR enables `rear mkrescue` when used with the **RAWDISK** output method to install the rescue/recovery system directly to one or more local disk partitions.

This is particularly useful on systems with redundant disks where a malfunction of one disk can be recovered via a rescue system available on another disk. It is also useful for testing as a separate rescue/recovery medium is no longer necessary.

##### Usage

1. Enable `RAWDISK` output.
1. Prepare one or more rescue partitions on local disk(s)
    * with an appropriate size (e.g. 1 GiB),
    * either empty or with a VFAT file system (which will be overwritten),
    * ideally identified as EFI system partition,
        ```
        sgdisk --typecode=$partnum:ef00 ...
        ```
    * with a specific partition name like `Rescue System`, e.g. via
        ```
        sgdisk --change-name="$partnum:Rescue System" ...
        ```
1. Set the configuration variable accordingly, e.g. in `local.conf`:
    ```
    RAWDISK_INSTALL_GPT_PARTITION_NAME='Rescue System'
    ```
1. When configured like this, each `rear mkrescue` invocation will install the rescue/recovery system to the respective disk partitions. This occurs in addition to creating and distributing the disk image as directed by the `OUTPUT_URL` variable.

##### Example Configuration
```
OUTPUT=RAWDISK
OUTPUT_URL=null
RAWDISK_INSTALL_GPT_PARTITION_NAME='Rescue System'
```