### PR TITLE
Better description and error checking for GRUB_RESCUE with UEFI plus some alignment with create_grub2_cfg function

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2936,9 +2936,16 @@ NETWORKING_PREPARATION_COMMANDS=()
 ##
 # GRUB_RESCUE [ GRUB_RESCUE_USER ]
 #
-# Add a ReaR rescue/recovery system to the GRUB/GRUB2 bootloader of the currently running system.
-# It adds kernel and the ReaR initrd to the bootloader directory in the currently running system and
-# adds a 'Relax-and-Recover' GRUB/GRUB2 menue entry to boot that locally installed ReaR rescue system.
+# Add a ReaR rescue/recovery system to the bootloader of the currently running system.
+# With BIOS a ReaR rescue system is added to the GRUB/GRUB2 bootloader of the currently running system.
+# With UEFI a ReaR rescue system is added to the EFI boot manager of the currently running system.
+# UEFI is only supported with GRUB2. GRUB_RESCUE with UEFI and GRUB is not supported.
+# It adds kernel and ReaR initrd to the bootloader directory in the currently running system.
+# It adds a 'Relax-and-Recover' boot entry to boot that locally installed ReaR rescue system.
+# With BIOS a 'Relax-and-Recover' boot entry is added to the GRUB/GRUB2 bootloader menu.
+# With UEFI a 'Relax-and-Recover' boot entry is added to the EFI boot manager.
+# With UEFI there is no 'Relax-and-Recover' boot entry in the GRUB2 bootloader menu
+# (cf. https://github.com/rear/rear/pull/954 and https://github.com/rear/rear/issues/2545).
 # Note that GRUB_RESCUE is the only functionality where "rear mkbackup" or "rear mkrescue"
 # changes the currently running system. It changes the currently running system even
 # in a critical way because it changes the bootloader of the currently running system.
@@ -2949,19 +2956,19 @@ NETWORKING_PREPARATION_COMMANDS=()
 # whole current system with a recreated system where all files are restored from the backup.
 # To be on the safe side the GRUB_RESCUE functionality is disabled by default:
 GRUB_RESCUE=n
-# Optional password protection via GRUB_RESCUE_USER only works for GRUB2 with Legacy BIOS booting.
-# GRUB_RESCUE_USER is not supported for UEFI booting (cf. https://github.com/rear/rear/pull/954).
+# Optional password protection via GRUB_RESCUE_USER only works for GRUB2 with BIOS.
+# GRUB_RESCUE_USER is not supported for UEFI (cf. https://github.com/rear/rear/pull/954).
 # GRUB2 password protection requires an existing GRUB2 user with a password.
 # If the GRUB_RESCUE functionality is enabled (e.g. via GRUB_RESCUE=y in /etc/rear/local.conf)
 # a non-empty GRUB_RESCUE_USER can be optionally set to get GRUB2 password protection
-# for the 'Relax-and-Recover' GRUB2 menue entry.
+# for the 'Relax-and-Recover' GRUB2 menu entry.
 # When GRUB_RESCUE_USER is non-empty it must specify an already configured GRUB2 user
 # except the special value 'unrestricted' is set via GRUB_RESCUE_USER="unrestricted"
-# which creates the 'Relax-and-Recover' GRUB2 menue entry so that it can be booted by anyone
+# which creates the 'Relax-and-Recover' GRUB2 menu entry so that it can be booted by anyone
 # which means anyone who can boot the currently running system can replace it via "rear recover".
 # When GRUB_RESCUE_USER is empty ReaR does not do a GRUB2 user related setup
 # so that the already existing GRUB2 users configuration determines
-# which users can boot the 'Relax-and-Recover' GRUB2 menue entry.
+# which users can boot the 'Relax-and-Recover' GRUB2 menu entry.
 # Usually this means anyone can boot 'Relax-and-Recover' which means anyone
 # who can boot the currently running system can replace it via "rear recover".
 GRUB_RESCUE_USER=""
