### PR TITLE
#2594 adding sleep period to give rsync daemon time to wake up

### DIFF
--- a/usr/share/rear/prep/RSYNC/default/050_prep_rsync.sh
+++ b/usr/share/rear/prep/RSYNC/default/050_prep_rsync.sh
@@ -48,3 +48,7 @@ rsync_err_msg=(
 "Error 34"
 "Timeout waiting for daemon connection"
 )
+
+# According issue #2594 we better sleep a few seconds to give the rsync daemon time
+# to wake and getting ready to accept rsync connections:
+sleep 5


### PR DESCRIPTION
Signed-off-by: Gratien D'haese <gratien.dhaese@gmail.com>

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): #2594 

* How was this pull request tested? by end-user of #2594 (@cvijayvinoth)

* Brief description of the changes in this pull request: adding sleep period to give the rsync daemon some extra time to wake up before accepting connections

