### PR TITLE
added grub bootloader for USB

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -978,6 +978,11 @@ USB_SUFFIX=""
 # This setting is ignored when USB_SUFFIX is set (see above).
 USB_RETAIN_BACKUP_NR=2
 #
+# This config will change/override the booloader used for the USB media.
+# At the moment only unset (keeping original behaviour) and "grub" is supported.
+# Default (when unset) is using grub for EFI other then elilo, extlinux for ext, syslinux otherwise.
+USB_BOOTLOADER=
+#
 # Variable will probably be filled automatically
 # if an USB device was manually mounted to avoid recursive backups:
 AUTOEXCLUDE_USB_PATH=()

--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -109,8 +109,7 @@ Log "Doing cleanup of ${EFI_MPT}"
 
 umount ${EFI_MPT}
 if [[ $? -eq 0 ]]; then
-    rmdir ${EFI_MPT}
-    LogIfError "Could not remove temporary directory ${EFI_MPT}, please check manually"
+    rmdir ${EFI_MPT} || Error "Could not remove temporary directory ${EFI_MPT}, please check manually"
 else
     Log "Could not umount ${EFI_MPT}, please check manually"
 fi

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -84,6 +84,12 @@ BEGIN {
     fi
 }
 
+# set nocasematch option
+shopt -s nocasematch
+if [ ! -z $USB_BOOTLOADER ] && [[ ! $USB_BOOTLOADER =~ syslinux|extlinux ]]; then
+    return 0
+fi
+
 if syslinux_needs_update; then
     SYSLINUX_NEEDS_UPDATE="y"
 fi

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -84,8 +84,6 @@ BEGIN {
     fi
 }
 
-# set nocasematch option
-shopt -s nocasematch
 if [ ! -z $USB_BOOTLOADER ] && [[ ! $USB_BOOTLOADER =~ syslinux|extlinux ]]; then
     return 0
 fi

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -101,8 +101,7 @@ esac
 
 USB_REAR_DIR="$BUILD_DIR/outputfs/$USB_PREFIX"
 if [ ! -d "$USB_REAR_DIR" ]; then
-    mkdir -p $v "$USB_REAR_DIR" >/dev/null
-    StopIfError "Could not create USB ReaR dir [$USB_REAR_DIR] !"
+    mkdir -p $v "$USB_REAR_DIR" >/dev/null || Error "Could not create USB ReaR dir [$USB_REAR_DIR] !"
 fi
 
 # We generate a single syslinux.cfg for the current system
@@ -255,8 +254,7 @@ EOF
 } 4>"$BUILD_DIR/outputfs/rear/syslinux.cfg"
 
 if [ ! -d "$BUILD_DIR/outputfs/$SYSLINUX_PREFIX" ]; then
-    mkdir -p $v "$BUILD_DIR/outputfs/$SYSLINUX_PREFIX" >/dev/null
-    StopIfError "Could not create USB syslinux dir [$BUILD_DIR/outputfs/$SYSLINUX_PREFIX] !"
+    mkdir -p $v "$BUILD_DIR/outputfs/$SYSLINUX_PREFIX" >/dev/null || Error "Could not create USB syslinux dir [$BUILD_DIR/outputfs/$SYSLINUX_PREFIX] !"
 fi
 
 echo "$VERSION_INFO" >$BUILD_DIR/outputfs/$SYSLINUX_PREFIX/message

