### PR TITLE
Fix setting boot path in case of UEFI partition (ESP) on MD RAID

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -58,23 +58,23 @@ if ! test "$boot_efi_parts" ; then
 fi
 
 # EFI\fedora\shim.efi
-BootLoader=$( echo $UEFI_BOOTLOADER | cut -d"/" -f4- | sed -e 's;/;\\;g' )
+bootloader=$( echo $UEFI_BOOTLOADER | cut -d"/" -f4- | sed -e 's;/;\\;g' )
 
 for efipart in $boot_efi_parts ; do
     # /dev/sda1 or /dev/mapper/vol34_part2 or /dev/mapper/mpath99p4
-    Dev=$( get_device_name $efipart )
+    partition_block_device=$( get_device_name $efipart )
     # 1 or 2 or 4 for the examples above
-    ParNr=$( get_partition_number $Dev )
-    Disk=$( get_device_from_partition $Dev $ParNr )
-    LogPrint "Creating  EFI Boot Manager entry '$OS_VENDOR $OS_VERSION' for '$BootLoader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER') "
-    Log efibootmgr --create --gpt --disk ${Disk} --part ${ParNr} --write-signature --label \"${OS_VENDOR} ${OS_VERSION}\" --loader \"\\${BootLoader}\"
-    if efibootmgr --create --gpt --disk ${Disk} --part ${ParNr} --write-signature --label "${OS_VENDOR} ${OS_VERSION}" --loader "\\${BootLoader}" ; then
+    partition_number=$( get_partition_number $partition_block_device )
+    disk=$( get_device_from_partition $partition_block_device $partition_number )
+    LogPrint "Creating  EFI Boot Manager entry '$OS_VENDOR $OS_VERSION' for '$bootloader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER') "
+    Log efibootmgr --create --gpt --disk $disk --part $partition_number --write-signature --label \"${OS_VENDOR} ${OS_VERSION}\" --loader \"\\${bootloader}\"
+    if efibootmgr --create --gpt --disk $disk --part $partition_number --write-signature --label "${OS_VENDOR} ${OS_VERSION}" --loader "\\${bootloader}" ; then
         # ok, boot loader has been set-up - continue with other disks (ESP can be on RAID)
         NOBOOTLOADER=''
     else
-        LogPrintError "efibootmgr failed to create EFI Boot Manager entry on $Disk partition $ParNr (ESP $Dev)"
+        LogPrintError "efibootmgr failed to create EFI Boot Manager entry on $disk partition $partition_number (ESP $partition_block_device )"
     fi
 done
 
 is_true $NOBOOTLOADER || return 0
-LogPrintError "efibootmgr failed to create EFI Boot Manager entry for '$BootLoader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER')"
+LogPrintError "efibootmgr failed to create EFI Boot Manager entry for '$bootloader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER')"

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -8,6 +8,8 @@ is_true $USING_UEFI_BOOTLOADER || return 0
 # (cf. finalize/Linux-i386/610_EFISTUB_run_efibootmgr.sh): 
 is_true $EFI_STUB && return
 
+LogPrint "Creating EFI Boot Manager entries..."
+
 local esp_mountpoint esp_mountpoint_inside boot_efi_parts boot_efi_dev
 
 # When UEFI_BOOTLOADER is not a regular file in the restored target system
@@ -23,7 +25,6 @@ if ! test -f "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" ; then
     return 1
 fi
 
-LogPrint "Creating EFI Boot Manager entries..."
 # Determine where the EFI System Partition (ESP) is mounted in the currently running recovery system:
 esp_mountpoint=$( filesystem_name "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" )
 # Use TARGET_FS_ROOT/boot/efi as fallback ESP mountpoint (filesystem_name returns "/"

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -75,7 +75,11 @@ for efipart in $boot_efi_parts ; do
     partition_block_device=$( get_device_name $efipart )
     # 1 or 2 or 4 for the examples above
     partition_number=$( get_partition_number $partition_block_device )
-    disk=$( get_device_from_partition $partition_block_device $partition_number )
+    if ! disk=$( get_device_from_partition $partition_block_device $partition_number ) ; then
+        LogPrintError "Cannot create EFI Boot Manager entry for ESP $partition_block_device (unable to find the underlying disk)"
+        # do not error out - we may be able to locate other disks if there are more of them
+        continue
+    fi
     LogPrint "Creating  EFI Boot Manager entry '$OS_VENDOR $OS_VERSION' for '$bootloader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER') "
     Log efibootmgr --create --gpt --disk $disk --part $partition_number --write-signature --label \"${OS_VENDOR} ${OS_VERSION}\" --loader \"\\${bootloader}\"
     if efibootmgr --create --gpt --disk $disk --part $partition_number --write-signature --label "${OS_VENDOR} ${OS_VERSION}" --loader "\\${bootloader}" ; then

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -20,8 +20,12 @@ test -f "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" || return 0
 
 # Determine where the EFI System Partition (ESP) is mounted in the currently running recovery system:
 esp_mountpoint=$( filesystem_name "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" )
