### PR TITLE
Support loop devices in format_usb_disk

### DIFF
--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -93,9 +93,14 @@ partprobe $RAW_USB_DEVICE
 sleep 5
 
 if is_true "$EFI" ; then
-    LogPrint "Creating vfat filesystem on EFI system partition on '${RAW_USB_DEVICE}1'"
-    if ! mkfs.vfat $v -F 16 -n REAR-EFI ${RAW_USB_DEVICE}1 >&2 ; then
-        Error "Failed to create vfat filesystem on '${RAW_USB_DEVICE}1'"
+    # detect loopback device parition naming"
+    local rear_efi_partition_device="${RAW_USB_DEVICE}1"
+    if [ ! -b "$rear_efi_partition_device" ] && [ -b "${RAW_USB_DEVICE}p1" ] ; then
+        rear_efi_partition_device="${RAW_USB_DEVICE}p1"
+    fi
+    LogPrint "Creating vfat filesystem on EFI system partition on '$rear_efi_partition_device'"
+    if ! mkfs.vfat $v -F 16 -n REAR-EFI $rear_efi_partition_device >&2 ; then
+        Error "Failed to create vfat filesystem on '$rear_efi_partition_device'"
     fi
     # create link for EFI partition in /dev/disk/by-label
     partprobe $RAW_USB_DEVICE
@@ -103,7 +108,11 @@ if is_true "$EFI" ; then
     sleep 5
 fi
 
+# detect loopback device parition naming"
 local rear_data_partition_device="$RAW_USB_DEVICE$rear_data_partition_number"
+if [ ! -b "$rear_data_partition_device" ] && [ -b "${RAW_USB_DEVICE}p${rear_data_partition_number}" ] ; then
+    rear_data_partition_device="${RAW_USB_DEVICE}p${rear_data_partition_number}"
+fi
 
 LogPrint "Creating $USB_DEVICE_FILESYSTEM filesystem with label '$USB_DEVICE_FILESYSTEM_LABEL' on '$rear_data_partition_device'"
 if ! mkfs.$USB_DEVICE_FILESYSTEM -L "$USB_DEVICE_FILESYSTEM_LABEL" $USB_DEVICE_FILESYSTEM_PARAMS $rear_data_partition_device >&2 ; then

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -93,7 +93,10 @@ partprobe $RAW_USB_DEVICE
 sleep 5
 
 if is_true "$EFI" ; then
-    # detect loopback device parition naming"
+    # detect loopback device parition naming
+    # on loop devices the first partition is named e.g. loop0p1
+    # instead of e.g. sdb1 on usual (USB) disks
+    # cf. https://github.com/rear/rear/pull/2555
     local rear_efi_partition_device="${RAW_USB_DEVICE}1"
     if [ ! -b "$rear_efi_partition_device" ] && [ -b "${RAW_USB_DEVICE}p1" ] ; then
         rear_efi_partition_device="${RAW_USB_DEVICE}p1"
@@ -108,7 +111,7 @@ if is_true "$EFI" ; then
     sleep 5
 fi
 
-# detect loopback device parition naming"
+# detect loopback device parition naming (same logic as above)
 local rear_data_partition_device="$RAW_USB_DEVICE$rear_data_partition_number"
 if [ ! -b "$rear_data_partition_device" ] && [ -b "${RAW_USB_DEVICE}p${rear_data_partition_number}" ] ; then
     rear_data_partition_device="${RAW_USB_DEVICE}p${rear_data_partition_number}"


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested?

I've created usb disk images using 

```
fallocate -l 8G /var/lib/rear/output/rear-hostname.img
losetup -P /dev/loop0 /var/lib/rear/output/rear-hostname.img
YES=true rear -v format -- --efi /dev/loop0
rear -v -c mkbackup
losetup -d /dev/loop0
```
With a local.conf
```
OUTPUT=USB
BACKUP=NETFS
BACKUP_URL=usb:///dev/disk/by-label/REAR-000
USB_UEFI_PART_SIZE=200
```

and tested them as usb disk image in libvirt/kvm

* Brief description of the changes in this pull request:

Support loop devices to create usb disk images without having a physical usb stick plugged in in to the server. The problem is loop devices is that the first partition is names **loop0p1** instead of **loop01** (like normal disk expands from **sda** to **sda1**) which the script assused. This makes creating bootable usbstick backups easier on remote servers. After that you just have to download them and dd'd them to the next stick available.