### PR TITLE
Changes for NetBackup (NBU) support

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1882,7 +1882,7 @@ OBDR_BLOCKSIZE=2048
 # BACKUP=NBU stuff (Symantec/Veritas NetBackup)
 ##
 #
-COPY_AS_IS_NBU=( /usr/openv/bin/vnetd /usr/openv/bin/vopied /usr/openv/lib /usr/openv/netbackup /usr/openv/var/auth/[mn]*.txt )
+COPY_AS_IS_NBU=( /usr/openv/bin/vnetd /usr/openv/bin/vopied /usr/openv/lib /usr/openv/netbackup /usr/openv/var/auth/[mn]*.txt /opt/VRTSpbx /etc/vx/VxICS /etc/vx/vrtslog.conf )
 COPY_AS_IS_EXCLUDE_NBU=( /usr/openv/netbackup/logs "/usr/openv/netbackup/bin/bpjava*" /usr/openv/netbackup/bin/xbp /usr/openv/netbackup/bin/private /usr/openv/lib/java /usr/openv/lib/shared/vddk /usr/openv/netbackup/baremetal )
 # See https://github.com/rear/rear/issues/2105 why /usr/openv/netbackup/sec/at/lib/ is needed:
 NBU_LD_LIBRARY_PATH="/usr/openv/lib:/usr/openv/netbackup/sec/at/lib/"

--- a/usr/share/rear/rescue/NBU/default/450_prepare_netbackup.sh
+++ b/usr/share/rear/rescue/NBU/default/450_prepare_netbackup.sh
@@ -7,6 +7,12 @@
 
 [[ $NBU_version -lt 7 ]] && return	# NBU is using xinetd when version <7.x
 
+if [ -e "/etc/init.d/vxpbx_exchanged" ]; then
+	cp $v /etc/init.d/vxpbx_exchanged $ROOTFS_DIR/etc/scripts/system-setup.d/vxpbx_exchanged.real
+	chmod $v +x $ROOTFS_DIR/etc/scripts/system-setup.d/vxpbx_exchanged.real
+	echo "( /etc/scripts/system-setup.d/vxpbx_exchanged.real start )" > $ROOTFS_DIR/etc/scripts/system-setup.d/89-vxpbx_exchanged.sh
+fi
+
 if [ -e "/etc/init.d/netbackup" ]; then
 	cp $v /etc/init.d/netbackup $ROOTFS_DIR/etc/scripts/system-setup.d/netbackup.real
 	chmod $v +x $ROOTFS_DIR/etc/scripts/system-setup.d/netbackup.real

--- a/usr/share/rear/skel/NBU/usr/openv/tmp/.gitignore
+++ b/usr/share/rear/skel/NBU/usr/openv/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* How was this pull request tested?

Tested by a customer using ReaR (2.4 version in RHEL 8) with NetBackup 8.2

* Brief description of the changes in this pull request:

It was found by our customer that when attempting to restore from NetBackup, bprestore is unable to restore data from NetBackup server:
```
EXIT STATUS 25: cannot connect on socket
bprestore failed (return code = 25)
```
The fix is to copy the NetBackup PBX (vxpbx_exchanged) service to the rescue system and start it on boot before starting NetBackup. Additionally, it was needed to add the /usr/openv/tmp directory.

The problem was reported for NetBackup 8.2, but the service is apparently needed even in older versions of NetBackup (https://www.veritas.com/support/en_US/article.100031908). There were fixes for previous NetBackup versions in ReaR reported by @rmetrich, so I don't know why the problem was not seen at that time.