--- a/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
@@ -1,0 +1,70 @@
+# only run for grub
+# set nocasematch option
+shopt -s nocasematch
+if [ -z $USB_BOOTLOADER ] && [[ ! $USB_BOOTLOADER =~ grub ]]; then
+    return 0
+fi
+
+# we assume that REAL_USB_DEVICE and RAW_USB_DEVICE are both set from the script
+# in prep/USB/Linux-i386/350_check_usb_disk.sh
+
+[ "$RAW_USB_DEVICE" -a "$REAL_USB_DEVICE" ]
+BugIfError "RAW_USB_DEVICE and REAL_USB_DEVICE should be already set"
+
+USB_REAR_DIR="$BUILD_DIR/outputfs/$USB_PREFIX"
+if [ ! -d "$USB_REAR_DIR" ]; then
+    mkdir -p $v "$USB_REAR_DIR" >/dev/null
+    StopIfError "Could not create USB ReaR dir [$USB_REAR_DIR] !"
+fi
+
+USB_BOOT_DIR="$BUILD_DIR/outputfs/boot"
+if [ ! -d "$USB_BOOT_DIR" ]; then
+    mkdir -p $v "$USB_BOOT_DIR" >/dev/null
+    StopIfError "Could not create USB boot dir [$USB_BOOT_DIR] !"
+fi
+
+# Hope this assumption is not wrong ...
+if has_binary grub-install grub2-install; then
+
+    # Choose right grub binary
+    # Issue #849
+    if has_binary grub2-install; then
+        Log "using grub2 binary"
+        NUM=2
+    fi
+
+    GRUB_INSTALL=grub${NUM}-install
+
+    # install
+    Log "installing grub..."
+    $GRUB_INSTALL --boot-directory=${USB_BOOT_DIR} --recheck $RAW_USB_DEVICE
+    StopIfError "Could not install grub on $RAW_USB_DEVICE !"
+
+    # What version of grub are we using
+    # substr() for awk did not work as expected for this reason cut was used
+    # First charecter should be enough to identify grub version
+    grub_version=$($GRUB_INSTALL --version | awk '{print $NF}' | cut -c1-1)
+
+    case ${grub_version} in
+        0)
+            BugError "grub 0.97 not supported"
+        ;;
+        2)
+            Log "Configuring grub 2.0 for legacy boot"
+            # We need to explicitly set $root variable to boot label
+            # (currently "REAR-BOOT") in Grub because default $root would
+            # point to memdisk, where kernel and initrd are NOT present.
+            # Variable grub2_set_usb_root will be used in later call of
+            # create_grub2_cfg().
+            grub2_set_usb_root="search --no-floppy --set=root --label REAR-BOOT"
+
+            # Create config for grub 2.0
+            Log "creating new grub config..."
+            create_grub2_cfg /$USB_PREFIX/kernel /$USB_PREFIX/$REAR_INITRD_FILENAME > ${USB_BOOT_DIR}/grub/grub.cfg
+        ;;
+        *)
+            BugError "Neither grub 0.97 nor 2.0"
+        ;;
+    esac
+
+fi

--- a/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
@@ -1,6 +1,4 @@
 # only run for grub
-# set nocasematch option
-shopt -s nocasematch
 if [ -z $USB_BOOTLOADER ] && [[ ! $USB_BOOTLOADER =~ grub ]]; then
     return 0
 fi

--- a/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
@@ -6,19 +6,16 @@ fi
 # we assume that REAL_USB_DEVICE and RAW_USB_DEVICE are both set from the script
 # in prep/USB/Linux-i386/350_check_usb_disk.sh
 
-[ "$RAW_USB_DEVICE" -a "$REAL_USB_DEVICE" ]
-BugIfError "RAW_USB_DEVICE and REAL_USB_DEVICE should be already set"
+[ "$RAW_USB_DEVICE" -a "$REAL_USB_DEVICE" ] || Error "RAW_USB_DEVICE and REAL_USB_DEVICE should be already set"
 
 USB_REAR_DIR="$BUILD_DIR/outputfs/$USB_PREFIX"
 if [ ! -d "$USB_REAR_DIR" ]; then
-    mkdir -p $v "$USB_REAR_DIR" >/dev/null
-    StopIfError "Could not create USB ReaR dir [$USB_REAR_DIR] !"
+    mkdir -p $v "$USB_REAR_DIR" >/dev/null || Error "Could not create USB ReaR dir [$USB_REAR_DIR] !"
 fi
 
 USB_BOOT_DIR="$BUILD_DIR/outputfs/boot"
 if [ ! -d "$USB_BOOT_DIR" ]; then
-    mkdir -p $v "$USB_BOOT_DIR" >/dev/null
-    StopIfError "Could not create USB boot dir [$USB_BOOT_DIR] !"
+    mkdir -p $v "$USB_BOOT_DIR" >/dev/null || Error "Could not create USB boot dir [$USB_BOOT_DIR] !"
 fi
 
 # Hope this assumption is not wrong ...
@@ -35,8 +32,7 @@ if has_binary grub-install grub2-install; then
 
     # install
     Log "installing grub..."
-    $GRUB_INSTALL --boot-directory=${USB_BOOT_DIR} --recheck $RAW_USB_DEVICE
-    StopIfError "Could not install grub on $RAW_USB_DEVICE !"
+    $GRUB_INSTALL --boot-directory=${USB_BOOT_DIR} --recheck $RAW_USB_DEVICE || Error "Could not install grub on $RAW_USB_DEVICE !"
 
     # What version of grub are we using
     # substr() for awk did not work as expected for this reason cut was used

--- a/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
@@ -41,7 +41,7 @@ if has_binary grub-install grub2-install; then
     # What version of grub are we using
     # substr() for awk did not work as expected for this reason cut was used
     # First charecter should be enough to identify grub version
