### PR TITLE
fixed output usb format script for none efi cases

### DIFF
--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -58,34 +58,69 @@ else
     if ! parted -s $RAW_USB_DEVICE mklabel $USB_DEVICE_PARTED_LABEL >&2 ; then
         Error "Failed to create $USB_DEVICE_PARTED_LABEL partition table on '$RAW_USB_DEVICE'"
     fi
-    # Calculate byte value for the start of the subsequent ReaR data partition:
-    data_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
+
     # rear_data_partition_number is used below and in the subsequent 350_label_usb_disk.sh script for the ReaR data partition:
     rear_data_partition_number=1
+
+    if [[ "$USB_DEVICE_PARTED_LABEL" == "gpt" ]] ; then
+        LogPrint "Creating bootloader system partition on '$RAW_USB_DEVICE' from sector 34 to 2047"
+        bootloader_partition_start_byte=34
+        bootloader_partition_end_byte=2047
+        if ! parted -s $RAW_USB_DEVICE unit s mkpart primary $bootloader_partition_start_byte $bootloader_partition_end_byte >&2 ; then
+            Error "Failed to create BOOTLOADER system partition on '$RAW_USB_DEVICE'"
+        fi
+        LogPrint "Setting 'bios_grub' flag on $RAW_USB_DEVICE$rear_data_partition_number"
+        if ! parted -s $RAW_USB_DEVICE set $rear_data_partition_number bios_grub on >&2 ; then
+            Error "Could not make first partition bootloader area on '$RAW_USB_DEVICE$rear_data_partition_number'"
+        fi
+        # move one number up
+        rear_data_partition_number=$(( rear_data_partition_number + 1 ))
+    fi
+
+    # Round BOOT partition size to nearest block size to make the 2nd partition (the ReaR data partition) also align to the block size:
+    test "$USB_BOOT_PART_SIZE" || USB_BOOT_PART_SIZE="$USB_UEFI_PART_SIZE"
+    USB_BOOT_PART_SIZE=$(( ( USB_BOOT_PART_SIZE + ( USB_PARTITION_ALIGN_BLOCK_SIZE / 2 ) ) / USB_PARTITION_ALIGN_BLOCK_SIZE * USB_PARTITION_ALIGN_BLOCK_SIZE ))
+    LogPrint "Creating BOOT system partition with size $USB_BOOT_PART_SIZE MiB aligned at $USB_PARTITION_ALIGN_BLOCK_SIZE MiB on '$RAW_USB_DEVICE'"
+    # Calculate byte values:
+    boot_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
+    boot_partition_size_bytes=$(( USB_BOOT_PART_SIZE * MiB_bytes ))
+    # The end byte is the last byte that belongs to that partition so that one must be careful to use "start_byte + partition_size_in_bytes - 1":
+    boot_partition_end_byte=$(( boot_partition_start_byte + boot_partition_size_bytes - 1 ))
+    if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $boot_partition_start_byte $boot_partition_end_byte >&2 ; then
+        Error "Failed to create BOOT system partition on '$RAW_USB_DEVICE'"
+    fi
+    # Choose correct boot flag for partition table (see issue #1153)
+    local boot_flag
+    case "$USB_DEVICE_PARTED_LABEL" in
+        "msdos")
+            boot_flag="boot"
+            ;;
+        "gpt")
+            test "$USB_BOOT_GPT_LEGACY" || USB_BOOT_GPT_LEGACY="legacy_boot"
+            boot_flag="$USB_BOOT_GPT_LEGACY"
+            ;;
+        *)
+            Error "USB_DEVICE_PARTED_LABEL is incorrectly set, please check your settings."
+            ;;
+    esac
+    # set boot flag in case it should get set
+    if [ ! -z $boot_flag ] ; then
+        LogPrint "Setting '$boot_flag' flag on $rear_boot_partition_device"
+        if ! parted -s $RAW_USB_DEVICE set $rear_data_partition_number $boot_flag on >&2 ; then
+            Error "Could not make boot partition bootable on '$rear_boot_partition_device'"
+        fi
+    fi
+    # move one number up
+    rear_data_partition_number=$(( rear_data_partition_number + 1 ))
+
+    # Calculate byte value for the start of the subsequent ReaR data partition:
+    data_partition_start_byte=$(( boot_partition_end_byte + 1 ))
 fi
+
 LogPrint "Creating ReaR data partition up to ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% of '$RAW_USB_DEVICE'"
 # Older parted versions (at least GNU Parted 1.6.25.1 on SLE10) support the '%' unit (cf. https://github.com/rear/rear/issues/1270):
 if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $data_partition_start_byte ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% >&2 ; then
     Error "Failed to create ReaR data partition on '$RAW_USB_DEVICE'"
-fi
-
-# Choose correct boot flag for partition table (see issue #1153)
-local boot_flag
-case "$USB_DEVICE_PARTED_LABEL" in
-    "msdos")
-        boot_flag="boot"
-        ;;
-    "gpt")
-        boot_flag="legacy_boot"
-        ;;
-    *)
-        Error "USB_DEVICE_PARTED_LABEL is incorrectly set, please check your settings."
-        ;;
-esac
-
-LogPrint "Setting '$boot_flag' flag on $RAW_USB_DEVICE"
-if ! parted -s $RAW_USB_DEVICE set 1 $boot_flag on >&2 ; then
-    Error "Could not make first partition bootable on '$RAW_USB_DEVICE'"
 fi
 
 partprobe $RAW_USB_DEVICE
