### PR TITLE
New ONLY_INCLUDE_DISKS variable

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2786,6 +2786,13 @@ EXCLUDE_COMPONENTS=()
 # syntax : e.g. ONLY_INCLUDE_VG=( "vg00" "vg01" )
 ONLY_INCLUDE_VG=()
 
+####
+# Only include specified physical devices listed in /sys/block/. This is useful
+# when excluding multipath devices and scan is very slow.
+# syntax : e.g. ONLY_INCLUDE_DISKS=( "/sys/block/sda" )
+# or without /sys/block/ prefix : e.g. ONLY_INCLUDE_DISKS=( sda sdb )
+ONLY_INCLUDE_DISKS=()
+
 # Automatically exclude disks that are not used by mounted filesystems
 AUTOEXCLUDE_DISKS=y
 

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -356,7 +356,7 @@ Log "Saving disk partitions."
 (
     # Disk sizes
     # format: disk <disk> <sectors> <partition label type>
-    for disk in /sys/block/* ; do
+    for disk in ${ONLY_INCLUDE_DISKS[@]:-/sys/block/*} ; do
         blockd=${disk#/sys/block/}
         if [[ $blockd = hd* || $blockd = sd* || $blockd = cciss* || $blockd = vd* || $blockd = xvd* || $blockd = dasd* || $blockd = nvme* || $blockd = mmcblk* ]] ; then
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): None

* How was this pull request tested?

Tested on multipath hardware from a customer. Saved 40 minutes creating the Rescue ISO.

* Brief description of the changes in this pull request:

This array variable enables to only process specified disks when building the `disklayout.conf` file.
This is particularly useful when having a lot of multipath devices which are slow to scan but anyway excluded in the end.

This is for experts only, since it may end up creating an inconsistent `disklayout.conf` file.
In particular the `EXCLUDE_MOUNTPOINTS` variable is not populated automatically because doing so would likely break things.

Usage example:
~~~
ONLY_INCLUDE_DISKS=( sda sdb )
~~~
or
~~~
ONLY_INCLUDE_DISKS=( /sys/block/sda )
~~~
