### PR TITLE
Use double quotes for remove_temporary_mountpoint "$BUILD_DIR/..."

### DIFF
--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -898,7 +898,7 @@ function cleanup_build_area_and_end_program () {
         # which is not yet sourced in case of early Error() in usr/sbin/rear
         if has_binary remove_temporary_mountpoint ; then
             # It is a bug in ReaR if BUILD_DIR/outputfs was not properly umounted and made empty by the scripts before:
-            remove_temporary_mountpoint '$BUILD_DIR/outputfs' || BugError "Directory $BUILD_DIR/outputfs not empty, cannot remove"
+            remove_temporary_mountpoint "$BUILD_DIR/outputfs" || BugError "Directory $BUILD_DIR/outputfs not empty, cannot remove"
         fi
         if ! rmdir $v "$BUILD_DIR" ; then
             LogPrintError "Could not remove build area $BUILD_DIR (something still exists therein)"

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -344,7 +344,14 @@ function url_path() {
 
 ### Returns true if one can upload files to the URL
 function scheme_accepts_files() {
-    local scheme=$1
+    # Be safe against 'set -eu' which would exit 'rear' with "bash: $1: unbound variable"
+    # when scheme_accepts_files is called without an argument
+    # by bash parameter expansion with using an empty default value if $1 unset or null.
+    # Bash parameter expansion with assigning a default value ${1:=} does not work
+    # (then it would still exit with "bash: $1: cannot assign in this way")
+    # but using a default value is sufficient here because $1 is used only once
+    # cf. https://github.com/rear/rear/pull/2675#discussion_r705018956
+    local scheme=${1:-}
     # Return false if scheme is empty or blank (e.g. when OUTPUT_URL is unset or empty or blank)
     # cf. https://github.com/rear/rear/issues/2676
     # and https://github.com/rear/rear/issues/2667#issuecomment-914447326
@@ -374,7 +381,8 @@ function scheme_accepts_files() {
 ### Returning true does not imply that the URL is currently mounted at a filesystem and usable,
 ### only that it can be mounted (use mount_url() first)
 function scheme_supports_filesystem() {
-    local scheme=$1
+    # Be safe against 'set -eu' exit if scheme_supports_filesystem is called without argument
+    local scheme=${1:-}
     # Return false if scheme is empty or blank or more than one word, cf. scheme_accepts_files() above
     test $scheme || return 1
     case $scheme in

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -345,6 +345,12 @@ function url_path() {
 ### Returns true if one can upload files to the URL
 function scheme_accepts_files() {
     local scheme=$1
+    # Return false if scheme is empty or blank (e.g. when OUTPUT_URL is unset or empty or blank)
+    # cf. https://github.com/rear/rear/issues/2676
+    # and https://github.com/rear/rear/issues/2667#issuecomment-914447326
+    # also return false if scheme is more than one word (so no quoted "$scheme" here)
+    # cf. https://github.com/rear/rear/pull/2675#discussion_r704401462
+    test $scheme || return 1
     case $scheme in
         (null|tape|obdr)
             # tapes do not support uploading arbitrary files, one has to handle them
@@ -369,9 +375,7 @@ function scheme_accepts_files() {
 ### only that it can be mounted (use mount_url() first)
 function scheme_supports_filesystem() {
     local scheme=$1
-    # Return false if scheme is empty or blank (e.g. when OUTPUT_URL is unset or empty or blank)
-    # cf. https://github.com/rear/rear/issues/2676
-    # and https://github.com/rear/rear/issues/2667#issuecomment-914447326
+    # Return false if scheme is empty or blank or more than one word, cf. scheme_accepts_files() above
     test $scheme || return 1
     case $scheme in
         (null|tape|obdr|rsync|fish|ftp|ftps|hftp|http|https|sftp)

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -346,10 +346,10 @@ function url_path() {
 function scheme_accepts_files() {
     # Be safe against 'set -eu' which would exit 'rear' with "bash: $1: unbound variable"
     # when scheme_accepts_files is called without an argument
-    # by bash parameter expansion with using an empty default value if $1 unset or null.
+    # by bash parameter expansion with using an empty default value if $1 is unset or null.
     # Bash parameter expansion with assigning a default value ${1:=} does not work
     # (then it would still exit with "bash: $1: cannot assign in this way")
-    # but using a default value is sufficient here because $1 is used only once
+    # but using a default value is practicable here because $1 is used only once
     # cf. https://github.com/rear/rear/pull/2675#discussion_r705018956
     local scheme=${1:-}
     # Return false if scheme is empty or blank (e.g. when OUTPUT_URL is unset or empty or blank)

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -369,6 +369,10 @@ function scheme_accepts_files() {
 ### only that it can be mounted (use mount_url() first)
 function scheme_supports_filesystem() {
     local scheme=$1
+    # Return false if scheme is empty or blank (e.g. when OUTPUT_URL is unset or empty or blank)
+    # cf. https://github.com/rear/rear/issues/2676
+    # and https://github.com/rear/rear/issues/2667#issuecomment-914447326
+    test $scheme || return 1
     case $scheme in
         (null|tape|obdr|rsync|fish|ftp|ftps|hftp|http|https|sftp)
             return 1

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -682,7 +682,7 @@ function umount_url() {
 
     RemoveExitTask "perform_umount_url '$url' '$mountpoint' lazy"
 
-    remove_temporary_mountpoint '$mountpoint' && RemoveExitTask "remove_temporary_mountpoint '$mountpoint'"
+    remove_temporary_mountpoint "$mountpoint" && RemoveExitTask "remove_temporary_mountpoint '$mountpoint'"
     return 0
 }
 


### PR DESCRIPTION
Use double quotes to get the variable evaluated in
remove_temporary_mountpoint "$BUILD_DIR/outputfs"
and
remove_temporary_mountpoint "$mountpoint"
to fix https://github.com/rear/rear/issues/2667

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2667

* How was this pull request tested?
Before see  https://github.com/rear/rear/issues/2667#issuecomment-912442380
but with the change here it works now for me:
```
++ remove_temporary_mountpoint /var/tmp/rear.LEl5cQbfB1jzo68/outputfs
++ test -d /var/tmp/rear.LEl5cQbfB1jzo68/outputfs
++ rmdir -v /var/tmp/rear.LEl5cQbfB1jzo68/outputfs
rmdir: removing directory, '/var/tmp/rear.LEl5cQbfB1jzo68/outputfs'
```

* Brief description of the changes in this pull request:
Use double quotes to get the variable evaluated in
remove_temporary_mountpoint "$BUILD_DIR/outputfs"
