### PR TITLE
minimal changes needed for hybrid boot (bios+uefi)

### DIFF
--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -29,10 +29,8 @@ local MiB_bytes=$(( 1024 * 1024 ))
 # i.e. current_partition_number is the number of the partition that can be set up next:
 local current_partition_number=1
 
-# Start byte of the data partition that is after the EFI system partition in case of UEFI
-# and otherwise (i.e. in case of BIOS) by default the first possible partitioning alignment
-# or after the boot partition (and the BIOS boot partition) if those partitions exist:
-local data_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
+# current start byte of the next partition to add
+local current_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
 
 # Flag for the partition wherefrom is booted which is the boot partition if exists
 # or the data partition as fallback when there is no boot partition:
@@ -53,56 +51,29 @@ if ! test $boot_partition_flag ; then
     esac
 fi
 
-# Initialize USB disk via "parted mklabel" and
-# boot partitions setup i.e. either a EFI system partition
-# or a BIOS boot partition if needed and a boot partition:
-if is_true "$FORMAT_EFI" ; then
+### Create partition table section
 
-    LogPrint "The --efi toggle was used with format - making an EFI bootable device $RAW_USB_DEVICE"
-    # Prompt user for size of EFI system partition on USB disk if no valid value is specified:
-    while ! is_positive_integer $USB_UEFI_PART_SIZE ; do
-        # When USB_UEFI_PART_SIZE is empty, do not falsely complain about "Invalid EFI partition size":
-        test "$USB_UEFI_PART_SIZE" && LogPrintError "Invalid EFI system partition size USB_UEFI_PART_SIZE='$USB_UEFI_PART_SIZE' (must be positive integer)"
-        USB_UEFI_PART_SIZE="$( UserInput -I USB_DEVICE_EFI_PARTITION_MIBS -p "Enter size for EFI system partition on $RAW_USB_DEVICE in MiB (default 512 MiB)" )"
-        # Plain 'Enter' defaults to 512 MiB (same as the default value in default.conf):
-        test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="512"
-    done
-    LogPrint "Creating GUID partition table (GPT) on $RAW_USB_DEVICE"
-    if ! parted -s $RAW_USB_DEVICE mklabel gpt ; then
-        Error "Failed to create GPT partition table on $RAW_USB_DEVICE"
-    fi
-    # Round UEFI partition size to nearest block size to make the 2nd partition (the data partition) also align to the block size:
-    USB_UEFI_PART_SIZE=$(( ( USB_UEFI_PART_SIZE + ( USB_PARTITION_ALIGN_BLOCK_SIZE / 2 ) ) / USB_PARTITION_ALIGN_BLOCK_SIZE * USB_PARTITION_ALIGN_BLOCK_SIZE ))
-    LogPrint "Creating EFI system partition $RAW_USB_DEVICE$current_partition_number with size $USB_UEFI_PART_SIZE MiB aligned at $USB_PARTITION_ALIGN_BLOCK_SIZE MiB"
-    # Calculate byte values:
-    local efi_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
-    local efi_partition_size_bytes=$(( USB_UEFI_PART_SIZE * MiB_bytes ))
-    # The end byte is the last byte that belongs to that partition so that one must be careful to use "start_byte + partition_size_in_bytes - 1":
-    local efi_partition_end_byte=$(( efi_partition_start_byte + efi_partition_size_bytes - 1 ))
-    if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $efi_partition_start_byte $efi_partition_end_byte ; then
-        Error "Failed to create EFI system partition $RAW_USB_DEVICE$current_partition_number"
-    fi
-    # Partition 1 is the EFI system partition (vfat partition) on which EFI/BOOT/BOOTX86.EFI resides
-    # so the number of the partition that can be set up next has to be one more (i.e. now 2):
-    current_partition_number=$(( current_partition_number + 1 ))
-    # Calculate byte value for the start of the subsequent data partition:
-    data_partition_start_byte=$(( efi_partition_end_byte + 1 ))
+# Initialize USB disk via "parted mklabel" (create partition table)
+# If not set use fallback value 'msdos' (same as the default value in default.conf):
+test "msdos" = "$USB_DEVICE_PARTED_LABEL" -o "gpt" = "$USB_DEVICE_PARTED_LABEL" || USB_DEVICE_PARTED_LABEL="msdos"
+LogPrint "Creating partition table of type $USB_DEVICE_PARTED_LABEL on $RAW_USB_DEVICE"
+if ! parted -s $RAW_USB_DEVICE mklabel $USB_DEVICE_PARTED_LABEL ; then
+    Error "Failed to create $USB_DEVICE_PARTED_LABEL partition table on $RAW_USB_DEVICE"
+fi
 
