### PR TITLE
Enhanced disk write-protection

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -527,19 +527,32 @@ AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE=10
 
 ##
 # Write-protection during "rear recover"
+# for OUTPUT=USB and OUTPUT=RAWDISK
 #
-# Designate target disk devices or partitions as write-protected
-# to avoid being accidentally overwritten during "rear recover".
+# Designate disks (i.e. its partition table), partitions, or file systems as write-protected
+# to avoid that those disks could get used as target disk during "rear recover" via
+# WRITE_PROTECTED_UUIDS and WRITE_PROTECTED_FS_LABEL_PATTERNS settings
+# in etc/rear/rescue.conf in the ReaR rescue/recovery system.
 #
-# List of partition table UUIDs, which designate write-protected disk devices.
-# ReaR's own disk device will be automatically added to this list if necessary.
-# Example: WRITE_PROTECTED_PARTITION_TABLE_UUIDS+=("ecacbce4-e05e-4eb9-835c-ade0c3ed0fea")
-WRITE_PROTECTED_PARTITION_TABLE_UUIDS=()
+# WRITE_PROTECTED_UUIDS is an array of UUIDs which designate write-protected disk devices.
+# UUIDs are those that 'lsblk' reports (which depends on the lsblk version):
+#       UUID filesystem UUID
+#     PTUUID partition table identifier (usually UUID)
+#   PARTUUID partition UUID
+# For OUTPUT=USB all available UUIDs of the ReaR recovery system disk (i.e. USB_DEVICE)
+# will be automatically added to the WRITE_PROTECTED_UUIDS array.
+# For OUTPUT=RAWDISK a partition table UUID is generated (provided 'uuidgen' is there)
+# that is automatically added to the WRITE_PROTECTED_UUIDS array.
+# Example: WRITE_PROTECTED_UUIDS+=( "ecacbce4-e05e-4eb9-835c-ade0c3ed0fea" )
+WRITE_PROTECTED_UUIDS=()
 #
-# List of (shell glob) patterns, which designate matching file system labels as write-protected partitions.
+# WRITE_PROTECTED_FS_LABEL_PATTERNS is an array of (shell glob) patterns
+# which designate matching file system labels as write-protected partitions.
 # Entries may be quoted and contain blanks, but they may not contain single quotes themselves.
-# Example: WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS+=("Backup *")
-WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS=()
+# For OUTPUT=USB all available file system labels of the ReaR recovery system disk (i.e. USB_DEVICE)
+# will be automatically added to the WRITE_PROTECTED_FS_LABEL_PATTERNS array.
+# Example: WRITE_PROTECTED_FS_LABEL_PATTERNS+=( "Backup *" )
+WRITE_PROTECTED_FS_LABEL_PATTERNS=()
 
 ##
 # Creating XFS filesystems during "rear recover"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -539,7 +539,6 @@ AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE=10
 #       UUID filesystem UUID
 #     PTUUID partition table identifier (usually UUID)
 #   PARTUUID partition UUID
-#     SERIAL disk serial number
 #        WWN unique storage identifier
 # For OUTPUT=USB all available IDs of the ReaR recovery system disk (i.e. USB_DEVICE)
 # will be automatically added to the WRITE_PROTECTED_IDS array.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -529,30 +529,35 @@ AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE=10
 # Write-protection during "rear recover"
 # for OUTPUT=USB and OUTPUT=RAWDISK
 #
-# Designate disks (i.e. its partition table), partitions, or file systems as write-protected
-# to avoid that those disks could get used as target disk during "rear recover" via
-# WRITE_PROTECTED_IDS and WRITE_PROTECTED_FS_LABEL_PATTERNS settings
+# Designate disks via disk specific IDs or file system labels as write-protected
+# to avoid that those disks could get used as target disk during "rear recover"
+# via WRITE_PROTECTED_IDS and WRITE_PROTECTED_FS_LABEL_PATTERNS
 # in etc/rear/rescue.conf in the ReaR rescue/recovery system.
 #
-# WRITE_PROTECTED_IDS is an array of IDs which designate write-protected disk devices.
-# IDs are those that 'lsblk' reports (which depends on the lsblk version):
+# WRITE_PROTECTED_ID_TYPES is a string of the 'lsblk' output columns where
+# their values are stored in WRITE_PROTECTED_IDS during "rear mkrescue/mkbackup".
+# During "rear recover" a disk is write-protected when one of the values
+# of this 'lsblk' output columns for the disk also exists in WRITE_PROTECTED_IDS.
+# The default 'lsblk' output columns for write-protection via disk specific IDs are
 #       UUID filesystem UUID
 #     PTUUID partition table identifier (usually UUID)
 #   PARTUUID partition UUID
 #        WWN unique storage identifier