-# Use TARGET_FS_ROOT/boot/efi as fallback ESP mountpoint:
-test "$esp_mountpoint" != "/" || esp_mountpoint="$TARGET_FS_ROOT/boot/efi"
+# Use TARGET_FS_ROOT/boot/efi as fallback ESP mountpoint (filesystem_name returns "/"
+# if mountpoint not found otherwise):
+if [ "$esp_mountpoint" = "/" ] ; then
+    esp_mountpoint="$TARGET_FS_ROOT/boot/efi"
+    Log "Mountpoint of $TARGET_FS_ROOT/$UEFI_BOOTLOADER not found, trying $esp_mountpoint"
+fi
 
 # Skip if there is no esp_mountpoint directory (e.g. the fallback ESP mountpoint may not exist).
 # Double quotes are mandatory here because 'test -d' without any (possibly empty) argument results true:

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -95,3 +95,4 @@ done
 
 is_true $NOBOOTLOADER || return 0
 LogPrintError "efibootmgr failed to create EFI Boot Manager entry for '$bootloader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER')"
+return 1

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -19,7 +19,9 @@ local esp_mountpoint esp_mountpoint_inside boot_efi_parts boot_efi_dev
 # because when UEFI_BOOTLOADER is empty the test below evaluates to
 #   test -f /mnt/local/
 # which also returns false because /mnt/local/ is a directory
-# (cf. https://github.com/rear/rear/pull/2051/files#r258826856):
+# (cf. https://github.com/rear/rear/pull/2051/files#r258826856)
+# but using BIOS conflicts with USING_UEFI_BOOTLOADER is true
+# i.e. we should create EFI Boot Manager entries but we cannot:
 if ! test -f "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" ; then
     LogPrintError "Failed to create EFI Boot Manager entries (UEFI bootloader $UEFI_BOOTLOADER not found under target $TARGET_FS_ROOT)"
     return 1

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -18,6 +18,7 @@ is_true $EFI_STUB && return
 # (cf. https://github.com/rear/rear/pull/2051/files#r258826856):
 test -f "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" || return 0
 
+LogPrint "Creating EFI Boot Manager entries..."
 # Determine where the EFI System Partition (ESP) is mounted in the currently running recovery system:
 esp_mountpoint=$( filesystem_name "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" )
 # Use TARGET_FS_ROOT/boot/efi as fallback ESP mountpoint (filesystem_name returns "/"

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -8,6 +8,8 @@ is_true $USING_UEFI_BOOTLOADER || return 0
 # (cf. finalize/Linux-i386/610_EFISTUB_run_efibootmgr.sh): 
 is_true $EFI_STUB && return
 
+local esp_mountpoint esp_mountpoint_inside boot_efi_parts boot_efi_dev
+
 # When UEFI_BOOTLOADER is not a regular file in the restored target system
 # (cf. how esp_mountpoint is set below) it means BIOS is used
 # (cf. rescue/default/850_save_sysfs_uefi_vars.sh)
@@ -56,6 +58,8 @@ if ! test "$boot_efi_parts" ; then
     fi
     LogPrint "Using fallback EFI boot partition(s) $boot_efi_parts (unable to find ESP $esp_mountpoint_inside in layout)"
 fi
+
+local bootloader partition_block_device partition_number disk efipart
 
 # EFI\fedora\shim.efi
 bootloader=$( echo $UEFI_BOOTLOADER | cut -d"/" -f4- | sed -e 's;/;\\;g' )

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -18,7 +18,10 @@ local esp_mountpoint esp_mountpoint_inside boot_efi_parts boot_efi_dev
 #   test -f /mnt/local/
 # which also returns false because /mnt/local/ is a directory
 # (cf. https://github.com/rear/rear/pull/2051/files#r258826856):
-test -f "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" || return 0
+if ! test -f "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" ; then
+    LogPrintError "Failed to create EFI Boot Manager entries (UEFI bootloader $UEFI_BOOTLOADER not found under target $TARGET_FS_ROOT)"
+    return 1
+fi
 
 LogPrint "Creating EFI Boot Manager entries..."
 # Determine where the EFI System Partition (ESP) is mounted in the currently running recovery system:
