### PR TITLE
Default TMPDIR should be /var/tmp

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -54,10 +54,16 @@
 #   export TMPDIR="/prefix/for/rear/working/directory"
 # before calling 'rear' (/prefix/for/rear/working/directory must already exist).
 # This is useful for example when there is not sufficient free space
-# in /tmp or $TMPDIR for the ISO image or even the backup archive.
-# TMPDIR cannot be set to a default value here, otherwise /usr/sbin/rear
+# in /var/tmp or $TMPDIR for the ISO image or even the backup archive.
+# TMPDIR cannot be set to a default value here unconditionally but only
+# if it is not set before calling the program, otherwise /usr/sbin/rear
 # would not work in compliance with the Linux/Unix standards regarding TMPDIR
 # see https://github.com/rear/rear/issues/968
+# The default is /var/tmp instead of the more usual /tmp (the system default),
+# because /tmp is not intended for such large amounts of data that ReaR usually
+# produces when creating the image (see file-hierarchy(7)). In particular,
+# /tmp can be a tmpfs, and thus restricted by the available RAM/swap.
+export TMPDIR="${TMPDIR-/var/tmp}"
 
 ##
 # ROOT_HOME_DIR

--- a/usr/share/rear/rescue/GNU/Linux/600_unset_TMPDIR_in_rescue_conf.sh
+++ b/usr/share/rear/rescue/GNU/Linux/600_unset_TMPDIR_in_rescue_conf.sh
@@ -1,8 +1,0 @@
-cat - <<EOF >> "$ROOTFS_DIR/etc/rear/rescue.conf"
-# TMPDIR variable may be defined in local.conf file as prefix dir for mktemp command
-# e.g. by defining TMPDIR=/var we would get our BUILD_DIR=/var/tmp/rear.XXXXXXXXXXXX
-# However, in rescue we want our BUILD_DIR=/tmp/rear.XXXXXXX as we are not sure that
-# the user defined TMPDIR would exist in our rescue image
-# by 'unset TMPDIR' we achieve above goal (as rescue.conf is read after local.conf)!
-unset TMPDIR
-EOF


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/2654#issuecomment-881609874

* How was this pull request tested? 
  Running `rear mkrescue` on a system with /tmp on tmpfs. Before, it has failed with the message `cp: error copying '/tmp/rear.ZLTj0NcVqlr4fiH/tmp/initrd.cgz' to '/tmp/rear.ZLTj0NcVqlr4fiH/tmp/isofs/isolinux/initrd.cgz': No space left on device`. After the change it succeeds.

* Brief description of the changes in this pull request:

The default temporary directory ( /tmp ) is not suited for ReaR, because ReaR needs lots of space. file-hierarchy(7) recommends to use /var/tmp as default for such programs.

If the user sets TMPDIR explicitly, it still takes precedence.

See the discussion in issue #2654 .