-# For OUTPUT=USB all available IDs of the ReaR recovery system disk (i.e. USB_DEVICE)
-# will be automatically added to the WRITE_PROTECTED_IDS array.
+WRITE_PROTECTED_ID_TYPES="UUID PTUUID PARTUUID WWN"
+#
+# For OUTPUT=USB the values of the 'lsblk' output columns in WRITE_PROTECTED_ID_TYPES
+# of the ReaR recovery system disk (i.e. USB_DEVICE) are automatically added
+# to the WRITE_PROTECTED_IDS array during "rear mkrescue/mkbackup".
 # For OUTPUT=RAWDISK a partition table UUID is generated (provided 'uuidgen' is there)
-# that is automatically added to the WRITE_PROTECTED_IDS array.
-# Example: WRITE_PROTECTED_IDS+=( "ecacbce4-e05e-4eb9-835c-ade0c3ed0fea" )
+# that is added to the WRITE_PROTECTED_IDS array.
 WRITE_PROTECTED_IDS=()
 #
-# WRITE_PROTECTED_FS_LABEL_PATTERNS is an array of (shell glob) patterns
-# which designate matching file system labels as write-protected partitions.
+# WRITE_PROTECTED_FS_LABEL_PATTERNS is an array of (shell glob) patterns which designate
+# matching file system labels as write-protected partitions to write-protect their disk.
 # Entries may be quoted and contain blanks, but they may not contain single quotes themselves.
-# For OUTPUT=USB all available file system labels of the ReaR recovery system disk (i.e. USB_DEVICE)
-# will be automatically added to the WRITE_PROTECTED_FS_LABEL_PATTERNS array.
 # Example: WRITE_PROTECTED_FS_LABEL_PATTERNS+=( "Backup *" )
+# For OUTPUT=USB the file system label of the ReaR data partition on the ReaR recovery system disk
+# is automatically added to WRITE_PROTECTED_FS_LABEL_PATTERNS during "rear mkrescue/mkbackup".
 WRITE_PROTECTED_FS_LABEL_PATTERNS=()
 
 ##

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -550,6 +550,13 @@ WRITE_PROTECTED_ID_TYPES="UUID PTUUID PARTUUID WWN"
 # to the WRITE_PROTECTED_IDS array during "rear mkrescue/mkbackup".
 # For OUTPUT=RAWDISK a partition table UUID is generated (provided 'uuidgen' is there)
 # that is added to the WRITE_PROTECTED_IDS array.
+# For the IDs in WRITE_PROTECTED_IDS their matching 'lsblk' output columns
+# must exist in WRITE_PROTECTED_ID_TYPES because only this ID types are used
+# to test if a disk is write-protected (see WRITE_PROTECTED_ID_TYPES above).
+# E.g. if you like to use additionally the 'lsblk' output column MODEL as ID
+# in WRITE_PROTECTED_IDS like WRITE_PROTECTED_IDS+=( "ACME_USB_DISK_XL" )
+# you must also append that 'lsblk' output column as separated additional word
+# to the WRITE_PROTECTED_ID_TYPES string like WRITE_PROTECTED_ID_TYPES+=" MODEL"
 WRITE_PROTECTED_IDS=()
 #
 # WRITE_PROTECTED_FS_LABEL_PATTERNS is an array of (shell glob) patterns which designate

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -531,20 +531,22 @@ AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE=10
 #
 # Designate disks (i.e. its partition table), partitions, or file systems as write-protected
 # to avoid that those disks could get used as target disk during "rear recover" via
-# WRITE_PROTECTED_UUIDS and WRITE_PROTECTED_FS_LABEL_PATTERNS settings
+# WRITE_PROTECTED_IDS and WRITE_PROTECTED_FS_LABEL_PATTERNS settings
 # in etc/rear/rescue.conf in the ReaR rescue/recovery system.
 #
-# WRITE_PROTECTED_UUIDS is an array of UUIDs which designate write-protected disk devices.
-# UUIDs are those that 'lsblk' reports (which depends on the lsblk version):
+# WRITE_PROTECTED_IDS is an array of IDs which designate write-protected disk devices.
+# IDs are those that 'lsblk' reports (which depends on the lsblk version):
 #       UUID filesystem UUID
 #     PTUUID partition table identifier (usually UUID)
 #   PARTUUID partition UUID
-# For OUTPUT=USB all available UUIDs of the ReaR recovery system disk (i.e. USB_DEVICE)
-# will be automatically added to the WRITE_PROTECTED_UUIDS array.
+#     SERIAL disk serial number
+#        WWN unique storage identifier
+# For OUTPUT=USB all available IDs of the ReaR recovery system disk (i.e. USB_DEVICE)
+# will be automatically added to the WRITE_PROTECTED_IDS array.
 # For OUTPUT=RAWDISK a partition table UUID is generated (provided 'uuidgen' is there)