@@ -32,7 +35,10 @@ fi
 
 # Skip if there is no esp_mountpoint directory (e.g. the fallback ESP mountpoint may not exist).
 # Double quotes are mandatory here because 'test -d' without any (possibly empty) argument results true:
-test -d "$esp_mountpoint" || return 0
+if ! test -d "$esp_mountpoint" ; then
+    LogPrintError "Failed to create EFI Boot Manager entries (no ESP mountpoint directory $esp_mountpoint)"
+    return 1
+fi
 
 # Mount point inside the target system,
 # accounting for possible trailing slashes in TARGET_FS_ROOT

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -24,27 +24,56 @@ esp_mountpoint=$( filesystem_name "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" )
 # if mountpoint not found otherwise):
 if [ "$esp_mountpoint" = "/" ] ; then
     esp_mountpoint="$TARGET_FS_ROOT/boot/efi"
-    Log "Mountpoint of $TARGET_FS_ROOT/$UEFI_BOOTLOADER not found, trying $esp_mountpoint"
+    LogPrint "Mountpoint of $TARGET_FS_ROOT/$UEFI_BOOTLOADER not found, trying $esp_mountpoint"
 fi
 
 # Skip if there is no esp_mountpoint directory (e.g. the fallback ESP mountpoint may not exist).
 # Double quotes are mandatory here because 'test -d' without any (possibly empty) argument results true:
 test -d "$esp_mountpoint" || return 0
 
-BootEfiDev="$( mount | grep "$esp_mountpoint" | awk '{print $1}' )"
-# /dev/sda1 or /dev/mapper/vol34_part2 or /dev/mapper/mpath99p4
-Dev=$( get_device_name $BootEfiDev )
-# 1 (must anyway be a low nr <9)
-ParNr=$( get_partition_number $Dev )
-Disk=$( get_device_from_partition $Dev $ParNr )
-# EFI\fedora\shim.efi
-BootLoader=$( echo $UEFI_BOOTLOADER | cut -d"/" -f4- | sed -e 's;/;\\;g' )
-LogPrint "Creating  EFI Boot Manager entry '$OS_VENDOR $OS_VERSION' for '$BootLoader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER')"
-Log efibootmgr --create --gpt --disk ${Disk} --part ${ParNr} --write-signature --label \"${OS_VENDOR} ${OS_VERSION}\" --loader \"\\${BootLoader}\"
-if efibootmgr --create --gpt --disk ${Disk} --part ${ParNr} --write-signature --label "${OS_VENDOR} ${OS_VERSION}" --loader "\\${BootLoader}" ; then
-    # ok, boot loader has been set-up - tell rear we are done using following var.
-    NOBOOTLOADER=''
-    return
+# Mount point inside the target system,
+# accounting for possible trailing slashes in TARGET_FS_ROOT
+esp_mountpoint_inside="${esp_mountpoint#${TARGET_FS_ROOT%%*(/)}}"
+
+boot_efi_parts=$( find_partition "fs:$esp_mountpoint_inside" fs )
+if ! test "$boot_efi_parts" ; then
+    LogPrint "Unable to find ESP $esp_mountpoint_inside in layout"
+    LogPrint "Trying to determine device currently mounted at $esp_mountpoint as fallback"
+    boot_efi_dev="$( mount | grep "$esp_mountpoint" | awk '{print $1}' )"
+    if ! test "$boot_efi_dev" ; then
+        LogPrintError "Cannot create EFI Boot Manager entry (unable to find ESP $esp_mountpoint among mounted devices)"
+        return 1
+    fi
+    if test $(get_component_type "$boot_efi_dev") = part ; then
+        boot_efi_parts="$boot_efi_dev"
+    else
+        boot_efi_parts=$( find_partition "$boot_efi_dev" )
+    fi
+    if ! test "$boot_efi_parts" ; then
+        LogPrintError "Cannot create EFI Boot Manager entry (unable to find partition for $boot_efi_dev)"
+        return 1
+    fi
+    LogPrint "Using fallback EFI boot partition(s) $boot_efi_parts (unable to find ESP $esp_mountpoint_inside in layout)"
 fi
 
