### PR TITLE
Automatically shrink LVs if needed during "rear recover"

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -270,7 +270,7 @@ $ifline
     if ! lvm lvcreate $lvopts $vg <<<y ; then
         LogPrintError "Failed to create LVM volume '$vg/$lvname' with lvcreate $lvopts $vg"
         if lvm lvcreate $fallbacklvopts $vg <<<y ; then
-            LogPrint "Created LVM volume '$vg/$lvname' using fallback options lvcreate $fallbacklvopts $vg"
+            LogPrintError "Created LVM volume '$vg/$lvname' using fallback options lvcreate $fallbacklvopts $vg"
         else
             LogPrintError "Also failed to create LVM volume '$vg/$lvname' with lvcreate $fallbacklvopts $vg"
             # Explicit 'false' is needed to let the whole 'if then else fi' command exit with non zero exit state

--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -273,6 +273,9 @@ $ifline
             LogPrint "Created LVM volume '$vg/$lvname' using fallback options lvcreate $fallbacklvopts $vg"
         else
             LogPrintError "Also failed to create LVM volume '$vg/$lvname' with lvcreate $fallbacklvopts $vg"
+            # Explicit 'false' is needed to let the whole 'if then else fi' command exit with non zero exit state
+            # to let diskrestore.sh abort here as usual when a command fails (diskrestore.sh runs with 'set -e'):
+            false
         fi
     fi
 fi

--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -128,7 +128,7 @@ elif lvm vgcfgrestore --force -f "$VAR_DIR/layout/lvm/${vg}.cfg" $vg >&2 ; then
 # It failed also ... restore using 'vgcreate/lvcreate' commands
 #
 else
-    LogPrint "Warning: could not restore LVM configuration using 'vgcfgrestore'. Using traditional 'vgcreate/lvcreate' commands instead..."
+    LogPrint "Could not restore LVM configuration using 'vgcfgrestore'. Using traditional 'vgcreate/lvcreate' commands instead"
 fi
 
 EOF
@@ -139,7 +139,7 @@ EOF
 
 cat >> "$LAYOUT_CODE" <<EOF
 if [ \$create_volume_group -eq 1 ] ; then
-    LogPrint "Creating LVM VG '$vg'; Warning: some properties may not be preserved..."
+    LogPrint "Creating LVM VG '$vg' (some properties may not be preserved)"
     lvm vgremove --force --force --yes $vg >&2 || true
     if [ -e "$vgrp" ] ; then
         rm -rf "$vgrp"
@@ -252,14 +252,29 @@ create_lvmvol() {
         warnraidline=""
     fi
 
+    local fallbacklvopts
+    # Assume lvcreate had failed because of "Volume group ... has insufficient free space"
+    # which usually happens when the replacement disk is a bit smaller than the original disk
+    # so that the following fallback attempt to create a LV could work at least once per VG
+    # which is sufficient when the replacement disk is a bit smaller than the original disk
+    # because then the last LV that is created gets shrinked to the remaining space in the VG.
+    # In the lvopts string replace the exact size option of the form '-L 123456b'
+    # with an option to use all remaining free space in the VG via '-l 100%FREE'
+    # so e.g. 'lvcreate -L 123456b -n LV VG' becomes 'lvcreate -l 100%FREE -n LV VG'
+    fallbacklvopts="$( sed -e 's/-L [0-9b]*/-l 100%FREE/' <<< "$lvopts" )"
+
     cat >> "$LAYOUT_CODE" <<EOF
-
 $ifline
-
-    LogPrint "Creating LVM volume '$vg/$lvname'; Warning: some properties may not be preserved..."
+    LogPrint "Creating LVM volume '$vg/$lvname' (some properties may not be preserved)"
     $warnraidline
-    lvm lvcreate $lvopts $vg <<<y
-
+    if ! lvm lvcreate $lvopts $vg <<<y ; then
+        LogPrintError "Failed to create LVM volume '$vg/$lvname' with lvcreate $lvopts $vg"
+        if lvm lvcreate $fallbacklvopts $vg <<<y ; then
+            LogPrint "Created LVM volume '$vg/$lvname' using fallback options lvcreate $fallbacklvopts $vg"
+        else
+            LogPrintError "Also failed to create LVM volume '$vg/$lvname' with lvcreate $fallbacklvopts $vg"
+        fi
+    fi
 fi
 EOF
 }

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -190,10 +190,54 @@ local lvs_exit_code
     # Example output of "lvs --separator=':' --noheadings --units b --nosuffix -o $lvs_fields"
     # with lvs_fields="origin,lv_name,vg_name,lv_size,lv_layout,pool_lv,chunk_size,stripes,stripe_size,seg_size"
     # i.e. when the 'lv_layout' field is supported:
