### PR TITLE
Add DP_LD_LIBRARY_PATH to include shared libraries used by BACKUP=DP

### DIFF
--- a/usr/share/rear/build/default/990_verify_rootfs.sh
+++ b/usr/share/rear/build/default/990_verify_rootfs.sh
@@ -95,6 +95,10 @@ if test "$BACKUP" = "FDRUPSTREAM" ; then
     # see https://github.com/rear/rear/pull/2296
     test $LD_LIBRARY_PATH && backup_tool_LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$FDRUPSTREAM_INSTALL_PATH/bin || backup_tool_LD_LIBRARY_PATH=$FDRUPSTREAM_INSTALL_PATH/bin
 fi
+if test "$BACKUP" = "DP" ; then
+    # Use a DP-specific LD_LIBRARY_PATH to find DP libraries
+    test $LD_LIBRARY_PATH && backup_tool_LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DP_LD_LIBRARY_PATH || backup_tool_LD_LIBRARY_PATH=$DP_LD_LIBRARY_PATH
+fi
 # Actually test all binaries for 'not found' libraries.
 # Find all binaries and libraries (in particular what is copied via COPY_AS_IS into arbitrary paths)
 # so find what is a regular file and which is executable or its name is '*.so' or '*.so.[0-9]*'

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1914,7 +1914,8 @@ PROGS_AVA=( )
 # are copied from the ReaR recovery system into the recovered/recreated target system.
 # For details see the usr/share/rear/finalize/DP/default/500_restore_ssc.sh script.
 COPY_AS_IS_DP=( /opt/omni /etc/opt/omni/client )
-COPY_AS_IS_EXCLUDE_DP=( /opt/omni/bin/telemetry /opt/omni/Depot /opt/omni/databases /opt/omni/jre /opt/omni/newconfig /opt/omni/bin/drim )
+COPY_AS_IS_EXCLUDE_DP=( /opt/omni/bin/telemetry /opt/omni/Depot /opt/omni/databases /opt/omni/jre /opt/omni/newconfig /opt/omni/bin/drim /opt/omni/AppServer /opt/omni/RS_idb /opt/omni/reporting )
+DP_LD_LIBRARY_PATH="/opt/omni/lib:/opt/omni/lib64"
 
 ##
 # BACKUP=NSR (EMC Networker; Legato)

--- a/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
+++ b/usr/share/rear/finalize/DP/default/500_restore_ssc.sh
@@ -13,8 +13,8 @@
 test -s /etc/opt/omni/client/ssconfig || return 0
 
 local sscpath=/etc/opt/omni/client/sscertificates
-local certfile=$sscpath/localhost_cert.pem
-local keyfile=$sscpath/localhost_key.pem
+local certfile=$sscpath/localhost_cert.*
+local keyfile=$sscpath/localhost_key.*
 
 # Nothing to do when the certificate files already exist in the recreated system:
 test -s $TARGET_FS_ROOT/$certfile -a -s $TARGET_FS_ROOT/$keyfile && return 0


### PR DESCRIPTION
Type: Enhancement

Impact: Medium
Add DP_LD_LIBRARY_PATH to include shared libraries used by BACKUP=DP and make ReaR compatible with changes in recent versions of Micro Focus Data Protector

Reference to related issue (URL):
none

How was this pull request tested?
Applied the changes to a SLES15 SP2 system running rear 2.6.1. Created a new ISO, booted the system and ran through various test cases.

Brief description of the changes in this pull request:
- Add DP_LD_LIBRARY_PATH to include shared libraries used by BACKUP=DP
- Handle new encrypted client certificates in Data Protector 10.80 and later
- Excludes files only used by Data Protector Reporting Server to reduce image footprint