### PR TITLE
Fix multiple vg recreation

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/100_include_partition_code.sh
@@ -30,15 +30,6 @@ create_disk() {
     [[ -b "$disk" ]]
     BugIfError "Disk $disk is not a block device."
 
-    ### Find out the actual disk size.
-    local disk_size=$( get_disk_size $(get_sysfs_name "$disk") )
-
-    [[ "$disk_size" ]]
-    BugIfError "Could not determine size of disk $disk, please file a bug."
-
-    [[ $disk_size -gt 0 ]]
-    StopIfError "Disk $disk has size $disk_size, unable to continue."
-
     cat >> "$LAYOUT_CODE" <<EOF
 
 #


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rmetrich/rear/commit/b184194f37dd22a7e55655ff388579297239e73c#r56498696 https://github.com/rmetrich/rear/commit/311bfb3da1d5e47a2ff144123a2457e634f67893#r56498755

* How was this pull request tested?
Backing up and recreating a system with two VGs, one contains thin pools, the other does not.

* Brief description of the changes in this pull request:
Fix a problem introduced in commits b184194f37dd22a7e55655ff388579297239e73c and 311bfb3da1d5e47a2ff144123a2457e634f67893 (PR #1806) that shows up when there are multiple VGs to restore.
Using variables `create_thin_volumes_only` and `create_logical_volumes` to propagate infromation from VG creation to LV creation does not work well in the case of multiple VGs, because the variables are global and if there are multiple VGs, their values will leak from one VG to another. The generated diskrestore.sh script does not guarantee that the LVs of a given VG are created immediately after their VG and before creating another VG. Currently, the script first creates all VGs and then all LVs, so all the LVs in all VGs will see the value of `create_logical_volumes` and `create_thin_volumes_only` from the last VG, not from their own. This matters when different VGs behave differently (typically if one has a thin pool and the other does not).
Fix by replacing the scalar values by arrays of VG names. If a given VG is in the array, it is the equivalent of the former scalar value being 1 for the given VG, if it is not in the array, it is an equivalent of a former value of 0.
For the `create_volume_group` variable the change is not needed, but do it nevertheless for symmetry with other variables.