-    # End of EFI case.
-else
-    # Begin non-EFI case:
+### Create partitions section
+# in order:
+# * BIOS partition (GPT only) / partition gap aka empty space for MSDOS
+# * EFI (in case of EFI)
+# * boot partition (optional but encuraged)
+# * backup/storage/data partition
 
-    # If not set use fallback value 'msdos' (same as the default value in default.conf):
-    test "msdos" = "$USB_DEVICE_PARTED_LABEL" -o "gpt" = "$USB_DEVICE_PARTED_LABEL" || USB_DEVICE_PARTED_LABEL="msdos"
-    LogPrint "Creating partition table of type $USB_DEVICE_PARTED_LABEL on $RAW_USB_DEVICE"
-    if ! parted -s $RAW_USB_DEVICE mklabel $USB_DEVICE_PARTED_LABEL ; then
-        Error "Failed to create $USB_DEVICE_PARTED_LABEL partition table on $RAW_USB_DEVICE"
-    fi
-
-    # USB_PARTITION_ALIGN_BLOCK_SIZE is the first byte of the boot partition:
-    local boot_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
-
+# In case of GPT with BIOS boot we need a 'bios_grub' partition
+# In case of MSDOS partition table we just need some free space in between the partition table and the first partition
+# This partition should be the first one afaik this has a better chance to work with odd BIOS firmwares
+if is_true "$FORMAT_BIOS" ; then
     if [[ "$USB_DEVICE_PARTED_LABEL" == "gpt" ]] ; then
+        LogPrint "The --bios toggle was used with format - making an BIOS bootable device $RAW_USB_DEVICE"
         # Create BIOS boot partition for GRUB2 second stage 'core.img'
         # cf. https://en.wikipedia.org/wiki/BIOS_boot_partition
         # and https://en.wikipedia.org/wiki/GUID_Partition_Table reads (excerpt)
@@ -120,7 +91,7 @@ else
         local bios_boot_partition_start_byte=24576
         LogPrint "Creating BIOS boot partition $RAW_USB_DEVICE$current_partition_number"
         # The BIOS boot partition goes up to (excluding) the byte where the boot partition starts:
-        local bios_boot_partition_end_byte=$(( boot_partition_start_byte - 1 ))
+        local bios_boot_partition_end_byte=$(( current_partition_start_byte - 1 ))
         if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $bios_boot_partition_start_byte $bios_boot_partition_end_byte ; then
             Error "Failed to create BIOS boot partition $RAW_USB_DEVICE$current_partition_number"
         fi
@@ -133,43 +104,78 @@ else
         # so the number of the partition that can be set up next has to be one more (i.e. now 2):
         current_partition_number=$(( current_partition_number + 1 ))
     fi
-
-    if is_positive_integer $USB_BOOT_PART_SIZE ; then
-        # Create a boot partition for the bootloader config/plugins/modules, the kernel and the ReaR recovery system initrd.
-        # Round boot partition size to nearest block size to make the next partition (the data partition) also align to the block size:
-        USB_BOOT_PART_SIZE=$(( ( USB_BOOT_PART_SIZE + ( USB_PARTITION_ALIGN_BLOCK_SIZE / 2 ) ) / USB_PARTITION_ALIGN_BLOCK_SIZE * USB_PARTITION_ALIGN_BLOCK_SIZE ))
-        LogPrint "Creating boot partition $RAW_USB_DEVICE$current_partition_number with size $USB_BOOT_PART_SIZE MiB aligned at $USB_PARTITION_ALIGN_BLOCK_SIZE MiB"
-        # Calculate byte values:
-        local boot_partition_size_bytes=$(( USB_BOOT_PART_SIZE * MiB_bytes ))
-        # The end byte is the last byte that belongs to that partition so that one must be careful to use "start_byte + partition_size_in_bytes - 1":
-        local boot_partition_end_byte=$(( boot_partition_start_byte + boot_partition_size_bytes - 1 ))
-        if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $boot_partition_start_byte $boot_partition_end_byte ; then
-            Error "Failed to create boot partition $RAW_USB_DEVICE$current_partition_number"
-        fi
-        # Set the right flag for the boot partition unless no flag should be set:
-        if ! is_false $boot_partition_flag ; then
-            LogPrint "Setting '$boot_partition_flag' flag on boot partition $RAW_USB_DEVICE$current_partition_number"
-            if ! parted -s $RAW_USB_DEVICE set $current_partition_number $boot_partition_flag on ; then
-                Error "Failed to set '$boot_partition_flag' flag on boot partition $RAW_USB_DEVICE$current_partition_number"
-            fi
-            # When the flag was set for the boot partition do not also set this flag for the data partition below:
-            boot_partition_flag="false"
-        fi
-        # With a boot partition the number of the partition that can be set up next has to be one more
-        # i.e. it is now 3 when also a BIOS boot partition was created and 2 otherwise:
-        current_partition_number=$(( current_partition_number + 1 ))  
-        # Calculate byte value for the start of the subsequent data partition:
-        data_partition_start_byte=$(( boot_partition_end_byte + 1 ))
-    fi
 fi
