### PR TITLE
Add terminal password check via 'TTY_ROOT_PASSWORD'

### DIFF
--- a/usr/share/rear/build/default/503_store_tty_root_password.sh
+++ b/usr/share/rear/build/default/503_store_tty_root_password.sh
@@ -1,3 +1,4 @@
 # Store TTY_ROOT_PASSWORD for terminal logins
 
-[[ -n "$TTY_ROOT_PASSWORD" ]] && echo "$TTY_ROOT_PASSWORD" > "$ROOTFS_DIR/.TTY_ROOT_PASSWORD"
+# stderr is redirected here to avoid exposing the password hash in the log file when ReaR runs in debugscript mode.
+{ [[ -n "$TTY_ROOT_PASSWORD" ]] && echo "$TTY_ROOT_PASSWORD" > "$ROOTFS_DIR/.TTY_ROOT_PASSWORD"; } 2>/dev/null

--- a/usr/share/rear/build/default/503_store_tty_root_password.sh
+++ b/usr/share/rear/build/default/503_store_tty_root_password.sh
@@ -1,0 +1,3 @@
+# Store TTY_ROOT_PASSWORD for terminal logins
+
+[[ -n "$TTY_ROOT_PASSWORD" ]] && echo "$TTY_ROOT_PASSWORD" > "$ROOTFS_DIR/.TTY_ROOT_PASSWORD"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1553,6 +1553,17 @@ CLONE_ALL_USERS_GROUPS="true"
 # Therefore special users and groups can be added via CLONE_USERS and CLONE_GROUPS
 # or even CLONE_ALL_USERS_GROUPS="all" can be specified.
 
+# A terminal login password as a salted hash.
+# If empty, a root login into the ReaR recovery system via the system console or a serial terminal
+# is possible without being asked for a password.
+# To generate a password hash,
+# 1. run
+#    - 'openssl passwd -6', if openssl 1.1.1 or newer is available, or
+#    - 'openssl passwd -1', otherwise (see https://github.com/rear/rear/pull/2455#discussion_r453613086 for information
+#      on the implications of its cryptographic weakness),
+# 2. copy its entire output line between single quotes and assign it to this variable.
+TTY_ROOT_PASSWORD=''
+
 ##
 # SSH_FILES
 # SSH_ROOT_PASSWORD

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1561,7 +1561,10 @@ CLONE_ALL_USERS_GROUPS="true"
 #    - 'openssl passwd -6', if openssl 1.1.1 or newer is available, or
 #    - 'openssl passwd -1', otherwise (see https://github.com/rear/rear/pull/2455#discussion_r453613086 for information
 #      on the implications of its cryptographic weakness),
-# 2. copy its entire output line between single quotes and assign it to this variable.
+# 2. copy its entire output line and insert it between the single quotes of the following line:
+#        { TTY_ROOT_PASSWORD=''; } 2>/dev/null
+#    NOTE: stderr is redirected in the above line to avoid exposing the password hash
+#          in the log file when ReaR runs in debugscript mode.
 TTY_ROOT_PASSWORD=''
 
 ##

--- a/usr/share/rear/prep/default/340_include_password_tools.sh
+++ b/usr/share/rear/prep/default/340_include_password_tools.sh
@@ -1,2 +1,4 @@
 # Include tools to check TTY_ROOT_PASSWORD for terminal logins
-[[ -n "$TTY_ROOT_PASSWORD" ]] && REQUIRED_PROGS+=( openssl )
+
+# stderr is redirected here to avoid exposing the password hash in the log file when ReaR runs in debugscript mode.
+{ [[ -n "$TTY_ROOT_PASSWORD" ]] && REQUIRED_PROGS+=( openssl ); } 2>/dev/null

--- a/usr/share/rear/prep/default/340_include_password_tools.sh
+++ b/usr/share/rear/prep/default/340_include_password_tools.sh
@@ -1,0 +1,2 @@
+# Include tools to check TTY_ROOT_PASSWORD for terminal logins
+[[ -n "$TTY_ROOT_PASSWORD" ]] && REQUIRED_PROGS+=( openssl )

--- a/usr/share/rear/skel/default/bin/login
+++ b/usr/share/rear/skel/default/bin/login
@@ -1,4 +1,44 @@
 #!/bin/bash
+#
+# This is a minimal version of login(1). It will be called by agetty for console and serial terminal logins.
+#
+
+function authenticate_user() {
+    # Authenticates the (only) user if a terminal login password is configured.
+    # Returns if successful or if no password is configured, exits after some failed attempts.
+    # The login name is always ignored as the recovery system knows only one user.
+    if [[ -f /.TTY_ROOT_PASSWORD ]]; then
+        trap '' SIGINT SIGQUIT SIGTSTP
+
+        # Read the configured hash signature from its file
+        read -r TTY_ROOT_PASSWORD </.TTY_ROOT_PASSWORD
+        # Extract hash algorithm and salt from the configured hash signature
+        IFS='$' read -r _ method salt _ </.TTY_ROOT_PASSWORD
+
+        for _ in 1 2 3; do
+            read -r -s -p "Password: " password 2>&1
+            echo ""
+
+            # Compute signature of the password to verify
+            password_signature="$(openssl passwd -"$method" -salt "$salt" "$password")"
+
+            if [[ "$password_signature" == "$TTY_ROOT_PASSWORD" ]]; then  # Password matches: Success!
+                trap - SIGINT SIGQUIT SIGTSTP
+                return
+            fi
+
+            sleep 5
+            echo -e "\nLogin incorrect"
+            read -r -p "$(hostname) login: " _ 2>&1 # Fake a login prompt although the user name is not used.
+        done
+
+        exit 1 # Exit after several unsuccessful attempts
+    fi
+}
+
+# Authenticate the (only) user if a password is configured.
+authenticate_user
+
 # setup standard environment for root user
 # ATM root is the only user who can logon at the rescue system
 export HOME=/root


### PR DESCRIPTION
##### Pull Request Details:

* Type: **New Feature**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested? On Ubuntu 20.04 LTS Server

* Brief description of the changes in this pull request:

Currently, ReaR allows a password check on SSH sessions only (via `SSH_ROOT_PASSWORD`).

This PR enables the rescue/recovery system to enforce a password check also on terminal connections (the system console and/or serial terminals).

This prevents unauthenticated local root access
* while the rescue/recovery system is being run via a remote SSH session, or
* when a system reboot has inadvertently started the recovery system installed on a local disk partition (e.g. where a buggy firmware has inadvertently reshuffled the boot order).

##### Usage

1. Configure `TTY_ROOT_PASSWORD` in the same way as `SSH_ROOT_PASSWORD`.
1. Run `rear mkrescue`.
1. Start the rescue/recovery system.
1. Log in locally, providing the correct password.

##### Example Configuration

Configure the password `test`:
```
TTY_ROOT_PASSWORD='$6$SixRXJl0b37m4rl3$alfGpFd3dp1tBk5/EDquyxqiviB2oQQq3z7VULx9qiBHweFlBquivq28.I4YNLknhKjDax1uM/4c2xuVzdNcy1'
SSH_ROOT_PASSWORD="$TTY_ROOT_PASSWORD"
```