@@ -2971,7 +2978,7 @@ GRUB_RESCUE_USER=""
 # but ReaR is not meant to change the general GRUB2 configuration of the currently running system.
 # It works by default reasonably backward compatible when formerly a GRUB_SUPERUSER was used
 # which means a GRUB2 superuser was set up by ReaR in /etc/grub.d/01_users with GRUB_RESCUE_PASSWORD
-# so that the empty GRUB_RESCUE_USER results that the 'Relax-and-Recover' GRUB2 menue entry
+# so that the empty GRUB_RESCUE_USER results that the 'Relax-and-Recover' GRUB2 menu entry
 # can only be booted by the formerly set GRUB_SUPERUSER with the formerly set GRUB_RESCUE_PASSWORD.
 # For background information see https://github.com/rear/rear/pull/942
 # and https://github.com/rear/rear/issues/703

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -63,8 +63,9 @@ function build_bootx86_efi {
         gmkstandalone=grub2-mkstandalone
     else
         # This build_bootx86_efi function is only called in output/ISO/Linux-i386/250_populate_efibootimg.sh
-        # which runs only if UEFI is used so that we simply error out here if we cannot make a bootable EFI image of GRUB2
-        # (normally a function should not exit out but return to its caller with a non-zero return code):
+        # and output/USB/Linux-i386/100_create_efiboot.sh and output/default/940_grub2_rescue.sh
+        # only if UEFI is used so that we simply error out here if we cannot make a bootable EFI image of GRUB2
+        # (normally a function should not exit but return to its caller with a non-zero return code):
         Error "Cannot make bootable EFI image of GRUB2 (neither grub-mkstandalone nor grub2-mkstandalone found)"
     fi
 

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -15,28 +15,31 @@ is_true "$GRUB_RESCUE" || return 0
 # in particular do not run this script when GRUB Legacy is used
 # (for GRUB Legacy output/default/940_grub_rescue.sh is run):
 if [[ ! $( type -p grub-probe ) && ! $( type -p grub2-probe ) ]] ; then
-    LogPrint "Skipping GRUB_RESCUE setup for GRUB 2 (no GRUB 2 found)."
-    return
+    LogPrint "Cannot do GRUB_RESCUE setup: GRUB 2 not found (neither grub-probe nor grub2-probe)"
+    return 1
 fi
 
 # Now GRUB_RESCUE is explicitly wanted and this script is the right one to set it up.
 local grub_rear_menu_entry_name="Relax-and-Recover"
-LogPrint "Setting up GRUB_RESCUE: Adding $grub_rear_menu_entry_name rescue system to the local GRUB 2 configuration."
-test "unrestricted" = "$GRUB_RESCUE_USER" && LogPrint "Anyone can boot that and replace the current system via 'rear recover'."
+# Refer to the "UEFI 'Relax-and-Recover' boot entry motivation" explanation below:
+if is_true $USING_UEFI_BOOTLOADER ; then
+    LogPrint "Setting up GRUB_RESCUE: Adding $grub_rear_menu_entry_name rescue system to the local UEFI boot manager"
+    LogPrint "Anyone who can select UEFI boot entries can boot it and replace the current system via 'rear recover'"
+else
+    LogPrint "Setting up GRUB_RESCUE: Adding $grub_rear_menu_entry_name rescue system to the local GRUB 2 configuration"
+    test "unrestricted" = "$GRUB_RESCUE_USER" && LogPrint "Anyone can boot it and replace the current system via 'rear recover'"
+fi
 # Now error out whenever it cannot setup the GRUB_RESCUE functionality.
 
 # We don't need to do grub(2)-probe all the time
-# adding $grub_num to whatever grub binary should do the trick
-# e.g. grub${grub_num}-mkimage
+# adding $grub_num to whatever grub thingy should do the trick:
 local grub_num=""
-if [[ $( type -p grub2-probe ) ]]; then
-    grub_num="2"
-fi
+type -p grub2-probe && grub_num="2"
 
 # Ensure that kernel and initrd are there:
-test -r "$KERNEL_FILE" || Error "Cannot setup GRUB_RESCUE: Cannot read kernel file '$KERNEL_FILE'."
+test -r "$KERNEL_FILE" || Error "Cannot setup GRUB_RESCUE: Cannot read kernel file '$KERNEL_FILE'"
 local initrd_file=$TMP_DIR/$REAR_INITRD_FILENAME
-test -r $initrd_file || Error "Cannot setup GRUB_RESCUE: Cannot read initrd '$initrd_file'."
+test -r $initrd_file || Error "Cannot setup GRUB_RESCUE: Cannot read initrd '$initrd_file'"
 
 # Some commonly needed values:
 local boot_dir="/boot"
@@ -62,14 +65,12 @@ local required_space=$( total_filesize $KERNEL_FILE $initrd_file )
 if (( available_space < required_space )) ; then
     required_MiB=$(( required_space / 1024 / 1024 ))
     available_MiB=$(( available_space / 1024 / 1024 ))
-    Error "Cannot setup GRUB_RESCUE: Not enough disk space in $boot_dir for $grub_rear_menu_entry_name rescue system. Required: $required_MiB MiB. Available: $available_MiB MiB."
+    Error "Cannot setup GRUB_RESCUE: Not enough disk space in $boot_dir for $grub_rear_menu_entry_name rescue system (required: $required_MiB MiB, available: $available_MiB MiB)"
 fi
 
-# TODO: @gozora this is quite long comment, maybe it could me moved to documentation?
+# UEFI 'Relax-and-Recover' boot entry motivation:
 #
-# UEFI "Relax-and-Recover" boot entry motivation:
-#
-# If UEFI boot is in use, we will not modify grub.cfg, but setup "Relax-and-Recover" entry in UEFI boot menu instead.
+# If UEFI boot is in use, we will not modify grub.cfg, but setup 'Relax-and-Recover' entry in UEFI boot menu instead.
 # This looks to be simplest and safest approach since finding out what mechanisms were used to boot OS in UEFI mode,
 # looks to be near to impossible.
 # One could argue that efibootmgr/efivars can tell you, however this entry is not mandatory and OS could be booted
@@ -78,7 +79,7 @@ fi
 # or configuration file can be even embedded in bootx64.efi (and friends) as file or memdisk.
 # Unfortunately there seems to be no reliable way how to track this back.
 #
-# Once "Relax-and-Recover" entry in UEFI boot menu is created, user can choose to boot it from OS at next boot:
+# Once 'Relax-and-Recover' entry in UEFI boot menu is created, user can choose to boot it from OS at next boot:
 # # efibootmgr
 #
 # BootCurrent: 0001
@@ -90,25 +91,25 @@ fi
 # Boot0004* Relax-and-Recover
 #
 # # /usr/sbin/efibootmgr --bootnext 4
-# At next boot "Relax-and-Recover" rescue image from /boot will be loaded.
+# At next boot 'Relax-and-Recover' rescue image from /boot will be loaded.
 #
-# To remove "Relax-and-Recover" UEFI boot entry:
+# To remove 'Relax-and-Recover' UEFI boot entry:
 #
 # # efibootmgr -B -b 4
 #
-# "Relax-and-Recover" entry can be of course selected during POST boot as well.
+# 'Relax-and-Recover' entry can be of course selected during POST boot as well.
 
 if ! is_true $USING_UEFI_BOOTLOADER ; then
     # Ensure a GRUB 2 configuration file is found:
     local grub_conf=$( readlink -f $grub_config_dir/grub.cfg )
-    test -w "$grub_conf" || Error "Cannot setup GRUB_RESCUE: GRUB 2 configuration '$grub_conf' cannot be modified."
+    test -w "$grub_conf" || Error "Cannot setup GRUB_RESCUE: GRUB 2 configuration '$grub_conf' cannot be modified"
 
     # Report no longer supported GRUB 2 superuser setup if GRUB_SUPERUSER is non-empty
     # (be prepared for 'set -u' by specifying an empty fallback value if GRUB_SUPERUSER is not set):
-    test ${GRUB_SUPERUSER:-} && LogPrint "Skipping GRUB 2 superuser setup: GRUB_SUPERUSER is no longer supported (see default.conf)."
+    test ${GRUB_SUPERUSER:-} && LogPrint "Skipping GRUB 2 superuser setup: GRUB_SUPERUSER is no longer supported (see default.conf)"
     # Report no longer supported GRUB 2 password setup if GRUB_RESCUE_PASSWORD is non-empty
     # (be prepared for 'set -u' by specifying an empty fallback value if GRUB_RESCUE_PASSWORD is not set):
-    test ${GRUB_RESCUE_PASSWORD:-} && LogPrint "Skipping GRUB 2 password setup: GRUB_RESCUE_PASSWORD is no longer supported (see default.conf)."
+    test ${GRUB_RESCUE_PASSWORD:-} && LogPrint "Skipping GRUB 2 password setup: GRUB_RESCUE_PASSWORD is no longer supported (see default.conf)"
     # It is no error when GRUB_SUPERUSER and/or GRUB_RESCUE_PASSWORD are non-empty
     # because it should work reasonably backward compatible, see default.conf
 
@@ -127,7 +128,7 @@ fi
 grub_boot_uuid=$( df $boot_dir | awk 'END {print $1}' | xargs blkid -s UUID -o value )
 
 # Stop if grub_boot_uuid is not a valid UUID
-blkid -U $grub_boot_uuid > /dev/null 2>&1 || Error "$grub_boot_uuid is not a valid UUID"
+blkid -U $grub_boot_uuid > /dev/null 2>&1 || Error "grub_boot_uuid '$grub_boot_uuid' is not a valid UUID"
 
 # Creating Relax-and-Recover GRUB 2 menu entry:
 local grub_rear_menu_entry_file="/etc/grub.d/45_rear"
@@ -141,13 +142,14 @@ if mountpoint -q $boot_dir ; then
     grub_boot_dir=""
 fi
 
-# Refer to: UEFI "Relax-and-Recover" boot entry motivation, near to beginning of this file ...
+# Refer to the "UEFI 'Relax-and-Recover' boot entry motivation" explanation above:
 if is_true $USING_UEFI_BOOTLOADER ; then
     # SLES12 SP1 throw kernel panic if root= variable was not set
     # probably a bug, as I was able to boot with value set to root=anything
-    root_uuid=$(get_root_disk_UUID)
+    root_uuid=$( get_root_disk_UUID )
+    test $root_uuid || LogPrintError "root_uuid '$root_uuid' empty or more than one word"
 
-    # Create configuration file for "Relax-and-Recover" UEFI boot entry.
+    # Create configuration file for 'Relax-and-Recover' UEFI boot entry.
     # This file will not interact with existing Grub2 configuration in any way.
     (   echo "set btrfs_relative_path=y"
         echo "insmod efi_gop"
@@ -175,25 +177,36 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     # Create rear.efi at UEFI default boot directory location.
     build_bootx86_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear.cfg "$boot_dir" "$UEFI_BOOTLOADER"
 
-    # If UEFI boot entry for "Relax-and-Recover" does not exist, create it.
-    # This will also add "Relax-and-Recover" to boot order because if UEFI entry is not listed in BootOrder,
+    # If UEFI boot entry for 'Relax-and-Recover' does not exist, create it.
+    # This will also add 'Relax-and-Recover' to boot order because if UEFI entry is not listed in BootOrder,
     # it is not visible in UEFI boot menu.
-    if [[ $(efibootmgr | grep -cw $grub_rear_menu_entry_name) -eq 0 ]]; then
-        # This part might not go that well with drivers like HPEs cciss...
+    if efibootmgr | grep -q $grub_rear_menu_entry_name ; then
+        LogPrint "Skip creating new 'Relax-and-Recover' UEFI boot entry (it is already there)"
+    else
+        # This part might not go that well with drivers like HPEs cciss ...
         # However UEFI booting is present since Gen8 (AFAIK), and cciss drivers were replaced by hpsa long time ago,
         # so it looks like impossible configuration, lets wait ...
-        efi_disk_part=$(grep -w /boot/efi /proc/mounts | awk '{print $1}')
-        efi_disk=$(echo $efi_disk_part | sed -e 's/[0-9]//g')
-        efi_part=$(echo $efi_disk_part | sed -e 's/[^0-9]//g')
-
-        # Save current BootOrder, as during `efibootmgr -c ...' phase (creating of "Relax-and-Recover" UEFI boot entry),
+        efi_disk_part=$( grep -w /boot/efi /proc/mounts | awk '{print $1}' )
+        efi_disk=$( echo $efi_disk_part | sed -e 's/[0-9]//g' )
+        test $efi_disk || LogPrintError "efi_disk '$efi_disk' empty or more than one word"
+        efi_part=$( echo $efi_disk_part | sed -e 's/[^0-9]//g' )
+        test $efi_part || LogPrintError "efi_part '$efi_part' empty or more than one word"
+        # Save current BootOrder, as during `efibootmgr -c ...' phase (creating of 'Relax-and-Recover' UEFI boot entry),
         # newly created entry will be set as primary, which is not something we don't really want
-        efi_boot_order=$(efibootmgr | grep "BootOrder" | cut -d ":" -f2)
-        efibootmgr -c -d $efi_disk -p $efi_part -L "$grub_rear_menu_entry_name" -l "\EFI\BOOT\rear.efi" > /dev/null 2>&1
-        rear_boot_id=$(efibootmgr | grep -w $grub_rear_menu_entry_name | cut -d " " -f1 | sed -e 's/[^0-9]//g')
-
-        # Set "Relax-and-Recover" as last entry in UEFI boot menu.
-        efibootmgr -o ${efi_boot_order},${rear_boot_id} > /dev/null 2>&1
+        efi_boot_order=$( efibootmgr | grep "BootOrder" | cut -d ":" -f2 )
+        # efibootmgr shows e.g. "BootOrder: 0000,0001,0002,0003,0004" (see the "UEFI 'Relax-and-Recover' boot entry motivation" above)
+        # so efi_boot_order becomes " 0000,0001,0002,0003,0004" (i.e. with a leading space which does not matter here and below):
+        test $efi_boot_order || LogPrintError "efi_boot_order '$efi_boot_order' empty or more than one word"
+        # Create 'Relax-and-Recover' UEFI boot entry:
+        if ! efibootmgr -c -d $efi_disk -p $efi_part -L "$grub_rear_menu_entry_name" -l "\EFI\BOOT\rear.efi" ; then
+            Error "Failed to create '$grub_rear_menu_entry_name' UEFI boot entry"
+        fi
+        rear_boot_id=$( efibootmgr | grep -w $grub_rear_menu_entry_name | cut -d " " -f1 | sed -e 's/[^0-9]//g' )
+        test $rear_boot_id || LogPrintError "rear_boot_id '$rear_boot_id' empty or more than one word"
+        # Set 'Relax-and-Recover' as last entry in UEFI boot menu:
+        if ! efibootmgr -o ${efi_boot_order},${rear_boot_id} ; then
+            LogPrintError "Failed to set '$grub_rear_menu_entry_name' as last entry in UEFI boot menu"
+        fi
     fi
 else
     # Create a GRUB 2 menu config file:
@@ -222,15 +235,15 @@ else
     # Generate a GRUB 2 configuration file:
     local generated_grub_conf="$TMP_DIR/grub.cfg"
     if [[ $( type -f grub2-mkconfig ) ]] ; then
-        grub2-mkconfig -o $generated_grub_conf || Error "Failed to generate GRUB 2 configuration file (using grub2-mkconfig)."
+        grub2-mkconfig -o $generated_grub_conf || Error "Failed to generate GRUB 2 configuration file (using grub2-mkconfig)"
     else
-        grub-mkconfig -o $generated_grub_conf || Error "Failed to generate GRUB 2 configuration file (using grub-mkconfig)."
+        grub-mkconfig -o $generated_grub_conf || Error "Failed to generate GRUB 2 configuration file (using grub-mkconfig)"
     fi
-    test -s $generated_grub_conf || BugError "Generated empty GRUB 2 configuration file '$generated_grub_conf'."
+    test -s $generated_grub_conf || BugError "Generated empty GRUB 2 configuration file '$generated_grub_conf'"
 
     # Modifying local GRUB 2 configuration if it was actually changed:
     if ! diff -u $grub_conf $generated_grub_conf >&2 ; then
-        LogPrint "Modifying local GRUB 2 configuration."
+        LogPrint "Modifying local GRUB 2 configuration"
         cp -af $v $grub_conf $grub_conf.old >&2
         cat $generated_grub_conf >$grub_conf
     fi
@@ -239,20 +252,23 @@ fi
 # Provide the kernel as boot_kernel_file (i.e. /boot/rear-kernel):
 if [[ $( stat -L -c '%d' $KERNEL_FILE ) == $( stat -L -c '%d' $boot_dir/ ) ]] ; then
     # Hardlink file, if possible:
-    cp -pLlf $v $KERNEL_FILE $boot_kernel_file || BugError "Failed to hardlink '$KERNEL_FILE' to '$boot_kernel_file'."
+    cp -pLlf $v $KERNEL_FILE $boot_kernel_file || BugError "Failed to hardlink '$KERNEL_FILE' to '$boot_kernel_file'"
 elif [[ $( stat -L -c '%s %Y' $KERNEL_FILE ) == $( stat -L -c '%s %Y' $boot_kernel_file ) ]] ; then
     # If an already existing boot_kernel_file has exact same size and modification time
     # as the current KERNEL_FILE, assume both are the same and do nothing:
     :
 else
     # In all other cases, replace boot_kernel_file with the current KERNEL_FILE:
-    cp -pLf $v $KERNEL_FILE $boot_kernel_file || BugError "Failed to copy '$KERNEL_FILE' to '$boot_kernel_file'."
+    cp -pLf $v $KERNEL_FILE $boot_kernel_file || BugError "Failed to copy '$KERNEL_FILE' to '$boot_kernel_file'"
 fi
 
 # Provide the ReaR recovery system in initrd_file (i.e. TMP_DIR/initrd.cgz or TMP_DIR/initrd.xz)
 # as boot_initrd_file (i.e. /boot/rear-initrd.cgz or /boot/rear-initrd.xz)
 # (regarding '.cgz' versus '.xz' see https://github.com/rear/rear/issues/1142)
-cp -af $v $initrd_file $boot_initrd_file || BugError "Failed to copy '$initrd_file' to '$boot_initrd_file'."
+cp -af $v $initrd_file $boot_initrd_file || BugError "Failed to copy '$initrd_file' to '$boot_initrd_file'"
 
-LogPrint "Finished GRUB_RESCUE setup: Added '$grub_rear_menu_entry_name' GRUB 2 menu entry."
-
+if is_true $USING_UEFI_BOOTLOADER ; then
+    LogPrint "Finished GRUB_RESCUE setup: Added '$grub_rear_menu_entry_name' UEFI boot manager entry"
+else
+    LogPrint "Finished GRUB_RESCUE setup: Added '$grub_rear_menu_entry_name' GRUB 2 menu entry"
+fi

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -175,6 +175,7 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     ) > $grub_config_dir/rear.cfg
 
     # Create rear.efi at UEFI default boot directory location.
+    # The build_bootx86_efi errors out if it cannot make a bootable EFI image of GRUB2:
     build_bootx86_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear.cfg "$boot_dir" "$UEFI_BOOTLOADER"
 
     # If UEFI boot entry for 'Relax-and-Recover' does not exist, create it.

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -2,7 +2,9 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-# Add the rescue kernel and initrd to the local GRUB 2 bootloader.
+# Either add the rescue kernel and initrd to the local GRUB 2 bootloader in case of BIOS
+# or don't modify grub.cfg but create a separate UEFI boot entry in case of UEFI
+# cf. https://github.com/rear/rear/pull/954
 
 # With EFI_STUB enabled there will be no Grub entry.
 is_true "$EFI_STUB" && return 0
@@ -68,7 +70,8 @@ if (( available_space < required_space )) ; then
     Error "Cannot setup GRUB_RESCUE: Not enough disk space in $boot_dir for $grub_rear_menu_entry_name rescue system (required: $required_MiB MiB, available: $available_MiB MiB)"
 fi
 
-# UEFI 'Relax-and-Recover' boot entry motivation:
+# UEFI 'Relax-and-Recover' boot entry motivation
+# (cf. https://github.com/rear/rear/pull/954):
 #
 # If UEFI boot is in use, we will not modify grub.cfg, but setup 'Relax-and-Recover' entry in UEFI boot menu instead.
 # This looks to be simplest and safest approach since finding out what mechanisms were used to boot OS in UEFI mode,

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -185,6 +185,9 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     if efibootmgr | grep -q $grub_rear_menu_entry_name ; then
         LogPrint "Skip creating new 'Relax-and-Recover' UEFI boot entry (it is already there)"
     else
+        # TODO: Probably this part won't work properly in case of ESP on MD RAID.
+        # When the ESP is located on MD RAID we need to determine the physical RAID components
+        # and call efibootmgr on each of them, cf. https://github.com/rear/rear/pull/2608
         # This part might not go that well with drivers like HPEs cciss ...
         # However UEFI booting is present since Gen8 (AFAIK), and cciss drivers were replaced by hpsa long time ago,
         # so it looks like impossible configuration, lets wait ...

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -151,11 +151,9 @@ if is_true $USING_UEFI_BOOTLOADER ; then
 
     # Create configuration file for 'Relax-and-Recover' UEFI boot entry.
     # This file will not interact with existing Grub2 configuration in any way.
+    # Regarding "insmod" of GRUB2 modules see what the create_grub2_cfg function does
+    # cf. https://github.com/rear/rear/pull/2609#issuecomment-831883795
     (   echo "set btrfs_relative_path=y"
-        echo "insmod efi_gop"
-        echo "insmod efi_uga"
-        echo "insmod video_bochs"
-        echo "insmod video_cirrus"
         echo "insmod all_video"
         echo ""
         echo "set gfxpayload=keep"

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -17,8 +17,8 @@ is_true "$GRUB_RESCUE" || return 0
 # in particular do not run this script when GRUB Legacy is used
 # (for GRUB Legacy output/default/940_grub_rescue.sh is run):
 if [[ ! $( type -p grub-probe ) && ! $( type -p grub2-probe ) ]] ; then
-    LogPrint "Cannot do GRUB_RESCUE setup: GRUB 2 not found (neither grub-probe nor grub2-probe)"
-    return 1
+    Log "Skipping GRUB_RESCUE setup for GRUB 2 (no GRUB 2 found)"
+    return
 fi
 
 # Now GRUB_RESCUE is explicitly wanted and this script is the right one to set it up.


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2545

* How was this pull request tested?
Not at all tested by me - currently I don't have a UEFI test system

* Brief description of the changes in this pull request:
Improved user messages during GRUB_RESCUE setup in particular for the UEFI case
plus some error checking in the UEFI case and some minor code simplifications.