### PR TITLE
Stop ReaR from overwriting its own disk and backup drives

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -514,6 +514,19 @@ AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE=2
 AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE=10
 
 ##
+# Designate target disk devices or partitions as write-protected to avoid being accidentally overwritten during
+# "rear recover"
+#
+# List of partition table UUIDs, which designate write-protected disk devices. ReaR's own disk device will be
+# automatically added to this list if necessary.
+# Example: WRITE_PROTECTED_PARTITION_TABLE_UUIDS+=("ecacbce4-e05e-4eb9-835c-ade0c3ed0fea")
+WRITE_PROTECTED_PARTITION_TABLE_UUIDS=()
+# List of (shell glob) patterns, which designate matching file system labels as write-protected partitions.
+# Entries may be quoted and contain blanks, but they may not contain single quotes themselves.
+# Example: WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS+=("Backup *")
+WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS=()
+
+##
 # Creating XFS filesystems during "rear recover"
 #
 # MKFS_XFS_OPTIONS

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -123,8 +123,8 @@ while read keyword orig_device orig_size junk ; do
         is_mapping_target "$preferred_target_device_name" && continue
         # Use the current one if it is of same size as the old one:
         if test "$orig_size" -eq "$current_size" ; then
-            # Ensure the determined target device is really a block device:
-            if test -b "$preferred_target_device_name" ; then
+            # Ensure the determined target device is really a block device and not write-protected:
+            if test -b "$preferred_target_device_name" && ! is_write_protected "$preferred_target_device_name"; then
                 add_mapping "$orig_device" "$preferred_target_device_name"
                 LogPrint "Using $preferred_target_device_name (same name and same size) for recreating $orig_device"
                 # Continue with next original device in the LAYOUT_FILE:
@@ -147,8 +147,8 @@ while read keyword orig_device orig_size junk ; do
         is_mapping_target "$preferred_target_device_name" && continue
         # Use the current one if it is of same size as the old one:
         if test "$orig_size" -eq "$current_size" ; then
-            # Ensure the determined target device is really a block device:
-            if test -b "$preferred_target_device_name" ; then
+            # Ensure the determined target device is really a block device and not write-protected:
+            if test -b "$preferred_target_device_name" && ! is_write_protected "$preferred_target_device_name"; then
                 add_mapping "$orig_device" "$preferred_target_device_name"
                 LogPrint "Using $preferred_target_device_name (same size) for recreating $orig_device"
                 # Break looping over all current block devices to find one

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -201,6 +201,14 @@ while read keyword orig_device orig_size junk ; do
             Log "$preferred_target_device_name excluded from device mapping choices (is already used as mapping target)"
             continue
         fi
+        if is_write_protected_by_pt_uuid "$preferred_target_device_name"; then
+            Log "$preferred_target_device_name excluded from device mapping choices (write-protected partition table UUID)"
+            continue
+        fi
+        if is_write_protected_by_fs_label "$preferred_target_device_name"; then
+            Log "$preferred_target_device_name excluded from device mapping choices (write-protected file system label)"
+            continue
+        fi
         # Add the current device as possible choice for the user:
         possible_targets+=( "$preferred_target_device_name" )
     done

