### PR TITLE
Cleanup rsync and fix error reporting

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -16,6 +16,8 @@ function set_tar_features () {
     FEATURE_TAR_IS_SET=1
 }
 
+local backup_prog_rc
+
 local scheme=$( url_scheme $BACKUP_URL )
 local path=$( url_path $BACKUP_URL )
 local opath=$( backup_path $scheme $path )

--- a/usr/share/rear/backup/RSYNC/GNU/Linux/610_start_selinux.sh
+++ b/usr/share/rear/backup/RSYNC/GNU/Linux/610_start_selinux.sh
@@ -1,5 +1,7 @@
 # Start SELinux if it was stopped - check presence of  $TMP_DIR/selinux.mode
 
+local backup_prog_rc
+
 [ -f $TMP_DIR/selinux.mode ] && {
 	touch "${TMP_DIR}/selinux.autorelabel"
 	cat $TMP_DIR/selinux.mode > $SELINUX_ENFORCE
@@ -13,9 +15,9 @@
 		ssh $RSYNC_USER@$RSYNC_HOST "chmod $v 755 ${RSYNC_PATH}/${RSYNC_PREFIX}/backup" 2>/dev/null
 		$BACKUP_PROG -a "${TMP_DIR}/selinux.autorelabel" \
 		 "$RSYNC_USER@$RSYNC_HOST:${RSYNC_PATH}/${RSYNC_PREFIX}/backup/.autorelabel" 2>/dev/null
-		_rc=$?
-		if [ $_rc -ne 0 ]; then
-			LogPrint "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup [${rsync_err_msg[$_rc]}]"
+		backup_prog_rc=$?
+		if [ $backup_prog_rc -ne 0 ]; then
+			LogPrint "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup [${rsync_err_msg[$backup_prog_rc]}]"
 			#StopIfError "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup"
 		fi
 		;;
@@ -23,9 +25,9 @@
 	(rsync)
 		$BACKUP_PROG -a "${TMP_DIR}/selinux.autorelabel" ${BACKUP_RSYNC_OPTIONS[@]} \
 		 "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/backup/.autorelabel"
-		_rc=$?
-		if [ $_rc -ne 0 ]; then
-			LogPrint "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup [${rsync_err_msg[$_rc]}]"
+		backup_prog_rc=$?
+		if [ $backup_prog_rc -ne 0 ]; then
+			LogPrint "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup [${rsync_err_msg[$backup_prog_rc]}]"
 			#StopIfError "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup"
 		fi
 		;;

--- a/usr/share/rear/backup/RSYNC/GNU/Linux/610_start_selinux.sh
+++ b/usr/share/rear/backup/RSYNC/GNU/Linux/610_start_selinux.sh
@@ -23,7 +23,7 @@ local backup_prog_rc
 		;;
 
 	(rsync)
-		$BACKUP_PROG -a "${TMP_DIR}/selinux.autorelabel" ${BACKUP_RSYNC_OPTIONS[@]} \
+		$BACKUP_PROG -a "${TMP_DIR}/selinux.autorelabel" "${BACKUP_RSYNC_OPTIONS[@]}" \
 		 "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/backup/.autorelabel"
 		backup_prog_rc=$?
 		if [ $backup_prog_rc -ne 0 ]; then

--- a/usr/share/rear/backup/RSYNC/GNU/Linux/620_force_autorelabel.sh
+++ b/usr/share/rear/backup/RSYNC/GNU/Linux/620_force_autorelabel.sh
@@ -37,8 +37,7 @@ local backup_prog_rc
 		# probably using the BACKUP=NETFS workflow instead
 		if [ -d "${opath}" ]; then
 			if [ ! -f "${opath}/selinux.autorelabel" ]; then
-				> "${opath}/selinux.autorelabel"
-				StopIfError "Failed to create selinux.autorelabel on ${opath}"
+				> "${opath}/selinux.autorelabel" || Error "Failed to create selinux.autorelabel on ${opath}"
 			fi
 		fi
 		;;

--- a/usr/share/rear/backup/RSYNC/GNU/Linux/620_force_autorelabel.sh
+++ b/usr/share/rear/backup/RSYNC/GNU/Linux/620_force_autorelabel.sh
@@ -1,3 +1,5 @@
+local backup_prog_rc
+
 [ -f $TMP_DIR/force.autorelabel ] && {
 
 	> "${TMP_DIR}/selinux.autorelabel"
@@ -11,9 +13,9 @@
 		ssh $RSYNC_USER@$RSYNC_HOST "chmod $v 755 ${RSYNC_PATH}/${RSYNC_PREFIX}/backup" 2>/dev/null
 		$BACKUP_PROG -a "${TMP_DIR}/selinux.autorelabel" \
 		 "$RSYNC_USER@$RSYNC_HOST:${RSYNC_PATH}/${RSYNC_PREFIX}/backup/.autorelabel" 2>/dev/null
-		_rc=$?
-		if [ $_rc -ne 0 ]; then
-			LogPrint "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup [${rsync_err_msg[$_rc]}]"
+		backup_prog_rc=$?
+		if [ $backup_prog_rc -ne 0 ]; then
+			LogPrint "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup [${rsync_err_msg[$backup_prog_rc]}]"
 			#StopIfError "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup"
 		fi
 		;;
@@ -21,9 +23,9 @@
 	(rsync)
 		$BACKUP_PROG -a "${TMP_DIR}/selinux.autorelabel" ${BACKUP_RSYNC_OPTIONS[@]} \
 		 "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/backup/.autorelabel"
-		_rc=$?
-		if [ $_rc -ne 0 ]; then
-			LogPrint "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup [${rsync_err_msg[$_rc]}]"
+		backup_prog_rc=$?
+		if [ $backup_prog_rc -ne 0 ]; then
+			LogPrint "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup [${rsync_err_msg[$backup_prog_rc]}]"
 			#StopIfError "Failed to create .autorelabel on ${RSYNC_PATH}/${RSYNC_PREFIX}/backup"
 		fi
 		;;

--- a/usr/share/rear/backup/RSYNC/GNU/Linux/620_force_autorelabel.sh
+++ b/usr/share/rear/backup/RSYNC/GNU/Linux/620_force_autorelabel.sh
@@ -21,7 +21,7 @@ local backup_prog_rc
 		;;
 
 	(rsync)
-		$BACKUP_PROG -a "${TMP_DIR}/selinux.autorelabel" ${BACKUP_RSYNC_OPTIONS[@]} \
+		$BACKUP_PROG -a "${TMP_DIR}/selinux.autorelabel" "${BACKUP_RSYNC_OPTIONS[@]}" \
 		 "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/backup/.autorelabel"
 		backup_prog_rc=$?
 		if [ $backup_prog_rc -ne 0 ]; then

--- a/usr/share/rear/backup/RSYNC/default/200_check_rsync_relative_option.sh
+++ b/usr/share/rear/backup/RSYNC/default/200_check_rsync_relative_option.sh
@@ -4,7 +4,7 @@
 # check for the --relative option in BACKUP_RSYNC_OPTIONS array
 # for the default values see the standard definition in conf/default.conf file
 
-if ! grep -q relative <<< $(echo ${BACKUP_RSYNC_OPTIONS[@]}); then
+if ! grep -q relative <<< "${BACKUP_RSYNC_OPTIONS[*]}" ; then
     BACKUP_RSYNC_OPTIONS+=( --relative )
     Log "Added option '--relative' to the BACKUP_RSYNC_OPTIONS array during $WORKFLOW workflow"
 fi

--- a/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
+++ b/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
@@ -14,9 +14,9 @@ while read -r ; do
 	Log " $REPLY"
 done < $TMP_DIR/backup-exclude.txt
 
-LogPrint "Creating $BACKUP_PROG archive on '${RSYNC_HOST}:${RSYNC_PATH}'"
+LogPrint "Creating $BACKUP_PROG backup on '${RSYNC_HOST}:${RSYNC_PATH}'"
 
-ProgressStart "Running archive operation"
+ProgressStart "Running backup operation"
 (
 	case "$(basename $BACKUP_PROG)" in
 
@@ -99,7 +99,7 @@ case "$(basename $BACKUP_PROG)" in
 			;;
 			esac
 
-			ProgressInfo "Archived $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec]"
+			ProgressInfo "Backed up $((size/1024/1024)) MiB [avg $((size/1024/(SECONDS-starttime))) KiB/sec]"
 		done
 		;;
 
@@ -121,8 +121,8 @@ backup_prog_rc="$(cat $TMP_DIR/retval)"
 sleep 1
 # everyone should see this warning, even if not verbose
 test "$backup_prog_rc" -gt 0 && LogPrintError "WARNING !
-There was an error (${rsync_err_msg[$backup_prog_rc]}) during archive creation.
-Please check the archive and see '$RUNTIME_LOGFILE' for more information.
+There was an error (${rsync_err_msg[$backup_prog_rc]}) during backup creation.
+Please check the destination and see '$RUNTIME_LOGFILE' for more information.
 
 Since errors are often related to files that cannot be saved by
 $BACKUP_PROG, we will continue the $WORKFLOW process. However, you MUST
@@ -134,6 +134,6 @@ backup_log_message="$(tail -14 ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log)"
 if [ $backup_prog_rc -eq 0 -a "$backup_log_message" ] ; then
 	LogPrint "$backup_log_message in $transfertime seconds."
 elif [ "$size" ]; then
-	LogPrint "Archived $((size/1024/1024)) MiB in $((transfertime)) seconds [avg $((size/1024/transfertime)) KiB/sec]"
+	LogPrint "Backed up $((size/1024/1024)) MiB in $((transfertime)) seconds [avg $((size/1024/transfertime)) KiB/sec]"
 fi
 

--- a/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
+++ b/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
@@ -37,7 +37,7 @@ ProgressStart "Running archive operation"
 			;;
 
 		(*)
-			# no other backup programs foreseen then rsync so far
+			# no other backup programs foreseen than rsync so far
 			:
 			;;
 

--- a/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
+++ b/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
@@ -3,6 +3,7 @@
 # Public License. Refer to the included COPYING for full text of license.
 
 local backup_prog_rc
+local backup_log_message
 
 Log "Include list:"
 while read -r ; do
@@ -129,9 +130,9 @@ verify the backup yourself before trusting it !
 
 "
 
-_message="$(tail -14 ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log)"
-if [ $backup_prog_rc -eq 0 -a "$_message" ] ; then
-	LogPrint "$_message in $transfertime seconds."
+backup_log_message="$(tail -14 ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log)"
+if [ $backup_prog_rc -eq 0 -a "$backup_log_message" ] ; then
+	LogPrint "$backup_log_message in $transfertime seconds."
 elif [ "$size" ]; then
 	LogPrint "Archived $((size/1024/1024)) MiB in $((transfertime)) seconds [avg $((size/1024/transfertime)) KiB/sec]"
 fi

--- a/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
+++ b/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
@@ -2,6 +2,8 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
+local backup_prog_rc
+
 Log "Include list:"
 while read -r ; do
 	Log "  $REPLY"
@@ -113,12 +115,12 @@ ProgressStop
 wait $BackupPID
 
 transfertime="$((SECONDS-starttime))"
-_rc="$(cat $TMP_DIR/retval)"
+backup_prog_rc="$(cat $TMP_DIR/retval)"
 
 sleep 1
 # everyone should see this warning, even if not verbose
-test "$_rc" -gt 0 && LogPrintError "WARNING !
-There was an error (${rsync_err_msg[$_rc]}) during archive creation.
+test "$backup_prog_rc" -gt 0 && LogPrintError "WARNING !
+There was an error (${rsync_err_msg[$backup_prog_rc]}) during archive creation.
 Please check the archive and see '$RUNTIME_LOGFILE' for more information.
 
 Since errors are often related to files that cannot be saved by
@@ -128,7 +130,7 @@ verify the backup yourself before trusting it !
 "
 
 _message="$(tail -14 ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log)"
-if [ $_rc -eq 0 -a "$_message" ] ; then
+if [ $backup_prog_rc -eq 0 -a "$_message" ] ; then
 	LogPrint "$_message in $transfertime seconds."
 elif [ "$size" ]; then
 	LogPrint "Archived $((size/1024/1024)) MiB in $((transfertime)) seconds [avg $((size/1024/transfertime)) KiB/sec]"

--- a/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
+++ b/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
@@ -117,7 +117,7 @@ _rc="$(cat $TMP_DIR/retval)"
 
 sleep 1
 # everyone should see this warning, even if not verbose
-test "$_rc" -gt 0 && VERBOSE=1 LogPrint "WARNING !
+test "$_rc" -gt 0 && LogPrintError "WARNING !
 There was an error (${rsync_err_msg[$_rc]}) during archive creation.
 Please check the archive and see '$RUNTIME_LOGFILE' for more information.
 

--- a/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
+++ b/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
@@ -120,13 +120,12 @@ backup_prog_rc="$(cat $TMP_DIR/retval)"
 
 sleep 1
 # everyone should see this warning, even if not verbose
-test "$backup_prog_rc" -gt 0 && LogPrintError "WARNING !
+test "$backup_prog_rc" -gt 0 && Error "
 There was an error (${rsync_err_msg[$backup_prog_rc]}) during backup creation.
 Please check the destination and see '$RUNTIME_LOGFILE' for more information.
 
-Since errors are often related to files that cannot be saved by
-$BACKUP_PROG, we will continue the $WORKFLOW process. However, you MUST
-verify the backup yourself before trusting it !
+If the error is related to files that cannot and should not be saved by
+$BACKUP_PROG, they should be excluded from the backup.
 
 "
 

--- a/usr/share/rear/backup/RSYNC/default/700_copy_backup_log.sh
+++ b/usr/share/rear/backup/RSYNC/default/700_copy_backup_log.sh
@@ -15,10 +15,10 @@ case $RSYNC_PROTO in
         $BACKUP_PROG -a "$RUNTIME_LOGFILE" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/rear-${Timestamp}.log" 2>/dev/null
         ;;
     (rsync)
-        $BACKUP_PROG -a "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log.gz" ${BACKUP_RSYNC_OPTIONS[@]} \
+        $BACKUP_PROG -a "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log.gz" "${BACKUP_RSYNC_OPTIONS[@]}" \
         "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/${BACKUP_PROG_ARCHIVE}-${Timestamp}.log.gz"
 
-        $BACKUP_PROG -a "$RUNTIME_LOGFILE" ${BACKUP_RSYNC_OPTIONS[@]} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}//rear-${Timestamp}.log"
+        $BACKUP_PROG -a "$RUNTIME_LOGFILE" "${BACKUP_RSYNC_OPTIONS[@]}" "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}//rear-${Timestamp}.log"
         ;;
 esac
 

--- a/usr/share/rear/backup/RSYNC/default/700_copy_backup_log.sh
+++ b/usr/share/rear/backup/RSYNC/default/700_copy_backup_log.sh
@@ -1,6 +1,8 @@
 
 # copy the backup.log & rear.log file to remote destination with timestamp added
-Timestamp=$( date +%Y%m%d.%H%M )
+local timestamp
+
+timestamp=$( date +%Y%m%d.%H%M )
 
 # compress the log file first
 gzip "$TMP_DIR/$BACKUP_PROG_ARCHIVE.log" || Error "Failed to 'gzip $TMP_DIR/$BACKUP_PROG_ARCHIVE.log'"
@@ -10,15 +12,15 @@ case $RSYNC_PROTO in
         # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
         # or remove it according to https://github.com/rear/rear/issues/1395
         $BACKUP_PROG -a "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log.gz" \
-        "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/${BACKUP_PROG_ARCHIVE}-${Timestamp}.log.gz" 2>/dev/null
+        "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/${BACKUP_PROG_ARCHIVE}-${timestamp}.log.gz" 2>/dev/null
 
-        $BACKUP_PROG -a "$RUNTIME_LOGFILE" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/rear-${Timestamp}.log" 2>/dev/null
+        $BACKUP_PROG -a "$RUNTIME_LOGFILE" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/rear-${timestamp}.log" 2>/dev/null
         ;;
     (rsync)
         $BACKUP_PROG -a "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log.gz" "${BACKUP_RSYNC_OPTIONS[@]}" \
-        "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/${BACKUP_PROG_ARCHIVE}-${Timestamp}.log.gz"
+        "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/${BACKUP_PROG_ARCHIVE}-${timestamp}.log.gz"
 
-        $BACKUP_PROG -a "$RUNTIME_LOGFILE" "${BACKUP_RSYNC_OPTIONS[@]}" "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}//rear-${Timestamp}.log"
+        $BACKUP_PROG -a "$RUNTIME_LOGFILE" "${BACKUP_RSYNC_OPTIONS[@]}" "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}//rear-${timestamp}.log"
         ;;
 esac
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1220,7 +1220,8 @@ BACKUP_ONLY_EXCLUDE="no"
 MANUAL_INCLUDE=NO
 # Disable SELinux policy during backup with NETFS or RSYNC (default yes)
 BACKUP_SELINUX_DISABLE=1
-# Enable integrity check of the backup archive (only with BACKUP=NETFS and BACKUP_PROG=tar)
+# Enable integrity check of the backup archive (full check only with BACKUP=NETFS and BACKUP_PROG=tar,
+# with BACKUP=rsync or BACKUP_PROG=rsync it only checks whether rsync completed the restore successfully)
 BACKUP_INTEGRITY_CHECK=
 # Define BACKUP_TYPE.
 # By default BACKUP_TYPE is empty which means "rear mkbackup" will create a full backup.

--- a/usr/share/rear/output/RSYNC/default/200_make_prefix_dir.sh
+++ b/usr/share/rear/output/RSYNC/default/200_make_prefix_dir.sh
@@ -13,7 +13,7 @@ case $RSYNC_PROTO in
 		;;
 
 	(rsync)
-		$BACKUP_PROG -a $v -r "${TMP_DIR}/rsync/${RSYNC_PREFIX}" ${BACKUP_RSYNC_OPTIONS[@]} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/" >/dev/null \
+		$BACKUP_PROG -a $v -r "${TMP_DIR}/rsync/${RSYNC_PREFIX}" "${BACKUP_RSYNC_OPTIONS[@]}" "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/" >/dev/null \
                     || Error "Could not create '${RSYNC_PATH}/${RSYNC_PREFIX}' on remote ${RSYNC_HOST}"
 		;;
 

--- a/usr/share/rear/output/RSYNC/default/200_make_prefix_dir.sh
+++ b/usr/share/rear/output/RSYNC/default/200_make_prefix_dir.sh
@@ -2,21 +2,19 @@
 # RSYNC_PREFIX=$HOSTNAME as set in default.conf
 
 # create temporary local work-spaces to collect files (we already make the remote backup dir with the correct mode!!)
-mkdir -p $v -m0750 "${TMP_DIR}/rsync/${RSYNC_PREFIX}" >&2
-StopIfError "Could not mkdir '${TMP_DIR}/rsync/${RSYNC_PREFIX}'"
-mkdir -p $v -m0755 "${TMP_DIR}/rsync/${RSYNC_PREFIX}/backup" >&2
-StopIfError "Could not mkdir '${TMP_DIR}/rsync/${RSYNC_PREFIX}/backup'"
+mkdir -p $v -m0750 "${TMP_DIR}/rsync/${RSYNC_PREFIX}" >&2 || Error "Could not mkdir '${TMP_DIR}/rsync/${RSYNC_PREFIX}'"
+mkdir -p $v -m0755 "${TMP_DIR}/rsync/${RSYNC_PREFIX}/backup" >&2 || Error "Could not mkdir '${TMP_DIR}/rsync/${RSYNC_PREFIX}/backup'"
 
 case $RSYNC_PROTO in
 
 	(ssh)
-		$BACKUP_PROG -a $v -r "${TMP_DIR}/rsync/${RSYNC_PREFIX}" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}" >/dev/null 2>&1
-		StopIfError "Could not create '${RSYNC_PATH}/${RSYNC_PREFIX}' on remote ${RSYNC_HOST}"
+		$BACKUP_PROG -a $v -r "${TMP_DIR}/rsync/${RSYNC_PREFIX}" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}" >/dev/null 2>&1 \
+                    || Error "Could not create '${RSYNC_PATH}/${RSYNC_PREFIX}' on remote ${RSYNC_HOST}"
 		;;
 
 	(rsync)
