### PR TITLE
Update 110_include_lvm_code.sh to make sure vgremove is called before recreating the VG

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -140,6 +140,7 @@ EOF
 cat >> "$LAYOUT_CODE" <<EOF
 if [ \$create_volume_group -eq 1 ] ; then
     LogPrint "Creating LVM VG '$vg'; Warning: some properties may not be preserved..."
+    lvm vgremove --force --force --yes $vg >&2 || true
     if [ -e "$vgrp" ] ; then
         rm -rf "$vgrp"
     fi


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* How was this pull request tested? Test on RHEL7 with a LVM Raid

* Brief description of the changes in this pull request:

Make sure we delete the volume group before re-creating it.
The issue happens in Migration mode when ReaR is not trying to use vgcfgrestore.

##### Reproducer:

1. Install a system
2. Add 2 additional disks that will be used to host a LVM VG

    - /dev/vdb
    - /dev/vdc

3. Create a Raid volume

    ~~~
    # pvcreate /dev/vdb
    # pvcreate /dev/vdc
    # vgcreate data /dev/vdb /dev/vdc
    # lvcreate -n vol1 -L 1G -m 1 data
    # mkfs.xfs /dev/data/vol1
    # mount /dev/data/vol1 /mnt
    ~~~

4. Build a rescue image and perform a recovery

    Error is shown below:

    ~~~
    Start system layout restoration.
    Disk '/dev/vda': creating 'msdos' partition table
    Disk '/dev/vda': creating partition number 1 with name 'primary'
    Disk '/dev/vda': creating partition number 2 with name 'primary'
    Creating LVM PV /dev/vdb
    Creating LVM PV /dev/vdc
    Creating LVM PV /dev/vda2
    Creating LVM VG 'data'; Warning: some properties may not be preserved...
    The disk layout recreation script failed
    ~~~

    Log excerpt:
    ~~~
    +++ Print 'Creating LVM VG '\''data'\''; Warning: some properties may not be preserved...'
    +++ '[' -e /dev/data ']'
    +++ lvm vgcreate --physicalextentsize 4096k data /dev/vdb /dev/vdc
      A volume group called data already exists.
    ~~~
