### PR TITLE
Replace possibly misleading "USB device" by generic "USB or disk device" wording

### DIFF
--- a/usr/share/rear/format/USB/default/200_check_usb_layout.sh
+++ b/usr/share/rear/format/USB/default/200_check_usb_layout.sh
@@ -55,6 +55,7 @@ ID_FS_TYPE=$(
 [[ "$ID_FS_TYPE" == btr* || "$ID_FS_TYPE" == ext* ]]
 if (( $? != 0 )) && [[ -z "$YES" ]]; then
     LogUserOutput "USB or disk device $REAL_USB_DEVICE is not formatted with ext2/3/4 or btrfs filesystem"
+    LogUserOutput "Formatting $REAL_USB_DEVICE will remove all currently existing data on that whole device"
     # When USER_INPUT_USB_DEVICE_CONFIRM_FORMAT has any 'true' value be liberal in what you accept and assume exactly 'Yes' was actually meant:
     is_true "$USER_INPUT_USB_DEVICE_CONFIRM_FORMAT" && USER_INPUT_USB_DEVICE_CONFIRM_FORMAT="Yes"
     USB_format_answer="$( UserInput -I USB_DEVICE_CONFIRM_FORMAT -p "Type exactly 'Yes' to format $REAL_USB_DEVICE with $USB_DEVICE_FILESYSTEM filesystem" -D 'No' )"

--- a/usr/share/rear/format/USB/default/200_check_usb_layout.sh
+++ b/usr/share/rear/format/USB/default/200_check_usb_layout.sh
@@ -1,5 +1,5 @@
 
-test "$DEVICE" || Error "Disk device is not set"
+test "$DEVICE" || Error "USB or disk device is not set"
 
 test -b "$DEVICE" || Error "Device $DEVICE is not a block device"
 
@@ -7,7 +7,7 @@ test -b "$DEVICE" || Error "Device $DEVICE is not a block device"
 # Return a proper short device name using udev
 REAL_USB_DEVICE=$(readlink -f $DEVICE)
 
-test "$REAL_USB_DEVICE" -a -b "$REAL_USB_DEVICE" || Error "Unable to determine real disk device for $DEVICE"
+test "$REAL_USB_DEVICE" -a -b "$REAL_USB_DEVICE" || Error "Unable to determine real device for $DEVICE"
 
 # We cannot use the layout dependency code in the backup phase (yet)
 #RAW_USB_DEVICE=$(find_disk $REAL_USB_DEVICE)
@@ -25,10 +25,10 @@ elif [[ "$TEMP_USB_DEVICE" && -d "/sys/block/$TEMP_USB_DEVICE" ]]; then
 elif [[ -z "$TEMP_USB_DEVICE" ]]; then
     RAW_USB_DEVICE="/dev/$(my_udevinfo -q name -n "$REAL_USB_DEVICE")"
 else
-    BugError "Unable to determine raw USB device for $REAL_USB_DEVICE"
+    BugError "Unable to determine raw device for $REAL_USB_DEVICE"
 fi
 
-test "$RAW_USB_DEVICE" -a -b "$RAW_USB_DEVICE" || Error "Unable to determine raw disk device for $REAL_USB_DEVICE"
+test "$RAW_USB_DEVICE" -a -b "$RAW_USB_DEVICE" || Error "Unable to determine raw device for $REAL_USB_DEVICE"
 
 USB_format_answer=""
 
@@ -54,7 +54,7 @@ ID_FS_TYPE=$(
 
 [[ "$ID_FS_TYPE" == btr* || "$ID_FS_TYPE" == ext* ]]
 if (( $? != 0 )) && [[ -z "$YES" ]]; then
-    LogUserOutput "disk device $REAL_USB_DEVICE is not formatted with ext2/3/4 or btrfs filesystem"
+    LogUserOutput "USB or disk device $REAL_USB_DEVICE is not formatted with ext2/3/4 or btrfs filesystem"
     # When USER_INPUT_USB_DEVICE_CONFIRM_FORMAT has any 'true' value be liberal in what you accept and assume exactly 'Yes' was actually meant:
     is_true "$USER_INPUT_USB_DEVICE_CONFIRM_FORMAT" && USER_INPUT_USB_DEVICE_CONFIRM_FORMAT="Yes"
     USB_format_answer="$( UserInput -I USB_DEVICE_CONFIRM_FORMAT -p "Type exactly 'Yes' to format $REAL_USB_DEVICE with $USB_DEVICE_FILESYSTEM filesystem" -D 'No' )"

--- a/usr/share/rear/format/USB/default/200_check_usb_layout.sh
+++ b/usr/share/rear/format/USB/default/200_check_usb_layout.sh
@@ -1,16 +1,13 @@
 
-[[ "$DEVICE" ]]
-StopIfError "USB device is not set."
+test "$DEVICE" || Error "Disk device is not set"
 
-[[ -b "$DEVICE" ]]
-StopIfError "USB device '$DEVICE' is not a block device"
+test -b "$DEVICE" || Error "Device $DEVICE is not a block device"
 
 # Attempt to find the real USB device by trying its parent
 # Return a proper short device name using udev
 REAL_USB_DEVICE=$(readlink -f $DEVICE)
 
-[[ "$REAL_USB_DEVICE" && -b "$REAL_USB_DEVICE" ]]
-StopIfError "Unable to determine real USB device based on USB device '$DEVICE'."
+test "$REAL_USB_DEVICE" -a -b "$REAL_USB_DEVICE" || Error "Unable to determine real disk device for $DEVICE"
 
 # We cannot use the layout dependency code in the backup phase (yet)
 #RAW_USB_DEVICE=$(find_disk $REAL_USB_DEVICE)
@@ -31,8 +28,7 @@ else
     BugError "Unable to determine raw USB device for $REAL_USB_DEVICE"
 fi
 
-[[ "$RAW_USB_DEVICE" && -b "$RAW_USB_DEVICE" ]]
-StopIfError "Unable to determine raw USB device for $REAL_USB_DEVICE"
+test "$RAW_USB_DEVICE" -a -b "$RAW_USB_DEVICE" || Error "Unable to determine raw disk device for $REAL_USB_DEVICE"
 
 USB_format_answer=""
 
@@ -58,12 +54,11 @@ ID_FS_TYPE=$(
 
 [[ "$ID_FS_TYPE" == btr* || "$ID_FS_TYPE" == ext* ]]
 if (( $? != 0 )) && [[ -z "$YES" ]]; then
-    LogUserOutput "USB device $REAL_USB_DEVICE is not formatted with ext2/3/4 or btrfs filesystem"
+    LogUserOutput "disk device $REAL_USB_DEVICE is not formatted with ext2/3/4 or btrfs filesystem"
     # When USER_INPUT_USB_DEVICE_CONFIRM_FORMAT has any 'true' value be liberal in what you accept and assume exactly 'Yes' was actually meant:
     is_true "$USER_INPUT_USB_DEVICE_CONFIRM_FORMAT" && USER_INPUT_USB_DEVICE_CONFIRM_FORMAT="Yes"
     USB_format_answer="$( UserInput -I USB_DEVICE_CONFIRM_FORMAT -p "Type exactly 'Yes' to format $REAL_USB_DEVICE with $USB_DEVICE_FILESYSTEM filesystem" -D 'No' )"
-    test "Yes" = "$USB_format_answer" || Error "Abort USB format process by user (user input '$USB_format_answer' is not 'Yes')"
+    test "Yes" = "$USB_format_answer" || Error "Aborted disk format by user (user input '$USB_format_answer' is not 'Yes')"
 elif [[ "$YES" ]]; then
     USB_format_answer="Yes"
 fi
-

--- a/usr/share/rear/layout/save/default/320_autoexclude.sh
+++ b/usr/share/rear/layout/save/default/320_autoexclude.sh
@@ -30,7 +30,7 @@ if [[ "$AUTOEXCLUDE_USB_PATH" ]] ; then
     for exclude in "${AUTOEXCLUDE_USB_PATH[@]}" ; do
         while read fs device mountpoint junk ; do
             if [[ "$exclude" = "$mountpoint" ]] ; then
-                DebugPrint "Automatically excluding filesystem $mountpoint (USB device $device)"
+                DebugPrint "Automatically excluding filesystem $mountpoint (USB or disk device $device)"
                 mark_as_done "fs:$mountpoint"
                 mark_tree_as_done "fs:$mountpoint"
                 ### by excluding the filesystem, the device will also be excluded

--- a/usr/share/rear/lib/format-workflow.sh
+++ b/usr/share/rear/lib/format-workflow.sh
@@ -68,7 +68,7 @@ WORKFLOW_format () {
         if is_true "$SIMULATE" ; then
             # Simulation mode should work even without a device specified
             # see https://github.com/rear/rear/issues/1098#issuecomment-268973536
-            LogPrint "Simulation mode for the format workflow with a USB device /dev/sdX:"
+            LogPrint "Simulation mode for the format workflow with a USB or disk device /dev/sdX:"
             OUTPUT=USB
             SourceStage "format"
             LogPrint "Simulation mode for the format workflow with a OBDR tape device /dev/stX:"

--- a/usr/share/rear/lib/output-functions.sh
+++ b/usr/share/rear/lib/output-functions.sh
@@ -18,9 +18,9 @@ function FindUsbDevices () {
         if [ -f $sysfspath/${device}1/partition ] ; then
             # find a device node matching this device in /dev
             DeviceNameToNode "$device" || return 1
-            Log "USB device $device selected."
+            Log "USB or disk device $device selected."
         else
-            Log "USB device /dev/$device does not contain a valid partition table - skip device."
+            Log "USB or disk device /dev/$device does not contain a valid partition table - skip device."
         fi
     done
 }

--- a/usr/share/rear/lib/udev-workflow.sh
+++ b/usr/share/rear/lib/udev-workflow.sh
@@ -30,18 +30,17 @@ WORKFLOW_udev () {
 
     # Set USB_DEVICE based on ID_FS_LABEL or UDEV DEVNAME
     if [[ "$ID_FS_LABEL" && -b "/dev/disk/by-label/$ID_FS_LABEL" ]]; then
-        Log "Using USB device based on udev ID_FS_LABEL '$ID_FS_LABEL'"
+        Log "Using USB or disk device based on udev ID_FS_LABEL '$ID_FS_LABEL'"
         USB_DEVICE="/dev/disk/by-label/$ID_FS_LABEL"
     elif [[ "$DEVNAME" && -b "$DEVNAME" ]]; then
-        Log "Using USB device based on udev DEVNAME '$DEVNAME'"
+        Log "Using USB or disk device based on udev DEVNAME '$DEVNAME'"
         USB_DEVICE="$DEVNAME"
     else
-        Log "We cannot determine USB device from udev, using configuration"
+        Log "We cannot determine USB or disk device from udev, using configuration"
     fi
 
     # If udev workflow does not exist, bail out loudly
-    has_binary WORKFLOW_$WORKFLOW
-    StopIfError "Udev workflow '$UDEV_WORKFLOW' does not exist"
+    has_binary WORKFLOW_$WORKFLOW || Error "Udev workflow '$UDEV_WORKFLOW' does not exist"
 
     # Turn the UID led on
     if has_binary hpasmcli && [[ "$UDEV_UID_LED" =~ ^[yY1] ]]; then
@@ -63,12 +62,12 @@ WORKFLOW_udev () {
     # Suspend USB port (works fine on RHEL6, fails on RHEL5 and older)
     if [[ "$DEVPATH" && "$UDEV_SUSPEND" =~ ^[yY1] ]]; then
         path="/sys$DEVPATH"
-        Log "Trying to suspend USB device at '$path'"
+        Log "Trying to suspend USB or disk device at '$path'"
         while [[ "$path" != "/sys" && ! -w "$path/power/level" ]]; do
             path=$(dirname $path)
         done
         if [[ -w "$path/power/level" ]]; then
-            Log "Suspending USB device at '$path'"
+            Log "Suspending USB or disk device at '$path'"
             echo -n suspend >$path/power/level
         fi
     fi

--- a/usr/share/rear/prep/USB/Linux-i386/350_check_usb_disk.sh
+++ b/usr/share/rear/prep/USB/Linux-i386/350_check_usb_disk.sh
@@ -1,15 +1,15 @@
 
-test "$USB_DEVICE" || Error "USB device (USB_DEVICE) is not set."
+test "$USB_DEVICE" || Error "USB or disk device (USB_DEVICE) is not set."
 
 # Attempt to find the real USB device by trying its parent.
 # Return a proper short device name using udev:
 REAL_USB_DEVICE=$( readlink -f $USB_DEVICE )
 
-test -b "$REAL_USB_DEVICE" || Error "USB device '$USB_DEVICE' is not a block device"
+test -b "$REAL_USB_DEVICE" || Error "USB or disk device '$USB_DEVICE' is not a block device"
 
 # Check if the ReaR USB device is not accidentally mounted on other than $BUILD_DIR location:
 if res=( $( grep -v $BUILD_DIR /proc/mounts | grep "^$REAL_USB_DEVICE" ) ) ; then
-    Error "USB device '$REAL_USB_DEVICE' is already mounted on '${res[1]}'"
+    Error "USB or disk device '$REAL_USB_DEVICE' is already mounted on '${res[1]}'"
 fi
 
 # Try to find the parent device (as we don't want to write MBR to a partition)
@@ -30,8 +30,8 @@ elif [ "$TEMP_USB_DEVICE" -a -d "/sys/block/$TEMP_USB_DEVICE" ]; then
 elif [ -z "$TEMP_USB_DEVICE" ] || [ -z "$RAW_USB_DEVICE" ] ; then
     RAW_USB_DEVICE="/dev/$(my_udevinfo -q name -n "$REAL_USB_DEVICE")"
 else
-    BugError "Unable to determine raw USB device for $REAL_USB_DEVICE"
+    BugError "Unable to determine raw device for $REAL_USB_DEVICE"
 fi
 
-test "$RAW_USB_DEVICE" -a -b "$RAW_USB_DEVICE" || Error "Unable to determine raw USB device for $REAL_USB_DEVICE"
+test "$RAW_USB_DEVICE" -a -b "$RAW_USB_DEVICE" || Error "Unable to determine raw device for $REAL_USB_DEVICE"
 


### PR DESCRIPTION
* Type: **Minor Bug Fix** / **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2588

* How was this pull request tested?
Not tested - basically only message text changes.

* Brief description of the changes in this pull request:
Replace possibly misleading "USB device" by generic "USB or disk device" wording
