### PR TITLE
Better default USER_INPUT_MAX_CHARS=0 makes correcting the input possible

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -281,11 +281,14 @@ test "$USER_INPUT_PROMPT" || USER_INPUT_PROMPT='enter your input'
 #
 # USER_INPUT_MAX_CHARS specifies the default maximum characters until
 # the UserInput function truncates further input and returns.
+# With the default USER_INPUT_MAX_CHARS=0 input is not truncated and it
+# also makes correcting the input possible (before [Enter] is pressed)
+# cf. https://github.com/rear/rear/issues/2622
 # USER_INPUT_MAX_CHARS is set to a default value here only
 # if not already set so that the user can set it also like
 #   export USER_INPUT_MAX_CHARS=200
 # directly before he calls "rear ...":
-test "$USER_INPUT_MAX_CHARS" || USER_INPUT_MAX_CHARS=1000
+test "$USER_INPUT_MAX_CHARS" || USER_INPUT_MAX_CHARS=0
 #
 # USER_INPUT_user_input_ID variables can be used to predefine automated
 # input for UserInput() calls with the matching user_input_ID value.

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -1038,9 +1038,9 @@ function UserInput () {
     # Avoid stderr if USER_INPUT_PROMPT is not set or empty:
     test "$USER_INPUT_PROMPT" 2>/dev/null && prompt="$USER_INPUT_PROMPT"
     local input_words_array_name=""
-    local input_max_chars=1000
-    # Avoid stderr if USER_INPUT_MAX_CHARS is not set or empty and ignore wrong USER_INPUT_MAX_CHARS:
-    test "$USER_INPUT_MAX_CHARS" -ge 0 2>/dev/null && input_max_chars=$USER_INPUT_MAX_CHARS
+    local input_max_chars=0
+    # Avoid stderr if USER_INPUT_MAX_CHARS is not set or empty and ignore useless '0' or wrong USER_INPUT_MAX_CHARS:
+    test "$USER_INPUT_MAX_CHARS" -ge 1 2>/dev/null && input_max_chars=$USER_INPUT_MAX_CHARS
     local input_delimiter=""
     local default_input=""
     local user_input_ID=""


### PR DESCRIPTION
With the default USER_INPUT_MAX_CHARS=0 input is not truncated and it
also makes correcting the input possible (before [Enter] is pressed)
cf. https://github.com/rear/rear/issues/2622

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2622

* How was this pull request tested?
By me on Leap 15.2

* Brief description of the changes in this pull request:

With the default USER_INPUT_MAX_CHARS=0 input is not truncated
and it also makes correcting the input possible (before [Enter] is pressed)