@@ -115,6 +150,13 @@ if is_true "$EFI" ; then
     partprobe $RAW_USB_DEVICE
     # Wait until udev has had the time to kick in
     sleep 5
+else
+    local rear_boot_partition_device="$RAW_USB_DEVICE$(( $rear_data_partition_number -1 ))"
+    test "$USB_DEVICE_BOOT_LABEL" || USB_DEVICE_BOOT_LABEL="REAR-BOOT"
+    LogPrint "Creating ext2 filesystem with label '$USB_DEVICE_BOOT_LABEL' on '$rear_boot_partition_device'"
+    if ! mkfs.ext2 -L "$USB_DEVICE_BOOT_LABEL" $rear_boot_partition_device >&2 ; then
+        Error "Failed to create ext2 filesystem on '$rear_boot_partition_device'"
+    fi
 fi
 
 # detect loopback device parition naming (same logic as above)

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -63,12 +63,14 @@ else
     rear_data_partition_number=1
 
     if [[ "$USB_DEVICE_PARTED_LABEL" == "gpt" ]] ; then
-        LogPrint "Creating bootloader system partition on '$RAW_USB_DEVICE' from sector 34 to 2047"
+        # Here we create the BIOS boot partition which may hold the second stage - also called core.img in grub
+        LogPrint "Creating BIOS boot partition on '$RAW_USB_DEVICE' from sector 34 to 2047"
         bootloader_partition_start_byte=34
         bootloader_partition_end_byte=2047
         if ! parted -s $RAW_USB_DEVICE unit s mkpart primary $bootloader_partition_start_byte $bootloader_partition_end_byte >&2 ; then
-            Error "Failed to create BOOTLOADER system partition on '$RAW_USB_DEVICE'"
+            Error "Failed to create BIOS boot partition on '$RAW_USB_DEVICE'"
         fi
+        # The parted uses the bios_grub flag to also change the partition type to ef02
         LogPrint "Setting 'bios_grub' flag on $RAW_USB_DEVICE$rear_data_partition_number"
         if ! parted -s $RAW_USB_DEVICE set $rear_data_partition_number bios_grub on >&2 ; then
             Error "Could not make first partition bootloader area on '$RAW_USB_DEVICE$rear_data_partition_number'"
@@ -77,17 +79,18 @@ else
         rear_data_partition_number=$(( rear_data_partition_number + 1 ))
     fi
 
+    # Now we create the boot partition later containing the bootloader config/plugins/modules, the kernel and a system boot image of some sort
     # Round BOOT partition size to nearest block size to make the 2nd partition (the ReaR data partition) also align to the block size:
     test "$USB_BOOT_PART_SIZE" || USB_BOOT_PART_SIZE="$USB_UEFI_PART_SIZE"
     USB_BOOT_PART_SIZE=$(( ( USB_BOOT_PART_SIZE + ( USB_PARTITION_ALIGN_BLOCK_SIZE / 2 ) ) / USB_PARTITION_ALIGN_BLOCK_SIZE * USB_PARTITION_ALIGN_BLOCK_SIZE ))
-    LogPrint "Creating BOOT system partition with size $USB_BOOT_PART_SIZE MiB aligned at $USB_PARTITION_ALIGN_BLOCK_SIZE MiB on '$RAW_USB_DEVICE'"
+    LogPrint "Creating BOOT partition with size $USB_BOOT_PART_SIZE MiB aligned at $USB_PARTITION_ALIGN_BLOCK_SIZE MiB on '$RAW_USB_DEVICE'"
     # Calculate byte values:
     boot_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
     boot_partition_size_bytes=$(( USB_BOOT_PART_SIZE * MiB_bytes ))
     # The end byte is the last byte that belongs to that partition so that one must be careful to use "start_byte + partition_size_in_bytes - 1":
     boot_partition_end_byte=$(( boot_partition_start_byte + boot_partition_size_bytes - 1 ))
     if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $boot_partition_start_byte $boot_partition_end_byte >&2 ; then
-        Error "Failed to create BOOT system partition on '$RAW_USB_DEVICE'"
+        Error "Failed to create BOOT partition on '$RAW_USB_DEVICE'"
     fi
     # Choose correct boot flag for partition table (see issue #1153)
     local boot_flag
@@ -96,6 +99,8 @@ else
             boot_flag="boot"
             ;;
         "gpt")
+            # AFAIK legacy_boot is a flag that is normally not set but may be required by some Firmware/BIOS versions
+            # Use USB_BOOT_GPT_LEGACY to change it if needed. When USB_BOOT_GPT_LEGACY is empty the flag will not get set
             test "$USB_BOOT_GPT_LEGACY" || USB_BOOT_GPT_LEGACY="legacy_boot"
             boot_flag="$USB_BOOT_GPT_LEGACY"
             ;;


### PR DESCRIPTION
* Type: **Bug Fix**
* Impact:  **High**
* Reference to related issue (URL): most parts of #2648 
* How was this pull request tested?
output usb on apu1 and apu2 boards - with msdos and gpt using extlinux/syslinux boot.

* Brief description of the changes in this pull request:
this PR fixes all blocking bugs for output usb on none efi devices.
** fixing boot by adding gpt boot partition (ef02)
** adding boot partition to get it closer to how efi formatting works
** adding option for gpt boot flag on separate boot partition

Additional note:
you may need to set OUTPUT_URL=usb:///dev/disk/by-label/REAR-BOOT