### PR TITLE
Fixes docker_root_dir not being set when `docker info` writes to stderr.

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -62,7 +62,7 @@ if service docker status ; then
     # When the Docker daemon/service is running, try to get its 'Docker Root Dir':
     # Kill 'docker info' with SIGTERM after 5 seconds and with SIGKILL after additional 2 seconds
     # because there are too many crippled Docker installations, cf. https://github.com/rear/rear/pull/2021
-    docker_root_dir=$( timeout -k 2s 5s docker info | grep 'Docker Root Dir' | awk '{print $4}' )
+    docker_root_dir=$( timeout -k 2s 5s docker info 2>/dev/null | grep 'Docker Root Dir' | awk '{print $4}' )
     # Things may go wrong in the 'Docker specific exclude part' below
     # when Docker is used but its 'Docker Root Dir' cannot be determined
     # cf. https://github.com/rear/rear/issues/1989


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): https://github.com/rear/rear/issues/1989

* How was this pull request tested?
  Modified local installation, performed `sudo rear -v mkbackup` and observed the 'Docker Root Dir' was recognized as expected.

* Brief description of the changes in this pull request:

On Ubuntu Server 20.04.2 LTS with Docker 19.03.13, rear "Cannot determine Docker Root Dir" even though 'Docker Root Dir' is found in `docker info`. This seems to be because docker also sends to stderr which interferes with the variable assignment:
```
$ timeout -k 2s 5s docker info | grep 'Docker Root Dir' | awk '{print $4}'
WARNING: No swap limit support
/var/lib/docker
```
redirecting stderr to null allows the 'Docker Root Dir' value to be assigned to the `docker_root_dir` variable correctly.

FYI: It appears that this redirection used to be there, but was omitted (probably by mistake) in https://github.com/rear/rear/pull/2021/commits/f6c32416dc9e1fffcf5090a4b52e11dd8cd61a15.
