### PR TITLE
Enable a clean log file without suppressing stderr unconditionally

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -404,21 +404,19 @@ test -r "$RUNTIME_LOGFILE" && mv -f "$RUNTIME_LOGFILE" "$RUNTIME_LOGFILE".old 2>
 # Start logging:
 mkdir -p $LOG_DIR || echo "ERROR: Could not create $LOG_DIR" >&2
 cat /dev/null >"$RUNTIME_LOGFILE"
-# Normally stdout and stderr are redirected to /dev/null.
-# In debug modes stdout and stderr are redirected to the log.
-# Cf. https://github.com/rear/rear/issues/2416
+# To be on the safe side append to the log file '>>' instead of plain writing to it '>'
+# because when a program (bash in this case) is plain writing to the log file it can overwrite
+# output of a possibly simultaneously running process that likes to append to the log file
+# (e.g. when a background process runs that also uses the ReaR log file for logging).
+exec 2>>"$RUNTIME_LOGFILE"
+# Normally stdout is redirected to /dev/null.
+# In debug modes stdout is redirected to the log.
 if test "$DEBUG" ; then
-    # To be on the safe side append to the log file '>>' instead of plain writing to it '>'
-    # because when a program (bash in this case) is plain writing to the log file it can overwrite
-    # output of a possibly simultaneously running process that likes to append to the log file
-    # (e.g. when a background process runs that also uses the ReaR log file for logging).
-    exec 2>>"$RUNTIME_LOGFILE"
     # Make stdout the same what stderr already is.
     # This keeps strict ordering of stdout and stderr outputs
     # because now both stdout and stderr use one same file descriptor.
     exec 1>&2
 else
-    exec 2>/dev/null
     exec 1>/dev/null
 fi
 

--- a/usr/share/rear/build/default/990_verify_rootfs.sh
+++ b/usr/share/rear/build/default/990_verify_rootfs.sh
@@ -224,10 +224,10 @@ for program in "${PROGS[@]}" ; do
     # or 'type ""' with empty argument fails
     # so both result unwanted error messages and unwanted proceeding
     # cf. https://github.com/rear/rear/issues/2372
-    test $program || continue
+    has_binary $program || continue
     # There are many programs in the PROGS array that may or may not exist on the original system
     # so that only those programs in the PROGS array that exist on the original system are tested:
-    type $program || continue
+    has_binary $program || continue
     # Use the basename because the path within the recovery system is usually different compared to the path on the original system:
     program=$( basename $program )
     # Redirected stdin for login shell avoids motd welcome message, cf. https://github.com/rear/rear/issues/2120.


### PR DESCRIPTION
This PR addresses concerns in https://github.com/rear/rear/issues/2623#issuecomment-855943435, just without throwing the baby out with the bath water.

When used with ReaR's default configuration, the only stderr messages remaining in the log are these (each preceded by one regular log line):
```
2021-06-07 22:44:07.949146931 Including prep/default/400_save_directories.sh
stat: cannot stat '/run/user/121/gvfs': Permission denied
stat: cannot stat '/run/user/7002/gvfs': Permission denied
stat: cannot stat '/run/user/7002/doc': Permission denied

2021-06-07 22:44:09.975175176 Saving filesystem layout (using the findmnt command).
WARNING: No blkio weight support
WARNING: No blkio weight_device support

2021-06-07 22:44:11.123708262 Including layout/save/default/445_guess_bootloader.sh
4+0 records in
4+0 records out
2048 bytes (2.0 kB, 2.0 KiB) copied, 6.7896e-05 s, 30.2 MB/s

2021-06-07 22:44:11.859673492 Including rescue/GNU/Linux/320_inet6.sh
fe80000000000000a1177f5f3e0b767b 05 40 20 80  bridge0
00000000000000000000000000000001 01 80 10 80       lo

2021-06-07 22:44:12.914842576 Files being excluded: /home/oliver/Repositories/open-source/rear/var/lib/rear/output/* dev/.udev dev/shm dev/shm/* dev/oracleasm dev/mapper dev/shm/* /etc/pki/tls/private /etc/pki/CA/private /etc/pki/nssdb/key*.db /usr/lib/ssl/private /usr/share/misc/magic /lib/udev/rules.d/66-snapd-autoimport.rules
tar: Removing leading `/' from member names
tar: Removing leading `/' from hard link targets

2021-06-07 22:44:25.892832876 Testing 'ldd /bin/bash' to ensure 'ldd' works for the subsequent 'ldd' tests within the recovery system
	linux-vdso.so.1 (0x00007fff401a2000)
	libtinfo.so.6 => /lib/x86_64-linux-gnu/libtinfo.so.6 (0x00007f2f158ed000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f2f158e7000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2f156f5000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f2f15a4e000)

2021-06-07 22:44:32.813354972 Creating md5sums for regular files in /tmp/rear.TjE89ak2ljRqq4y/rootfs
/tmp/rear.TjE89ak2ljRqq4y/rootfs /home/oliver/Repositories/open-source/rear
/home/oliver/Repositories/open-source/rear

2021-06-07 22:45:17.189352792 Including output/ISO/Linux-i386/700_create_efibootimg.sh
3+0 records in
3+0 records out
100663296 bytes (101 MB, 96 MiB) copied, 0.0484193 s, 2.1 GB/s

2021-06-07 22:45:17.527583107 Including ISO UEFI boot (as triggered by USING_UEFI_BOOTLOADER=1)
xorriso 1.5.2 : RockRidge filesystem manipulator, libburnia project.

Drive current: -outdev 'stdio:/home/oliver/Repositories/open-source/rear/var/lib/rear/output/rear-juliet.iso'
Media current: stdio file, overwriteable
Media status : is blank
Media summary: 0 sessions, 0 data blocks, 0 data, 83.6g free
xorriso : WARNING : -volid text does not comply to ISO 9660 / ECMA 119 rules
Added to ISO image: directory '/'='/tmp/rear.TjE89ak2ljRqq4y/tmp/isofs'
xorriso : UPDATE :      31 files added in 1 seconds
xorriso : UPDATE :      31 files added in 1 seconds
xorriso : WARNING : Boot image load size exceeds 65535 blocks of 512 bytes. Will record 0 in El Torito to extend ESP to end-of-medium.
xorriso : UPDATE :  24.48% done
ISO image produced: 265653 sectors
Written to medium : 265653 sectors at LBA 0
Writing to 'stdio:/home/oliver/Repositories/open-source/rear/var/lib/rear/output/rear-juliet.iso' completed successfully.

2021-06-07 22:45:22.151615205 rear,148575 usr/sbin/rear -v mkrescue
  `-rear,164333 usr/sbin/rear -v mkrescue
      `-pstree,164334 -Aplau 148575
/home/oliver/Repositories/open-source/rear/usr/share/rear/lib/_input-output-functions.sh: line 151: kill: (164337) - No such process
```

In my view, all of these should not raise concerns even for the casual user, with the following exceptions, which indicate that something should be fixed:
* ReaR should probably not mess with the `/run` temporary file system:
    ```
    stat: cannot stat '/run/user/121/gvfs': Permission denied
    stat: cannot stat '/run/user/7002/gvfs': Permission denied
    stat: cannot stat '/run/user/7002/doc': Permission denied
    ```
* A process supposed to be killed doesn't exist:
    ```
    /home/oliver/Repositories/open-source/rear/usr/share/rear/lib/_input-output-functions.sh: line 151: kill: (164337) - No such process
    ```

I have checked other `type` invocations throughout ReaR. They all use either `-p`, `-P`, or `-t` (all of which do not produce stderr messages), or they redirect `stderr` to `/dev/null`.