-# End of boot partitions setup.
+
+# In case of EFI boot we need a EFI system partition
+if is_true "$FORMAT_EFI" ; then
+    LogPrint "The --efi toggle was used with format - making an EFI bootable device $RAW_USB_DEVICE"
+    # Prompt user for size of EFI system partition on USB disk if no valid value is specified:
+    while ! is_positive_integer $USB_UEFI_PART_SIZE ; do
+        # When USB_UEFI_PART_SIZE is empty, do not falsely complain about "Invalid EFI partition size":
+        test "$USB_UEFI_PART_SIZE" && LogPrintError "Invalid EFI system partition size USB_UEFI_PART_SIZE='$USB_UEFI_PART_SIZE' (must be positive integer)"
+        USB_UEFI_PART_SIZE="$( UserInput -I USB_DEVICE_EFI_PARTITION_MIBS -p "Enter size for EFI system partition on $RAW_USB_DEVICE in MiB (default 512 MiB)" )"
+        # Plain 'Enter' defaults to 512 MiB (same as the default value in default.conf):
+        test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="512"
+    done
+
+    # Round UEFI partition size to nearest block size to make the 2nd partition (the data partition) also align to the block size:
+    USB_UEFI_PART_SIZE=$(( ( USB_UEFI_PART_SIZE + ( USB_PARTITION_ALIGN_BLOCK_SIZE / 2 ) ) / USB_PARTITION_ALIGN_BLOCK_SIZE * USB_PARTITION_ALIGN_BLOCK_SIZE ))
+    LogPrint "Creating EFI system partition $RAW_USB_DEVICE$current_partition_number with size $USB_UEFI_PART_SIZE MiB aligned at $USB_PARTITION_ALIGN_BLOCK_SIZE MiB"
+    # Calculate byte values:
+    local efi_partition_size_bytes=$(( USB_UEFI_PART_SIZE * MiB_bytes ))
+    # The end byte is the last byte that belongs to that partition so that one must be careful to use "start_byte + partition_size_in_bytes - 1":
+    local efi_partition_end_byte=$(( current_partition_start_byte + efi_partition_size_bytes - 1 ))
+    if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $current_partition_start_byte $efi_partition_end_byte ; then
+        Error "Failed to create EFI system partition $RAW_USB_DEVICE$current_partition_number"
+    fi
+    # Set the right flag for the EFI partition:
+    LogPrint "Setting 'esp' flag on EFI partition $RAW_USB_DEVICE$current_partition_number"
+    if ! parted -s $RAW_USB_DEVICE set $current_partition_number esp on ; then
+        Error "Failed to set 'esp' flag on EFI partition $RAW_USB_DEVICE$current_partition_number"
+    fi
+    # Partition 1 is the EFI system partition (vfat partition) on which EFI/BOOT/BOOTX86.EFI resides
+    # so the number of the partition that can be set up next has to be one more (i.e. now 2):
+    current_partition_number=$(( current_partition_number + 1 ))
+    # Calculate byte value for the start of the subsequent partition:
+    current_partition_start_byte=$(( efi_partition_end_byte + 1 ))
+fi
+
+# A boot partition is never strictly required but allows for a clear separation of concerns
+# Also the EFI partition could be misused to also store boot details
+if is_positive_integer $USB_BOOT_PART_SIZE ; then
+    # Create a boot partition for the bootloader config/plugins/modules, the kernel and the ReaR recovery system initrd.
+    # Round boot partition size to nearest block size to make the next partition (the data partition) also align to the block size:
+    USB_BOOT_PART_SIZE=$(( ( USB_BOOT_PART_SIZE + ( USB_PARTITION_ALIGN_BLOCK_SIZE / 2 ) ) / USB_PARTITION_ALIGN_BLOCK_SIZE * USB_PARTITION_ALIGN_BLOCK_SIZE ))
+    LogPrint "Creating boot partition $RAW_USB_DEVICE$current_partition_number with size $USB_BOOT_PART_SIZE MiB aligned at $USB_PARTITION_ALIGN_BLOCK_SIZE MiB"
+    # Calculate byte values:
+    local boot_partition_size_bytes=$(( USB_BOOT_PART_SIZE * MiB_bytes ))
+    # The end byte is the last byte that belongs to that partition so that one must be careful to use "start_byte + partition_size_in_bytes - 1":
+    local boot_partition_end_byte=$(( current_partition_start_byte + boot_partition_size_bytes - 1 ))
+    if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $current_partition_start_byte $boot_partition_end_byte ; then
+        Error "Failed to create boot partition $RAW_USB_DEVICE$current_partition_number"
+    fi
+    # Set the right flag for the boot partition unless no flag should be set:
+    if ! is_false $boot_partition_flag ; then
+        LogPrint "Setting '$boot_partition_flag' flag on boot partition $RAW_USB_DEVICE$current_partition_number"
+        if ! parted -s $RAW_USB_DEVICE set $current_partition_number $boot_partition_flag on ; then
+            Error "Failed to set '$boot_partition_flag' flag on boot partition $RAW_USB_DEVICE$current_partition_number"
+        fi
+        # When the flag was set for the boot partition do not also set this flag for the data partition below:
+        boot_partition_flag="false"
+    fi
+    # With a boot partition the number of the partition that can be set up next has to be one more
+    # i.e. it is now 3 when also a BIOS boot partition was created and 2 otherwise:
+    current_partition_number=$(( current_partition_number + 1 ))  
+    # Calculate byte value for the start of the subsequent partition:
+    current_partition_start_byte=$(( boot_partition_end_byte + 1 ))
+fi
 
 # USB_DATA_PARTITION_NUMBER is also needed in the subsequent format/USB/default/350_label_usb_disk.sh
 USB_DATA_PARTITION_NUMBER=$current_partition_number
 
 LogPrint "Creating ReaR data partition $RAW_USB_DEVICE$USB_DATA_PARTITION_NUMBER up to ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% of $RAW_USB_DEVICE"
 # Older parted versions (at least GNU Parted 1.6.25.1 on SLE10) support the '%' unit (cf. https://github.com/rear/rear/issues/1270):