+# EFI\fedora\shim.efi
+BootLoader=$( echo $UEFI_BOOTLOADER | cut -d"/" -f4- | sed -e 's;/;\\;g' )
+
+for efipart in $boot_efi_parts ; do
+    # /dev/sda1 or /dev/mapper/vol34_part2 or /dev/mapper/mpath99p4
+    Dev=$( get_device_name $efipart )
+    # 1 or 2 or 4 for the examples above
+    ParNr=$( get_partition_number $Dev )
+    Disk=$( get_device_from_partition $Dev $ParNr )
+    LogPrint "Creating  EFI Boot Manager entry '$OS_VENDOR $OS_VERSION' for '$BootLoader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER') "
+    Log efibootmgr --create --gpt --disk ${Disk} --part ${ParNr} --write-signature --label \"${OS_VENDOR} ${OS_VERSION}\" --loader \"\\${BootLoader}\"
+    if efibootmgr --create --gpt --disk ${Disk} --part ${ParNr} --write-signature --label "${OS_VENDOR} ${OS_VERSION}" --loader "\\${BootLoader}" ; then
+        # ok, boot loader has been set-up - continue with other disks (ESP can be on RAID)
+        NOBOOTLOADER=''
+    else
+        LogPrintError "efibootmgr failed to create EFI Boot Manager entry on $Disk partition $ParNr (ESP $Dev)"
+    fi
+done
+
+is_true $NOBOOTLOADER || return 0
 LogPrintError "efibootmgr failed to create EFI Boot Manager entry for '$BootLoader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER')"

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -23,7 +23,7 @@ local esp_mountpoint esp_mountpoint_inside boot_efi_parts boot_efi_dev
 # but using BIOS conflicts with USING_UEFI_BOOTLOADER is true
 # i.e. we should create EFI Boot Manager entries but we cannot:
 if ! test -f "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" ; then
-    LogPrintError "Failed to create EFI Boot Manager entries (UEFI bootloader $UEFI_BOOTLOADER not found under target $TARGET_FS_ROOT)"
+    LogPrintError "Failed to create EFI Boot Manager entries (UEFI bootloader '$UEFI_BOOTLOADER' not found under target $TARGET_FS_ROOT)"
     return 1
 fi
 

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -19,9 +19,9 @@ is_true $EFI_STUB && return
 test -f "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" || return 0
 
 # Determine where the EFI System Partition (ESP) is mounted in the currently running recovery system:
-esp_mountpoint=$( df -P "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" | tail -1 | awk '{print $6}' )
+esp_mountpoint=$( filesystem_name "$TARGET_FS_ROOT/$UEFI_BOOTLOADER" )
 # Use TARGET_FS_ROOT/boot/efi as fallback ESP mountpoint:
-test "$esp_mountpoint" || esp_mountpoint="$TARGET_FS_ROOT/boot/efi"
+test "$esp_mountpoint" != "/" || esp_mountpoint="$TARGET_FS_ROOT/boot/efi"
 
 # Skip if there is no esp_mountpoint directory (e.g. the fallback ESP mountpoint may not exist).
 # Double quotes are mandatory here because 'test -d' without any (possibly empty) argument results true:

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -454,6 +454,7 @@ function get_device_from_partition() {
     local partition_number
 
     partition_block_device=$1
+    test -b "$partition_block_device" || BugError "get_device_from_partition called with '$partition_block_device' that is no block device"
     partition_number=${2-$(get_partition_number $partition_block_device )}
     # /dev/sda or /dev/mapper/vol34_part or /dev/mapper/mpath99p or /dev/mmcblk0p
     device=${partition_block_device%$partition_number}
@@ -488,7 +489,7 @@ function get_device_from_partition() {
         device=${device%p}
     fi
 
-    echo $device
+    test -b "$device" && echo $device
 }
 
 # Returns partition start block or 'unknown'


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL): #2595

* How was this pull request tested?
Backup & restore on a RHEL 8 host with UEFI but without RAID and on a CentOS 7 host with UEFI and RAID (ESP on RAID). Examination of logs to check that correct efibootmgr commands were executed.

* Brief description of the changes in this pull request:

Use dependencies when determining partitions for UEFI

The ESP may be located on a RAID device. In this case, we need to determine the physical RAID components and call efibootmgr on them (after restoring - during the finalize step), because efibootmgr does not know how to tell the firmware to boot from RAID. Moreover, the current code tries to parse a device like `/dev/md125` into a disk called `/dev/md` and partition `125`.

Fix by using storage dependencies: RAID components (the actual ESP copies) can be found as dependencies of the ESP block device. For consistency, use dependencies also to locate the ESP block device itself (the old method is preserved as a fallback).  Similar strategy is used by the GRUB2 installation code (finalize/Linux-i386/660_install_grub2.sh), which is able to install GRUB2 on the RAID components correctly.

In addition, clean up usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh a bit and add more logging to ease analysis when something goes wrong in this area.

TODO: finalize/Linux-i386/610_EFISTUB_run_efibootmgr.sh needs a similar fix.

Fixes #2595