### PR TITLE
On POWER require bootlist & ofpathname if needed

### DIFF
--- a/usr/share/rear/conf/Linux-ppc64.conf
+++ b/usr/share/rear/conf/Linux-ppc64.conf
@@ -1,17 +1,25 @@
-REQUIRED_PROGS+=( sfdisk )
+REQUIRED_PROGS+=( sfdisk ofpathname )
 
 PROGS+=(
 mkofboot
 ofpath
 ybin
 yabootconfig
-bootlist
 pseries_platform
 nvram
-ofpathname
 bc
 agetty
 )
+
+if grep -q "emulated by qemu" /proc/cpuinfo ; then
+    # Qemu/KVM virtual machines don't need bootlist - don't complain if
+    # it is missing
+    PROGS+=( bootlist )
+else
+    # PowerVM environment, we need to run bootlist, otherwise
+    # we can't make the system bpotable. Be strict about requiring it
+    REQUIRED_PROGS+=( bootlist )
+fi
 
 COPY_AS_IS+=(
 /usr/lib/yaboot/yaboot

--- a/usr/share/rear/conf/Linux-ppc64le.conf
+++ b/usr/share/rear/conf/Linux-ppc64le.conf
@@ -1,10 +1,8 @@
 REQUIRED_PROGS+=( sfdisk )
 
 PROGS+=(
-bootlist
 pseries_platform
 nvram
-ofpathname
 bc
 agetty
 )
@@ -17,4 +15,18 @@ agetty
 if [[ $(awk '/platform/ {print $NF}' < /proc/cpuinfo) != PowerNV ]] ; then
     # No firmware files when ppc64le Linux is not run in BareMetal Mode (PowerNV):
     test "${FIRMWARE_FILES[*]}" || FIRMWARE_FILES=( 'no' )
+    # grub2-install for powerpc-ieee1275 calls ofpathname, so without it,
+    # the rescue system can't make the recovered system bootable
+    REQUIRED_PROGS+=( ofpathname )
+    if grep -q "emulated by qemu" /proc/cpuinfo ; then
+        # Qemu/KVM virtual machines don't need bootlist - don't complain if
+        # it is missing
+        PROGS+=( bootlist )
+    else
+        # PowerVM environment, we need to run bootlist, otherwise
+        # we can't make the system bpotable. Be strict about requiring it
+        REQUIRED_PROGS+=( bootlist )
+    fi
+else
+    PROGS+=( ofpathname bootlist )
 fi


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL): https://bugzilla.redhat.com/show_bug.cgi?id=1983008 https://bugzilla.redhat.com/show_bug.cgi?id=1983000

* How was this pull request tested?
   * Run `rear mkrescue` in a KVM virtual machine on RHEL 8 without `powerpc-utils-core` (which contains those two utilities) and checked that it immediately aborts with `ERROR: Cannot find required programs: ofpathname`. With `powerpc-utils-core` installed and `/usr/sbin/bootlist` manually removed it succeeds and the initrd contains `ofpathname`. With `powerpc-utils-core` installed normally it succeeds and the initrd contains both `ofpathname` and `bootlist`.
   * Run `rear mkrescue` in a PowerVM LPAR on RHEL 8 without `powerpc-utils-core` (which contains those two utilities) and checked that it immediately aborts with `ERROR: Cannot find required programs: ofpathname bootlist`. With `powerpc-utils-core` installed it succeeds and the initrd contains both `ofpathname` and `bootlist`.
   * Run `rear mkrescue` on a PowerNV server (bare metal) on RHEL 8 without `powerpc-utils-core`, it completes fine. Verified that if `powerpc-utils-core` is installed, the initrd contains both `ofpathname` and `bootlist`.

* Brief description of the changes in this pull request:

As reported by @rmetrich, the `ofpathname` binary is called by grub2-install. Therefore, it is required in the rescue system in order to make the recovered system bootable, except for the PowerNV (Not Virtualized - bare metal) case. Under PowerVM, we also need the `bootlist` executable to make the system bootable.

Add those two binaries to `REQUIRED_PROGS` instead of `PROGS` under the appropriate conditions.

Do not handle PowerNV for ppc64: according to 89ddb9fc17adb022ce9c10be0c3e5b835ba139d7, only ppc64le Linux can run in PowerNV.

(Wouldn't it be simpler though to symlink Linux-ppc64.conf to Linux-ppc64le.conf? Their differences seem to be minimal.)