-if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $data_partition_start_byte ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% ; then
+if ! parted -s $RAW_USB_DEVICE unit B mkpart primary $current_partition_start_byte ${USB_DEVICE_FILESYSTEM_PERCENTAGE}% ; then
     Error "Failed to create ReaR data partition $RAW_USB_DEVICE$USB_DATA_PARTITION_NUMBER"
 fi
 # Set the right flag for the data partition unless no flag should be set or when it was already set for the boot partition above:
@@ -180,18 +186,26 @@ if ! is_false $boot_partition_flag ; then
     fi
 fi
 
+# signal the kernel it should re-read the partition table and update the devfs
+# so mkfs writes to the correct byte offsets of the partition
 partprobe $RAW_USB_DEVICE
 # Wait until udev has had the time to kick in
 sleep 5
 
+### make FS and label section
+
 if is_true "$FORMAT_EFI" ; then
+    local rear_efi_partition_number="1"
+    if is_true "$FORMAT_BIOS" && [[ "$USB_DEVICE_PARTED_LABEL" == "gpt" ]] ; then
+        rear_efi_partition_number="2"
+    fi
     # Detect loopback device parition naming
     # on loop devices the first partition is named e.g. loop0p1
     # instead of e.g. sdb1 on usual (USB) disks
     # cf. https://github.com/rear/rear/pull/2555
