### PR TITLE
Add 2 more 32MiB blocks to efi_img_sz (issue 2552)

### DIFF
--- a/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
@@ -13,7 +13,7 @@ efi_img_sz=( $( du --block-size=32M --summarize $TMP_DIR/mnt ) ) || Error "Faile
 # "cp: error writing '/tmp/rear.XXX/tmp/efi_virt/./EFI/BOOT/...': No space left on device"
 # where the above calculated $efi_img_sz is a bit too small in practice
 # cf. https://github.com/rear/rear/issues/2552
-efi_img_sz=$(( efi_img_sz + 2 ))
+(( efi_img_sz += 2 ))
 # Prepare EFI virtual image aligned to 32MiB blocks:
 dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$efi_img_sz bs=32M
 mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2

--- a/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
@@ -8,10 +8,13 @@ is_true $USING_UEFI_BOOTLOADER || return 0 # empty or 0 means NO UEFI
 # The du output is stored in an artificial bash array
 # so that $efi_img_sz can be simply used to get the first word
 # which is the disk usage of the directory measured in 32MiB blocks:
-efi_img_sz=( $( du --block-size=32M --summarize $TMP_DIR/mnt ) )
-StopIfError "Failed to determine disk usage of EFI virtual image content directory."
-
-# prepare EFI virtual image aligned to 32MiB blocks:
+efi_img_sz=( $( du --block-size=32M --summarize $TMP_DIR/mnt ) ) || Error "Failed to determine disk usage of EFI virtual image content directory."
+# We add 2 more 32MiB blocks to be on the safe side against inexplicaple failures like
+# "cp: error writing '/tmp/rear.XXX/tmp/efi_virt/./EFI/BOOT/elilo.conf': No space left on device"
+# where the above calculated $efi_img_sz is a bit too small in practice
+# cf. https://github.com/rear/rear/issues/2552
+efi_img_sz=$(( efi_img_sz + 2 ))
+# Prepare EFI virtual image aligned to 32MiB blocks:
 dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$efi_img_sz bs=32M
 mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
 mkdir -p $v $TMP_DIR/efi_virt >&2

--- a/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
@@ -9,8 +9,8 @@ is_true $USING_UEFI_BOOTLOADER || return 0 # empty or 0 means NO UEFI
 # so that $efi_img_sz can be simply used to get the first word
 # which is the disk usage of the directory measured in 32MiB blocks:
 efi_img_sz=( $( du --block-size=32M --summarize $TMP_DIR/mnt ) ) || Error "Failed to determine disk usage of EFI virtual image content directory."
-# We add 2 more 32MiB blocks to be on the safe side against inexplicaple failures like
-# "cp: error writing '/tmp/rear.XXX/tmp/efi_virt/./EFI/BOOT/elilo.conf': No space left on device"
+# We add 2 more 32MiB blocks to be on the safe side against inexplicable failures like
+# "cp: error writing '/tmp/rear.XXX/tmp/efi_virt/./EFI/BOOT/...': No space left on device"
 # where the above calculated $efi_img_sz is a bit too small in practice
 # cf. https://github.com/rear/rear/issues/2552
 efi_img_sz=$(( efi_img_sz + 2 ))


### PR DESCRIPTION
* Type: **Bug Fix** / **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2552

* How was this pull request tested?
Not at all tested by me (I don't use EFI).

* Brief description of the changes in this pull request:

Add 2 more 32MiB blocks to be on the safe side against inexplicaple failures like
"cp: error writing '/tmp/rear.XXX/tmp/efi_virt/./EFI/BOOT/elilo.conf': No space left on device"
where the above calculated $efi_img_sz is a bit too small in practice.
