### PR TITLE
Avoid that *_ROOT_PASSWORD values are shown in debugscript mode

### DIFF
--- a/usr/share/rear/build/default/500_ssh_setup.sh
+++ b/usr/share/rear/build/default/500_ssh_setup.sh
@@ -12,9 +12,14 @@ is_false "$SSH_FILES" && return
 # only etc/ssh/sshd_config is used cf. https://github.com/rear/rear/pull/1538#issuecomment-337904240
 local sshd_config_file="$ROOTFS_DIR/etc/ssh/sshd_config"
 if [[ -f "$sshd_config_file" ]]; then
+
     # Enable root login with a password only if SSH_ROOT_PASSWORD is set
     local password_authentication_value=no
-    [[ -n "$SSH_ROOT_PASSWORD" ]] && password_authentication_value=yes
+    # Avoid that the SSH_ROOT_PASSWORD value is shown in debugscript mode
+    # cf. the comment of the UserInput function in lib/_input-output-functions.sh
+    # how to keep things confidential when usr/sbin/rear is run in debugscript mode:
+    # ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
+    { test "$SSH_ROOT_PASSWORD" ; } 2>/dev/null && password_authentication_value=yes
 
     # List of setting overrides required for the rescue system's sshd - see sshd_config(5)
     # Each list element must be a string of the form 'keyword [value]' or a comment '#...'.

--- a/usr/share/rear/build/default/500_ssh_setup.sh
+++ b/usr/share/rear/build/default/500_ssh_setup.sh
@@ -17,7 +17,7 @@ if [[ -f "$sshd_config_file" ]]; then
     local password_authentication_value=no
     # Avoid that the SSH_ROOT_PASSWORD value is shown in debugscript mode
     # cf. the comment of the UserInput function in lib/_input-output-functions.sh
-    # how to keep things confidential when usr/sbin/rear is run in debugscript mode:
+    # how to keep things confidential when usr/sbin/rear is run in debugscript mode
     # ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
     { test "$SSH_ROOT_PASSWORD" ; } 2>/dev/null && password_authentication_value=yes
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1623,7 +1623,18 @@ SSH_FILES='avoid_sensitive_files'
 # and use the output of openssl to set SSH_ROOT_PASSWORD='output_of_openssl'
 # (single quotes avoid issues with the special bash character $ in the openssl output).
 # SSH_ROOT_PASSWORD is ignored when SSH_FILES is set to a 'false' value.
-SSH_ROOT_PASSWORD=
+# Avoid that the SSH_ROOT_PASSWORD value is shown when usr/sbin/rear was called with 'set -x'
+# for debugging usr/sbin/rear cf. https://github.com/rear/rear/issues/2144#issuecomment-493908133
+# In debugscript mode only scripts sourced by the Source function in lib/framework-functions.sh
+# are run with 'set -x' but default.conf is sourced by usr/sbin/rear directly.
+# See the comment of the UserInput function in lib/_input-output-functions.sh
+# how to keep things confidential when usr/sbin/rear is run in debugscript mode
+# ('2>/dev/null' should be sufficient here because 'test' does not output on stdout).
+# SSH_ROOT_PASSWORD is set to a default value here only
+# if not already set so that the user can set it also like
+#   export SSH_ROOT_PASSWORD='my_recovery_system_root_password'
+# directly before he calls "rear ...":
+{ test "$SSH_ROOT_PASSWORD" ; } 2>/dev/null || SSH_ROOT_PASSWORD=''
 #
 # SSH_UNPROTECTED_PRIVATE_KEYS="yes" makes ReaR also include SSH keys without a passphrase
 # in the ReaR rescue/recovery system at the price of having the rescue system/medium

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2481,8 +2481,19 @@ PROGS_ZYPPER=()
 # should be set manually by the admin after "rear recover".
 # As fallback "rear recover" sets 'root' as root password in the target system.
 # If SSH_ROOT_PASSWORD is specified it is used as root password in the target system
-# unless ZYPPER_ROOT_PASSWORD is specified which is used with highest priority:
-ZYPPER_ROOT_PASSWORD='root'
+# unless ZYPPER_ROOT_PASSWORD is specified which is used with highest priority.
+# Avoid that the ZYPPER_ROOT_PASSWORD value is shown when usr/sbin/rear was called with 'set -x'
+# for debugging usr/sbin/rear cf. https://github.com/rear/rear/issues/2144#issuecomment-493908133
+# In debugscript mode only scripts sourced by the Source function in lib/framework-functions.sh
+# are run with 'set -x' but default.conf is sourced by usr/sbin/rear directly.
+# See the comment of the UserInput function in lib/_input-output-functions.sh
+# how to keep things confidential when usr/sbin/rear is run in debugscript mode
+# ('2>/dev/null' should be sufficient here because 'test' does not output on stdout).
+# ZYPPER_ROOT_PASSWORD is set to a default value here only
+# if not already set so that the user can set it also like
+#   export ZYPPER_ROOT_PASSWORD='my_zypper_root_password'
+# directly before he calls "rear ...":
+{ test "$ZYPPER_ROOT_PASSWORD" ; } 2>/dev/null || ZYPPER_ROOT_PASSWORD='root'
 # ZYPPER_NETWORK_SETUP_COMMANDS specifies the initial network setup in the target system for BACKUP=ZYPPER:
 # This initial network setup is only meant to make the target system
 # accessible from remote in a very basic way (e.g. for 'ssh').