-    local rear_efi_partition_device="${RAW_USB_DEVICE}1"
-    if [ ! -b "$rear_efi_partition_device" ] && [ -b "${RAW_USB_DEVICE}p1" ] ; then
-        rear_efi_partition_device="${RAW_USB_DEVICE}p1"
+    local rear_efi_partition_device="${RAW_USB_DEVICE}${rear_efi_partition_number}"
+    if [ ! -b "$rear_efi_partition_device" ] && [ -b "${RAW_USB_DEVICE}p${rear_efi_partition_number}" ] ; then
+        rear_efi_partition_device="${RAW_USB_DEVICE}p${rear_efi_partition_number}"
     fi
     LogPrint "Creating vfat filesystem on EFI system partition on $rear_efi_partition_device"
     # Make a FAT filesystem on the EFI system partition
@@ -203,19 +217,15 @@ if is_true "$FORMAT_EFI" ; then
     if ! mkfs.vfat $v -n REAR-EFI $rear_efi_partition_device ; then
         Error "Failed to create vfat filesystem on EFI system partition $rear_efi_partition_device"
     fi
-    # Create link for EFI partition in /dev/disk/by-label
-    partprobe $RAW_USB_DEVICE
-    # Wait until udev has had the time to kick in
-    sleep 5
-else
-    if is_positive_integer $USB_BOOT_PART_SIZE ; then
-        local rear_boot_partition_device="$RAW_USB_DEVICE$(( $USB_DATA_PARTITION_NUMBER -1 ))"
-        # To be on the safe side have the boot partition fallback label "REARBOOT" only 8 characters long:
-        test "$USB_DEVICE_BOOT_LABEL" || USB_DEVICE_BOOT_LABEL="REARBOOT"
-        LogPrint "Creating ext2 filesystem with label '$USB_DEVICE_BOOT_LABEL' on boot partition $rear_boot_partition_device"
-        if ! mkfs.ext2 -L "$USB_DEVICE_BOOT_LABEL" $rear_boot_partition_device ; then
-            Error "Failed to create ext2 filesystem on boot partition $rear_boot_partition_device"
-        fi
+fi
+
+if is_positive_integer $USB_BOOT_PART_SIZE ; then
+    local rear_boot_partition_device="$RAW_USB_DEVICE$(( $USB_DATA_PARTITION_NUMBER -1 ))"
+    # To be on the safe side have the boot partition fallback label "REARBOOT" only 8 characters long:
+    test "$USB_DEVICE_BOOT_LABEL" || USB_DEVICE_BOOT_LABEL="REARBOOT"
+    LogPrint "Creating ext2 filesystem with label '$USB_DEVICE_BOOT_LABEL' on boot partition $rear_boot_partition_device"
+    if ! mkfs.ext2 -L "$USB_DEVICE_BOOT_LABEL" $rear_boot_partition_device ; then
+        Error "Failed to create ext2 filesystem on boot partition $rear_boot_partition_device"
     fi
 fi
 
@@ -234,3 +244,8 @@ LogPrint "Adjusting filesystem parameters on ReaR data partition $data_partition
 if ! tune2fs -c 0 -i 0 -o acl,journal_data,journal_data_ordered $data_partition_device ; then
     Error "Failed to adjust filesystem parameters on ReaR data partition $data_partition_device"
 fi
+
+# signal the kernel to read the partition table again to get /dev/disk/by-label
+partprobe $RAW_USB_DEVICE
+# Wait until udev has had the time to kick in
+sleep 5

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -73,7 +73,7 @@ fi
 # This partition should be the first one afaik this has a better chance to work with odd BIOS firmwares
 if is_true "$FORMAT_BIOS" ; then
     if [[ "$USB_DEVICE_PARTED_LABEL" == "gpt" ]] ; then
-        LogPrint "The --bios toggle was used with format - making an BIOS bootable device $RAW_USB_DEVICE"
+        LogPrint "Making a BIOS bootable device $RAW_USB_DEVICE"
         # Create BIOS boot partition for GRUB2 second stage 'core.img'
         # cf. https://en.wikipedia.org/wiki/BIOS_boot_partition
         # and https://en.wikipedia.org/wiki/GUID_Partition_Table reads (excerpt)