-    grub_version=$($GRUB_INSTALL --version | awk '{print $NF}' | cut -c1-1)
+    grub_version=$(( $GRUB_INSTALL --version | awk '{print $NF}' | cut -c1-1 ))
 
     case ${grub_version} in
         0)

--- a/usr/share/rear/output/USB/Linux-i386/830_copy_kernel_initrd.sh
+++ b/usr/share/rear/output/USB/Linux-i386/830_copy_kernel_initrd.sh
@@ -1,11 +1,9 @@
 # copy kernel and initrd to USB dir for Relax-and-Recover
 #
 
-cp -pL $v "$KERNEL_FILE" "$BUILD_DIR/outputfs/$USB_PREFIX/kernel" >&2
-StopIfError "Could not create $BUILD_DIR/outputfs/$USB_PREFIX/kernel"
+cp -pL $v "$KERNEL_FILE" "$BUILD_DIR/outputfs/$USB_PREFIX/kernel" >&2 || Error "Could not create $BUILD_DIR/outputfs/$USB_PREFIX/kernel"
 
-cp -p $v "$TMP_DIR/$REAR_INITRD_FILENAME" "$BUILD_DIR/outputfs/$USB_PREFIX/$REAR_INITRD_FILENAME" >&2
-StopIfError "Could not create $BUILD_DIR/outputfs/$USB_PREFIX/$REAR_INITRD_FILENAME"
+cp -p $v "$TMP_DIR/$REAR_INITRD_FILENAME" "$BUILD_DIR/outputfs/$USB_PREFIX/$REAR_INITRD_FILENAME" >&2 || Error "Could not create $BUILD_DIR/outputfs/$USB_PREFIX/$REAR_INITRD_FILENAME"
 
 Log "Copied kernel and $REAR_INITRD_FILENAME to $USB_PREFIX"
 
@@ -15,8 +13,7 @@ Log "Copied kernel and $REAR_INITRD_FILENAME to $USB_PREFIX"
 # but later user config files are sourced in the main script where LOGFILE can be set different
 # so that the user config LOGFILE basename is used as target logfile name:
 logfile_basename=$( basename $LOGFILE )
-cat "$RUNTIME_LOGFILE" >"$BUILD_DIR/outputfs/$USB_PREFIX/$logfile_basename"
-StopIfError "Could not copy $RUNTIME_LOGFILE to $BUILD_DIR/outputfs/$USB_PREFIX/$logfile_basename"
+cat "$RUNTIME_LOGFILE" >"$BUILD_DIR/outputfs/$USB_PREFIX/$logfile_basename" || Error "Could not copy $RUNTIME_LOGFILE to $BUILD_DIR/outputfs/$USB_PREFIX/$logfile_basename"
 LogPrint "Saved $RUNTIME_LOGFILE as $USB_PREFIX/$logfile_basename"
 
 # FIXME: This is meaningless ATM, RESULT_FILES should be put somewhere reliable and not on a temporary mounted media.

--- a/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
+++ b/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
@@ -1,3 +1,8 @@
+# Only run for syslinux and extlinux
+if [ ! -z $USB_BOOTLOADER ] && [[ ! $USB_BOOTLOADER =~ syslinux|extlinux ]]; then
+    return 0
+fi
+
 # Test for features in dd
 # true if dd supports oflag= option
 FEATURE_DD_OFLAG=

--- a/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
+++ b/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
@@ -15,8 +15,7 @@ fi
 # we assume that REAL_USB_DEVICE and RAW_USB_DEVICE are both set from the script
 # in prep/USB/Linux-i386/350_check_usb_disk.sh
 
-[ "$RAW_USB_DEVICE" -a "$REAL_USB_DEVICE" ]
-BugIfError "RAW_USB_DEVICE and REAL_USB_DEVICE should be already set"
+[ "$RAW_USB_DEVICE" -a "$REAL_USB_DEVICE" ] || Error "RAW_USB_DEVICE and REAL_USB_DEVICE should be already set"
 
 usb_syslinux_version=$(get_usb_syslinux_version)
 syslinux_version=$(get_syslinux_version)


### PR DESCRIPTION
* Type: **New Feature** / **Enhancement**
* Impact: **Normal**
* Reference to related issue (URL): partially #2648
* How was this pull request tested?

tested output usb with:
1. USB_BOOTLOADER=
2. USB_BOOTLOADER=grub
on apu2 board (coreboot/seabios) - no efi


* Brief description of the changes in this pull request:
added option to write grub bootloader to usb (no efi)
it may not be perfect but a good starting point