-		$BACKUP_PROG -a $v -r "${TMP_DIR}/rsync/${RSYNC_PREFIX}" ${BACKUP_RSYNC_OPTIONS[@]} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/" >/dev/null
-		StopIfError "Could not create '${RSYNC_PATH}/${RSYNC_PREFIX}' on remote ${RSYNC_HOST}"
+		$BACKUP_PROG -a $v -r "${TMP_DIR}/rsync/${RSYNC_PREFIX}" ${BACKUP_RSYNC_OPTIONS[@]} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/" >/dev/null \
+                    || Error "Could not create '${RSYNC_PATH}/${RSYNC_PREFIX}' on remote ${RSYNC_HOST}"
 		;;
 
 esac

--- a/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
+++ b/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
@@ -5,7 +5,7 @@ LogPrint "Copying resulting files to $OUTPUT_URL location"
 
 # if called as mkbackuponly then we just don't have any result files.
 if test "$RESULT_FILES" ; then
-    Log "Copying files '${RESULT_FILES[@]}' to $OUTPUT_URL location"
+    Log "Copying files '${RESULT_FILES[*]}' to $OUTPUT_URL location"
     cp $v "${RESULT_FILES[@]}" "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" \
         || Error "Could not copy files to local rsync location"
 fi
@@ -26,7 +26,7 @@ case $RSYNC_PROTO in
     # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
     # or remove it according to https://github.com/rear/rear/issues/1395
     $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null \