--- a/usr/share/rear/lib/write-protect-functions.sh
+++ b/usr/share/rear/lib/write-protect-functions.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Functions to identify write-protected disks and partitions
+#
+
+function write_protected_candidate_device() {
+    local device="$1"
+    # prints the path of the block device, translating it if given as /sys/block/*.
+
+    if [[ "$device" == /sys/block/* ]]; then
+        device="$(get_device_name "$device")"
+    fi
+    [[ ! -b "$device" ]] && Error "Could not check '$1' ('$device') for write protection – not a block device"
+    echo "$device"
+}
+
+function is_write_protected_by_pt_uuid() {
+    local device="$(write_protected_candidate_device "$1")"
+    # returns 0 if the device's partition table UUID is in the list of write-protected UUIDs.
+
+    local partition_table_uuid="$(lsblk --output PTUUID --noheadings --nodeps "$device")"
+
+    if [[ " ${WRITE_PROTECTED_PARTITION_TABLE_UUIDS[*]} " == *" $partition_table_uuid "* ]]; then
+        Log "$device is designated as write-protected by partition table UUID '$partition_table_uuid'"
+        return 0
+    fi
+
+    return 1
+}
+
+function is_write_protected_by_fs_label() {
+    local device="$(write_protected_candidate_device "$1")"
+    # returns 0 if one of the device's file system labels matches a prefix from the list of write-protected
+    # label prefixes.
+
+    # Check all partitions of a device for a matching label
+    local write_protected_pattern
+    while read -r partition_label; do
+        if [[ -n "$partition_label" ]]; then
+            for write_protected_pattern in "${WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS[@]}"; do
+                if [[ "$partition_label" == $write_protected_pattern ]]; then
+                    Log "$device is designated as write-protected, its label '$partition_label' matches '$write_protected_pattern'"
+                    return 0
+                fi
+            done
+        fi
+    done < <(lsblk --output LABEL --noheadings "$device")
+
+    return 1
+}
+
+function is_write_protected() {
+    local device="$(write_protected_candidate_device "$1")"
+    # returns 0 if the device is designated as write-protected by any of the above means.
+
+    is_write_protected_by_pt_uuid "$device" || is_write_protected_by_fs_label "$device"
+}

--- a/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/280_create_bootable_disk_image.sh
@@ -53,7 +53,10 @@ local typecode="8300"  # Linux partition for non-EFI booting
 local legacy_boot_option=""
 is_true $use_syslinux_legacy && legacy_boot_option="--attributes=1:set:2"  # mark partition as Legacy BIOS-bootable
 
-sgdisk --new 1::0 --typecode=1:"$typecode" --change-name=1:"${RAWDISK_GPT_PARTITION_NAME:-Rescue System}" $legacy_boot_option "$disk_image"
+local guid_option=""
+[[ -n "$RAWDISK_PTUUID" ]] && guid_option="--disk-guid=$RAWDISK_PTUUID"  # Use a pre-determined partition UUID
+
+sgdisk "$guid_option" --new 1::0 --typecode=1:"$typecode" --change-name=1:"${RAWDISK_GPT_PARTITION_NAME:-Rescue System}" $legacy_boot_option "$disk_image"
 StopIfError "Could not create GPT partition table on $disk_image"
 
 Log "Raw disk image partition table:"

--- a/usr/share/rear/prep/RAWDISK/Linux-i386/480_initialize_write_protect_settings.sh
+++ b/usr/share/rear/prep/RAWDISK/Linux-i386/480_initialize_write_protect_settings.sh
@@ -1,0 +1,13 @@
+# RAWDISK output typically resides on a writable disk device, which should be protected against
+# accidental overwriting by rear recover. This code initializes RAWDISK_PTUUID, a partition table UUID
+# designating ReaR's own boot device and registers it as write protected.
+
+if has_binary uuidgen; then
+    # Generate a partition table UUID now and add it to the kernel's command line options.
+    #
+    # Normally, a partition table UUID is generated automatically during partitioning. We cannot wait for this
+    # to happen as the variable will be part of the initrd, which is completed before any partition table is
+    # created.
+    RAWDISK_PTUUID="$(uuidgen)"
+    WRITE_PROTECTED_PARTITION_TABLE_UUIDS+=( $RAWDISK_PTUUID )
+fi

--- a/usr/share/rear/prep/USB/default/480_initialize_write_protect_settings.sh
+++ b/usr/share/rear/prep/USB/default/480_initialize_write_protect_settings.sh
@@ -1,0 +1,4 @@
+# USB output typically resides on a writable disk device, which should be protected against
+# accidental overwriting by rear recover. This code registers it as write protected.
+
+WRITE_PROTECTED_PARTITION_TABLE_UUIDS+=( $(lsblk --output PTUUID --noheadings --nodeps "$USB_DEVICE") )

--- a/usr/share/rear/prep/default/490_store_write_protect_settings.sh
+++ b/usr/share/rear/prep/default/490_store_write_protect_settings.sh
@@ -1,0 +1,15 @@
+# Store settings for write-protected file systems in the rescue configuration.
+
+{
+    echo "# The following lines were added by 490_store_write_protect_settings.sh"
+
+    echo "WRITE_PROTECTED_PARTITION_TABLE_UUIDS=( ${WRITE_PROTECTED_PARTITION_TABLE_UUIDS[*]} )"
+
+    echo -n "WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS=("
+    for prefix in "${WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS[@]}"; do
+        [[ -n "$prefix" ]] && echo -n " '$prefix'"
+    done
+    echo " )"
+
+    echo ""
+} >> "$ROOTFS_DIR/etc/rear/rescue.conf"


### PR DESCRIPTION
### Use Cases

1. I start `rear recover` on a virtual machine. The original system has three drives (`sda`, `sdb`, `sdc`), the recovery VM has two drives (`vda`, `vdb`), plus the recovery partition on another drive (`vdc`). The intention is to leave `sdc` unmapped. ReaR asks remapping questions for `sda` and `sdb`. Then it decides to map `sdc` to `vdc` without even asking. Continuing would overwrite the recovery system. I have to edit `/var/lib/rear/layout/disk_mappings` manually.

2. I start `rear recover` on a virtual machine, with a USB backup drive connected as `/dev/sda`. The original system's boot drive was also `/dev/sda`. ReaR asks remapping questions, but I do not notice that the `/dev/sdaX` partitions on the VM are actually those of the backup drive, while the VM boot drive would have been `/dev/vdaX`. ReaR happily overwrites the backup drive. This should never be possible.

### Background

* Overwriting a ReaR rescue system partition is currently possible if it resides on a writable disk device (physical or virtual). This applies to the `RAWDISK` and `USB` output methods.
* Accidentally overwriting backup devices is currently possible in any ReaR configuration.
* Related issue: #1271.

### Solution

* This PR protects against accidentally overwriting a rescue system partition by keeping track of its partition ID. The capability is automatically enabled for the `RAWDISK` and `USB` output methods. No configuration is necessary.
* To allow for additional user-configurable protection of devices, this PR introduces the following configuration section:
    ```
    ##
    # Designate target disk devices or partitions as write-protected to avoid being accidentally overwritten during
    # "rear recover"
    #
    # List of partition table UUIDs, which designate write-protected disk devices. ReaR's own disk device will be
    # automatically added to this list if necessary.
    # Example: WRITE_PROTECTED_PARTITION_TABLE_UUIDS+=("ecacbce4-e05e-4eb9-835c-ade0c3ed0fea")
    WRITE_PROTECTED_PARTITION_TABLE_UUIDS=()
    # List of (shell glob) patterns, which designate matching file system labels as write-protected partitions.
    # Entries may be quoted and contain blanks, but they may not contain single quotes themselves.
    # Example: WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS+=("Backup *")
    WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS=()
    ``` 
* Disks designated as write protected or containing a partition designated as write protected will not be used as recovery targets by ReaR, whether in `MIGRATION_MODE` or not.

### Testing

* I have tested complete `rear mkrescue` and `rear recover` cycles for `RAWDISK` output in various configurations on Ubuntu 20.04.
* I have not tested `USB` output, as I find it too baroque to use. However, the added code for `USB` is simple and should just work.

### Compatibility

This PR uses command invocations and options which are present in existing ReaR code with the following exception:

* `RAWDISK` output invokes `sgdisk` with the `--disk-guid` option. This has been present in `sgdisk` [since release 0.8.0 (September 2011) at least](https://github.com/samangh/gptfdisk/blame/81c8bbee46ad6ebacf72eae70ba5147f376205a4/gptcl.cc).

### Note

In migration mode, ReaR asks to remap disks until there is only one left. Then it maps the last drive without asking. The comment states:

> Automatically map when only one appropriate current block device is found where to it could be mapped. At the end the mapping file is shown and the user can edit it if he does not like an automated mapping

Here, ReaR takes away control from the user (or at least makes it more complicated that it needs to be). I think this should change (but separately from this PR) as it does not conform to ReaR's principle.
