### PR TITLE
Error out in sbin/rear when it failed to source or Source mandatory files

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -58,6 +58,9 @@ readonly PROGRAM=${0##*/}
 readonly VERSION=2.6
 readonly RELEASE_DATE=Git
 
+# Where users should report bugs:
+readonly BUG_REPORT_SITE="https://github.com/rear/rear/issues"
+
 # Set machine readable and human readable start date and time values.
 # START_SECONDS is set to have a single fixed point in time
 # where other date and time formats can be derived from in a consistent way.
@@ -333,7 +336,10 @@ export LC_CTYPE=C LC_ALL=C LANG=C
 # setting the right RUNTIME_LOGFILE value requires values from default.conf
 # in particular the default LOGFILE value and the values of the
 # LOCKLESS_WORKFLOWS and SIMULTANEOUS_RUNNABLE_WORKFLOWS arrays:
-source $SHARE_DIR/conf/default.conf
+if ! source $SHARE_DIR/conf/default.conf ; then
+    echo -e "ERROR: BUG in $PRODUCT\nFailed to source $SHARE_DIR/conf/default.conf\nPlease report it at $BUG_REPORT_SITE" >&2
+    exit 1
+fi
 
 # Use RUNTIME_LOGFILE for the logfile that is actually used during runtime
 # so that the user can specify a different LOGFILE in his local.conf file.
@@ -398,7 +404,10 @@ fi
 # so that ReaR functions for actually intended user messages can use fd7 and fd8
 # to show messages to the user regardless where to STDOUT and STDERR are redirected
 # and fd6 to get input from the user regardless where to STDIN is redirected:
-source $SHARE_DIR/lib/_input-output-functions.sh
+if ! source $SHARE_DIR/lib/_input-output-functions.sh ; then
+    echo -e "ERROR: BUG in $PRODUCT\nFailed to source $SHARE_DIR/lib/_input-output-functions.sh\nPlease report it at $BUG_REPORT_SITE" >&2
+    exit 1
+fi
 
 # Via source usr/share/rear/lib/_input-output-functions.sh
 # those exit tasks are now set to be executed (via bash EXIT trap) in the following order:
@@ -478,7 +487,7 @@ fi
 # Include functions after RUNTIME_LOGFILE is set and readonly
 # so that functions can use a fixed RUNTIME_LOGFILE value:
 for script in $SHARE_DIR/lib/[a-z]*.sh ; do
-    source $script
+    source $script || BugError "Failed to source $script"
 done
 
 # Show initial startup messages:
@@ -510,21 +519,27 @@ fi
 Debug "Combining configuration files"
 # Use this file to manually override the OS detection:
 test -d "$CONFIG_DIR" || Error "Configuration directory $CONFIG_DIR is not a directory"
-test -r "$CONFIG_DIR/os.conf" && Source "$CONFIG_DIR/os.conf" || true
-test -r "$CONFIG_DIR/$WORKFLOW.conf" && Source "$CONFIG_DIR/$WORKFLOW.conf" || true
+if test -r "$CONFIG_DIR/os.conf" ; then
+    Source "$CONFIG_DIR/os.conf" || Error "Failed to Source $CONFIG_DIR/os.conf"
+fi
+if test -r "$CONFIG_DIR/$WORKFLOW.conf" ; then
+    Source "$CONFIG_DIR/$WORKFLOW.conf" || Error "Failed to Source $CONFIG_DIR/$WORKFLOW.conf"
+fi
 SetOSVendorAndVersion
 # Distribution configuration files:
 for config in "$ARCH" "$OS" \
         "$OS_MASTER_VENDOR" "$OS_MASTER_VENDOR_ARCH" "$OS_MASTER_VENDOR_VERSION" "$OS_MASTER_VENDOR_VERSION_ARCH" \
         "$OS_VENDOR" "$OS_VENDOR_ARCH" "$OS_VENDOR_VERSION" "$OS_VENDOR_VERSION_ARCH" ; do
-    test -r "$SHARE_DIR/conf/$config.conf" && Source "$SHARE_DIR/conf/$config.conf" || true
+    if test -r "$SHARE_DIR/conf/$config.conf" ; then
+        Source "$SHARE_DIR/conf/$config.conf" || BugError "Failed to Source $SHARE_DIR/conf/$config.conf"
+    fi
 done
 # User configuration files, last thing is to overwrite variables if we are in the rescue system:
 for config in site local rescue ; do
     if test -r "$CONFIG_DIR/$config.conf" ; then
         # Delete all characters except '\r' and error out if the resulting string is not empty:
         test "$( tr -d -c '\r' < $CONFIG_DIR/$config.conf )" && Error "Carriage return character in $CONFIG_DIR/$config.conf (perhaps DOS or Mac format)"
-        Source "$CONFIG_DIR/$config.conf" || true
+        Source "$CONFIG_DIR/$config.conf" || Error "Failed to Source $CONFIG_DIR/$config.conf"
     fi
 done
 # Finally source additional configuration files if specified on the command line:
@@ -567,10 +582,10 @@ if test "$CONFIG_APPEND_FILES" ; then
         # try if 'foo.conf' exists and if yes, use that:
         if test -r "$config_append_file_path" ; then
             LogPrint "Sourcing additional configuration file '$config_append_file_path'"
-            Source "$config_append_file_path"
+            Source "$config_append_file_path" || Error "Failed to Source $config_append_file_path"
         else if test -r "$config_append_file_path.conf" ; then
                  LogPrint "Sourcing additional configuration file '$config_append_file_path.conf'"
-                 Source "$config_append_file_path.conf"
+                 Source "$config_append_file_path.conf" || Error "Failed to Source $config_append_file_path.conf"
              else
                  LogPrintError "There is '-C $config_append_file' but neither '$config_append_file_path' nor '$config_append_file_path.conf' can be read."
              fi
@@ -583,7 +598,7 @@ readonly SHARE_DIR CONFIG_DIR VAR_DIR LOG_DIR KERNEL_VERSION
 
 # Enable progress subsystem only in verbose mode, set some stuff that others can use:
 if test "$VERBOSE" ; then
-    source $SHARE_DIR/lib/progresssubsystem.nosh
+    source $SHARE_DIR/lib/progresssubsystem.nosh || BugError "Failed to source $SHARE_DIR/lib/progresssubsystem.nosh"
 fi
 
 SourceStage "init"

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -764,8 +764,8 @@ function BugError () {
 BUG in $caller_source:
 '$@'
 --------------------
-Please report this issue at https://github.com/rear/rear/issues
-and include at least all related parts from $RUNTIME_LOGFILE
+Please report it at $BUG_REPORT_SITE
+and include all related parts from $RUNTIME_LOGFILE
 preferably the whole debug information via 'rear -D $WORKFLOW'
 ===================="
 }


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **High**
Normally there should be no difference when things are OK
but for users with e.g. broken config files the impact is high
because now they see that their config files are broken.

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2686

* How was this pull request tested?
I did some quick "rear -D mkrescue" tests with artificial syntax errors
in default.conf, _input-output-functions.sh, and local.conf

* Brief description of the changes in this pull request:
Error out or BugError in sbin/rear when
it failed to source or Source mandatory files