-    #   :root:system:19927138304:linear::0:1:0:19927138304
-    #   :swap:system:1535115264:linear::0:1:0:1535115264
-    # There are two leading blanks in the output (at least on SLES12-SP4 with LVM 2.02.180).
-    lvm lvs --separator=':' --noheadings --units b --nosuffix -o $lvs_fields | while read line ; do
+    
+    #   :home:system:6148849664:linear::0:1:0:6148849664
+    #   :root:system:14050918400:linear::0:1:0:14050918400
+    #   :swap:system:1262485504:linear::0:1:0:1262485504
+    # There are two leading blanks in the output (at least on SLES12-SP4 with LVM 2.02.180 and SLES15-SP3 with LVM 2.03.05).
+    # The 'lvs' output lines ordering does not match the ordering of the LVs kernel device nodes /dev/dm-N
+    #   # lsblk -ipbo NAME,KNAME,TYPE,FSTYPE,SIZE,MOUNTPOINT /dev/sda2
+    #   NAME                      KNAME     TYPE FSTYPE             SIZE MOUNTPOINT
+    #   /dev/sda2                 /dev/sda2 part LVM2_member 21465382400
+    #   |-/dev/mapper/system-swap /dev/dm-0 lvm  swap         1262485504 [SWAP]
+    #   |-/dev/mapper/system-root /dev/dm-1 lvm  btrfs       14050918400 /
+    #   `-/dev/mapper/system-home /dev/dm-2 lvm  xfs          6148849664 /home
+    # This means during "rear recover" the LVs would get recreated according to the ordering of the 'lvs' output lines
+    # because during "rear recover" LVs get recreated according to the ordering of the 'lvmvol' lines in disklayout.conf
+    # so the recreated LVs get different kernel device nodes /dev/dm-N compared to what there was on the original system.
+    # This did not cause any issue at ReaR so far so it seems safe to assume it does not matter in practice
+    # what kernel device node /dev/dm-0 /dev/dm-1 /dev/dm-2 belongs to the LVs
+    # because in practice LVs seem to be always accessed via their symlinks
+    # /dev/mapper/system-swap /dev/mapper/system-root /dev/mapper/system-home
+    # cf. https://github.com/rear/rear/pull/2291#issuecomment-567933705
+    # Therefore we can re-order the 'lvs' output lines as we need it to make "rear recover" behave more fail safe
+    # when it is run on a bit smaller replacement disk(s) so one or more LVs need to be automatically shrinked a bit.
+    # The automated LVs shrinking is not intended when replacement disk(s) are substantially smaller.
+    # To migrate onto a substantially smaller replacement disk the user must in advance
+    # manually adapt his disklayout.conf file before he runs "rear recover".
+    # The basic idea to automatically shrink LVs is to implement a "minimal changes" approach
+    # cf. "minimal changes" in layout/prepare/default/420_autoresize_last_partitions.sh
+    # where the "minimal changes" approach is here to only shrink one single LV per disk if needed.
+    # A LV needs to be shrinked only if it is not possible to recreate all LVs with their specified size
+    # i.e. when during "rear recover" 'lvcreate' fails with "Volume group ... has insufficient free space".
+    # In this case 'lvcreate' is called again where the exact size option of the form '-L 123456b'
+    # is replaced with an option to use all remaining free space in the VG via '-l 100%FREE'
+    # so e.g. 'lvcreate -L 123456b -n LV VG' becomes 'lvcreate -l 100%FREE -n LV VG'
+    # see layout/prepare/GNU/Linux/110_include_lvm_code.sh
+    # The most reasonable LVs that can be shrinked a bit with a "minimal changes" approach are the biggest LVs
+    # because we assume that the data of the backup can still be restored into a big LV after it was shrinked a bit.
+    # So we sort the 'lvs' output lines by the size of the LVs (4th field in the output lines, 1st field is two blanks)
+    # so that the biggest LVs get listed last in disklayout.conf and get recreated last during "rear recover"
+    # so 'lvcreate' may only fail with "Volume group ... has insufficient free space" for some of the biggest LVs.
+    # Additionally it had happened during my <jsmeix@suse.de> initial tests that shrinking the 'swap' LV somehow caused
+    # that the recreated system did not boot (boot screen showed GRUB but there it hung with constant 100% CPU usage)
+    # so automatically shrinking only the biggest LVs avoids that a relatively small 'swap' LV gets shrinked.
+    # With 'sort -n -t ':' -k 4' the above 'lvs' output lines become
+    #   :swap:system:1262485504:linear::0:1:0:1262485504
+    #   :home:system:6148849664:linear::0:1:0:6148849664
+    #   :root:system:14050918400:linear::0:1:0:14050918400
+    # so only the 'root' LV may get automatically shrinked if needed.
+    lvm lvs --separator=':' --noheadings --units b --nosuffix -o $lvs_fields | sort -n -t ':' -k 4 | while read line ; do
 
         # Output lvmvol header only once to DISKLAYOUT_FILE:
         if is_false $header_printed ; then


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **High**
This enables to run "rear recover" with automated LVM LVs shrinking as needed
on a bit smaller replacement disk (e.g. when a nominally same sized replacement disk
is actually a bit smaller than the original disk).
The automated LVs shrinking is not intended when replacement disk(s) are substantially smaller.
To migrate onto a substantially smaller replacement disk the user must in advance
manually adapt his disklayout.conf file before he runs "rear recover".

