### PR TITLE
Do not specify '-F 16'  for mkfs.vfat and also no '-o fat=16' when mounting it

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -895,13 +895,18 @@ USB_PARTITION_ALIGN_BLOCK_SIZE="8"
 # in MiB when formatting a medium by the format workflow.
 # If USB_UEFI_PART_SIZE is empty or invalid (i.e. not an unsigned integer larger than 0)
 # the user must interactively enter a valid value while running the format workflow.
-# The default value of 400 MiB should be sufficiently big and it is in compliance
-# with the 8 MiB partition alignment default value ( 400 = 8 * 50 )
-# and even with a 16 MiB partition alignment value ( 400 = 16 * 25 )
+# The default value of 512 MiB should be sufficiently big and it is in compliance
+# with the 8 MiB partition alignment default value ( 512 = 8 * 64 )
+# and also with higher 2^n MiB partition alignment values
 # cf. https://github.com/rear/rear/pull/1205
+# Furthermore the default value of 512 MiB results that the FAT filesystem of the ESP
+# will be in compliance with that the ESP should officially use a FAT32 filesystem
+# because mkfs.vfat automatically makes a FAT32 filesystem starting at 512 MiB
+# (a FAT16 ESP works in most cases but causes issues with certain UEFI firmware)
+# cf. https://github.com/rear/rear/issues/2575
 # The value of USB_UEFI_PART_SIZE will be rounded to the nearest
 # USB_PARTITION_ALIGN_BLOCK_SIZE chunk:
-USB_UEFI_PART_SIZE="400"
+USB_UEFI_PART_SIZE="512"
 #
 # Default boot option (i.e. what gets booted automatically after some timeout)
 # when EXTLINUX boots the USB stick or USB disk or other disk device on BIOS systems.

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -102,7 +102,13 @@ if is_true "$EFI" ; then
         rear_efi_partition_device="${RAW_USB_DEVICE}p1"
     fi
     LogPrint "Creating vfat filesystem on EFI system partition on '$rear_efi_partition_device'"
-    if ! mkfs.vfat $v -F 16 -n REAR-EFI $rear_efi_partition_device >&2 ; then
+    # Make a FAT filesystem on the EFI system partition
+    # cf. https://github.com/rear/rear/issues/2575
+    # and output/ISO/Linux-i386/700_create_efibootimg.sh
+    # and output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+    # Let mkfs.vfat automatically select the FAT type based on the size.
+    # I.e. do not use a '-F 16' or '-F 32' option and hope for the best:
+    if ! mkfs.vfat $v -n REAR-EFI $rear_efi_partition_device >&2 ; then
         Error "Failed to create vfat filesystem on '$rear_efi_partition_device'"
     fi
     # create link for EFI partition in /dev/disk/by-label

--- a/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
@@ -16,13 +16,13 @@ efi_img_sz=( $( du --block-size=32M --summarize $TMP_DIR/mnt ) ) || Error "Faile
 (( efi_img_sz += 2 ))
 # Prepare EFI virtual image aligned to 32MiB blocks:
 dd if=/dev/zero of=$TMP_DIR/efiboot.img count=$efi_img_sz bs=32M
-mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img >&2
-mkdir -p $v $TMP_DIR/efi_virt >&2
-mount $v -o loop -t vfat -o fat=16 $TMP_DIR/efiboot.img $TMP_DIR/efi_virt >&2
+mkfs.vfat $v -F 16 $TMP_DIR/efiboot.img
+mkdir -p $v $TMP_DIR/efi_virt
+mount $v -o loop -t vfat $TMP_DIR/efiboot.img $TMP_DIR/efi_virt || Error "Failed to loop mount efiboot.img"
 
-# copy files from staging directory
+# Copy files from staging directory into efiboot.img
 cp $v -r $TMP_DIR/mnt/. $TMP_DIR/efi_virt
+umount $v $TMP_DIR/efiboot.img
 
-umount $v $TMP_DIR/efiboot.img >&2
-mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/isofs/boot/efiboot.img >&2
-StopIfError "Could not move efiboot.img file"
+# Move efiboot.img into ISO directory:
+mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/isofs/boot/efiboot.img || Error "Failed to move efiboot.img to isofs/boot/efiboot.img"

--- a/usr/share/rear/output/ISO/Linux-ia64/200_mount_bootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-ia64/200_mount_bootimg.sh
@@ -1,9 +1,11 @@
 # 200_mount_bootimg.sh
 dd if=/dev/zero of=$TMP_DIR/boot.img count=64000 bs=1024
-# make sure we select FAT16 instead of FAT12 as size >30MB
-mkfs.vfat $v -F 16 $TMP_DIR/boot.img
-mkdir -p $v $TMP_DIR/mnt
-# Do not specify '-o fat=16' when loop mounting boot.img file
-# but rely on the automatic FAT type detection when mounting
+# Make a FAT filesystem on the boot.img file and loop mount it
 # cf. https://github.com/rear/rear/issues/2575
+# and output/ISO/Linux-i386/700_create_efibootimg.sh
+# and output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+# Let mkfs.vfat automatically select the FAT type based on the size.
+# I.e. do not use a '-F 16' or '-F 32' option and hope for the best:
+mkfs.vfat $v $TMP_DIR/boot.img
+mkdir -p $v $TMP_DIR/mnt
 mount $v -o loop -t vfat $TMP_DIR/boot.img $TMP_DIR/mnt || Error "Failed to loop mount boot.img"

--- a/usr/share/rear/output/ISO/Linux-ia64/200_mount_bootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-ia64/200_mount_bootimg.sh
@@ -1,6 +1,9 @@
 # 200_mount_bootimg.sh
 dd if=/dev/zero of=$TMP_DIR/boot.img count=64000 bs=1024
 # make sure we select FAT16 instead of FAT12 as size >30MB
-mkfs.vfat $v -F 16 $TMP_DIR/boot.img >&2
-mkdir -p $v $TMP_DIR/mnt >&2
-mount $v -o loop -t vfat -o fat=16 $TMP_DIR/boot.img $TMP_DIR/mnt >&2
+mkfs.vfat $v -F 16 $TMP_DIR/boot.img
+mkdir -p $v $TMP_DIR/mnt
+# Do not specify '-o fat=16' when loop mounting boot.img file
+# but rely on the automatic FAT type detection when mounting
+# cf. https://github.com/rear/rear/issues/2575
+mount $v -o loop -t vfat $TMP_DIR/boot.img $TMP_DIR/mnt || Error "Failed to loop mount boot.img"


### PR DESCRIPTION
* Type: **Minor Bug Fix** / **Enhancement** / **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2575

* How was this pull request tested?
Not tested by me but SUSE user reported that it is ok, see
https://github.com/rear/rear/issues/2575

* Brief description of the changes in this pull request:

Do no longer specify '-o fat=16' when loop mounting efiboot.img file
but rely on the automatic FAT type detection when mounting
cf. https://github.com/rear/rear/issues/2575
plus some general generic code cleanup in
output/ISO/Linux-i386/700_create_efibootimg.sh