-# that is automatically added to the WRITE_PROTECTED_UUIDS array.
-# Example: WRITE_PROTECTED_UUIDS+=( "ecacbce4-e05e-4eb9-835c-ade0c3ed0fea" )
-WRITE_PROTECTED_UUIDS=()
+# that is automatically added to the WRITE_PROTECTED_IDS array.
+# Example: WRITE_PROTECTED_IDS+=( "ecacbce4-e05e-4eb9-835c-ade0c3ed0fea" )
+WRITE_PROTECTED_IDS=()
 #
 # WRITE_PROTECTED_FS_LABEL_PATTERNS is an array of (shell glob) patterns
 # which designate matching file system labels as write-protected partitions.

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -227,12 +227,9 @@ while read keyword orig_device orig_size junk ; do
             Log "$preferred_target_device_name excluded from device mapping choices (is already used as mapping target)"
             continue
         fi
-        if is_write_protected_by_pt_uuid "$preferred_target_device_name"; then
-            Log "$preferred_target_device_name excluded from device mapping choices (write-protected partition table UUID)"
-            continue
-        fi
-        if is_write_protected_by_fs_label "$preferred_target_device_name"; then
-            Log "$preferred_target_device_name excluded from device mapping choices (write-protected file system label)"
+        # Continue with next block device if the current one is designated as write-protected:
+        if is_write_protected "$preferred_target_device_name"; then
+            Log "$preferred_target_device_name excluded from device mapping choices (is designated as write-protected)"
             continue
         fi
         # Add the current device as possible choice for the user:

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -253,7 +253,7 @@ while read keyword orig_device orig_size junk ; do
     # At the end the mapping file is shown and the user can edit it if he does not like an automated mapping:
     if test "1" -eq "${#possible_targets[@]}" ; then
         add_mapping "$orig_device" "$possible_targets"
-        LogPrint "Using $possible_targets (the only appropriate) for recreating $orig_device"
+        LogPrint "Using $possible_targets (the only available of the disks) for recreating $orig_device"
         # Continue with next original device in the LAYOUT_FILE:
         continue
     fi

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -115,6 +115,11 @@ while read keyword orig_device orig_size junk ; do
         continue
     fi
     # The original device is not yet mapped (i.e. not used as source in the mapping file) so it needs to be mapped.
+    # Remember when target devices get known by the "same name and same size" tests
+    # that they cannot be used for recreating the current original device
+    # to avoid that already excluded target devices get needlessly
+    # considered again during the subsequent "same size" tests:
+    excluded_target_device_names=()
     # First, try to find if there is a current disk with same name and same size as the original:
     sysfs_device_name="$( get_sysfs_name "$orig_device" )"
     current_device="/sys/block/$sysfs_device_name"
@@ -132,10 +137,12 @@ while read keyword orig_device orig_size junk ; do
                 # Do not map if the current one is already used as target in the mapping file:
                 if is_mapping_target "$preferred_target_device_name" ; then
                     DebugPrint "Cannot use $preferred_target_device_name (same name and same size) for recreating $orig_device ($preferred_target_device_name already exists as target in $MAPPING_FILE)"
+                    excluded_target_device_names+=( "$preferred_target_device_name" )
                 else
                     # Ensure the determined target device is not write-protected:
                     if is_write_protected "$preferred_target_device_name" ; then
                         DebugPrint "Cannot use $preferred_target_device_name (same name and same size) for recreating $orig_device ($preferred_target_device_name is write-protected)"
+                        excluded_target_device_names+=( "$preferred_target_device_name" )
                     else
                         add_mapping "$orig_device" "$preferred_target_device_name"
                         LogPrint "Using $preferred_target_device_name (same name and same size $current_size) for recreating $orig_device"
@@ -160,9 +167,11 @@ while read keyword orig_device orig_size junk ; do
         preferred_target_device_name="$( get_device_name $current_device_path )"
         # Ensure the determined target device is really a block device (cf. above):
         test -b "$preferred_target_device_name" || continue
-        # Continue with next current block device if the current one is not of same size as the original:
+        # Continue with next block device if the current one is not of same size as the original:
         test "$orig_size" -eq "$current_size" || continue
