### PR TITLE
Overhauled RAID code

### DIFF
--- a/doc/user-guide/06-layout-configuration.adoc
+++ b/doc/user-guide/06-layout-configuration.adoc
@@ -605,7 +605,7 @@ part <disk name> <size(B)> <start(B)> <partition name/type> <flags/"none"> <part
 
 === Software RAID ===
 ----------------------------------
-raid /dev/<name> level=<RAID level> raid-devices=<nr of devices> [uuid=<uuid>] [spare-devices=<nr of spares>] [layout=<RAID layout>] [chunk=<chunk size>] devices=<device1,device2,...>
+raid /dev/<kernel RAID device> level=<RAID level> raid-devices=<nr of active devices> devices=<component device1,component device2,...> [name=<array name>] [metadata=<metadata style>] [uuid=<UUID>] [layout=<data layout>] [chunk=<chunk size>] [spare-devices=<nr of spare devices>] [size=<container size>]
 ----------------------------------
 
 === Multipath ===

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -426,10 +426,19 @@ test "$MIGRATION_MODE" || MIGRATION_MODE=''
 # This is currently new and experimental functionality,
 # see https://github.com/rear/rear/pull/2514
 #
-# An empty DISKS_TO_BE_WIPED='' means that disks will be wiped.
-# The disks that will be completely wiped are those disks
+# An empty DISKS_TO_BE_WIPED='' means that disks will be automatically wiped.
+# The disks that will be automatically wiped are those disks
 # where in diskrestore.sh the create_disk_label function is called
 # i.e. disks where the whole partitioning will be recreated from scratch.
+# The automatism cannot work when the create_disk_label function is called
+# for higher level block devices like RAID devices that do not exist as disks
+# on the bare hardware or on a bare virtual machine.
+# When disk devices are specified like DISKS_TO_BE_WIPED="/dev/sda /dev/sdb"
+# all those that actually exist as block devices in the recovery system will be wiped
+# without any safety conditions and regardless if they are needed to recreate the system
+# so e.g. DISKS_TO_BE_WIPED="/dev/sd[a-z]" will wipe all /dev/sda ... /dev/sdz that exist
+# or when the ReaR recovery system was booted from a USB disk that is /dev/sda on the
+# replacement hardware then DISKS_TO_BE_WIPED="/dev/sda ..." will destroy the ReaR disk.
 # In migration mode there is a user confirmation dialog for the disks that will be wiped.
 # By default no disk is wiped to avoid regressions until this feature was more tested:
 DISKS_TO_BE_WIPED='false'

--- a/usr/share/rear/layout/prepare/GNU/Linux/120_include_raid_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/120_include_raid_code.sh
@@ -1,101 +1,124 @@
+
 # Code to recreate a software RAID configuration.
 
-if ! has_binary mdadm; then
-    return
-fi
+# Nothing to do when there is no mdadm command:
+has_binary mdadm || return 0
 
-# Test for features of mdadm.
-# True if mdadm supports uuid restoration.
-FEATURE_MDADM_UUID=
+# Whether or not mdadm supports UUID restoration via the '--uuid' option:
+# Since SLE10 mdadm supports '--uuid'
+# cf. https://github.com/rear/rear/pull/2714#issuecomment-973938852
+# so by default we assume mdadm supports the '--uuid' option:
+FEATURE_MDADM_UUID="yes"
+local mdadm_version
+mdadm_version=$( get_version mdadm --version )
+test "$mdadm_version" || LogPrintError "Assuming mdadm supports '--uuid' option (could not detect mdadm version)"
+version_newer "$mdadm_version" 2.0 || FEATURE_MDADM_UUID="no"
 
-# Test for the mdadm version, version gets printed on stderr.
-mdadm_version=$(get_version mdadm --version)
+# For example 'mdadm --detail --scan --config=partitions' output looks like
+# ARRAY /dev/md/raid1sdab metadata=1.0 name=any:raid1sdab UUID=8d05eb84:2de831d1:dfed54b2:ad592118
+# for a RAID1 array and for a RAID CONTAINER with IMSM metadata it looks like
+# ARRAY /dev/md/imsm0 metadata=imsm UUID=4d5cf215:80024c95:e19fdff4:2fba35a8
+# ARRAY /dev/md/Volume0_0 container=/dev/md/imsm0 member=0 UUID=ffb80762:127807b3:3d7e4f4d:4532022f
+#
+# For the 'mdadm --detail --scan --config=partitions' examples above 'raid' entries in disklayout.conf look like
+# raid /dev/md127 level=raid1 raid-devices=2 devices=/dev/sda,/dev/sdb name=raid1sdab metadata=1.0 uuid=8d05eb84:2de831d1:dfed54b2:ad592118
+# for a RAID1 array and for a RAID CONTAINER with IMSM metadata it looks like
+# raid /dev/md127 metadata=imsm level=container raid-devices=2 uuid=4d5cf215:80024c95:e19fdff4:2fba35a8 name=imsm0 devices=/dev/sda,/dev/sdb
+# raid /dev/md126 level=raid1 raid-devices=2 uuid=ffb80762:127807b3:3d7e4f4d:4532022f name=Volume0_0 devices=/dev/md127 size=390706176
+# cf. layout/save/GNU/Linux/210_raid_layout.sh
+# and the matching 'part' entries in disklayout.conf look like
+# part /dev/md127 10485760 1048576 rear-noname bios_grub /dev/md127p1
+# part /dev/md127 12739067392 11534336 rear-noname none /dev/md127p2
+# for a RAID1 array and for a RAID CONTAINER with IMSM metadata it looks like
+# part /dev/md126 629145600 1048576 EFI%20System%20Partition boot,esp /dev/md126p1
+# part /dev/md126 1073741824 630194176 md126p2 none /dev/md126p2
+# part /dev/md126 398378139648 1703936000 md126p3 lvm /dev/md126p3
+# cf. https://github.com/rear/rear/pull/2702#issuecomment-968904230
 