-        || Error "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
+        || Error "Could not copy '${RESULT_FILES[*]}' to $OUTPUT_URL location"
     ;;
 
     (rsync)
@@ -34,7 +34,7 @@ case $RSYNC_PROTO in
     # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
     # or remove it according to https://github.com/rear/rear/issues/1395
     $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" "${BACKUP_RSYNC_OPTIONS[@]}" "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null \
-        || Error "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
+        || Error "Could not copy '${RESULT_FILES[*]}' to $OUTPUT_URL location"
     ;;
 
 esac

--- a/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
+++ b/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
@@ -30,10 +30,10 @@ case $RSYNC_PROTO in
     ;;
 
     (rsync)
-    Log "$BACKUP_PROG -a ${TMP_DIR}/rsync/${RSYNC_PREFIX}/ ${BACKUP_RSYNC_OPTIONS[@]} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/"
+    Log "$BACKUP_PROG -a ${TMP_DIR}/rsync/${RSYNC_PREFIX}/ ${BACKUP_RSYNC_OPTIONS[*]} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/"
     # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
     # or remove it according to https://github.com/rear/rear/issues/1395
-    $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" ${BACKUP_RSYNC_OPTIONS[@]} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null \
+    $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" "${BACKUP_RSYNC_OPTIONS[@]}" "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null \
         || Error "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
     ;;
 