-        # Continue with next current block device if the current one is already used as target in the mapping file:
+        # Continue with next block device if the current one was already excluded by the "same name and same size" tests above:
+        IsInArray "$preferred_target_device_name" "${excluded_target_device_names[@]}" && continue
+        # Continue with next block device if the current one is already used as target in the mapping file:
         if is_mapping_target "$preferred_target_device_name" ; then
             DebugPrint "Cannot use $preferred_target_device_name (same size) for recreating $orig_device ($preferred_target_device_name already exists as target in $MAPPING_FILE)"
             continue

--- a/usr/share/rear/lib/write-protect-functions.sh
+++ b/usr/share/rear/lib/write-protect-functions.sh
@@ -17,11 +17,6 @@ function write_protected_candidate_device() {
 function write_protection_ids() {
     local device="$( write_protected_candidate_device "$1" )"
     # Output the IDs for write-protection, each ID on a separated line.
-    # IDs are those that 'lsblk' reports (which depends on the lsblk version):
-    #       UUID filesystem UUID
-    #     PTUUID partition table identifier (usually UUID)
-    #   PARTUUID partition UUID
-    #        WWN unique storage identifier
 
     # At least for OUTPUT=USB $device is of the form /dev/disk/by-label/$USB_DEVICE_FILESYSTEM_LABEL
     # which is a symlink to the ReaR data partition (e.g. /dev/sdb3 on a USB disk /dev/sdb).
@@ -46,6 +41,7 @@ function write_protection_ids() {
     test -b "$parent_device" && device="$parent_device"
 
     local column
+    # The default WRITE_PROTECTED_ID_TYPES are UUID PTUUID PARTUUID WWN.
     # Older lsblk versions do not support all output columns UUID PTUUID PARTUUID WWN
     # e.g. lsblk in util-linux 2.19.1 in SLES11 only supports UUID but neither PTUUID nor PARTUUID nor WWN
     # cf. https://github.com/rear/rear/pull/2626#issuecomment-856700823
@@ -56,7 +52,7 @@ function write_protection_ids() {
     #  or for all columns except UUID when a child device is a /dev/mapper/* device
     #  and some devices do not have any WWN set)
     # and we remove duplicate reported IDs (in particular PTUUID is reported also for each partition):
-    for column in UUID PTUUID PARTUUID WWN ; do lsblk -ino $column "$device" 2>/dev/null ; done | awk NF | sort -u
+    for column in $WRITE_PROTECTED_ID_TYPES ; do lsblk -ino $column "$device" 2>/dev/null ; done | awk NF | sort -u
 }
 
 function is_write_protected_by_id() {

--- a/usr/share/rear/lib/write-protect-functions.sh
+++ b/usr/share/rear/lib/write-protect-functions.sh
@@ -94,7 +94,7 @@ function is_write_protected_by_fs_label() {
             done
         fi
     done < <(lsblk --output LABEL --noheadings "$device")
-
+    Log "$device is not write-protected by file system label"
     return 1
 }
 

--- a/usr/share/rear/lib/write-protect-functions.sh
+++ b/usr/share/rear/lib/write-protect-functions.sh
@@ -8,23 +8,52 @@ function write_protected_candidate_device() {
     # prints the path of the block device, translating it if given as /sys/block/*.
 
     if [[ "$device" == /sys/block/* ]]; then
-        device="$(get_device_name "$device")"
+        device="$( get_device_name "$device" )"
     fi
-    [[ ! -b "$device" ]] && Error "Could not check '$1' ('$device') for write protection – not a block device"
+    test -b "$device" || BugError "write_protected_candidate_device called for '$device' which is no block device"
     echo "$device"
 }
 
-function is_write_protected_by_pt_uuid() {
+function write_protection_uuids() {
+    local device="$( write_protected_candidate_device "$1") "
+    # Output the UUIDs for write-protection, each UUID on a separated line.
+    # UUIDs are those that 'lsblk' reports (which depends on the lsblk version):
+    #       UUID filesystem UUID
+    #     PTUUID partition table identifier (usually UUID)
+    #   PARTUUID partition UUID
+
+    local column
+    # Older lsblk versions do not support all output columns UUID PTUUID PARTUUID
+    # e.g. lsblk in util-linux 2.19.1 in SLES11 only supports UUID but neither PTUUID no PARTUUID
+    # cf. https://github.com/rear/rear/pull/2626#issuecomment-856700823
+    # When an unsupported output column is specified lsblk aborts with "unknown column" error message
+    # without output for supported output columns so we run lsblk for each output column separately
+    # and ignore lsblk failures and error messages and we skip empty lines in the output via 'awk NF'
+    # cf. https://unix.stackexchange.com/questions/274708/most-elegant-pipe-to-get-rid-of-empty-lines-you-can-think-of
+    # and https://stackoverflow.com/questions/23544804/how-awk-nf-filename-is-working
+    # (empty lines appear when a partition does not have a filesystem UUID or for the whole device that has no PARTUUID)
+    # and we remove duplicate reported UUIDs (in particular PTUUID is reported also for each partition):
+    for column in UUID PTUUID PARTUUID ; do lsblk -ino $column "$USB_DEVICE" 2>/dev/null ; done | awk NF | sort -u
+}
+
+function is_write_protected_by_uuid() {
     local device="$(write_protected_candidate_device "$1")"
-    # returns 0 if the device's partition table UUID is in the list of write-protected UUIDs.
+    # returns 0 if one of the device's UUID is in the list of write-protected UUIDs.
 
-    local partition_table_uuid="$(lsblk --output PTUUID --noheadings --nodeps "$device")"
-
-    if [[ " ${WRITE_PROTECTED_PARTITION_TABLE_UUIDS[*]} " == *" $partition_table_uuid "* ]]; then
-        Log "$device is designated as write-protected by partition table UUID '$partition_table_uuid'"
-        return 0
+    local uuids uuid
+    uuids="$( write_protection_uuids "$device" )"
+    # uuids is a string of UUIDs separated by newline characters
+    if ! test "$uuids" ; then
+        LogPrintError "Cannot check write protection by UUID for $device (no UUID found)"
+        return 1
     fi
-
+    for uuid in $uuids ; do
+        if IsInArray "$uuid" "${WRITE_PROTECTED_UUIDS[@]}" ; then
+            Log "$device is designated as write-protected by UUID $uuid"
+            return 0
+        fi
+    done
+    Log "$device is not write-protected by UUID"
     return 1
 }
 
@@ -37,7 +66,7 @@ function is_write_protected_by_fs_label() {
     local write_protected_pattern
     while read -r partition_label; do
         if [[ -n "$partition_label" ]]; then
-            for write_protected_pattern in "${WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS[@]}"; do
+            for write_protected_pattern in "${WRITE_PROTECTED_FS_LABEL_PATTERNS[@]}"; do
                 if [[ "$partition_label" == $write_protected_pattern ]]; then
                     Log "$device is designated as write-protected, its label '$partition_label' matches '$write_protected_pattern'"
                     return 0
@@ -53,5 +82,5 @@ function is_write_protected() {
     local device="$(write_protected_candidate_device "$1")"
     # returns 0 if the device is designated as write-protected by any of the above means.
 
-    is_write_protected_by_pt_uuid "$device" || is_write_protected_by_fs_label "$device"
+    is_write_protected_by_uuid "$device" || is_write_protected_by_fs_label "$device"
 }

--- a/usr/share/rear/lib/write-protect-functions.sh
+++ b/usr/share/rear/lib/write-protect-functions.sh
@@ -21,7 +21,6 @@ function write_protection_ids() {
     #       UUID filesystem UUID
     #     PTUUID partition table identifier (usually UUID)
     #   PARTUUID partition UUID
-    #     SERIAL disk serial number
     #        WWN unique storage identifier
 
     # At least for OUTPUT=USB $device is of the form /dev/disk/by-label/$USB_DEVICE_FILESYSTEM_LABEL
@@ -47,18 +46,17 @@ function write_protection_ids() {
     test -b "$parent_device" && device="$parent_device"
 
     local column
-    # Older lsblk versions do not support all output columns UUID PTUUID PARTUUID SERIAL WWN
-    # e.g. lsblk in util-linux 2.19.1 in SLES11 only supports UUID but neither PTUUID nor PARTUUID nor SERIAL nor WWN
+    # Older lsblk versions do not support all output columns UUID PTUUID PARTUUID WWN
+    # e.g. lsblk in util-linux 2.19.1 in SLES11 only supports UUID but neither PTUUID nor PARTUUID nor WWN
     # cf. https://github.com/rear/rear/pull/2626#issuecomment-856700823
     # When an unsupported output column is specified lsblk aborts with "unknown column" error message
     # without output for supported output columns so we run lsblk for each output column separately
     # and ignore lsblk failures and error messages and we skip empty lines in the output via 'awk NF'
     # (empty lines appear when a partition does not have a filesystem UUID or for the whole device that has no PARTUUID
-    #  or for all child devices because only the whole disk device has a SERIAL number
     #  or for all columns except UUID when a child device is a /dev/mapper/* device
     #  and some devices do not have any WWN set)
     # and we remove duplicate reported IDs (in particular PTUUID is reported also for each partition):
-    for column in UUID PTUUID PARTUUID SERIAL WWN ; do lsblk -ino $column "$device" 2>/dev/null ; done | awk NF | sort -u
+    for column in UUID PTUUID PARTUUID WWN ; do lsblk -ino $column "$device" 2>/dev/null ; done | awk NF | sort -u
 }
 
 function is_write_protected_by_id() {

--- a/usr/share/rear/lib/write-protect-functions.sh
+++ b/usr/share/rear/lib/write-protect-functions.sh
@@ -15,7 +15,7 @@ function write_protected_candidate_device() {
 }
 
 function write_protection_uuids() {
-    local device="$( write_protected_candidate_device "$1") "
+    local device="$( write_protected_candidate_device "$1" )"
     # Output the UUIDs for write-protection, each UUID on a separated line.
     # UUIDs are those that 'lsblk' reports (which depends on the lsblk version):
     #       UUID filesystem UUID

--- a/usr/share/rear/lib/write-protect-functions.sh
+++ b/usr/share/rear/lib/write-protect-functions.sh
@@ -10,7 +10,7 @@ function write_protected_candidate_device() {
     if [[ "$device" == /sys/block/* ]]; then
         device="$( get_device_name "$device" )"
     fi
-    test -b "$device" || BugError "write_protected_candidate_device called for '$device' which is no block device"
+    test -b "$device" || BugError "write_protected_candidate_device called for '$1' but '$device' is no block device"
     echo "$device"
 }
 

--- a/usr/share/rear/lib/write-protect-functions.sh
+++ b/usr/share/rear/lib/write-protect-functions.sh
@@ -33,7 +33,7 @@ function write_protection_uuids() {
     # and https://stackoverflow.com/questions/23544804/how-awk-nf-filename-is-working
     # (empty lines appear when a partition does not have a filesystem UUID or for the whole device that has no PARTUUID)
     # and we remove duplicate reported UUIDs (in particular PTUUID is reported also for each partition):
-    for column in UUID PTUUID PARTUUID ; do lsblk -ino $column "$USB_DEVICE" 2>/dev/null ; done | awk NF | sort -u
+    for column in UUID PTUUID PARTUUID ; do lsblk -ino $column "$device" 2>/dev/null ; done | awk NF | sort -u
 }
 
 function is_write_protected_by_uuid() {

--- a/usr/share/rear/prep/RAWDISK/Linux-i386/480_initialize_write_protect_settings.sh
+++ b/usr/share/rear/prep/RAWDISK/Linux-i386/480_initialize_write_protect_settings.sh
@@ -8,6 +8,12 @@ if has_binary uuidgen; then
     # Normally, a partition table UUID is generated automatically during partitioning. We cannot wait for this
     # to happen as the variable will be part of the initrd, which is completed before any partition table is
     # created.
-    RAWDISK_PTUUID="$(uuidgen)"
-    WRITE_PROTECTED_PARTITION_TABLE_UUIDS+=( $RAWDISK_PTUUID )
+    RAWDISK_PTUUID="$( uuidgen )"
+    if test "$RAWDISK_PTUUID"; then
+        WRITE_PROTECTED_UUIDS+=( $RAWDISK_PTUUID )
+    else
+        LogPrintError "Cannot write protect '${RAWDISK_GPT_PARTITION_NAME:-Rescue System}' disk (no partition table UUID)"
+    fi
+else
+    LogPrintError "Cannot write protect '${RAWDISK_GPT_PARTITION_NAME:-Rescue System}' disk (no 'uuidgen' found)"
 fi

--- a/usr/share/rear/prep/RAWDISK/Linux-i386/480_initialize_write_protect_settings.sh
+++ b/usr/share/rear/prep/RAWDISK/Linux-i386/480_initialize_write_protect_settings.sh
@@ -10,7 +10,7 @@ if has_binary uuidgen; then
     # created.
     RAWDISK_PTUUID="$( uuidgen )"
     if test "$RAWDISK_PTUUID"; then
-        WRITE_PROTECTED_UUIDS+=( $RAWDISK_PTUUID )
+        WRITE_PROTECTED_IDS+=( $RAWDISK_PTUUID )
     else
         LogPrintError "Cannot write protect '${RAWDISK_GPT_PARTITION_NAME:-Rescue System}' disk (no partition table UUID)"
     fi

--- a/usr/share/rear/prep/USB/default/480_initialize_write_protect_settings.sh
+++ b/usr/share/rear/prep/USB/default/480_initialize_write_protect_settings.sh
@@ -3,21 +3,27 @@
 # cf. https://github.com/rear/rear/issues/1271
 # This code registers the USB output device as write protected.
 
-# All available IDs of the ReaR recovery system disk (i.e. USB_DEVICE)
-# are added to the WRITE_PROTECTED_IDS array.
-# IDs are those that 'lsblk' reports (which depends on the lsblk version):
-#       UUID filesystem UUID
-#     PTUUID partition table identifier (usually UUID)
-#   PARTUUID partition UUID
-#        WWN unique storage identifier
+# The values of the 'lsblk' output columns in WRITE_PROTECTED_ID_TYPES
+# of the ReaR recovery system disk (parent of USB_DEVICE) are automatically added
+# to the WRITE_PROTECTED_IDS array during "rear mkrescue/mkbackup".
+# The default WRITE_PROTECTED_ID_TYPES are UUID PTUUID PARTUUID WWN.
 local ids
 ids="$( write_protection_ids "$USB_DEVICE" )"
 # ids is a string of IDs separated by newline characters so quoting for 'test' is required
 # but no quoting to add them to the array to get each ID as a separated array element:
-test "$ids" && WRITE_PROTECTED_IDS+=( $ids ) || LogPrintError "Cannot write protect USB disk '$USB_DEVICE' via ID (no ID found)"
+if test "$ids" ; then
+    WRITE_PROTECTED_IDS+=( $ids )
+    DebugPrint "USB disk IDs of '$USB_DEVICE' added to WRITE_PROTECTED_IDS"
+else
+    LogPrintError "Cannot write protect USB disk of '$USB_DEVICE' via ID (no ID found)"
+fi
 
-# All available file system labels of the ReaR recovery system disk (i.e. USB_DEVICE)
-# are added to the WRITE_PROTECTED_FS_LABEL_PATTERNS array.
+# The file system label of the ReaR data partition (i.e. USB_DEVICE) on the ReaR recovery system disk
+# is automatically added to WRITE_PROTECTED_FS_LABEL_PATTERNS during "rear mkrescue/mkbackup".
 # Empty lines in the lsblk output get automatically ignored (i.e. no empty array elements get added)
 # and we do not alert the user via LogPrintError because file system labels are optional:
-WRITE_PROTECTED_FS_LABEL_PATTERNS+=( $( lsblk -ino LABEL "$USB_DEVICE" ) ) || DebugPrint "Cannot write protect USB disk '$USB_DEVICE' via file system label (none found)"
+if WRITE_PROTECTED_FS_LABEL_PATTERNS+=( $( lsblk -ino LABEL "$USB_DEVICE" ) ) ; then
+    DebugPrint "File system label of '$USB_DEVICE' added to WRITE_PROTECTED_FS_LABEL_PATTERNS"
+else
+    DebugPrint "Cannot write protect USB disk of '$USB_DEVICE' via file system label (none found)"
+fi

--- a/usr/share/rear/prep/USB/default/480_initialize_write_protect_settings.sh
+++ b/usr/share/rear/prep/USB/default/480_initialize_write_protect_settings.sh
@@ -3,17 +3,19 @@
 # cf. https://github.com/rear/rear/issues/1271
 # This code registers the USB output device as write protected.
 
-# All available UUIDs of the ReaR recovery system disk (i.e. USB_DEVICE)
-# are added to the WRITE_PROTECTED_UUIDS array.
-# UUIDs are those that 'lsblk' reports (which depends on the lsblk version):
+# All available IDs of the ReaR recovery system disk (i.e. USB_DEVICE)
+# are added to the WRITE_PROTECTED_IDS array.
+# IDs are those that 'lsblk' reports (which depends on the lsblk version):
 #       UUID filesystem UUID
 #     PTUUID partition table identifier (usually UUID)
 #   PARTUUID partition UUID
-local uuids
-uuids="$( write_protection_uuids "$USB_DEVICE" )"
-# uuids is a string of UUIDs separated by newline characters so quoting for 'test' is required
-# but no quoting to add them to the array to get each UUID as a separated array element:
-test "$uuids" && WRITE_PROTECTED_UUIDS+=( $uuids ) || LogPrintError "Cannot write protect USB disk '$USB_DEVICE' via UUID (no UUID found)"
+#     SERIAL disk serial number
+#        WWN unique storage identifier
+local ids
+ids="$( write_protection_ids "$USB_DEVICE" )"
+# ids is a string of IDs separated by newline characters so quoting for 'test' is required
+# but no quoting to add them to the array to get each ID as a separated array element:
+test "$ids" && WRITE_PROTECTED_IDS+=( $ids ) || LogPrintError "Cannot write protect USB disk '$USB_DEVICE' via ID (no ID found)"
 
 # All available file system labels of the ReaR recovery system disk (i.e. USB_DEVICE)
 # are added to the WRITE_PROTECTED_FS_LABEL_PATTERNS array.

--- a/usr/share/rear/prep/USB/default/480_initialize_write_protect_settings.sh
+++ b/usr/share/rear/prep/USB/default/480_initialize_write_protect_settings.sh
@@ -1,4 +1,22 @@
-# USB output typically resides on a writable disk device, which should be protected against
-# accidental overwriting by rear recover. This code registers it as write protected.
+# USB output typically resides on a writable disk device
+# which should be protected against overwriting by "rear recover"
+# cf. https://github.com/rear/rear/issues/1271
+# This code registers the USB output device as write protected.
 
-WRITE_PROTECTED_PARTITION_TABLE_UUIDS+=( $(lsblk --output PTUUID --noheadings --nodeps "$USB_DEVICE") )
+# All available UUIDs of the ReaR recovery system disk (i.e. USB_DEVICE)
+# are added to the WRITE_PROTECTED_UUIDS array.
+# UUIDs are those that 'lsblk' reports (which depends on the lsblk version):
+#       UUID filesystem UUID
+#     PTUUID partition table identifier (usually UUID)
+#   PARTUUID partition UUID
+local uuids
+uuids="$( write_protection_uuids "$USB_DEVICE" )"
+# uuids is a string of UUIDs separated by newline characters so quoting for 'test' is required
+# but no quoting to add them to the array to get each UUID as a separated array element:
+test "$uuids" && WRITE_PROTECTED_UUIDS+=( $uuids ) || LogPrintError "Cannot write protect USB disk '$USB_DEVICE' via UUID (no UUID found)"
+
+# All available file system labels of the ReaR recovery system disk (i.e. USB_DEVICE)
+# are added to the WRITE_PROTECTED_FS_LABEL_PATTERNS array.
+# Empty lines in the lsblk output get automatically ignored (i.e. no empty array elements get added)
+# and we do not alert the user via LogPrintError because file system labels are optional:
+WRITE_PROTECTED_FS_LABEL_PATTERNS+=( $( lsblk -ino LABEL "$USB_DEVICE" ) ) || DebugPrint "Cannot write protect USB disk '$USB_DEVICE' via file system label (none found)"

--- a/usr/share/rear/prep/USB/default/480_initialize_write_protect_settings.sh
+++ b/usr/share/rear/prep/USB/default/480_initialize_write_protect_settings.sh
@@ -9,7 +9,6 @@
 #       UUID filesystem UUID
 #     PTUUID partition table identifier (usually UUID)
 #   PARTUUID partition UUID
-#     SERIAL disk serial number
 #        WWN unique storage identifier
 local ids
 ids="$( write_protection_ids "$USB_DEVICE" )"

--- a/usr/share/rear/prep/default/490_store_write_protect_settings.sh
+++ b/usr/share/rear/prep/default/490_store_write_protect_settings.sh
@@ -3,10 +3,10 @@
 {
     echo "# The following lines were added by 490_store_write_protect_settings.sh"
 
-    echo "WRITE_PROTECTED_PARTITION_TABLE_UUIDS=( ${WRITE_PROTECTED_PARTITION_TABLE_UUIDS[*]} )"
+    echo "WRITE_PROTECTED_UUIDS=( ${WRITE_PROTECTED_UUIDS[*]} )"
 
-    echo -n "WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS=("
-    for prefix in "${WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS[@]}"; do
+    echo -n "WRITE_PROTECTED_FS_LABEL_PATTERNS=("
+    for prefix in "${WRITE_PROTECTED_FS_LABEL_PATTERNS[@]}"; do
         [[ -n "$prefix" ]] && echo -n " '$prefix'"
     done
     echo " )"

--- a/usr/share/rear/prep/default/490_store_write_protect_settings.sh
+++ b/usr/share/rear/prep/default/490_store_write_protect_settings.sh
@@ -3,7 +3,7 @@
 {
     echo "# The following lines were added by 490_store_write_protect_settings.sh"
 
-    echo "WRITE_PROTECTED_UUIDS=( ${WRITE_PROTECTED_UUIDS[*]} )"
+    echo "WRITE_PROTECTED_IDS=( ${WRITE_PROTECTED_IDS[*]} )"
 
     echo -n "WRITE_PROTECTED_FS_LABEL_PATTERNS=("
     for prefix in "${WRITE_PROTECTED_FS_LABEL_PATTERNS[@]}"; do


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2626

* How was this pull request tested?
Not yet tested by me - will test soon...

* Brief description of the changes in this pull request:

The specific WRITE_PROTECTED_PARTITION_TABLE_UUIDS
is replaced by WRITE_PROTECTED_UUIDS with generic functionality
cf. https://github.com/rear/rear/pull/2626#issuecomment-950953826

WRITE_PROTECTED_FILE_SYSTEM_LABEL_PATTERNS
is shortened to WRITE_PROTECTED_FS_LABEL_PATTERNS