-[ "$mdadm_version" ]
-BugIfError "Function get_version could not detect mdadm version."
-
-if version_newer "$mdadm_version" 2.0 ; then
-    FEATURE_MDADM_UUID="y"
-fi
+# List of raid devices for which create_raid was already done
+# i.e. those raid devices for which there is already code in diskrestore.sh
+# but those raid devices are not yet created (they are created after diskrestore.sh was run).
+# This global variable is set and used in each call of create_raid().
+# This global variable is initialized here only once when this script is run:
+CREATE_RAID_DEVICES_CODE=()
 
 create_raid() {
-    local raid device options
-    read raid device options < <(grep "^raid $1 " "$LAYOUT_FILE")
+    local raid raiddevice options
+    read raid raiddevice options < <(grep "^raid $1 " "$LAYOUT_FILE")
 
-    local mdadmcmd="mdadm --create $device --force"
+    local mdadmcmd="mdadm --create $raiddevice --force"
 
-    local devices_total=0
-    local devices_found=0
-    local devices=""
+    local raid_devices=0
+    local component_devices=()
     local option
     for option in $options ; do
         case "$option" in
             (devices=*)
-                local list=${option#devices=}
-                OIFS=$IFS
-                IFS=","
-                local raiddevice
-                for raiddevice in $list ; do
-                    devices="$devices$raiddevice "
-                    let devices_found+=1
-                done
-                IFS=$OIFS
-                ;;
-            (uuid=*)
-                if [ -n "$FEATURE_MDADM_UUID" ] ; then
-                    mdadmcmd="$mdadmcmd --$option"
-                fi
+                # E.g. when option is "devices=/dev/sda,/dev/sdb,/dev/sdc"
+                # then ${option#devices=} is "/dev/sda,/dev/sdb,/dev/sdc"
+                # so that echo ${option#devices=} | tr ',' ' '
+                # results "/dev/sda /dev/sdb /dev/sdc"
+                component_devices=( $( echo ${option#devices=} | tr ',' ' ' ) )
                 ;;
             (raid-devices=*)
-                devices_total=${option#raid-devices=}
-                mdadmcmd="$mdadmcmd --$option"
+                raid_devices=${option#raid-devices=}
+                mdadmcmd+=" --$option"
+                ;;
+            (uuid=*)
+                is_true $FEATURE_MDADM_UUID && mdadmcmd+=" --$option"
                 ;;
             (*)
-                mdadmcmd="$mdadmcmd --$option"
+                mdadmcmd+=" --$option"
                 ;;
         esac
     done
 
     # If some devices are missing, add 'missing' special devices
-    if [ $devices_found -lt $devices_total ] ; then
-        # Print as many 'missing' as there are missing devices
-        let missing=$devices_total-$devices_found
-        LogPrint "Software RAID $device has not enough physical devices, adding $missing 'missing' devices"
-        devices="$devices $(printf "missing%.0s " $(seq $missing))"
+    local component_devices_count=${#component_devices[@]}
+    local missing_devices_count=$(( raid_devices - component_devices_count ))
+    if test $missing_devices_count -gt 0 ; then
+        # Don't consider raid inside a container (it's expected to have 1 device only: the container)
+        if [ $component_devices_count -ne 1 ] || ! IsInArray ${component_devices[0]} "${CREATE_RAID_DEVICES_CODE[@]}" ; then
+            LogPrint "Software RAID $raiddevice has not enough component devices, adding $missing_devices_count 'missing' devices"
+            # Print as many 'missing' as there are missing devices
+            # cf. https://stackoverflow.com/questions/54396599/bash-printf-how-to-understand-zero-dot-s-0-s-syntax
+            # that reads (excerpts)
+            #  "when the width is 0, then the field is not printed at all
+            #   if there are more arguments than fields, printf repeats the format"
+            component_devices+=( $( printf "missing%.0s " $( seq $missing_devices_count ) ) )
+        fi
     fi
 
-    # Try to make mdadm non-interactive...
-    mdadmcmd="echo \"Y\" | $mdadmcmd $devices"
+    CREATE_RAID_DEVICES_CODE+=( $raiddevice )
+
+    # Try to make mdadm non-interactive:
+    mdadmcmd="echo Y | $mdadmcmd ${component_devices[@]}"
 
     cat >> "$LAYOUT_CODE" <<EOF
-
 #
-# Code handling Software Raid '$device'
+# Code handling Software RAID $raiddevice
 #
-
-LogPrint "Creating software RAID $device"
-test -b $device && mdadm --stop $device
-
+LogPrint "Creating software RAID $raiddevice"
+test -b $raiddevice && mdadm --stop $raiddevice
+for component_device in ${component_devices[@]} ; do
+    wipefs -a \$component_device
+done
 $mdadmcmd >&2
 EOF
 
-    ### Create partitions on MD (if any).
-    # 'label' argument is not specified here because we don't know (there may
-    # be none), but it will be computed automatically by create_partitions.
-    create_partitions "$device"
+    # Create partitions on RAID device (if any).
+    # 'label' argument is not specified here because we don't know (there may be none),
+    # but it will be computed automatically by create_partitions.
+    create_partitions "$raiddevice"
 
     cat >> "$LAYOUT_CODE" <<EOF
-
 # Make sure device nodes are visible (eg. in RHEL4)
 my_udevtrigger
 my_udevsettle
-
 # Clean up transient partitions and resize shrinked ones
 delete_dummy_partitions_and_resize_real_ones
-
 #
-# End of code handling Software Raid '$device'
+# End of code handling Software RAID $raiddevice
 #
-
 EOF
 }

--- a/usr/share/rear/layout/prepare/GNU/Linux/120_include_raid_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/120_include_raid_code.sh
@@ -4,19 +4,6 @@
 # Nothing to do when there is no mdadm command:
 has_binary mdadm || return 0
 
-# Whether or not mdadm supports UUID restoration via the '--uuid' option:
-# Since SLE10 mdadm supports '--uuid'
-# cf. https://github.com/rear/rear/pull/2714#issuecomment-973938852
-# so by default we assume mdadm supports the '--uuid' option:
-FEATURE_MDADM_UUID="yes"
-local mdadm_version
-mdadm_version=$( get_version mdadm --version )
-if test "$mdadm_version" ; then
-    version_newer "$mdadm_version" 2.0 || FEATURE_MDADM_UUID="no"
-else
-    LogPrintError "Assuming mdadm supports '--uuid' option (could not detect mdadm version)"
-fi
-
 # For example 'mdadm --detail --scan --config=partitions' output looks like
 # ARRAY /dev/md/raid1sdab metadata=1.0 name=any:raid1sdab UUID=8d05eb84:2de831d1:dfed54b2:ad592118
 # for a RAID1 array and for a RAID CONTAINER with IMSM metadata it looks like
@@ -66,9 +53,6 @@ create_raid() {
             (raid-devices=*)
                 raid_devices=${option#raid-devices=}
                 mdadmcmd+=" --$option"
-                ;;
-            (uuid=*)
-                is_true $FEATURE_MDADM_UUID && mdadmcmd+=" --$option"
                 ;;
             (*)
                 mdadmcmd+=" --$option"

--- a/usr/share/rear/layout/prepare/GNU/Linux/120_include_raid_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/120_include_raid_code.sh
@@ -11,8 +11,11 @@ has_binary mdadm || return 0
 FEATURE_MDADM_UUID="yes"
 local mdadm_version
 mdadm_version=$( get_version mdadm --version )
-test "$mdadm_version" || LogPrintError "Assuming mdadm supports '--uuid' option (could not detect mdadm version)"
-version_newer "$mdadm_version" 2.0 || FEATURE_MDADM_UUID="no"
+if test "$mdadm_version" ; then
+    version_newer "$mdadm_version" 2.0 || FEATURE_MDADM_UUID="no"
+else
+    LogPrintError "Assuming mdadm supports '--uuid' option (could not detect mdadm version)"
+fi
 
 # For example 'mdadm --detail --scan --config=partitions' output looks like
 # ARRAY /dev/md/raid1sdab metadata=1.0 name=any:raid1sdab UUID=8d05eb84:2de831d1:dfed54b2:ad592118

--- a/usr/share/rear/layout/recreate/default/150_wipe_disks.sh
+++ b/usr/share/rear/layout/recreate/default/150_wipe_disks.sh
@@ -9,6 +9,7 @@ is_false "$DISKS_TO_BE_WIPED" && return 0
 #   create_disk_label /dev/sda gpt
 #   create_disk_label /dev/sdb msdos
 # so in this example DISKS_TO_BE_WIPED="/dev/sda /dev/sdb "
+# or if the user has specified DISKS_TO_BE_WIPED use only the existing block devices therein
 # cf. layout/recreate/default/120_confirm_wipedisk_disks.sh
 
 # Log the currently existing block devices structure on the unchanged replacement hardware

--- a/usr/share/rear/layout/recreate/default/220_verify_layout.sh
+++ b/usr/share/rear/layout/recreate/default/220_verify_layout.sh
@@ -1,0 +1,58 @@
+#
+# Verify some known things in the recreated disk layout that could go wrong
+# cf. https://github.com/rear/rear/pull/2702#issuecomment-971331028
+#
+
+# Verify RAID devices are actually recreated with the UUIDs in disklayout.conf
+# because mdadm silently ignores this option when creating IMSM arrays
+# (both containers and the volumes inside them) and picks a random UUID
+# cf. https://github.com/rear/rear/pull/2702#issuecomment-970395567
+
+# Get recreated RAID devices.
+# lsblk lists RAID devices with '*_raid_member' FSTYPE values
+# e.g. 'linux_raid_member' or 'isw_raid_member' - for the latter
+# see https://github.com/rear/rear/pull/2702#issuecomment-968904230
+local name kname fstype uuid
+local uuid_alnum_lowercase
+lsblk -nrpo NAME,KNAME,FSTYPE,UUID | grep '_raid_member' | while read name kname fstype uuid ; do
+    # Check recreated RAID device UUID:
+    if test $uuid ; then
+        # When there is a recreated RAID device with UUID
+        # we grep for 'raid' entries in disklayout.conf that contain this UUID and
+        # if found things are considered to be OK because UUIDs must be unique
+        # so it cannot happen that a different device also has this UUID
+        # i.e. we omit to check if the found UUID matches this RAID device
+        # 'raid' entries in disklayout.conf contain RAID UUIDs like (excerpts)
+        # raid /dev/md127 uuid=8d05eb84:2de831d1:dfed54b2:ad592118 devices=/dev/sda,/dev/sdb
+        # but lsblk shows that UUID as 8d05eb84-2de8-31d1-dfed-54b2ad592118
+        # so we make uuid_alnum_lowercase=8d05eb842de831d1dfed54b2ad592118
+        # and make the 'raid' entries alphanumeric lowercase characters plus spaces and '=' characters
+        # raid devmd127 uuid=8d05eb842de831d1dfed54b2ad592118 devices=devsdadevsdb
+        # where we can grep for "uuid=$uuid_alnum_lowercase":
+        uuid_alnum_lowercase="$( echo "$uuid" | tr -d -c '[:alnum:]' | tr '[:upper:]' '[:lower:]' )"
+        if ! grep "^raid " $LAYOUT_FILE | tr -d -c '[:alnum:] =' | tr '[:upper:]' '[:lower:]' | grep "uuid=$uuid_alnum_lowercase" ; then
+            LogPrintError "RAID device $name ($kname) recreated with UUID $uuid that is not in $LAYOUT_FILE"
+        fi
+    else    
+        # When there is a recreated RAID device without UUID
+        # we grep for 'raid' entries in disklayout.conf that contain its NAME or KNAME
+        # and check if such 'raid' entries have a 'uuid=...' option set and
+        # if yes we assume the recreated RAID device was falsely recreated without UUID:
+        # 'raid' entries can contain RAID devices like
+        # raid /dev/md127 ... devices=/dev/sda,/dev/sdb ...  uuid=...
+        # raid /dev/md127 ...  uuid=... devices=/dev/sda,/dev/sdb
+        # so we use end of word delimiter '\>' that matches space comma and end of line.
+        # The first grep may find more than one line and the second grep may find more that one UUID.
+        # Check RAID devices named NAME:
+        if grep "^raid .*$name\>" $LAYOUT_FILE | grep 'uuid=' ; then
+            LogPrintError "RAID device $name ($kname) recreated without UUID but there is a UUID for $name in $LAYOUT_FILE"
+        fi
+        # Check RAID devices named KNAME if different than NAME:
+        if test "$kname" != "$name" ; then
+            if grep "^raid .*$kname\>" $LAYOUT_FILE | grep 'uuid=' ; then
+                LogPrintError "RAID device $kname ($name) recreated without UUID but there is a UUID for $kname in $LAYOUT_FILE"
+            fi
+        fi
+    fi
+    # Additional checks could be added here if needed:
+done

--- a/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
@@ -217,6 +217,8 @@ mdadm --detail --scan --config=partitions | while read array raiddevice junk ; d
 
     test $container_size -gt 0 && raid_layout_entry+=" size=$container_size"
 
+    echo "# RAID device $raiddevice" >>$DISKLAYOUT_FILE
+    echo "# Format: raid /dev/<kernel RAID device> level=<RAID level> raid-devices=<nr of active devices> devices=<component device1,component device2,...> [name=<array name>] [metadata=<metadata style>] [uuid=<UUID>] [layout=<data layout>] [chunk=<chunk size>] [spare-devices=<nr of spare devices>] [size=<container size>]" >>$DISKLAYOUT_FILE
     echo "$raid_layout_entry" >>$DISKLAYOUT_FILE
 
     # extract_partitions is run as a separated process (in a subshell)
@@ -224,6 +226,8 @@ mdadm --detail --scan --config=partitions | while read array raiddevice junk ; d
     # so things only work here if extract_partitions does not set variables
     # that are meant to be used outside of this pipe, check extract_partitions()
     # in layout/save/GNU/Linux/200_partition_layout.sh
+    echo "# Partitions on $raiddevice" >>$DISKLAYOUT_FILE
+    echo "# Format: part <device> <partition size(bytes)> <partition start(bytes)> <partition type|name> <flags> /dev/<partition>" >>$DISKLAYOUT_FILE
     extract_partitions "$raiddevice" >>$DISKLAYOUT_FILE
 
 done

--- a/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
@@ -1,3 +1,4 @@
+
 # Save the Software RAID layout
 
 # Nothing to do when there is no /proc/mdstat
@@ -8,225 +9,211 @@ grep -q blocks /proc/mdstat || return 0
 
 Log "Saving Software RAID configuration"
 
-# Subshell that appends to disklayout.conf
-(
-    # Have 'mdadm --detail --scan --config=partitions' output as comment in disklayout.conf:
-    ( echo "Software RAID devices (mdadm --detail --scan --config=partitions)" ; mdadm --detail --scan --config=partitions ) | grep -v '^$' | sed -e 's/^/# /'
+# Have 'mdadm --detail --scan --config=partitions' output as comment in disklayout.conf:
+( echo "Software RAID devices (mdadm --detail --scan --config=partitions)" ; mdadm --detail --scan --config=partitions ) | grep -v '^$' | sed -e 's/^/# /' >>$DISKLAYOUT_FILE
 
-    local array raiddevice junk
-    local basename
-    local line
-    locat metadata level raid_devices uuid name spare_devices layout chunksize component_devices size
-    local container array_size
-    local param copies number
-    local component_device
+local array raiddevice junk
+local basename
+local line
+local metadata level raid_devices uuid name spare_devices layout chunksize component_devices container_size
+local container array_size
+local param copies number
+local component_device
+local raid_layout_entry
 
-    # Read 'mdadm --detail --scan --config=partitions' output which looks like
-    # ARRAY /dev/md/raid1sdab metadata=1.0 name=any:raid1sdab UUID=8d05eb84:2de831d1:dfed54b2:ad592118
+# Read 'mdadm --detail --scan --config=partitions' output which looks like
+# ARRAY /dev/md/raid1sdab metadata=1.0 name=any:raid1sdab UUID=8d05eb84:2de831d1:dfed54b2:ad592118
+# for a RAID1 array and for a RAID CONTAINER with IMSM metadata it looks like
+# ARRAY /dev/md/imsm0 metadata=imsm UUID=4d5cf215:80024c95:e19fdff4:2fba35a8
+# ARRAY /dev/md/Volume0_0 container=/dev/md/imsm0 member=0 UUID=ffb80762:127807b3:3d7e4f4d:4532022f
+# cf. https://github.com/rear/rear/pull/2702#issuecomment-968904230
+while read array raiddevice junk ; do
+
+    # Skip if it is not an "ARRAY":
+    test "$array" = "ARRAY" || continue
+
+    # 'raid' entries in disklayout.conf look like (cf. the 'mdadm --detail --scan --config=partitions' examples above)
+    # raid /dev/md127 metadata=1.0 level=raid1 raid-devices=2 uuid=8d05eb84:2de831d1:dfed54b2:ad592118 name=raid1sdab devices=/dev/sda,/dev/sdb
     # for a RAID1 array and for a RAID CONTAINER with IMSM metadata it looks like
-    # ARRAY /dev/md/imsm0 metadata=imsm UUID=4d5cf215:80024c95:e19fdff4:2fba35a8
-    # ARRAY /dev/md/Volume0_0 container=/dev/md/imsm0 member=0 UUID=ffb80762:127807b3:3d7e4f4d:4532022f
+    # raid /dev/md127 metadata=imsm level=container raid-devices=2 uuid=4d5cf215:80024c95:e19fdff4:2fba35a8 name=imsm0 devices=/dev/sda,/dev/sdb
+    # raid /dev/md126 level=raid1 raid-devices=2 uuid=ffb80762:127807b3:3d7e4f4d:4532022f name=Volume0_0 devices=/dev/md127 size=390706176
     # cf. https://github.com/rear/rear/pull/2702#issuecomment-968904230
-    while read array raiddevice junk ; do
+    raid_layout_entry="raid"
 
-        # Skip if it is not an "ARRAY":
-        test "$array" = "ARRAY" || continue
+    # Do not use an array name from a previous run of the while loop:
+    name=""
+    basename=${raiddevice##*/}
+    # When raiddevice is a symlink like /dev/md/raid1sdab -> /dev/md127
+    # Use the kernel device node and set the array name to the symlink's basename:
+    if test -h $raiddevice ; then
+        raiddevice=$( readlink -e $raiddevice )
+        name=$basename
+    fi
+    test -b "$raiddevice" && raid_layout_entry+=" $raiddevice" || Error "RAID device '$raiddevice' is no block device"
 
-        # Do not use an array name from a previous run of the while loop:
-        name=""
-        basename=${raiddevice##*/}
-        # When raiddevice is a symlink like /dev/md/raid1sdab -> /dev/md127
-        # Use the kernel device node and set the array name to the symlink's basename:
-        if test -h $raiddevice ; then
-            raiddevice=$( readlink -e $raiddevice )
-            name=$basename
+    # We use the detailed mdadm output quite a lot so run the mdadm command only once:
+    mdadm_details="$TMP_DIR/mdraid.$basename"
+    mdadm --misc --detail $raiddevice | grep -v '^$' > $mdadm_details
+
+    # Have 'mdadm --misc --detail $raiddevice' output as comment in disklayout.conf:
+    ( echo "Software RAID $name device $raiddevice (mdadm --misc --detail $raiddevice)" ; cat $mdadm_details ) | sed -e 's/^/# /' >>$DISKLAYOUT_FILE
+
+    # Example 'mdadm --misc --detail $raiddevice' output for a RAID1 array:
+    #
+    # /dev/md/raid1sdab:
+    #            Version : 1.0
+    #      Creation Time : Wed Oct 13 13:17:13 2021
+    #         Raid Level : raid1
+    #         Array Size : 12582784 (12.00 GiB 12.88 GB)
+    #      Used Dev Size : 12582784 (12.00 GiB 12.88 GB)
+    #       Raid Devices : 2
+    #      Total Devices : 2
+    #        Persistence : Superblock is persistent
+    #      Intent Bitmap : Internal
+    #        Update Time : Tue Nov 16 11:06:16 2021
+    #              State : clean 
+    #     Active Devices : 2
+    #    Working Devices : 2
+    #     Failed Devices : 0
+    #      Spare Devices : 0
+    # Consistency Policy : bitmap
+    #               Name : any:raid1sdab
+    #               UUID : 8d05eb84:2de831d1:dfed54b2:ad592118
+    #             Events : 216
+    #     Number   Major   Minor   RaidDevice State
+    #        0       8        0        0      active sync   /dev/sda
+    #        1       8       16        1      active sync   /dev/sdb
+    #
+    # Example 'mdadm --misc --detail $raiddevice' output for a RAID CONTAINER with IMSM metadata
+    # cf. https://github.com/rear/rear/pull/2702#issuecomment-968904230
+    # /dev/md127:
+    #            Version : imsm
+    #         Raid Level : container
+    #      Total Devices : 2
+    #    Working Devices : 2
+    #               UUID : 4d5cf215:80024c95:e19fdff4:2fba35a8
+    #      Member Arrays : /dev/md/Volume0_0
+    #     Number   Major   Minor   RaidDevice
+    #        -       8        0        -        /dev/sda
+    #        -       8       16        -        /dev/sdb
+    #
+    # /dev/md126:
+    #          Container : /dev/md/imsm0, member 0
+    #         Raid Level : raid1
+    #         Array Size : 390706176 (372.61 GiB 400.08 GB)
+    #      Used Dev Size : 390706176 (372.61 GiB 400.08 GB)
+    #       Raid Devices : 2
+    #      Total Devices : 2
+    #              State : active
+    #     Active Devices : 2
+    #    Working Devices : 2
+    #     Failed Devices : 0
+    # Consistency Policy : resync
+    #               UUID : ffb80762:127807b3:3d7e4f4d:4532022f
+    #     Number   Major   Minor   RaidDevice State
+    #        1       8       16        0      active sync   /dev/sdb
+    #        0       8        0        1      active sync   /dev/sda
+
+    # doc/user-guide/06-layout-configuration.adoc reads
+    #   Disk layout file syntax
+    #   Software RAID
+    #   raid /dev/<name> level=<RAID level> raid-devices=<nr of devices> [uuid=<uuid>] [spare-devices=<nr of spares>] [layout=<RAID layout>] [chunk=<chunk size>] devices=<device1,device2,...>
+    # so the mdadm options --level --raid-devices and the component-devices are mandatory:
+
+    line=( $( grep "Raid Level :" $mdadm_details ) )
+    level=${line[3]}
+    # A RAID level that is more than one word would make 'read' fail for this 'raid' entry in disklayout.conf
+    test $level || Error "RAID $raiddevice level '$level' is not a single word"
+    raid_layout_entry+=" level=$level"
+
+    line=( $( grep "Raid Devices :" $mdadm_details ) )
+    raid_devices=${line[3]}
+    line=( $( grep "Total Devices :" $mdadm_details ) )
+    total_devices=${line[3]}
+    if test $raid_devices && test $raid_devices -gt 0 ; then
+        raid_layout_entry+=" raid-devices=$raid_devices"
+    elif test $total_devices && test $total_devices -gt 0 ; then
+        raid_layout_entry+=" raid-devices=$total_devices"
+    else
+        Error "Neither number of active devices nor number of total devices is greater than 0 for RAID $raiddevice"
+    fi
+
+    container=$( grep "Container" $mdadm_details | tr -d " " | cut -d ":" -f "2" | cut -d "," -f "1")
+    line=( $( grep "Used Dev Size :" $mdadm_details ) )
+    used_dev_size=${line[4]}
+    line=( $( grep "Array Size :" $mdadm_details ) )
+    array_size=${line[3]}
+    if test "$container" ; then
+        component_devices=" devices=$( readlink -e $container )"
+        if test "$used_dev_size" ; then
+            container_size=$used_dev_size
+        elif test "$array_size" ; then
+            container_size=$(( array_size / raid_devices ))
         fi
-
-        # We use the detailed mdadm output quite a lot so run the mdadm command only once:
-        mdadm_details="$TMP_DIR/mdraid.$basename"
-        mdadm --misc --detail $raiddevice | grep -v '^$' > $mdadm_details
-
-        # Have 'mdadm --misc --detail $raiddevice' output as comment in disklayout.conf:
-        ( echo "Software RAID $name device $raiddevice (mdadm --misc --detail $raiddevice)" ; cat $mdadm_details ) | sed -e 's/^/# /'
-
-        # Extract values:
-        # Example 'mdadm --misc --detail $raiddevice' output for a RAID1 array:
-        #
-        # /dev/md/raid1sdab:
-        #            Version : 1.0
-        #      Creation Time : Wed Oct 13 13:17:13 2021
-        #         Raid Level : raid1
-        #         Array Size : 12582784 (12.00 GiB 12.88 GB)
-        #      Used Dev Size : 12582784 (12.00 GiB 12.88 GB)
-        #       Raid Devices : 2
-        #      Total Devices : 2
-        #        Persistence : Superblock is persistent
-        #      Intent Bitmap : Internal
-        #        Update Time : Tue Nov 16 11:06:16 2021
-        #              State : clean 
-        #     Active Devices : 2
-        #    Working Devices : 2
-        #     Failed Devices : 0
-        #      Spare Devices : 0
-        # Consistency Policy : bitmap
-        #               Name : any:raid1sdab
-        #               UUID : 8d05eb84:2de831d1:dfed54b2:ad592118
-        #             Events : 216
-        #     Number   Major   Minor   RaidDevice State
-        #        0       8        0        0      active sync   /dev/sda
-        #        1       8       16        1      active sync   /dev/sdb
-        #
-        # Example 'mdadm --misc --detail $raiddevice' output for a RAID CONTAINER with IMSM metadata
-        # cf. https://github.com/rear/rear/pull/2702#issuecomment-968904230
-        # /dev/md127:
-        #            Version : imsm
-        #         Raid Level : container
-        #      Total Devices : 2
-        #    Working Devices : 2
-        #               UUID : 4d5cf215:80024c95:e19fdff4:2fba35a8
-        #      Member Arrays : /dev/md/Volume0_0
-        #     Number   Major   Minor   RaidDevice
-        #        -       8        0        -        /dev/sda
-        #        -       8       16        -        /dev/sdb
-        #
-        # /dev/md126:
-        #          Container : /dev/md/imsm0, member 0
-        #         Raid Level : raid1
-        #         Array Size : 390706176 (372.61 GiB 400.08 GB)
-        #      Used Dev Size : 390706176 (372.61 GiB 400.08 GB)
-        #       Raid Devices : 2
-        #      Total Devices : 2
-        #              State : active
-        #     Active Devices : 2
-        #    Working Devices : 2
-        #     Failed Devices : 0
-        # Consistency Policy : resync
-        #               UUID : ffb80762:127807b3:3d7e4f4d:4532022f
-        #     Number   Major   Minor   RaidDevice State
-        #        1       8       16        0      active sync   /dev/sdb
-        #        0       8        0        1      active sync   /dev/sda
-        line=( $( grep "Version :" $mdadm_details ) )
-        metadata=${line[2]}
-        line=( $( grep "Raid Level :" $mdadm_details ) )
-        level=${line[3]}
-        line=( $( grep "UUID :" $mdadm_details ) )
-        uuid=${line[2]}
-        line=( $( grep "Layout :" $mdadm_details ) )
-        layout=${line[2]}
-        # fix up layout for RAID10:
-        # > near=2,far=1 -> n2
-        if [ "$level" = "raid10" ] ; then
-            OIFS=$IFS
-            IFS=","
-            for param in "$layout" ; do
-                copies=${layout%=*}
-                number=${layout#*=}
-                if [ "$number" -gt 1 ] ; then
-                    layout="${copies:0:1}$number"
-                fi
-            done
-            IFS=$OIFS
-        fi
-        chunksize=$( grep "Chunk Size" $mdadm_details | tr -d " " | cut -d ":" -f "2" | sed -r 's/^([0-9]+).+/\1/')
-        container=$( grep "Container" $mdadm_details | tr -d " " | cut -d ":" -f "2" | cut -d "," -f "1")
-        line=( $( grep "Array Size :" $mdadm_details ) )
-        array_size=${line[3]}
-        line=( $( grep "Used Dev Size :" $mdadm_details ) )
-        used_dev_size=${line[4]}
-        line=( $( grep "Total Devices :" $mdadm_details ) )
-        total_devices=${line[3]}
-        line=( $( grep "Raid Devices :" $mdadm_details ) )
-        raid_devices=${line[3]}
-        if [[ "$raid_devices" ]] ; then
-            let spare_devices=$total_devices-$raid_devices
-        else
-            let spare_devices=0
-        fi
-
+    else
+        # Find all component devices
+        # use the output of mdadm, but skip the array itself that is e.g. /dev/md127 or /dev/md/raid1sdab
+        # sysfs has the information in RHEL 5+, but RHEL 4 lacks it.
         component_devices=""
-        let size=0
-        if [[ "$container" ]] ; then
-            component_devices=" devices=$( readlink -e $container )"
-            if [[ "$used_dev_size" ]] ; then
-                let size=$used_dev_size
-            elif [[ "$array_size" ]] ; then
-                let size=$array_size/$raid_devices
-            fi
-        else
-            # Find all component devices
-            # use the output of mdadm, but skip the array itself that is e.g. /dev/md127 or /dev/md/raid1sdab
-            # sysfs has the information in RHEL 5+, but RHEL 4 lacks it.
-            for component_device in $(  grep -o '/dev/.*' $mdadm_details | grep -v '/dev/md' | tr "\n" " " ) ; do
-                component_device=$( get_device_name $component_device )
-                if [ -z "$component_devices" ] ; then
-                    component_devices=" devices=$component_device"
-                else
-                    component_devices+=",$component_device"
-                fi
-            done
-        fi
+        for component_device in $(  grep -o '/dev/.*' $mdadm_details | grep -v '/dev/md' | tr "\n" " " ) ; do
+            component_device=$( get_device_name $component_device )
+            test -b "$component_device" || Error "RAID $raiddevice component device '$component_device' is no block device"
+            # A component device that is more than one word would make 'read' fail for this 'raid' entry in disklayout.conf
+            test $component_device || Error "RAID $raiddevice component device '$component_device' is not a single word"
+            # Have the component devices string as "first_component_device,second_component_device,..."
+            test $component_devices && component_devices+=",$component_device" || component_devices="$component_device"
+        done
+    fi
+    test $component_devices && raid_layout_entry+=" devices=$component_devices" || Error "No component devices for RAID $raiddevice"
 
-        if [ "$size" -gt 0 ] ; then
-            size=" size=$size"
-        else
-            size=""
-        fi
+    # Optional mdadm option settings:
+    test $name && raid_layout_entry+=" name=$name"
 
-        if [[ "$metadata" ]] ; then
-            metadata=" metadata=$metadata"
-        else
-            metadata=""
-        fi
+    line=( $( grep "Version :" $mdadm_details ) )
+    metadata=${line[2]}
+    test $metadata && raid_layout_entry+=" metadata=$metadata"
 
-        level=" level=$level"
-        if [[ "$raid_devices" ]] && [ $raid_devices -gt 0 ] ; then
-            raid_devices=" raid-devices=$raid_devices"
-        elif [[ "$total_devices" ]] ; then
-            raid_devices=" raid-devices=$total_devices"
-        else
-            raid_devices=""
-        fi
+    line=( $( grep "UUID :" $mdadm_details ) )
+    uuid=${line[2]}
+    test $uuid && raid_layout_entry+=" uuid=$uuid"
 
-        uuid=" uuid=$uuid"
+    line=( $( grep "Layout :" $mdadm_details ) )
+    layout=${line[2]}
+    # fix up layout for RAID10:
+    # > near=2,far=1 -> n2
+    if test "$level" = "raid10" ; then
+        OIFS=$IFS
+        IFS=","
+        for param in "$layout" ; do
+            copies=${layout%=*}
+            number=${layout#*=}
+            test "$number" -gt 1 && layout="${copies:0:1}$number"
+        done
+        IFS=$OIFS
+    fi
+    # mdadm can print '-unknown-' for a RAID layout
+    # which got recently (2019-12-02) added to RAID0 (it existed before for RAID5 and RAID6 and RAID10) see
+    # https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/commit/Detail.c?id=329dfc28debb58ffe7bd1967cea00fc583139aca
+    # so we treat '-unknown-' same as an empty value to avoid that layout/prepare/GNU/Linux/120_include_raid_code.sh
+    # will create a 'mdadm' command in diskrestore.sh like "mdadm ... --layout=-unknown- ..." which would fail
+    # during "rear recover" with something like "mdadm: layout -unknown- not understood for raid0"
+    # see https://github.com/rear/rear/issues/2616
+    test $layout -a '-unknown-' != "$layout" && raid_layout_entry+=" layout=$layout"
 
-        if [ "$spare_devices" -gt 0 ] ; then
-            spare_devices=" spare-devices=$spare_devices"
-        else
-            spare_devices=""
-        fi
+    chunksize=$( grep "Chunk Size" $mdadm_details | tr -d " " | cut -d ":" -f "2" | sed -r 's/^([0-9]+).+/\1/')
+    test $chunksize && raid_layout_entry+=" chunk=$chunksize"
 
-        # mdadm can print '-unknown-' for a RAID layout
-        # which got recently (2019-12-02) added to RAID0 (it existed before for RAID5 and RAID6 and RAID10) see
-        # https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/commit/Detail.c?id=329dfc28debb58ffe7bd1967cea00fc583139aca
-        # so we treat '-unknown-' same as an empty value to avoid that layout/prepare/GNU/Linux/120_include_raid_code.sh
-        # will create a 'mdadm' command in diskrestore.sh like "mdadm ... --layout=-unknown- ..." which would fail
-        # during "rear recover" with something like "mdadm: layout -unknown- not understood for raid0"
-        # see https://github.com/rear/rear/issues/2616
-        if test "$layout" -a '-unknown-' != "$layout" ; then
-            layout=" layout=$layout"
-        else
-            layout=""
-        fi
+    spare_devices=""
+    test $raid_devices && spare_devices=$(( total_devices - raid_devices ))
+    test $spare_devices -gt 0 && raid_layout_entry+=" spare-devices=$spare_devices"
 
-        if [ -n "$chunksize" ] ; then
-            chunksize=" chunk=$chunksize"
-        else
-            chunksize=""
-        fi
+    test $container_size -gt 0 && raid_layout_entry+=" size=$container_size"
 
-        if [[ "$name" ]] ; then
-            name=" name=$name"
-        else
-            name=""
-        fi
+    echo "$raid_layout_entry" >>$DISKLAYOUT_FILE
 
-        echo "raid ${raiddevice}${metadata}${level}${raid_devices}${uuid}${name}${spare_devices}${layout}${chunksize}${component_devices}${size}"
+    extract_partitions "$raiddevice" >>$DISKLAYOUT_FILE
 
-        extract_partitions "$raiddevice"
-
-    done < <( mdadm --detail --scan --config=partitions )
-
-) >> $DISKLAYOUT_FILE
+done < <( mdadm --detail --scan --config=partitions )
 
 # mdadm is required in the recovery system if disklayout.conf contains at least one 'raid' entry
 # see the create_raid function in layout/prepare/GNU/Linux/120_include_raid_code.sh

--- a/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
@@ -1,109 +1,236 @@
 # Save the Software RAID layout
 
-if [ -e /proc/mdstat ] &&  grep -q blocks /proc/mdstat ; then
-    Log "Saving Software RAID configuration."
-    (
-        while read array device junk ; do
-            if [ "$array" != "ARRAY" ] ; then
-                continue
-            fi
+# Nothing to do when there is no /proc/mdstat
+test -e /proc/mdstat || return 0
 
-            ### Get the actual device node
-            if [[ -h $device ]] ; then
-                name=${device##*/}
-                device=$(readlink -f $device)
-            fi
+# Nothing to do when /proc/mdstat does not contain "blocks"
+grep -q blocks /proc/mdstat || return 0
 
-            # We use the detailed mdadm output quite a lot
-            mdadm --misc --detail $device > $TMP_DIR/mdraid
+Log "Saving Software RAID configuration"
 
-            # Gather information
-            metadata=$( grep "Version" $TMP_DIR/mdraid | tr -d " " | cut -d ":" -f "2")
-            level=$( grep "Raid Level" $TMP_DIR/mdraid | tr -d " " | cut -d ":" -f "2")
-            uuid=$( grep "UUID" $TMP_DIR/mdraid | tr -d " " | cut -d "(" -f "1" | cut -d ":" -f "2-")
-            layout=$( grep "Layout" $TMP_DIR/mdraid | tr -d " " | cut -d ":" -f "2")
-            chunksize=$( grep "Chunk Size" $TMP_DIR/mdraid | tr -d " " | cut -d ":" -f "2" | sed -r 's/^([0-9]+).+/\1/')
+# Subshell that appends to disklayout.conf
+(
+    # Have 'mdadm --detail --scan --config=partitions' output as comment in disklayout.conf:
+    ( echo "Software RAID devices (mdadm --detail --scan --config=partitions)" ; mdadm --detail --scan --config=partitions ) | grep -v '^$' | sed -e 's/^/# /'
 
-            # fix up layout for RAID10:
-            # > near=2,far=1 -> n2
-            if [ "$level" = "raid10" ] ; then
-                OIFS=$IFS
-                IFS=","
-                for param in "$layout" ; do
-                    copies=${layout%=*}
-                    number=${layout#*=}
-                    if [ "$number" -gt 1 ] ; then
-                        layout="${copies:0:1}$number"
-                    fi
-                done
-                IFS=$OIFS
-            fi
+    local array raiddevice junk
+    local basename
+    local line
+    locat metadata level raid_devices uuid name spare_devices layout chunksize component_devices size
+    local container array_size
+    local param copies number
+    local component_device
 
-            ndevices=$( grep "Raid Devices" $TMP_DIR/mdraid | tr -d " " | cut -d ":" -f "2")
-            totaldevices=$( grep "Total Devices" $TMP_DIR/mdraid | tr -d " " | cut -d ":" -f "2")
-            let sparedevices=$totaldevices-$ndevices
+    # Read 'mdadm --detail --scan --config=partitions' output which looks like
+    # ARRAY /dev/md/raid1sdab metadata=1.0 name=any:raid1sdab UUID=8d05eb84:2de831d1:dfed54b2:ad592118
+    # for a RAID1 array and for a RAID CONTAINER with IMSM metadata it looks like
+    # ARRAY /dev/md/imsm0 metadata=imsm UUID=4d5cf215:80024c95:e19fdff4:2fba35a8
+    # ARRAY /dev/md/Volume0_0 container=/dev/md/imsm0 member=0 UUID=ffb80762:127807b3:3d7e4f4d:4532022f
+    # cf. https://github.com/rear/rear/pull/2702#issuecomment-968904230
+    while read array raiddevice junk ; do
 
-            # Find all devices
-            # use the output of mdadm, but skip the array itself
-            # sysfs has the information in RHEL 5+, but RHEL 4 lacks it.
-            devices=""
-            for disk in $( grep -o -E "/dev/[^m].*$" $TMP_DIR/mdraid | tr "\n" " ") ; do
-                disk=$( get_device_name $disk )
-                if [ -z "$devices" ] ; then
-                    devices=" devices=$disk"
-                else
-                    devices="$devices,$disk"
+        # Skip if it is not an "ARRAY":
+        test "$array" = "ARRAY" || continue
+
+        # Do not use an array name from a previous run of the while loop:
+        name=""
+        basename=${raiddevice##*/}
+        # When raiddevice is a symlink like /dev/md/raid1sdab -> /dev/md127
+        # Use the kernel device node and set the array name to the symlink's basename:
+        if test -h $raiddevice ; then
+            raiddevice=$( readlink -e $raiddevice )
+            name=$basename
+        fi
+
+        # We use the detailed mdadm output quite a lot so run the mdadm command only once:
+        mdadm_details="$TMP_DIR/mdraid.$basename"
+        mdadm --misc --detail $raiddevice | grep -v '^$' > $mdadm_details
+
+        # Have 'mdadm --misc --detail $raiddevice' output as comment in disklayout.conf:
+        ( echo "Software RAID $name device $raiddevice (mdadm --misc --detail $raiddevice)" ; cat $mdadm_details ) | sed -e 's/^/# /'
+
+        # Extract values:
+        # Example 'mdadm --misc --detail $raiddevice' output for a RAID1 array:
+        #
+        # /dev/md/raid1sdab:
+        #            Version : 1.0
+        #      Creation Time : Wed Oct 13 13:17:13 2021
+        #         Raid Level : raid1
+        #         Array Size : 12582784 (12.00 GiB 12.88 GB)
+        #      Used Dev Size : 12582784 (12.00 GiB 12.88 GB)
+        #       Raid Devices : 2
+        #      Total Devices : 2
+        #        Persistence : Superblock is persistent
+        #      Intent Bitmap : Internal
+        #        Update Time : Tue Nov 16 11:06:16 2021
+        #              State : clean 
+        #     Active Devices : 2
+        #    Working Devices : 2
+        #     Failed Devices : 0
+        #      Spare Devices : 0
+        # Consistency Policy : bitmap
+        #               Name : any:raid1sdab
+        #               UUID : 8d05eb84:2de831d1:dfed54b2:ad592118
+        #             Events : 216
+        #     Number   Major   Minor   RaidDevice State
+        #        0       8        0        0      active sync   /dev/sda
+        #        1       8       16        1      active sync   /dev/sdb
+        #
+        # Example 'mdadm --misc --detail $raiddevice' output for a RAID CONTAINER with IMSM metadata
+        # cf. https://github.com/rear/rear/pull/2702#issuecomment-968904230
+        # /dev/md127:
+        #            Version : imsm
+        #         Raid Level : container
+        #      Total Devices : 2
+        #    Working Devices : 2
+        #               UUID : 4d5cf215:80024c95:e19fdff4:2fba35a8
+        #      Member Arrays : /dev/md/Volume0_0
+        #     Number   Major   Minor   RaidDevice
+        #        -       8        0        -        /dev/sda
+        #        -       8       16        -        /dev/sdb
+        #
+        # /dev/md126:
+        #          Container : /dev/md/imsm0, member 0
+        #         Raid Level : raid1
+        #         Array Size : 390706176 (372.61 GiB 400.08 GB)
+        #      Used Dev Size : 390706176 (372.61 GiB 400.08 GB)
+        #       Raid Devices : 2
+        #      Total Devices : 2
+        #              State : active
+        #     Active Devices : 2
+        #    Working Devices : 2
+        #     Failed Devices : 0
+        # Consistency Policy : resync
+        #               UUID : ffb80762:127807b3:3d7e4f4d:4532022f
+        #     Number   Major   Minor   RaidDevice State
+        #        1       8       16        0      active sync   /dev/sdb
+        #        0       8        0        1      active sync   /dev/sda
+        line=( $( grep "Version :" $mdadm_details ) )
+        metadata=${line[2]}
+        line=( $( grep "Raid Level :" $mdadm_details ) )
+        level=${line[3]}
+        line=( $( grep "UUID :" $mdadm_details ) )
+        uuid=${line[2]}
+        line=( $( grep "Layout :" $mdadm_details ) )
+        layout=${line[2]}
+        # fix up layout for RAID10:
+        # > near=2,far=1 -> n2
+        if [ "$level" = "raid10" ] ; then
+            OIFS=$IFS
+            IFS=","
+            for param in "$layout" ; do
+                copies=${layout%=*}
+                number=${layout#*=}
+                if [ "$number" -gt 1 ] ; then
+                    layout="${copies:0:1}$number"
                 fi
             done
+            IFS=$OIFS
+        fi
+        chunksize=$( grep "Chunk Size" $mdadm_details | tr -d " " | cut -d ":" -f "2" | sed -r 's/^([0-9]+).+/\1/')
+        container=$( grep "Container" $mdadm_details | tr -d " " | cut -d ":" -f "2" | cut -d "," -f "1")
+        line=( $( grep "Array Size :" $mdadm_details ) )
+        array_size=${line[3]}
+        line=( $( grep "Used Dev Size :" $mdadm_details ) )
+        used_dev_size=${line[4]}
+        line=( $( grep "Total Devices :" $mdadm_details ) )
+        total_devices=${line[3]}
+        line=( $( grep "Raid Devices :" $mdadm_details ) )
+        raid_devices=${line[3]}
+        if [[ "$raid_devices" ]] ; then
+            let spare_devices=$total_devices-$raid_devices
+        else
+            let spare_devices=0
+        fi
 
-            # prepare for output
+        component_devices=""
+        let size=0
+        if [[ "$container" ]] ; then
+            component_devices=" devices=$( readlink -e $container )"
+            if [[ "$used_dev_size" ]] ; then
+                let size=$used_dev_size
+            elif [[ "$array_size" ]] ; then
+                let size=$array_size/$raid_devices
+            fi
+        else
+            # Find all component devices
+            # use the output of mdadm, but skip the array itself that is e.g. /dev/md127 or /dev/md/raid1sdab
+            # sysfs has the information in RHEL 5+, but RHEL 4 lacks it.
+            for component_device in $(  grep -o '/dev/.*' $mdadm_details | grep -v '/dev/md' | tr "\n" " " ) ; do
+                component_device=$( get_device_name $component_device )
+                if [ -z "$component_devices" ] ; then
+                    component_devices=" devices=$component_device"
+                else
+                    component_devices+=",$component_device"
+                fi
+            done
+        fi
+
+        if [ "$size" -gt 0 ] ; then
+            size=" size=$size"
+        else
+            size=""
+        fi
+
+        if [[ "$metadata" ]] ; then
             metadata=" metadata=$metadata"
-            level=" level=$level"
-            ndevices=" raid-devices=$ndevices"
-            uuid=" uuid=$uuid"
+        else
+            metadata=""
+        fi
 
-            if [ "$sparedevices" -gt 0 ] ; then
-                sparedevices=" spare-devices=$sparedevices"
-            else
-                sparedevices=""
-            fi
+        level=" level=$level"
+        if [[ "$raid_devices" ]] && [ $raid_devices -gt 0 ] ; then
+            raid_devices=" raid-devices=$raid_devices"
+        elif [[ "$total_devices" ]] ; then
+            raid_devices=" raid-devices=$total_devices"
+        else
+            raid_devices=""
+        fi
 
-            # mdadm can print '-unknown-' for a RAID layout
-            # which got recently (2019-12-02) added to RAID0 (it existed before for RAID5 and RAID6 and RAID10) see
-            # https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/commit/Detail.c?id=329dfc28debb58ffe7bd1967cea00fc583139aca
-            # so we treat '-unknown-' same as an empty value to avoid that layout/prepare/GNU/Linux/120_include_raid_code.sh
-            # will create a 'mdadm' command in diskrestore.sh like "mdadm ... --layout=-unknown- ..." which would fail
-            # during "rear recover" with something like "mdadm: layout -unknown- not understood for raid0"
-            # see https://github.com/rear/rear/issues/2616
-            if test "$layout" -a '-unknown-' != "$layout" ; then
-                layout=" layout=$layout"
-            else
-                layout=""
-            fi
+        uuid=" uuid=$uuid"
 
-            if [ -n "$chunksize" ] ; then
-                chunksize=" chunk=$chunksize"
-            else
-                chunksize=""
-            fi
+        if [ "$spare_devices" -gt 0 ] ; then
+            spare_devices=" spare-devices=$spare_devices"
+        else
+            spare_devices=""
+        fi
 
-            if [[ "$name" ]] ; then
-                name=" name=$name"
-            else
-                name=""
-            fi
+        # mdadm can print '-unknown-' for a RAID layout
+        # which got recently (2019-12-02) added to RAID0 (it existed before for RAID5 and RAID6 and RAID10) see
+        # https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/commit/Detail.c?id=329dfc28debb58ffe7bd1967cea00fc583139aca
+        # so we treat '-unknown-' same as an empty value to avoid that layout/prepare/GNU/Linux/120_include_raid_code.sh
+        # will create a 'mdadm' command in diskrestore.sh like "mdadm ... --layout=-unknown- ..." which would fail
+        # during "rear recover" with something like "mdadm: layout -unknown- not understood for raid0"
+        # see https://github.com/rear/rear/issues/2616
+        if test "$layout" -a '-unknown-' != "$layout" ; then
+            layout=" layout=$layout"
+        else
+            layout=""
+        fi
 
-            echo "raid ${device}${metadata}${level}${ndevices}${uuid}${name}${sparedevices}${layout}${chunksize}${devices}"
+        if [ -n "$chunksize" ] ; then
+            chunksize=" chunk=$chunksize"
+        else
+            chunksize=""
+        fi
 
-            extract_partitions "$device"
-        done < <(mdadm --detail --scan --config=partitions)
-    ) >> $DISKLAYOUT_FILE
+        if [[ "$name" ]] ; then
+            name=" name=$name"
+        else
+            name=""
+        fi
 
-    # mdadm is required in the recovery system if disklayout.conf contains at least one 'raid' entry
-    # see the create_raid function in layout/prepare/GNU/Linux/120_include_raid_code.sh
-    # what program calls are written to diskrestore.sh
-    # cf. https://github.com/rear/rear/issues/1963
-    grep -q '^raid ' $DISKLAYOUT_FILE && REQUIRED_PROGS+=( mdadm ) || true
+        echo "raid ${raiddevice}${metadata}${level}${raid_devices}${uuid}${name}${spare_devices}${layout}${chunksize}${component_devices}${size}"
 
-fi
+        extract_partitions "$raiddevice"
 
+    done < <( mdadm --detail --scan --config=partitions )
+
+) >> $DISKLAYOUT_FILE
+
+# mdadm is required in the recovery system if disklayout.conf contains at least one 'raid' entry
+# see the create_raid function in layout/prepare/GNU/Linux/120_include_raid_code.sh
+# what program calls are written to diskrestore.sh
+# cf. https://github.com/rear/rear/issues/1963
+grep -q '^raid ' $DISKLAYOUT_FILE && REQUIRED_PROGS+=( mdadm ) || true
+grep -q '^raid ' $DISKLAYOUT_FILE && PROGS+=( mdmon ) || true


### PR DESCRIPTION
* Type: **Cleanup**

* Impact: **High**
That old code drives me nuts.
In particular its confusing variable names, cf. the "By the way" part in
https://github.com/rear/rear/pull/2702#issuecomment-968934959

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2702

* How was this pull request tested?
With a simple RAID1 array (two component devices /dev/sda and /dev/sdb)
I got same `raid` line values in disklayout.conf after "rear mkrescue".
But I could have made mistakes for other types of RAID arrays.

* Brief description of the changes in this pull request:

Overhauled layout/save/GNU/Linux/210_raid_layout.sh
based on https://github.com/rear/rear/pull/2702
i.e. with the changes in https://github.com/rear/rear/pull/2702