--- a/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
+++ b/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
@@ -6,18 +6,18 @@ LogPrint "Copying resulting files to $OUTPUT_URL location"
 # if called as mkbackuponly then we just don't have any result files.
 if test "$RESULT_FILES" ; then
     Log "Copying files '${RESULT_FILES[@]}' to $OUTPUT_URL location"
-    cp $v "${RESULT_FILES[@]}" "${TMP_DIR}/rsync/${RSYNC_PREFIX}/"
-    StopIfError "Could not copy files to local rsync location"
+    cp $v "${RESULT_FILES[@]}" "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" \
+        || Error "Could not copy files to local rsync location"
 fi
 
-echo "$VERSION_INFO" >"${TMP_DIR}/rsync/${RSYNC_PREFIX}/VERSION"
-StopIfError "Could not create VERSION file on local rsync location"
+echo "$VERSION_INFO" >"${TMP_DIR}/rsync/${RSYNC_PREFIX}/VERSION" \
+    || Error "Could not create VERSION file on local rsync location"
 
-cp $v $(get_template "RESULT_usage_$OUTPUT.txt") "${TMP_DIR}/rsync/${RSYNC_PREFIX}/README"
-StopIfError "Could not copy usage file to local rsync location"
+cp $v $(get_template "RESULT_usage_$OUTPUT.txt") "${TMP_DIR}/rsync/${RSYNC_PREFIX}/README" \
+    || Error "Could not copy usage file to local rsync location"
 
-cat "$RUNTIME_LOGFILE" >"${TMP_DIR}/rsync/${RSYNC_PREFIX}/rear.log"
-StopIfError "Could not copy $RUNTIME_LOGFILE to local rsync location"
+cat "$RUNTIME_LOGFILE" >"${TMP_DIR}/rsync/${RSYNC_PREFIX}/rear.log" \
+    || Error "Could not copy $RUNTIME_LOGFILE to local rsync location"
 
 case $RSYNC_PROTO in
 
@@ -25,20 +25,20 @@ case $RSYNC_PROTO in
     Log "$BACKUP_PROG -a ${TMP_DIR}/rsync/${RSYNC_PREFIX}/ ${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/"
     # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
     # or remove it according to https://github.com/rear/rear/issues/1395
