### PR TITLE
fixed serial console for syslinux

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2906,6 +2906,11 @@ SIMPLIFY_TEAMING=no
 # e.g. when no VGA console is available (say y, n or leave empty to autodetect):
 USE_SERIAL_CONSOLE=
 
+# Since syslinux does not work with more then one serial device at once it must be explicitly named.
+# Here you can configute the serial console device to use when USE_SERIAL_CONSOLE is turned on.
+# By default device /dev/ttyS0 is used.
+SERIAL_CONSOLE_DEVICE=/dev/ttyS0
+
 # Say "y", "Yes", etc, to enable or "n", "No" etc. to disable the DHCP client protocol or leave empty to autodetect.
 # When enabled, lets the rescue/recovery system run dhclient to get an IP address
 # instead of using the same IP address as the original system:

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2907,9 +2907,9 @@ SIMPLIFY_TEAMING=no
 USE_SERIAL_CONSOLE=
 
 # Since syslinux does not work with more then one serial device at once it must be explicitly named.
-# Here you can configute the serial console device to use e.g. 'SERIAL_CONSOLE_DEVICE=/dev/ttyS0' when USE_SERIAL_CONSOLE is turned on.
+# Here you can configute the serial console device to use e.g. 'SERIAL_CONSOLE_DEVICE_SYSLINUX=/dev/ttyS0' when USE_SERIAL_CONSOLE is turned on.
 # By default (when unset) all found serial devices are used.
-SERIAL_CONSOLE_DEVICE=
+SERIAL_CONSOLE_DEVICE_SYSLINUX=
 
 # Say "y", "Yes", etc, to enable or "n", "No" etc. to disable the DHCP client protocol or leave empty to autodetect.
 # When enabled, lets the rescue/recovery system run dhclient to get an IP address

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2907,9 +2907,9 @@ SIMPLIFY_TEAMING=no
 USE_SERIAL_CONSOLE=
 
 # Since syslinux does not work with more then one serial device at once it must be explicitly named.
-# Here you can configute the serial console device to use when USE_SERIAL_CONSOLE is turned on.
-# By default device /dev/ttyS0 is used.
-SERIAL_CONSOLE_DEVICE=/dev/ttyS0
+# Here you can configute the serial console device to use e.g. 'SERIAL_CONSOLE_DEVICE=/dev/ttyS0' when USE_SERIAL_CONSOLE is turned on.
+# By default (when unset) all found serial devices are used.
+SERIAL_CONSOLE_DEVICE=
 
 # Say "y", "Yes", etc, to enable or "n", "No" etc. to disable the DHCP client protocol or leave empty to autodetect.
 # When enabled, lets the rescue/recovery system run dhclient to get an IP address

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2904,11 +2904,13 @@ SIMPLIFY_TEAMING=no
 # are set when booting the rescue/recovery system (see KERNEL_CMDLINE above).
 # IA64 platforms do require it, and sometimes people still use serial console
 # e.g. when no VGA console is available (say y, n or leave empty to autodetect):
+# This config value may change in the near future and may merge with SERIAL_CONSOLE_DEVICE_SYSLINUX.
 USE_SERIAL_CONSOLE=
 
 # Since syslinux does not work with more then one serial device at once it must be explicitly named.
 # Here you can configute the serial console device to use e.g. 'SERIAL_CONSOLE_DEVICE_SYSLINUX=/dev/ttyS0' when USE_SERIAL_CONSOLE is turned on.
 # By default (when unset) all found serial devices are used.
