### PR TITLE
fixed vfat mkfs using uuid from layout if possible

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
@@ -278,9 +278,27 @@ function create_fs () {
                     label2="$(echo $label | sed -e 's/\\b/ /g')" # replace \b with a " "
                     label="$label2"
                 fi
-                echo "mkfs.vfat -n \"$label\" $device" >> "$LAYOUT_CODE"
+                # Create FS with UUID if possible
+                if [ -n "$uuid" ]; then
+                    ( echo "#Try to create with old uuid but when -i is not available fallback to a newly created one."
+                      echo "if ! mkfs.vfat -n "$label" -i "$(echo $uuid | sed s/-//)" $device >&2 ; then"
+                      echo "    mkfs.vfat -n "$label" $device >&2"
+                      echo "fi"
+                    ) >> "$LAYOUT_CODE"
+                else
+                    echo "mkfs.vfat -n \"$label\" $device" >> "$LAYOUT_CODE"
+                fi
             else
-                echo "mkfs.vfat $device" >> "$LAYOUT_CODE"
+                # Create FS with UUID if possible
+                if [ -n "$uuid" ]; then
+                    ( echo "#Try to create with old uuid but when -i is not available fallback to a newly created one."
+                    echo "if ! mkfs.vfat -i "$(echo $uuid | sed s/-//)" $device >&2 ; then"
+                    echo "    mkfs.vfat $device >&2"
+                    echo "fi"
+                    ) >> "$LAYOUT_CODE"
+                else
+                    echo "mkfs.vfat $device" >> "$LAYOUT_CODE"
+                fi
             fi
             # Set the UUID:
             if [ -n "$uuid" ]; then


### PR DESCRIPTION
* Type: **Bug Fix** / **Enhancement**
* Impact: **Normal**
* How was this pull request tested? **manually by me - only the no label but uuid path**
* Issue #2548 related to this PR but it is not the same
* Brief description of the changes in this pull request:
mkfs.vfat (used for e.g. uefi partition) did not honor the uuid from the layout so "boot original system" was failing (by id/no label) after a recover. It also adds new boot menu entries and changes boot order on HP machines when a efi partition with new id is detected. The change tries to use -i option to set the uuid on creation and falls back to not using it when it fails (like done in the script for ext and others). This fixes the issues.