-    $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null
-    StopIfError "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
+    $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" "${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null \
+        || Error "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
     ;;
 
     (rsync)
     Log "$BACKUP_PROG -a ${TMP_DIR}/rsync/${RSYNC_PREFIX}/ ${BACKUP_RSYNC_OPTIONS[@]} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/"
     # FIXME: Add an explanatory comment why "2>/dev/null" is useful here
     # or remove it according to https://github.com/rear/rear/issues/1395
-    $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" ${BACKUP_RSYNC_OPTIONS[@]} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null
-    StopIfError "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
+    $BACKUP_PROG -a "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" ${BACKUP_RSYNC_OPTIONS[@]} "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/" 2>/dev/null \
+        || Error "Could not copy '${RESULT_FILES[@]}' to $OUTPUT_URL location"
     ;;
 
 esac
 
 # cleanup the temporary space (need it for the log file during backup)
-rm -rf "${TMP_DIR}/rsync/${RSYNC_PREFIX}/"
-LogIfError "Could not cleanup temporary rsync space: ${TMP_DIR}/rsync/${RSYNC_PREFIX}/"
+rm -rf "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" \
+    || Log "Could not cleanup temporary rsync space: ${TMP_DIR}/rsync/${RSYNC_PREFIX}/"

--- a/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
+++ b/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
@@ -41,4 +41,4 @@ esac
 
 # cleanup the temporary space (need it for the log file during backup)
 rm -rf "${TMP_DIR}/rsync/${RSYNC_PREFIX}/"
-LogIfError "Could not cleanup temoprary rsync space: ${TMP_DIR}/rsync/${RSYNC_PREFIX}/"
+LogIfError "Could not cleanup temporary rsync space: ${TMP_DIR}/rsync/${RSYNC_PREFIX}/"

--- a/usr/share/rear/prep/NETFS/default/400_automatic_exclude_recreate.sh
+++ b/usr/share/rear/prep/NETFS/default/400_automatic_exclude_recreate.sh
@@ -31,7 +31,7 @@ case $scheme in
         backup_directory_mountpoint=$( df -P "$backup_directory" | tail -1 | awk '{print $6}' )
         test "/" = "$backup_directory_mountpoint" && Error "URL '$BACKUP_URL' has the backup directory '$backup_directory' in the '/' filesystem which is forbidden."
         # When the mountpoint of the backup directory is not yet excluded add its mountpoint to the EXCLUDE_RECREATE array:
-        if ! grep -q "$backup_directory_mountpoint" <<< $( echo ${EXCLUDE_RECREATE[@]} ) ; then
+        if ! grep -q "$backup_directory_mountpoint" <<< "${EXCLUDE_RECREATE[*]}" ; then
             DebugPrint "Adding backup directory mountpoint 'fs:$backup_directory_mountpoint' to EXCLUDE_RECREATE"
             EXCLUDE_RECREATE+=( "fs:$backup_directory_mountpoint" )
         fi

--- a/usr/share/rear/prep/RSYNC/GNU/Linux/200_selinux_in_use.sh
+++ b/usr/share/rear/prep/RSYNC/GNU/Linux/200_selinux_in_use.sh
@@ -33,7 +33,7 @@ case $(basename $BACKUP_PROG) in
 			touch $TMP_DIR/force.autorelabel	# after reboot the restored system do a forced SELinux relabeling
 		else
 			# if --xattrs is already set; no need to do it again
-			if ! grep -q xattrs <<< $(echo ${BACKUP_RSYNC_OPTIONS[@]}); then
+			if ! grep -q xattrs <<< "${BACKUP_RSYNC_OPTIONS[*]}" ; then
 				BACKUP_RSYNC_OPTIONS+=( --xattrs )
 			fi
 			RSYNC_SELINUX=1		# variable used in recover mode (means using xattr and not disable SELinux)

--- a/usr/share/rear/prep/RSYNC/default/100_check_rsync.sh
+++ b/usr/share/rear/prep/RSYNC/default/100_check_rsync.sh
@@ -88,8 +88,8 @@ fi
 case "$RSYNC_PROTO" in
 
     (rsync)
-        Log "Test: $BACKUP_PROG ${BACKUP_RSYNC_OPTIONS[@]} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/"
-        $BACKUP_PROG ${BACKUP_RSYNC_OPTIONS[@]} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/ >/dev/null \
+        Log "Test: $BACKUP_PROG ${BACKUP_RSYNC_OPTIONS[*]} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/"
+        $BACKUP_PROG "${BACKUP_RSYNC_OPTIONS[@]}" ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/ >/dev/null \
             || Error "Rsync daemon not running on $RSYNC_HOST"
         ;;
 

--- a/usr/share/rear/prep/RSYNC/default/100_check_rsync.sh
+++ b/usr/share/rear/prep/RSYNC/default/100_check_rsync.sh
@@ -79,8 +79,7 @@ esac
 
 # check if host is reachable
 if test "$PING" ; then
-    ping -c 2 "$RSYNC_HOST" >/dev/null
-    StopIfError "Backup host [$RSYNC_HOST] not reachable."
+    ping -c 2 "$RSYNC_HOST" >/dev/null || Error "Backup host [$RSYNC_HOST] not reachable."
 else
     Log "Skipping ping test"
 fi
@@ -90,14 +89,14 @@ case "$RSYNC_PROTO" in
 
     (rsync)
         Log "Test: $BACKUP_PROG ${BACKUP_RSYNC_OPTIONS[@]} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/"
-        $BACKUP_PROG ${BACKUP_RSYNC_OPTIONS[@]} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/ >/dev/null
-        StopIfError "Rsync daemon not running on $RSYNC_HOST"
+        $BACKUP_PROG ${BACKUP_RSYNC_OPTIONS[@]} ${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/ >/dev/null \
+            || Error "Rsync daemon not running on $RSYNC_HOST"
         ;;
 
     (ssh)
         Log "Test: ssh ${RSYNC_USER}@${RSYNC_HOST} /bin/true"
-        ssh ${RSYNC_USER}@${RSYNC_HOST} /bin/true >/dev/null 2>&1
-        StopIfError "Secure shell connection not setup properly [$RSYNC_USER@$RSYNC_HOST]"
+        ssh ${RSYNC_USER}@${RSYNC_HOST} /bin/true >/dev/null 2>&1 \
+            || Error "Secure shell connection not setup properly [$RSYNC_USER@$RSYNC_HOST]"
         ;;
 
 esac

--- a/usr/share/rear/prep/RSYNC/default/100_check_rsync.sh
+++ b/usr/share/rear/prep/RSYNC/default/100_check_rsync.sh
@@ -33,22 +33,20 @@ RSYNC_PORT=873                  # default port (of rsync server)
 RSYNC_PATH=
 
 
-echo $BACKUP_URL | egrep -q '(::)'      # new style '::' means rsync protocol
-if [[ $? -eq 0 ]]; then
+if egrep -q '(::)' <<< $BACKUP_URL ; then # new style '::' means rsync protocol
     RSYNC_PROTO=rsync
 else
     RSYNC_PROTO=ssh
 fi
 
-echo $host | grep -q '@'
-if [[ $? -eq 0 ]]; then
+if grep -q '@' <<< $host ; then
     RSYNC_USER="${host%%@*}"    # grab user name
 else
     RSYNC_USER=root
 fi
 
 # remove USER@ if present (we don't need it anymore)
-tmp2="${host#*@}"
+local tmp2="${host#*@}"
 
 case "$RSYNC_PROTO" in
 
@@ -56,8 +54,7 @@ case "$RSYNC_PROTO" in
         # tmp2=witsbebelnx02::backup or tmp2=witsbebelnx02::
         RSYNC_HOST="${tmp2%%::*}"
         # path=/gdhaese1@witsbebelnx02::backup or path=/backup
-        echo $path | grep -q '::'
-        if [[ $? -eq 0 ]]; then
+        if grep -q '::' <<< $path ; then
             RSYNC_PATH="${path##*::}"
         else
             RSYNC_PATH="${path##*/}"

--- a/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
+++ b/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
@@ -10,8 +10,8 @@ if [ -z "$RSYNC_PROTOCOL_VERSION" ]; then
     case $RSYNC_PROTO in
 
     (ssh)
-        ssh ${RSYNC_USER}@${RSYNC_HOST} rsync --version >"$TMP_DIR/rsync_protocol" 2>&1
-        StopIfError "Secure shell connection not setup properly [$RSYNC_USER@$RSYNC_HOST]"
+        ssh ${RSYNC_USER}@${RSYNC_HOST} rsync --version >"$TMP_DIR/rsync_protocol" 2>&1 \
+            || Error "Secure shell connection not setup properly [$RSYNC_USER@$RSYNC_HOST]"
         grep -q "protocol version" "$TMP_DIR/rsync_protocol"
         if [ $? -eq 0 ]; then
             RSYNC_PROTOCOL_VERSION=$(grep 'protocol version' "$TMP_DIR/rsync_protocol" | awk '{print $6}')
@@ -41,8 +41,8 @@ if [ "${RSYNC_USER}" != "root" ]; then
         else
             # when using --fake-super we must have user_xattr mount options on the remote mntpt
             remote_mountpoint=$(ssh ${RSYNC_USER}@${RSYNC_HOST} 'cd ${RSYNC_PATH}; df -P .' 2>/dev/null | tail -1 | awk '{print $6}')
-            ssh ${RSYNC_USER}@${RSYNC_HOST} "cd ${RSYNC_PATH} && touch .is_xattr_supported && setfattr -n user.comment -v 'File created by ReaR to test if this filesystems supports extended attributes.' .is_xattr_supported && getfattr -n user.comment .is_xattr_supported 1>/dev/null; find .is_xattr_supported -empty -delete"
-            StopIfError "Remote file system $remote_mountpoint does not have user_xattr mount option set!"
+            ssh ${RSYNC_USER}@${RSYNC_HOST} "cd ${RSYNC_PATH} && touch .is_xattr_supported && setfattr -n user.comment -v 'File created by ReaR to test if this filesystems supports extended attributes.' .is_xattr_supported && getfattr -n user.comment .is_xattr_supported 1>/dev/null; find .is_xattr_supported -empty -delete" \
+                || Error "Remote file system $remote_mountpoint does not have user_xattr mount option set!"
             #BACKUP_RSYNC_OPTIONS+=( --xattrs --rsync-path="rsync --fake-super" )
             # see issue #366 for explanation of removing --xattrs
             BACKUP_RSYNC_OPTIONS+=( --rsync-path="rsync --fake-super" )

--- a/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
+++ b/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
@@ -40,9 +40,9 @@ if [ "${RSYNC_USER}" != "root" ]; then
             _mntpt=$(ssh ${RSYNC_USER}@${RSYNC_HOST} 'cd ${RSYNC_PATH}; df -P .' 2>/dev/null | tail -1 | awk '{print $6}')
             ssh ${RSYNC_USER}@${RSYNC_HOST} "cd ${RSYNC_PATH} && touch .is_xattr_supported && setfattr -n user.comment -v 'File created by ReaR to test if this filesystems supports extended attributes.' .is_xattr_supported && getfattr -n user.comment .is_xattr_supported 1>/dev/null; find .is_xattr_supported -empty -delete"
             StopIfError "Remote file system $_mntpt does not have user_xattr mount option set!"
-            #BACKUP_RSYNC_OPTIONS+=( --xattrs --rsync-path="""rsync --fake-super""" )
+            #BACKUP_RSYNC_OPTIONS+=( --xattrs --rsync-path="rsync --fake-super" )
             # see issue #366 for explanation of removing --xattrs
-            BACKUP_RSYNC_OPTIONS+=( --rsync-path="""rsync --fake-super""" )
+            BACKUP_RSYNC_OPTIONS+=( --rsync-path="rsync --fake-super" )
         fi
     else
         if [ ${BACKUP_RSYNC_OPTIONS[@]/--fake-super/} != ${BACKUP_RSUNC_OPTIONS[@]} ]; then

--- a/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
+++ b/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
@@ -2,6 +2,9 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 # try to grab the rsync protocol version of rsync on the remote server
+
+local remote_mountpoint
+
 if [ -z "$RSYNC_PROTOCOL_VERSION" ]; then
 
     case $RSYNC_PROTO in
@@ -37,9 +40,9 @@ if [ "${RSYNC_USER}" != "root" ]; then
             Error "rsync --fake-super not possible on system ($RSYNC_HOST) (no xattrs compiled in rsync)"
         else
             # when using --fake-super we must have user_xattr mount options on the remote mntpt
-            _mntpt=$(ssh ${RSYNC_USER}@${RSYNC_HOST} 'cd ${RSYNC_PATH}; df -P .' 2>/dev/null | tail -1 | awk '{print $6}')
+            remote_mountpoint=$(ssh ${RSYNC_USER}@${RSYNC_HOST} 'cd ${RSYNC_PATH}; df -P .' 2>/dev/null | tail -1 | awk '{print $6}')
             ssh ${RSYNC_USER}@${RSYNC_HOST} "cd ${RSYNC_PATH} && touch .is_xattr_supported && setfattr -n user.comment -v 'File created by ReaR to test if this filesystems supports extended attributes.' .is_xattr_supported && getfattr -n user.comment .is_xattr_supported 1>/dev/null; find .is_xattr_supported -empty -delete"
-            StopIfError "Remote file system $_mntpt does not have user_xattr mount option set!"
+            StopIfError "Remote file system $remote_mountpoint does not have user_xattr mount option set!"
             #BACKUP_RSYNC_OPTIONS+=( --xattrs --rsync-path="rsync --fake-super" )
             # see issue #366 for explanation of removing --xattrs
             BACKUP_RSYNC_OPTIONS+=( --rsync-path="rsync --fake-super" )

--- a/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
+++ b/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
@@ -47,10 +47,6 @@ if [ "${RSYNC_USER}" != "root" ]; then
             BACKUP_RSYNC_OPTIONS+=( --rsync-path="rsync --fake-super" )
         fi
     else
-        if [ ${BACKUP_RSYNC_OPTIONS[@]/--fake-super/} != ${BACKUP_RSUNC_OPTIONS[@]} ]; then
-            Error "rsync --fake-super not possible on system ($RSYNC_HOST) (please upgrade rsync to 3.x)"
-        else
-            Log "Warning: rsync --fake-super not possible on system ($RSYNC_HOST) (please upgrade rsync to 3.x)"
-        fi
+        Error "rsync --fake-super not possible on system ($RSYNC_HOST) (please upgrade rsync to 3.x)"
     fi
 fi

--- a/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
+++ b/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
@@ -12,8 +12,7 @@ if [ -z "$RSYNC_PROTOCOL_VERSION" ]; then
     (ssh)
         ssh ${RSYNC_USER}@${RSYNC_HOST} rsync --version >"$TMP_DIR/rsync_protocol" 2>&1 \
             || Error "Secure shell connection not setup properly [$RSYNC_USER@$RSYNC_HOST]"
-        grep -q "protocol version" "$TMP_DIR/rsync_protocol"
-        if [ $? -eq 0 ]; then
+        if grep -q "protocol version" "$TMP_DIR/rsync_protocol" ; then
             RSYNC_PROTOCOL_VERSION=$(grep 'protocol version' "$TMP_DIR/rsync_protocol" | awk '{print $6}')
         else
             RSYNC_PROTOCOL_VERSION=29   # being conservative (old rsync version < 3.0)

--- a/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
+++ b/usr/share/rear/prep/RSYNC/default/150_check_rsync_protocol_version.sh
@@ -32,7 +32,7 @@ else
 
 fi
 
-if [ "${RSYNC_USER}" != "root" ]; then
+if [ "${RSYNC_USER}" != "root" -a $RSYNC_PROTO = "ssh" ]; then
     if [ $RSYNC_PROTOCOL_VERSION -gt 29 ]; then
         if grep -q "no xattrs" "$TMP_DIR/rsync_protocol"; then
             # no xattrs available in remote rsync, so --fake-super is not possible

--- a/usr/share/rear/restore/DUPLICITY/default/400_restore_duplicity.sh
+++ b/usr/share/rear/restore/DUPLICITY/default/400_restore_duplicity.sh
@@ -5,6 +5,7 @@
 # Restore from remote backup via DUPLICIY over rsync
 
 if [ "$BACKUP_PROG" = "duplicity" ]; then
+    local backup_prog_rc
 
     LogPrint "========================================================================"
     LogPrint "Restoring backup with $BACKUP_PROG from '$BACKUP_DUPLICITY_URL'"
@@ -49,7 +50,8 @@ if [ "$BACKUP_PROG" = "duplicity" ]; then
         LogPrint "with CMD: $DUPLICITY_PROG -v 5 ${BACKUP_DUPLICITY_OPTIONS} $GPG_KEY --force --tempdir=$DUPLICITY_TEMPDIR $BACKUP_DUPLICITY_URL/$HOSTNAME/ $TARGET_FS_ROOT"
         $DUPLICITY_PROG -v 5 ${BACKUP_DUPLICITY_OPTIONS} $GPG_KEY --force --tempdir="$DUPLICITY_TEMPDIR" $BACKUP_DUPLICITY_URL/$HOSTNAME/ $TARGET_FS_ROOT 0<&6 | tee $TMP_DIR/duplicity-restore.log
     fi
-    _rc=$?
+    # FIXME: this collects the exit code from "tee", not from $DUPLICITY_PROG
+    backup_prog_rc=$?
 
     transfertime="$((SECONDS-$starttime))"
     sleep 1
@@ -65,7 +67,7 @@ if [ "$BACKUP_PROG" = "duplicity" ]; then
     LogPrint "========================================================================"
 
 
-    if [ "$_rc" -gt 0 ]; then
+    if [ "$backup_prog_rc" -gt 0 ]; then
         LogPrint "WARNING !
     There was an error while restoring the archive.
     Please check '$RUNTIME_LOGFILE' and $TMP_DIR/duplicity-restore.log for more information.
@@ -78,7 +80,7 @@ if [ "$BACKUP_PROG" = "duplicity" ]; then
         LogPrint "$_message"
     fi
 
-    if [ $_rc -eq 0 ] ; then
+    if [ $backup_prog_rc -eq 0 ] ; then
         LogPrint "Restore completed in $transfertime seconds."
     fi
 

--- a/usr/share/rear/restore/DUPLICITY/default/400_restore_duplicity.sh
+++ b/usr/share/rear/restore/DUPLICITY/default/400_restore_duplicity.sh
@@ -6,6 +6,7 @@
 
 if [ "$BACKUP_PROG" = "duplicity" ]; then
     local backup_prog_rc
+    local restore_log_message
 
     LogPrint "========================================================================"
     LogPrint "Restoring backup with $BACKUP_PROG from '$BACKUP_DUPLICITY_URL'"
@@ -74,10 +75,10 @@ if [ "$BACKUP_PROG" = "duplicity" ]; then
     You should also manually check the restored system to see whether it is complete.
     "
 
-        _message="$(tail -14 ${TMP_DIR}/duplicity-restore.log)"
+        restore_log_message="$(tail -14 ${TMP_DIR}/duplicity-restore.log)"
 
         LogPrint "Last 14 Lines of ${TMP_DIR}/duplicity-restore.log:"
-        LogPrint "$_message"
+        LogPrint "$restore_log_message"
     fi
 
     if [ $backup_prog_rc -eq 0 ] ; then

--- a/usr/share/rear/restore/RBME/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/RBME/default/400_restore_backup.sh
@@ -2,6 +2,8 @@ if [[ -z "$RBME_BACKUP" ]] ; then
     Error "No RBME backup selected (BACKUP_URL?). Aborting."
 fi
 
+local backup_prog_rc
+
 scheme=$(url_scheme "$BACKUP_URL")
 
 LogPrint "Restoring from backup $RBME_BACKUP."
@@ -43,11 +45,11 @@ transfertime="$((SECONDS-starttime))"
 # harvest return code from background job. The kill -0 $BackupPID loop above should
 # have made sure that this wait won't do any real "waiting" :-)
 wait $BackupPID
-_rc=$?
+backup_prog_rc=$?
 
 sleep 1
-test "$_rc" -gt 0 && LogPrint "WARNING !
-There was an error (${rsync_err_msg[$_rc]}) while restoring the archive.
+test "$backup_prog_rc" -gt 0 && LogPrint "WARNING !
+There was an error (${rsync_err_msg[$backup_prog_rc]}) while restoring the archive.
 Please check '$RUNTIME_LOGFILE' for more information. You should also
 manually check the restored system to see whether it is complete.
 "

--- a/usr/share/rear/restore/RSYNC/default/200_remove_relative_rsync_option.sh
+++ b/usr/share/rear/restore/RSYNC/default/200_remove_relative_rsync_option.sh
@@ -4,11 +4,11 @@
 # without the --relative option ; my feeling says it is better to remove it from array BACKUP_RSYNC_OPTIONS
 # If I'm wrong please let us know (use issue mentioned above to comment)
 
-if grep -q -- "--relative" <<< $(echo ${BACKUP_RSYNC_OPTIONS[@]}); then
+if grep -q -- "--relative" <<< "${BACKUP_RSYNC_OPTIONS[*]}" ; then
     BACKUP_RSYNC_OPTIONS=( $( RmInArray "--relative" "${BACKUP_RSYNC_OPTIONS[@]}" ) )
     Log "Removed option '--relative' from the BACKUP_RSYNC_OPTIONS array during $WORKFLOW workflow"
 fi
-if grep -q -- "-R" <<< $(echo ${BACKUP_RSYNC_OPTIONS[@]}); then
+if grep -q -- "-R" <<< "${BACKUP_RSYNC_OPTIONS[*]}" ; then
     BACKUP_RSYNC_OPTIONS=( $( RmInArray "-R" "${BACKUP_RSYNC_OPTIONS[@]}" ) )
     Log "Removed option '-R' from the BACKUP_RSYNC_OPTIONS array during $WORKFLOW workflow"
 fi

--- a/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
+++ b/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
@@ -7,7 +7,7 @@ get_size() {
 local backup_prog_rc
 local restore_log_message
 
-LogPrint "Restoring $BACKUP_PROG archive from '${RSYNC_HOST}:${RSYNC_PATH}'"
+LogPrint "Restoring $BACKUP_PROG backup from '${RSYNC_HOST}:${RSYNC_PATH}'"
 
 ProgressStart "Restore operation"
 (
@@ -81,7 +81,7 @@ backup_prog_rc="$(cat $TMP_DIR/retval)"
 
 sleep 1
 test "$backup_prog_rc" -gt 0 && LogPrintError "WARNING !
-There was an error (${rsync_err_msg[$backup_prog_rc]}) while restoring the archive.
+There was an error (${rsync_err_msg[$backup_prog_rc]}) while restoring the backup.
 Please check '$RUNTIME_LOGFILE' for more information. You should also
 manually check the restored system to see whether it is complete.
 "

--- a/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
+++ b/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
@@ -7,9 +7,6 @@ get_size() {
 local backup_prog_rc
 local restore_log_message
 
-mkdir -p "${TMP_DIR}/rsync/${NETFS_PREFIX}"
-StopIfError "Could not mkdir '$TMP_DIR/rsync/${NETFS_PREFIX}'"
-
 LogPrint "Restoring $BACKUP_PROG archive from '${RSYNC_HOST}:${RSYNC_PATH}'"
 
 ProgressStart "Restore operation"

--- a/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
+++ b/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
@@ -36,6 +36,7 @@ ProgressStart "Restore operation"
 			# no other backup programs foreseen then rsync so far
 			:
 			;;
+
 	esac
 	echo $? >$TMP_DIR/retval
 ) >"${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log" &
@@ -65,6 +66,7 @@ case "$(basename $BACKUP_PROG)" in
 			ProgressStep
 		done
 		;;
+
 esac
 ProgressStop
 

--- a/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
+++ b/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
@@ -80,11 +80,15 @@ wait $BackupPID || LogPrintError "Restore job returned a nonzero exit code $?"
 backup_prog_rc="$(cat $TMP_DIR/retval)"
 
 sleep 1
-test "$backup_prog_rc" -gt 0 && LogPrintError "WARNING !
+if test "$backup_prog_rc" -gt 0 ; then
+    # TODO: Shouldn't we tell the user to check ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log as well?
+    LogPrintError "WARNING !
 There was an error (${rsync_err_msg[$backup_prog_rc]}) while restoring the backup.
 Please check '$RUNTIME_LOGFILE' for more information. You should also
 manually check the restored system to see whether it is complete.
 "
+    is_true "$BACKUP_INTEGRITY_CHECK" && Error "Integrity check failed, restore aborted because BACKUP_INTEGRITY_CHECK is enabled"
+fi
 
 restore_log_message="$(tail -14 ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log)"
 

--- a/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
+++ b/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
@@ -33,7 +33,7 @@ ProgressStart "Restore operation"
 			;;
 
 		(*)
-			# no other backup programs foreseen then rsync so far
+			# no other backup programs foreseen than rsync so far
 			:
 			;;
 

--- a/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
+++ b/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
@@ -74,8 +74,10 @@ transfertime="$((SECONDS-starttime))"
 
 # harvest return code from background job. The kill -0 $BackupPID loop above should
 # have made sure that this wait won't do any real "waiting" :-)
-wait $BackupPID
-_rc=$?
+wait $BackupPID || LogPrintError "Restore job returned a nonzero exit code $?"
+# harvest the actual return code of rsync. Finishing the pipeline with an error code above is actually unlikely,
+# because rsync is not the last command in it. But error returns from rsync are common and must be handled.
+_rc="$(cat $TMP_DIR/retval)"
 
 sleep 1
 test "$_rc" -gt 0 && LogPrint "WARNING !

--- a/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
+++ b/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
@@ -97,3 +97,5 @@ if [ $backup_prog_rc -eq 0 -a "$restore_log_message" ] ; then
 elif [ "$size" ]; then
         LogPrint "Restored $((size/1024/1024)) MiB in $((transfertime)) seconds [avg $((size/1024/transfertime)) KiB/sec]"
 fi
+
+return $backup_prog_rc

--- a/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
+++ b/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
@@ -5,6 +5,7 @@ get_size() {
 }
 
 local backup_prog_rc
+local restore_log_message
 
 mkdir -p "${TMP_DIR}/rsync/${NETFS_PREFIX}"
 StopIfError "Could not mkdir '$TMP_DIR/rsync/${NETFS_PREFIX}'"
@@ -88,10 +89,10 @@ Please check '$RUNTIME_LOGFILE' for more information. You should also
 manually check the restored system to see whether it is complete.
 "
 
-_message="$(tail -14 ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log)"
+restore_log_message="$(tail -14 ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log)"
 
-if [ $backup_prog_rc -eq 0 -a "$_message" ] ; then
-        LogPrint "$_message in $transfertime seconds."
+if [ $backup_prog_rc -eq 0 -a "$restore_log_message" ] ; then
+        LogPrint "$restore_log_message in $transfertime seconds."
 elif [ "$size" ]; then
         LogPrint "Restored $((size/1024/1024)) MiB in $((transfertime)) seconds [avg $((size/1024/transfertime)) KiB/sec]"
 fi

--- a/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
+++ b/usr/share/rear/restore/RSYNC/default/400_restore_rsync_backup.sh
@@ -80,7 +80,7 @@ wait $BackupPID || LogPrintError "Restore job returned a nonzero exit code $?"
 _rc="$(cat $TMP_DIR/retval)"
 
 sleep 1
-test "$_rc" -gt 0 && LogPrint "WARNING !
+test "$_rc" -gt 0 && LogPrintError "WARNING !
 There was an error (${rsync_err_msg[$_rc]}) while restoring the archive.
 Please check '$RUNTIME_LOGFILE' for more information. You should also
 manually check the restored system to see whether it is complete.

--- a/usr/share/rear/verify/RSYNC/GNU/Linux/600_check_rsync_xattr.sh
+++ b/usr/share/rear/verify/RSYNC/GNU/Linux/600_check_rsync_xattr.sh
@@ -4,7 +4,7 @@
 
 	# if --xattrs is already set; no need to do it again
 	if ! grep -q xattrs <<< "${BACKUP_RSYNC_OPTIONS[*]}" ; then
-		RSYNC_OPTIONS=( "${BACKUP_RSYNC_OPTIONS[@]}" --xattrs )
+		BACKUP_RSYNC_OPTIONS+=( --xattrs )
 	fi
 
 }

--- a/usr/share/rear/verify/RSYNC/GNU/Linux/600_check_rsync_xattr.sh
+++ b/usr/share/rear/verify/RSYNC/GNU/Linux/600_check_rsync_xattr.sh
@@ -3,7 +3,7 @@
 [[ $RSYNC_SELINUX ]] && {
 
 	# if --xattrs is already set; no need to do it again
-	if ! grep -q xattrs <<< $(echo ${BACKUP_RSYNC_OPTIONS[@]}); then
+	if ! grep -q xattrs <<< "${BACKUP_RSYNC_OPTIONS[*]}" ; then
 		RSYNC_OPTIONS=( "${BACKUP_RSYNC_OPTIONS[@]}" --xattrs )
 	fi
 

--- a/usr/share/rear/verify/RSYNC/default/550_check_remote_backup_archive.sh
+++ b/usr/share/rear/verify/RSYNC/default/550_check_remote_backup_archive.sh
@@ -3,12 +3,12 @@
 case $RSYNC_PROTO in
 
 	(ssh)
-		ssh ${RSYNC_USER}@${RSYNC_HOST} "ls -ld ${RSYNC_PATH}/${RSYNC_PREFIX}/backup" >/dev/null 2>&1
-		StopIfError "Archive not found on [$RSYNC_USER@$RSYNC_HOST:${RSYNC_PATH}/${RSYNC_PREFIX}]"
+		ssh ${RSYNC_USER}@${RSYNC_HOST} "ls -ld ${RSYNC_PATH}/${RSYNC_PREFIX}/backup" >/dev/null 2>&1 \
+		    || Error "Archive not found on [$RSYNC_USER@$RSYNC_HOST:${RSYNC_PATH}/${RSYNC_PREFIX}]"
 		;;
 
 	(rsync)
-		$BACKUP_PROG "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/backup" >/dev/null 2>&1
-		StopIfError "Archive not found on [$RSYNC_USER@$RSYNC_HOST:${RSYNC_PATH}/${RSYNC_PREFIX}]"
+		$BACKUP_PROG "${RSYNC_PROTO}://${RSYNC_USER}@${RSYNC_HOST}:${RSYNC_PORT}/${RSYNC_PATH}/${RSYNC_PREFIX}/backup" >/dev/null 2>&1 \
+		    || Error "Archive not found on [$RSYNC_USER@$RSYNC_HOST:${RSYNC_PATH}/${RSYNC_PREFIX}]"
 		;;
 esac


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix** / **Cleanup**

* Impact: **High**

* Reference to related issue (URL): #2612, #2577

* How was this pull request tested?
Against CentOS 7:
  1. full backup and restore using rsync over ssh
  2. added nonsensical rsync option `BACKUP_RSYNC_OPTIONS+=( -M--nonsense )`, verified that ReaR aborts mkbackup instead of displaying a warning message and continuing
  3.  added nonsensical rsync option `BACKUP_RSYNC_OPTIONS+=( -M--nonsense )` in the rescue system, verified that ReaR displays a prominent warning during mkrescue before continuing and aborting later at a different place
  4. added  `BACKUP_INTEGRITY_CHECK=1` and a nonsensical rsync option `BACKUP_RSYNC_OPTIONS+=( -M--nonsense )` in the rescue system, verified that ReaR displays a rsync error and aborts during mkrescue instead of continuing and aborting later at a different place

  Against CentOS 8:
full backup and restore using rsync over ssh

* Brief description of the changes in this pull request:
Cleanups of rsync code to use better variable names and local variables, stop using `StopIfError`, use better redirections etc.
Fix a problem with rsync error detection that caused rsync errors during backup restore to be ignored (fixes #2612). Now a warning is displayed and if `BACKUP_INTEGRITY_CHECK` is true, it is elevated to an error and ReaR aborts.
Detect errors during rsync backup: they were reported only as warnings, which is risky, because if nobody reads them, one could easily end up with a broken backup (therefore impact High).