* How was this pull request tested?
On my SLES 15 SP 3 system with the YaST default LVM setup as in
"SLES 15 SP 1 with default LVM and btrfs structure" in
https://github.com/rear/rear/wiki/Test-Matrix-rear-2.6
where "rear recover" runs on a 1GiB smaller disk
i.e. 19GiB on the replacement VM
with those additional entries in etc/rear/local.conf
```
AUTORESIZE_PARTITIONS=( /dev/sda2 )
AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE=20
```

* Brief description of the changes in this pull request:

In layout/prepare/GNU/Linux/110_include_lvm_code.sh
assume lvcreate had failed because of "Volume group ... has insufficient free space"
which usually happens when the replacement disk is a bit smaller than the original disk
so that the following fallback attempt to create a LV could work at least once per VG
which is sufficient when the replacement disk is a bit smaller than the original disk
because then the last LV that is created gets shrinked to the remaining space in the VG.
In the lvopts string replace the exact size option of the form `-L 123456b`
with an option to use all remaining free space in the VG via `-l 100%FREE`
so e.g. `lvcreate -L 123456b -n LV VG`
becomes `lvcreate -l 100%FREE -n LV VG`

In layout/save/GNU/Linux/220_lvm_layout.sh
sort the 'lvs' output lines by the size of the LVs
as a precondition to make automated shrinking of LVs
work reasonably well with a "minimal changes" approach where
only some biggest LVs may get automatically shrinked (if needed)
because we assume that the data of the backup can still be restored
into a big LV after it was shrinked a bit.