@@ -108,7 +108,7 @@ fi
 
 # In case of EFI boot we need a EFI system partition
 if is_true "$FORMAT_EFI" ; then
-    LogPrint "The --efi toggle was used with format - making an EFI bootable device $RAW_USB_DEVICE"
+    LogPrint "Making an EFI bootable device $RAW_USB_DEVICE"
     # Prompt user for size of EFI system partition on USB disk if no valid value is specified:
     while ! is_positive_integer $USB_UEFI_PART_SIZE ; do
         # When USB_UEFI_PART_SIZE is empty, do not falsely complain about "Invalid EFI partition size":

--- a/usr/share/rear/format/USB/default/350_label_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/350_label_usb_disk.sh
@@ -41,6 +41,11 @@ for dummy in "once" ; do
     esac
 done
 
+# signal kernel to reread partition table to get /dev/disk/by-label
+partprobe $RAW_USB_DEVICE
+# Wait until udev has had the time to kick in
+sleep 5
+
 # Report the final result to the user:
 LogPrint "Data partition $data_partition_device has filesystem label '$USB_LABEL'"
 

--- a/usr/share/rear/lib/format-workflow.sh
+++ b/usr/share/rear/lib/format-workflow.sh
@@ -29,6 +29,10 @@ WORKFLOW_format () {
     eval set -- "$format_workflow_opts"
     while true ; do
         case "$1" in
+            (-b|--bios)
+                # Note: is handled the same as if FORMAT_EFI is not set in most scripts
+                FORMAT_BIOS=y
+                ;;
             (-e|--efi)
                 FORMAT_EFI=y
                 ;;
@@ -37,7 +41,7 @@ WORKFLOW_format () {
                 ;;
             (-h|--help)
                 LogPrintError "Use '$PROGRAM format [ -- OPTIONS ] DEVICE' like '$PROGRAM -v format -- --efi /dev/sdX'"
-                LogPrintError "Valid format workflow options are: -e/--efi -f/--force -y/--yes"
+                LogPrintError "Valid format workflow options are: -b/--bios -e/--efi -f/--force -y/--yes"
                 # No "rear format failed, check ...rear...log for details" message:
                 EXIT_FAIL_MESSAGE=0
                 # TODO: Use proper exit codes cf. https://github.com/rear/rear/issues/1134
@@ -63,6 +67,12 @@ WORKFLOW_format () {
         esac
         shift
     done
+
+    # if none of the format options is used then both should be set as default
+    if [ -z "$FORMAT_EFI" ] && [ -z "$FORMAT_BIOS" ] ; then
+        FORMAT_BIOS=y
+        FORMAT_EFI=y
+    fi
 
     if test -z "$FORMAT_DEVICE" ; then
         if is_true "$SIMULATE" ; then

--- a/usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
+++ b/usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
@@ -111,7 +111,12 @@ for dummy in "once" ; do
             uefi_bootloader_DOS_path=$( uefi_extract_bootloader $SYSFS_DIR_EFI_VARS/Boot${boot_current}-* )
             ;;
         (*)
-            BugError "EFI variables directory $SYSFS_DIR_EFI_VARS is neither /sys/firmware/efi/vars nor /sys/firmware/efi/efivars (ReaR supports only those)"
+            LogPrint "EFI variables directory $SYSFS_DIR_EFI_VARS is neither /sys/firmware/efi/vars nor /sys/firmware/efi/efivars (ReaR supports only those)"
+            LogPrint "This is expected if you try to make a UEFI boot media on a BIOS system"
+            # try some path guessing now
+            UEFI_BOOTLOADER=$( find /usr/lib/grub -iname "grubx64.efi" | tail -1 )
+            # Continue with the code after the outer 'for' loop:
+            test -f "$UEFI_BOOTLOADER" && continue 2
             ;;
     esac
     # Replace backslashes with slashes because uefi_bootloader_DOS_path contains path in DOS format:


### PR DESCRIPTION
* Type: **New Feature** / **Enhancement**
* Impact: **Normal**
* Reference to related issue (URL): #2698
* How was this pull request tested?
created with the following config on a BIOS machine:
```
OUTPUT=USB
BACKUP=BORG
USB_DEVICE=/dev/disk/by-label/REAR-000
USB_DEVICE_FILESYSTEM_LABEL=REAR-000
USB_DEVICE_PARTED_LABEL=gpt
USB_DEVICE_FILESYSTEM=ext4
USB_UEFI_PART_SIZE="512"
CLONE_USERS=(root)
CLONE_GROUPS=(root)
CLONE_ALL_USERS_GROUPS="false"
BORGBACKUP_REPO="/borg"
BORGBACKUP_UMASK="0002"
BORGBACKUP_ENC_TYPE="repokey"
export BORG_RELOCATED_REPO_ACCESS_IS_OK="yes"
export BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK="yes"
export TMPDIR="/wsp_var/tmp/"
USE_RESOLV_CONF="no"
USE_DHCLIENT=no
USE_STATIC_NETWORKING=1
USE_SERIAL_CONSOLE=y
COPY_KERNEL_PARAMETERS=( 'net.ifnames' 'biosdevname', 'console' )
REAR_INITRD_COMPRESSION="fast"
USING_UEFI_BOOTLOADER=1
OUTPUT_URL=usb:///dev/disk/by-label/REARBOOT
USB_BOOTLOADER=grub
GRUB2_DEFAULT_BOOT="1"
USB_BOOT_PART_SIZE="2048"
MODULES=( 'no_modules' )
FIRMWARE_FILES=( 'no' )
EXCLUDE_RUNTIME_LOGFILE="yes"
SERIAL_CONSOLE_DEVICES="/dev/ttyS0"
```
tested boot on PCEngines APU2 (BIOS) and HP gen9 UEFI.

* Brief description of the changes in this pull request:
As discussed in #2698 this is a startingpoint for implementing a hybrid boot supporting BIOS and UEFI from the same media.

* prerequisit:
For this to work you must have the following packages installed: `grub-efi-amd64-bin` and `grub-pc-bin`. They will install the grub binaries needed for efi and bios boot installation. Don't confuse those packages with `grub-efi`, `grub-efi-amd64` and `grub-pc` which configure the systems primary boot option and they conflict the other one for a reason I don't quite get. (this is on ubuntu 20.04)

* format command change
In addition to the --efi format switch I added a --bios switch. If none is given it will do a hybrid installation.

* more details:
This is more like a minimal changeset and prrof of concept but not a full featured or super clean PR.
Since realizing how this is done in `RAWDISK` (basically a complete rewrite bypassing lib code and features) and that `RAWDISK` does use syslinux but not grub (with which I am more familiar) I decided to ignore the `RAWDISK` for the moment.
I mostly rearanged the code in 300_format_usb_disk.sh without changing much beside checking the --efi/--bios switches. There are however two fixes to mention: 1) setting esp with parted for EFI to have the correct partition type set. 2) using partprobe more offten to make sure data gets written to the correct locations. I think this code change is very clean.
The code change in 850_save_sysfs_uefi_vars.sh is a bit more hacky and you may want to do this differently.
I did not change output/USB/Linux-i386/300_create_grub.sh for the moment since it was not strictly needed but it may be better to install the grub efi binary with `grub-install --efi-directory=<path> --target=x86_64-efi --recheck <device>` instead of the way done in 850_save_sysfs_uefi_vars.sh and such.

* future work:
1) while working on this I realized once more that the same basic stuff like partitioning, formatting, writing bootloaders and boot config is written multiple times in the code base and basically every workflow and output method has its own rewrites instead of using some common lib code for those things. I think a major cleanup of those things would make perfect sense. Maybe starting with the partitioning code - moving in a library script and creating functions out of it.
2) Also testing is very time consuming and a bit of a pain due to all those options and combinations. Maybe it would be a good idea to use some build/test server. For example by adding travis jobs or such.
3) Since I only did the work for `output=USB` and `GRUB` it may make sense to add this feature to all variants or deprecate some of those. Also keep in mind that GRUB could mount a ISO image and boot from there (stored on boot partition / where the kernel and initrd is stored).
4) When using Serial tty and non Serial tty machines the grub config is at the moment not flexible enough to provide both options. One with ttyS0 and one entry with just tty. This issue may occur everywhere a tty is used in some sort. So thats also some feature or more flexibiliy to consider adding.

Of course I would like to see a merge and the hacktoberfest-accepted label ;)
I am aware that this PR is not touching all config variants and is maybe not super clean. A complete integration on all configuration variants would however mean a quite big change.

edit: please note that there is no 32bit grub efi I know of but it may exist