### PR TITLE
Fix rsync --fake-super option on remote server

### DIFF
--- a/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
+++ b/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
@@ -42,7 +42,7 @@ if [ "${RSYNC_USER}" != "root" ]; then
             StopIfError "Remote file system $_mntpt does not have user_xattr mount option set!"
             #BACKUP_RSYNC_OPTIONS+=( --xattrs --rsync-path="""rsync --fake-super""" )
             # see issue #366 for explanation of removing --xattrs
-            BACKUP_RSYNC_OPTIONS+=( --rsync-path="""rsync --fake-super""" )
+            BACKUP_RSYNC_OPTIONS+=( --rsync-path=\"rsync --fake-super\" )
         fi
     else
         if [ ${BACKUP_RSYNC_OPTIONS[@]/--fake-super/} != ${BACKUP_RSUNC_OPTIONS[@]} ]; then


### PR DESCRIPTION
With """, in the expected arg for rsync: 
`--rsync-path="""rsync_ --fake-super"""`, the arg will remove all """, thus the --fake-super will not be executed on the remote server.
And the ownerships will not be saved and restored.

A workaround is to add 
`BACKUP_RSYNC_OPTIONS=( "${BACKUP_RSYNC_OPTIONS[@]}" -M--fake-super )`

 in /etc/rear/local.conf

Thanks

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix** 

* Impact: **High** 

* Reference to related issue (URL):

* How was this pull request tested?
* 
Backup/restore with rsync on RHEL8.2

* Brief description of the changes in this pull request:

Only changed """ to \"