### PR TITLE
more control over serial devices used

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2931,13 +2931,13 @@ USE_SERIAL_CONSOLE=
 SERIAL_CONSOLE_DEVICES=
 
 # Since syslinux does not always work with more then one serial device at once it can be explicitly named.
-# Here you can configute the serial console device to use e.g. 'SERIAL_CONSOLE_DEVICE_SYSLINUX=/dev/ttyS0' when USE_SERIAL_CONSOLE is turned on.
+# Here you can configure the serial console device to use e.g. 'SERIAL_CONSOLE_DEVICE_SYSLINUX=/dev/ttyS0' when USE_SERIAL_CONSOLE is turned on.
 # By default (when unset) all found serial devices are used.
 # This config value may change in the near future and may get merged with USE_SERIAL_CONSOLE.
 SERIAL_CONSOLE_DEVICE_SYSLINUX=
 
 # Since grub does not always work with more then one serial device at once it ca be explicitly named.
-# Here you can configute the serial console device to use e.g. 'SERIAL_CONSOLE_DEVICE_GRUB=/dev/ttyS0' when USE_SERIAL_CONSOLE is turned on.
+# Here you can configure the serial console device to use e.g. 'SERIAL_CONSOLE_DEVICE_GRUB=/dev/ttyS0' when USE_SERIAL_CONSOLE is turned on.
 # By default (when unset) all found serial devices are used.
 SERIAL_CONSOLE_DEVICE_GRUB=
 

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -199,7 +199,7 @@ function make_syslinux_config {
 
     # Enable serial console, unless explicitly disabled (only last entry is used on some systems thats where SERIAL_CONSOLE_DEVICE_SYSLINUX comes in :-/)
     if [[ "$USE_SERIAL_CONSOLE" =~ ^[yY1] ]]; then
-        for devnode in $(get_serial_devices); do
+        for devnode in $(get_serial_console_devices); do
             # Not sure if using all serial devices do screw up syslinux in general
             # for me listing more then one serial line in the config screwed it
             # see https://github.com/rear/rear/pull/2650
@@ -536,9 +536,9 @@ function create_grub2_cfg {
 
     function create_grub2_serial_entry {
         # Enable serial console, unless explicitly disabled
-        # Note: as for syslinux it may be usefull to reduce it to exact one device since the last 'serial' line wins in grub...
+        # Note: as for syslinux it may be useful to reduce it to exact one device since the last 'serial' line wins in grub...
         if [[ "$USE_SERIAL_CONSOLE" =~ ^[yY1] ]]; then
-            for devnode in $(get_serial_devices); do
+            for devnode in $(get_serial_console_devices); do
                 if [ -z $SERIAL_CONSOLE_DEVICE_GRUB ] || [[ $SERIAL_CONSOLE_DEVICE_GRUB == $devnode ]]; then
                     speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
                     if [ "$speed" ]; then

--- a/usr/share/rear/lib/serial-functions.sh
+++ b/usr/share/rear/lib/serial-functions.sh
@@ -1,5 +1,5 @@
 # Get available serial devices
-function get_serial_devices {
+function get_serial_console_devices {
     if [ -z $SERIAL_CONSOLE_DEVICES ]; then
         serial_devices=$(ls /dev/ttyS[0-9]* /dev/hvsi[0-9]* | sort)
         echo "$serial_devices"
@@ -8,7 +8,7 @@ function get_serial_devices {
     fi
 }
 
-function build_cmdline {
+function cmdline_add_console {
     # Enable serial console, unless explicitly disabled
     if [[ ! "$USE_SERIAL_CONSOLE" =~ ^[yY1] ]]; then
         return
@@ -20,12 +20,12 @@ function build_cmdline {
     for param in $KERNEL_CMDLINE; do
         case "$param" in
             (console=*) ;;
-            (*) cmdline="$cmdline$param ";;
+            (*) cmdline+=" $param";;
         esac
     done
 
-    # add seril config to kernel cmd line
-    serial_devices=$(get_serial_devices)
+    # add serial console config to kernel cmd line
+    serial_devices=$(get_serial_console_devices)
     for devnode in $serial_devices; do
         speed=$(stty -F $devnode 2>/dev/null | awk '/^speed / { print $2 }')
         if [ "$speed" ]; then
@@ -33,7 +33,7 @@ function build_cmdline {
         fi
     done
 
-    # add serial default if no real serial device was found
+    # add console default if no real serial console device was found
     if [ -z $serial_devices ]; then
         cmdline="${cmdline}console=tty0 "
     fi

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -264,7 +264,7 @@ Log "Creating $SYSLINUX_PREFIX/extlinux.conf"
 {
     # Enable serial console, unless explicitly disabled
     if [[ "$USE_SERIAL_CONSOLE" =~ ^[yY1] ]]; then
-        for devnode in $(get_serial_devices); do
+        for devnode in $(get_serial_console_devices); do
             # Not sure if using all serial devices do screw up syslinux in general
             # for me listing more then one serial line in the config screwed it
             # see https://github.com/rear/rear/pull/2650

--- a/usr/share/rear/rescue/GNU/Linux/400_use_serial_console.sh
+++ b/usr/share/rear/rescue/GNU/Linux/400_use_serial_console.sh
@@ -1,2 +1,2 @@
-cmdline=$(build_cmdline)
+cmdline=$(cmdline_add_console)
 Log "Modified kernel commandline to: '$KERNEL_CMDLINE'"


### PR DESCRIPTION
* Type: **Bug Fix** / **Enhancement**
* Impact: **Normal**
* Reference to related issue (URL): #2663 ( #2648 )
* How was this pull request tested: the basic options for serial on a APU2
* Brief description of the changes in this pull request:

* added SERIAL_CONSOLE_DEVICES to name a list of devices instead of using all found ones
* added SERIAL_CONSOLE_DEVICE_GRUB to use a specific one for grub instead of the first one
* moved some potentially reusable parts in lib/serial-functions.sh 
* fixed a ubuntu 20.04/systemd issue if ttyS0 and tty0 was given to the kernel (tty0 was added by mistake in some cases)

Please add hacktoberfest topic to teh repo or hacktoberfest-accepted label to the PR if you are willing to merge ;)