+# This config value may change in the near future and may get merged with USE_SERIAL_CONSOLE.
 SERIAL_CONSOLE_DEVICE_SYSLINUX=
 
 # Say "y", "Yes", etc, to enable or "n", "No" etc. to disable the DHCP client protocol or leave empty to autodetect.

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -199,12 +199,17 @@ function make_syslinux_config {
         SYSLINUX_DIR="$syslinux_modules_dir"
     fi
 
-    # Enable serial console, unless explicitly disabled (only last entry is used :-/)
+    # Enable serial console, unless explicitly disabled (only last entry is used on some systems thats where SERIAL_CONSOLE_DEVICE_SYSLINUX comes in :-/)
     if [[ "$USE_SERIAL_CONSOLE" =~ ^[yY1] ]]; then
         for devnode in $(ls /dev/ttyS[0-9]* | sort); do
-            speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
-            if [ "$speed" ]; then
-                echo "serial ${devnode##/dev/ttyS} $speed"
+            # Not sure if using all serial devices do screw up syslinux in general
+            # for me listing more then one serial line in the config screwed it
+            # see https://github.com/rear/rear/pull/2650
+            if [ -z $SERIAL_CONSOLE_DEVICE_SYSLINUX ] || [[ $SERIAL_CONSOLE_DEVICE_SYSLINUX == $devnode ]]; then
+                speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
+                if [ "$speed" ]; then
+                    echo "serial ${devnode##/dev/ttyS} $speed"
+                fi
             fi
         done
     fi

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -175,21 +175,6 @@ fi
 # We generate a ReaR syslinux.cfg based on existing ReaR syslinux.cfg files.
 Log "Creating /rear/syslinux.cfg"
 {
-    # Enable serial console, unless explicitly disabled
-    if [[ "$USE_SERIAL_CONSOLE" =~ ^[yY1] ]]; then
-        for devnode in $(ls /dev/ttyS[0-9]* | sort); do
-            # Not sure if using all serial devices do screw up syslinux in general
-            # for me listing more then one serial line in the config screwed it
-            # see https://github.com/rear/rear/pull/2650
-            if [ -z $SERIAL_CONSOLE_DEVICE_SYSLINUX ] || [[ $SERIAL_CONSOLE_DEVICE_SYSLINUX == $devnode ]]; then
-                speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
-                if [ "$speed" ]; then
-                    syslinux_write "serial ${devnode##/dev/ttyS} $speed"
-                fi
-            fi
-        done
-    fi
-
     syslinux_write <<EOF
 label rear
     say Relax-and-Recover - Recover $HOSTNAME from $time

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -180,6 +180,7 @@ Log "Creating /rear/syslinux.cfg"
         for devnode in $(ls /dev/ttyS[0-9]* | sort); do
             # Not sure if using all serial devices do screw up syslinux in general
             # for me listing more then one serial line in the config screwed it
+            # see https://github.com/rear/rear/pull/2650
             if [ -z $SERIAL_CONSOLE_DEVICE_SYSLINUX ] || [[ $SERIAL_CONSOLE_DEVICE_SYSLINUX == $devnode ]]; then
                 speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
                 if [ "$speed" ]; then
@@ -280,6 +281,7 @@ Log "Creating $SYSLINUX_PREFIX/extlinux.conf"
         for devnode in $(ls /dev/ttyS[0-9]* | sort); do
             # Not sure if using all serial devices do screw up syslinux in general
             # for me listing more then one serial line in the config screwed it
+            # see https://github.com/rear/rear/pull/2650
             if [ -z $SERIAL_CONSOLE_DEVICE_SYSLINUX ] || [[ $SERIAL_CONSOLE_DEVICE_SYSLINUX == $devnode ]]; then
                 speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
                 if [ "$speed" ]; then

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -180,7 +180,7 @@ Log "Creating /rear/syslinux.cfg"
         for devnode in $(ls /dev/ttyS[0-9]* | sort); do
             # Not sure if using all serial devices do screw up syslinux in general
             # for me listing more then one serial line in the config screwed it
-            if [[ $SERIAL_CONSOLE_DEVICE == $devnode ]]; then
+            if [ -z $SERIAL_CONSOLE_DEVICE ] || [[ $SERIAL_CONSOLE_DEVICE == $devnode ]]; then
                 speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
                 if [ "$speed" ]; then
                     syslinux_write "serial ${devnode##/dev/ttyS} $speed"
@@ -280,7 +280,7 @@ Log "Creating $SYSLINUX_PREFIX/extlinux.conf"
         for devnode in $(ls /dev/ttyS[0-9]* | sort); do
             # Not sure if using all serial devices do screw up syslinux in general
             # for me listing more then one serial line in the config screwed it
-            if [[ $SERIAL_CONSOLE_DEVICE == $devnode ]]; then
+            if [ -z $SERIAL_CONSOLE_DEVICE ] || [[ $SERIAL_CONSOLE_DEVICE == $devnode ]]; then
                 speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
                 if [ "$speed" ]; then
                     syslinux_write "serial ${devnode##/dev/ttyS} $speed"

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -180,7 +180,7 @@ Log "Creating /rear/syslinux.cfg"
         for devnode in $(ls /dev/ttyS[0-9]* | sort); do
             # Not sure if using all serial devices do screw up syslinux in general
             # for me listing more then one serial line in the config screwed it
-            if [ -z $SERIAL_CONSOLE_DEVICE ] || [[ $SERIAL_CONSOLE_DEVICE == $devnode ]]; then
+            if [ -z $SERIAL_CONSOLE_DEVICE_SYSLINUX ] || [[ $SERIAL_CONSOLE_DEVICE_SYSLINUX == $devnode ]]; then
                 speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
                 if [ "$speed" ]; then
                     syslinux_write "serial ${devnode##/dev/ttyS} $speed"
@@ -280,7 +280,7 @@ Log "Creating $SYSLINUX_PREFIX/extlinux.conf"
         for devnode in $(ls /dev/ttyS[0-9]* | sort); do
             # Not sure if using all serial devices do screw up syslinux in general
             # for me listing more then one serial line in the config screwed it
-            if [ -z $SERIAL_CONSOLE_DEVICE ] || [[ $SERIAL_CONSOLE_DEVICE == $devnode ]]; then
+            if [ -z $SERIAL_CONSOLE_DEVICE_SYSLINUX ] || [[ $SERIAL_CONSOLE_DEVICE_SYSLINUX == $devnode ]]; then
                 speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
                 if [ "$speed" ]; then
                     syslinux_write "serial ${devnode##/dev/ttyS} $speed"


### PR DESCRIPTION
* Type: **Bug Fix**
* Impact: **Normal**
* Reference to related issue (URL): kind of related #2644
* Relax-and-Recover 2.6 / 2020-06-17
* syslinux 6.04  Copyright 1994-2015 H. Peter Anvin et al
* extlinux 6.04  Copyright 1994-2015 H. Peter Anvin et al
* How was this pull request tested?
using output=usb I created a bootable USB stick with working serial on a apu board based machine. (ex6linux)
* Brief description of the changes in this pull request:
I can not find any statement in syslinux documentation if multiple `serial` lines are allowed. The docs just state the line must be the first one in the config file. On my apu board based machine I have two serial interfaces (and nothing else) but as soon as I have `serial` config lines for two different devices/ports it is not working for any of them.
Only when having one serial device in the config it is working.

So this PR does two things:
* it writes only one serial line matching the configured device (when found) to the config
* it also writes it for the syslinux config in case it is used without extlinux