@@ -2515,7 +2526,18 @@ COPY_AS_IS_YUM=( '/etc/yum*' '/etc/logrotate.d/yum*' '/usr/bin/python*' '/bin/py
 COPY_AS_IS_EXCLUDE_YUM=()
 REQUIRED_PROGS_YUM=( yum rpm rpm2cpio rpmdb rpmquery rpmverify chpasswd )
 PROGS_YUM=()
-YUM_ROOT_PASSWORD='root'
+# Avoid that the YUM_ROOT_PASSWORD value is shown when usr/sbin/rear was called with 'set -x'
+# for debugging usr/sbin/rear cf. https://github.com/rear/rear/issues/2144#issuecomment-493908133
+# In debugscript mode only scripts sourced by the Source function in lib/framework-functions.sh
+# are run with 'set -x' but default.conf is sourced by usr/sbin/rear directly.
+# See the comment of the UserInput function in lib/_input-output-functions.sh
+# how to keep things confidential when usr/sbin/rear is run in debugscript mode
+# ('2>/dev/null' should be sufficient here because 'test' does not output on stdout).
+# YUM_ROOT_PASSWORD is set to a default value here only
+# if not already set so that the user can set it also like
+#   export YUM_ROOT_PASSWORD='my_yum_root_password'
+# directly before he calls "rear ...":
+{ test "$YUM_ROOT_PASSWORD" ; } 2>/dev/null || YUM_ROOT_PASSWORD='root'
 YUM_NETWORK_SETUP_COMMANDS=()
 YUM_EXCLUDE_PKGS=("")
 ##

--- a/usr/share/rear/restore/YUM/default/970_set_root_password.sh
+++ b/usr/share/rear/restore/YUM/default/970_set_root_password.sh
@@ -21,18 +21,27 @@ set -e -u -o pipefail
 # As fallback use 'root' as root password in the target system.
 # A non-empty fallback is needed because 'passwd' does not accept empty input:
 local root_password="root"
-# If SSH_ROOT_PASSWORD is specified used that as root password in the target system:
-test "$SSH_ROOT_PASSWORD" && root_password="$SSH_ROOT_PASSWORD"
-# If YUM_ROOT_PASSWORD is specified used that as root password in the target system:
-test "$YUM_ROOT_PASSWORD" && root_password="$YUM_ROOT_PASSWORD"
 
-# Set the root password in the target system.
-# Use a login shell in between so that one has in the chrooted environment
-# all the advantages of a "normal working shell" which means one can write
-# the commands inside 'chroot' as one would type them in a normal working shell.
-# In particular one can call programs (like 'passwd') by their basename without path
-# cf. https://github.com/rear/rear/issues/862#issuecomment-274068914
-chroot $TARGET_FS_ROOT /bin/bash --login -c "echo -e '$root_password\n$root_password' | passwd root"
+# Avoid that the SSH_ROOT_PASSWORD or the YUM_ROOT_PASSWORD value is shown in debugscript mode
+# cf. the comment of the UserInput function in lib/_input-output-functions.sh
+# how to keep things confidential when usr/sbin/rear is run in debugscript mode
+# ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
+{ # If SSH_ROOT_PASSWORD is specified used that as root password in the target system:
+  test "$SSH_ROOT_PASSWORD" && root_password="$SSH_ROOT_PASSWORD"
+  # If YUM_ROOT_PASSWORD is specified used that as root password in the target system:
+  test "$YUM_ROOT_PASSWORD" && root_password="$YUM_ROOT_PASSWORD"
+  # Set the root password in the target system.
+  # Use a login shell in between so that one has in the chrooted environment
+  # all the advantages of a "normal working shell" which means one can write
+  # the commands inside 'chroot' as one would type them in a normal working shell.
+  # In particular one can call programs (like 'passwd') by their basename without path
+  # cf. https://github.com/rear/rear/issues/862#issuecomment-274068914
+  if chroot $TARGET_FS_ROOT /bin/bash --login -c "echo -e '$root_password\n$root_password' | passwd root" ; then
+      Log "Set root password in the target system"
+  else
+      LogPrintError "Failed to set root password in the target system"
+  fi
+} 2>/dev/null
 
 # Restore the ReaR default bash flags and options (see usr/sbin/rear):
 apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"


### PR DESCRIPTION
* Type: **Bug Fix**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2540

* Brief description of the changes in this pull request:
Use `{ confidential_command ; } 2>/dev/null`
cf. the comment for the `UserInput` function in
lib/_input-output-functions.sh
