### PR TITLE
In 400_save_directories.sh also exclude mountpoints below mountpoints of "type autofs"

### DIFF
--- a/usr/share/rear/prep/default/400_save_directories.sh
+++ b/usr/share/rear/prep/default/400_save_directories.sh
@@ -25,10 +25,14 @@ local directories_permissions_owner_group_file="$VAR_DIR/recovery/directories_pe
 # see https://github.com/rear/rear/pull/1648
 local excluded_fs_types="anon_inodefs|autofs|bdev|cgroup|cgroup2|configfs|cpuset|debugfs|devfs|devpts|devtmpfs|dlmfs|efivarfs|fuse.gvfs-fuse-daemon|fusectl|hugetlbfs|mqueue|nfsd|none|nsfs|overlay|pipefs|proc|pstore|ramfs|rootfs|rpc_pipefs|securityfs|sockfs|spufs|sysfs|tmpfs"
 # Mountpoints of "type autofs" are excluded via excluded_fs_types above.
-# Also exclude mountpoints that are below mountpoints of "type autofs"
-# because automounted NFS filesystems can cause this script to hang up if NFS server fails
-# because the below 'stat' command may then wait indefinitely for the NFS server to respond,
+# Also exclude mountpoints that are below mountpoints of "type autofs",
 # see https://github.com/rear/rear/issues/2610
+# Such mountpoints are below an ancestor mountpoint that is owned/created by the automounter.
+# It is possible to create a sub-mountpoint below an automounted mountpoint
+# but the fact that the sub-mountpoint is not local means it should be excluded
+# (i.e. there is no need to recreate the non-local sub-mountpoint directory).
+# Furthermore automounted NFS filesystems can cause this script to hang up if NFS server fails
+# because the below 'stat' command may then wait indefinitely for the NFS server to respond.
 # Assume 'mount' shows (excerpts)
 # <something> on /some/mp type autofs (...)
 # <some_NFS_export> on /some/mp/sub_mp type nfs (...)

--- a/usr/share/rear/prep/default/400_save_directories.sh
+++ b/usr/share/rear/prep/default/400_save_directories.sh
@@ -97,8 +97,8 @@ local directoryglob
 for directoryglob in $FHSdirectories ; do
     for directory in $( echo $directoryglob ) ; do
         # Skip when it is already listed in the directories_permissions_owner_group file:
-        grep "^$directory" "$directories_permissions_owner_group_file" 1>&2 && continue
-        # Skip when it is neither a normal directory nor a symbolic links that points to a normal directory
+        grep -q "^$directory " "$directories_permissions_owner_group_file" && continue
+        # Skip when it is neither a normal directory nor a symbolic link that points to a normal directory
         # which means: Skip when it does not exist on the currently running system:
         if ! test -d "$directory" ; then
             Log "FHS directory $directory does not exist"

--- a/usr/share/rear/prep/default/400_save_directories.sh
+++ b/usr/share/rear/prep/default/400_save_directories.sh
@@ -49,7 +49,9 @@ if test "$autofs_mountpoints" ; then
     local autofs_and_below_mountpoints=()
     local autofs_mountpoint
     for autofs_mountpoint in $autofs_mountpoints ; do
-        autofs_and_below_mountpoints+=( $( findmnt -R -M $autofs_mountpoint -n -o TARGET --raw ) )
+        # Using findmnt option '-T' but not '-M' which is not supported on Fedora based distributions
+        # at least not on RHEL 7.9 cf. https://github.com/rear/rear/pull/2613#pullrequestreview-654678482
+        autofs_and_below_mountpoints+=( $( findmnt -R -T $autofs_mountpoint -n -o TARGET --raw ) )
     done
     exclude_autofs_and_below_mountpoints="$( tr ' ' '|' <<<"${autofs_and_below_mountpoints[@]}" )"
 fi


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2610

* How was this pull request tested?

Right now only a preliminary proposal
that is not yet at all tested by me.

* Brief description of the changes in this pull request:

In prep/default/400_save_directories.sh
also exclude mountpoints that are below mountpoints of "type autofs".
Such mountpoints are below an ancestor mountpoint that is owned/created by the automounter.
It is possible to create a sub-mountpoint below an automounted mountpoint
but the fact that the sub-mountpoint is not local means it should be excluded
(i.e. there is no need to recreate the non-local sub-mountpoint directory).
Furthermore automounted NFS filesystems can cause this script to hang up if NFS server fails
because the below 'stat' command may then wait indefinitely for the NFS server to respond.
