### PR TITLE
Improved wiping disks

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -430,17 +430,23 @@ test "$MIGRATION_MODE" || MIGRATION_MODE=''
 # The disks that will be automatically wiped are those disks
 # where in diskrestore.sh the create_disk_label function is called
 # i.e. disks where the whole partitioning will be recreated from scratch.
-# The automatism cannot work when the create_disk_label function is called
+# This automatism cannot work when the create_disk_label function is called
 # for higher level block devices like RAID devices that do not exist as disks
-# on the bare hardware or on a bare virtual machine.
+# on the bare replacement hardware or on a bare replacement virtual machine.
 # When disk devices are specified like DISKS_TO_BE_WIPED="/dev/sda /dev/sdb"
-# all those that actually exist as block devices in the recovery system will be wiped
-# without any safety conditions and regardless if they are needed to recreate the system
-# so e.g. DISKS_TO_BE_WIPED="/dev/sd[a-z]" will wipe all /dev/sda ... /dev/sdz that exist
-# or when the ReaR recovery system was booted from a USB disk that is /dev/sda on the
-# replacement hardware then DISKS_TO_BE_WIPED="/dev/sda ..." will destroy the ReaR disk.
-# In migration mode there is a user confirmation dialog for the disks that will be wiped.
-# By default no disk is wiped to avoid regressions until this feature was more tested:
+# all those that actually exist as block devices in the recovery system
+# (i.e. on the replacement hardware or on the replacement virtual machine)
+# will be wiped without any safety condition (except WRITE_PROTECTED_IDS)
+# and regardless if those disks are actually needed to recreate the system.
+# So e.g. DISKS_TO_BE_WIPED="/dev/sd[a-z]" will wipe all /dev/sda ... /dev/sdz that exist
+# except when for a disk in the recovery system its ID is listed in WRITE_PROTECTED_IDS
+# (listing disk IDs of the original system in WRITE_PROTECTED_IDS does not help).
+# When the ReaR recovery system was booted from a (USB) disk that is /dev/sda on the
+# replacement hardware then DISKS_TO_BE_WIPED="/dev/sda ..." may destroy the ReaR disk
+# unless that disk is (by default automatically) listed in WRITE_PROTECTED_IDS
+# (here it works because the ReaR disk ID is same on the replacement hardware).
+# In any case there is a user confirmation dialog for the disks that will be wiped.
+# Currently by default no disk is wiped to avoid issues until this feature was more tested:
 DISKS_TO_BE_WIPED='false'
 
 ##

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -269,13 +269,13 @@ test "$USER_INPUT_TIMEOUT" || USER_INPUT_TIMEOUT=300
 # when a predefined input value is specified for a particular UserInput() call
 # via a matching USER_INPUT_user_input_ID variable (see below).
 # The minimum waiting time to interrupt an automated input is one second.
-# The default is 5 seconds to give the user a better chance to recognize
+# The default is 10 seconds to give the user a better chance to recognize
 # an automated input and be able to actually hit a key to interrupt.
 # USER_INPUT_INTERRUPT_TIMEOUT is set to a default value here only
 # if not already set so that the user can set it also like
-#   export USER_INPUT_INTERRUPT_TIMEOUT=10
+#   export USER_INPUT_INTERRUPT_TIMEOUT=5
 # directly before he calls "rear ...":
-test "$USER_INPUT_INTERRUPT_TIMEOUT" || USER_INPUT_INTERRUPT_TIMEOUT=5
+test "$USER_INPUT_INTERRUPT_TIMEOUT" || USER_INPUT_INTERRUPT_TIMEOUT=10
 #
 # USER_INPUT_PROMPT specifies the default prompt text that is shown
 # if no prompt was specified for a particular UserInput() call.

--- a/usr/share/rear/layout/recreate/default/120_confirm_wipedisk_disks.sh
+++ b/usr/share/rear/layout/recreate/default/120_confirm_wipedisk_disks.sh
@@ -6,35 +6,67 @@ is_false "$DISKS_TO_BE_WIPED" && return 0
 # that will be completely wiped (as far as possible)
 # so that the disk layout recreation code (diskrestore.sh)
 # can run on clean disks that behave like pristine new disks.
+LogPrint "Determining disks to be wiped ..."
 
+local disk_to_be_wiped
+local disks_to_be_wiped=""
 if test "$DISKS_TO_BE_WIPED" ; then
     # If the user has specified DISKS_TO_BE_WIPED (i.e. when it is not empty)
     # use only those that actually exist as block devices in the recovery system:
-    local disk_to_be_wiped
-    local disks_to_be_wiped=""
     for disk_to_be_wiped in $DISKS_TO_BE_WIPED ; do
         # 'test -b' succeeds when there is no argument but fails when the argument is empty:
         test -b "$disk_to_be_wiped" || continue
+        # Write-protection for the disks in DISKS_TO_BE_WIPED
+        # cf. https://github.com/rear/rear/pull/2703#issuecomment-979928423
+        if is_write_protected "$disk_to_be_wiped" ; then
+          LogPrint "Excluding $disk_to_be_wiped from DISKS_TO_BE_WIPED ($disk_to_be_wiped is write-protected)"
+          continue
+        fi
         # Have a trailing space delimiter to get e.g. disks_to_be_wiped="/dev/sda /dev/sdb "
         # same as DISKS_TO_BE_WIPED (cf. below) with a trailing space (looks better in user messages):
         disks_to_be_wiped+="$disk_to_be_wiped "
     done
-    DISKS_TO_BE_WIPED="$disks_to_be_wiped"
 else
-    # The disks that will be completely wiped are those disks
+    # When the user has not specified DISKS_TO_BE_WIPED use an automatism:
+    # The disks that will be completely overwritten are those disks
     # where in diskrestore.sh the create_disk_label function is called
     # (the create_disk_label function calls "parted -s $disk mklabel $label")
     # for example like
     #   create_disk_label /dev/sda gpt
     #   create_disk_label /dev/sdb msdos
-    # so in this example DISKS_TO_BE_WIPED="/dev/sda /dev/sdb "
+    #   create_disk_label /dev/md127 gpt
+    # so in this example DISKS_TO_BE_WIPED="/dev/sda /dev/sdb /dev/md127 "
     DISKS_TO_BE_WIPED="$( grep '^ *create_disk_label /dev/' $LAYOUT_CODE | grep -o '/dev/[^ ]*' | sort -u | tr -s '[:space:]' ' ' )"
+    DebugPrint "Disks to be completely overwritten: $DISKS_TO_BE_WIPED"
+    # The above automatism cannot work when the create_disk_label function is called
+    # for higher level block devices like RAID devices e.g. as 'create_disk_label /dev/md127 gpt'
+    # that do not exist as disks on the bare hardware or on a bare virtual machine:
+    for disk_to_be_wiped in $DISKS_TO_BE_WIPED ; do
+        # 'test -b' succeeds when there is no argument but fails when the argument is empty:
+        if ! test -b "$disk_to_be_wiped" ; then
+          DebugPrint "Skipping $disk_to_be_wiped to be wiped ($disk_to_be_wiped does not exist as block device)"
+          continue
+        fi
+        # Write-protection for the disks in DISKS_TO_BE_WIPED
+        # cf. https://github.com/rear/rear/pull/2703#issuecomment-979928423
+        if is_write_protected "$disk_to_be_wiped" ; then
+          DebugPrint "Excluding $disk_to_be_wiped to be wiped ($disk_to_be_wiped is write-protected)"
+          continue
+        fi
+        # Have a trailing space delimiter to get e.g. disks_to_be_wiped="/dev/sda /dev/sdb "
+        # same as DISKS_TO_BE_WIPED (cf. below) with a trailing space (looks better in user messages):
+        disks_to_be_wiped+="$disk_to_be_wiped "
+    done
 fi
+DISKS_TO_BE_WIPED="$disks_to_be_wiped"
+# The DISKS_TO_BE_WIPED string is needed in the subsequent layout/recreate/default/150_wipe_disks.sh script
 
-# The DISKS_TO_BE_WIPED string is needed in any case
-# in the subsequent layout/recreate/default/150_wipe_disks.sh script
-# so skip this user dialog if not in migration mode after the DISKS_TO_BE_WIPED string was set:
-is_true "$MIGRATION_MODE" || return 0
+# When not in migration mode show the user confirmation dialog nevertheless
+# but have a predefined user input to automatically proceed after USER_INPUT_INTERRUPT_TIMEOUT
+# provided USER_INPUT_WIPE_DISKS_CONFIRMATION is not already set by the user
+# so that the user can see what disks will be wiped and completely overwritten
+# and needed abort with [Ctrl]+[C] (within USER_INPUT_INTERRUPT_TIMEOUT):
+is_true "$MIGRATION_MODE" || test "$USER_INPUT_WIPE_DISKS_CONFIRMATION" || USER_INPUT_WIPE_DISKS_CONFIRMATION="yes"
 
 rear_workflow="rear $WORKFLOW"
 rear_shell_history="lsblk"
@@ -42,7 +74,7 @@ unset choices
 choices[0]="Confirm disks to be completely overwritten and continue '$rear_workflow'"
 choices[1]="Use Relax-and-Recover shell and return back to here"
 choices[2]="Abort '$rear_workflow'"
-prompt="Disks to be overwritten: $DISKS_TO_BE_WIPED"
+prompt="Disks to be wiped: $DISKS_TO_BE_WIPED"
 choice=""
 wilful_input=""
 # When USER_INPUT_WIPE_DISKS_CONFIRMATION has any 'true' value be liberal in what you accept and
@@ -53,7 +85,7 @@ while true ; do
     case "$choice" in
         (${choices[0]})
             # Confirm disk that will be completely overwritten and continue:
-            is_true "$wilful_input" && LogPrint "User confirmed disks to be overwritten" || LogPrint "Continuing '$rear_workflow' by default"
+            is_true "$wilful_input" && LogPrint "User confirmed disks to be wiped" || LogPrint "Continuing '$rear_workflow' by default"
             break
             ;;
         (${choices[1]})

--- a/usr/share/rear/layout/recreate/default/120_confirm_wipedisk_disks.sh
+++ b/usr/share/rear/layout/recreate/default/120_confirm_wipedisk_disks.sh
@@ -109,8 +109,11 @@ else
                 test $parent_device || parent_device="$( lsblk -inpo KNAME "$component_device" 2>/dev/null | awk NF | head -n1 )"
                 # Without quoting an empty parent_device would result plain "test -b" which would (falsely) succeed:
                 if test -b "$parent_device" ; then
-                    DebugPrint "$parent_device is a parent disk of $raiddevice that should be wiped"
-                    # Write-protection for the disks in DISKS_TO_BE_WIPED (see above):
+                    # parent_device is usually a disk but in the KNAME fallback case it could be a partition:
+                    DebugPrint "$parent_device is a parent of $raiddevice that should be wiped"
+                    # Write-protection for the disks in DISKS_TO_BE_WIPED (see above).
+                    # When parent_device is a partition the function write_protection_ids() in lib/write-protect-functions.sh
+                    # also tries to determine its parent disk if possible to check the disk device in DISKS_TO_BE_WIPED:
                     if is_write_protected "$parent_device" ; then
                         DebugPrint "Excluding parent $parent_device to be wiped ($parent_device is write-protected)"
                         # Continue with the next component_device

--- a/usr/share/rear/layout/recreate/default/150_wipe_disks.sh
+++ b/usr/share/rear/layout/recreate/default/150_wipe_disks.sh
@@ -5,9 +5,10 @@ is_false "$DISKS_TO_BE_WIPED" && return 0
 # The disks that will be completely wiped are those disks
 # where in diskrestore.sh the create_disk_label function is called
 # (the create_disk_label function calls "parted -s $disk mklabel $label")
-# for example like
+# for those that exist as disks on the bare hardware for example like
 #   create_disk_label /dev/sda gpt
 #   create_disk_label /dev/sdb msdos
+#   create_disk_label /dev/md127 gpt
 # so in this example DISKS_TO_BE_WIPED="/dev/sda /dev/sdb "
 # or if the user has specified DISKS_TO_BE_WIPED use only the existing block devices therein
 # cf. layout/recreate/default/120_confirm_wipedisk_disks.sh
@@ -17,36 +18,7 @@ is_false "$DISKS_TO_BE_WIPED" && return 0
 Log "Block devices structure on the unchanged replacement hardware before the disks $DISKS_TO_BE_WIPED will be wiped (lsblk):"
 Log "$( lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,SIZE,MOUNTPOINT || lsblk -io NAME,KNAME,FSTYPE,SIZE,MOUNTPOINT || lsblk -i || lsblk )"
 
-# Open LUKS volumes so that nested storage objects inside LUKS volumes become visible.
-# For example in SLES the YaST installer provides a default LUKS encrypted LVM storage structure
-# where LVM storage objects are nested storage objects inside a LUKS encrypted volume as follows (lsblk output):
-#   NAME                                               KNAME     PKNAME    TRAN TYPE  FSTYPE       SIZE MOUNTPOINT
-#   /dev/sda                                           /dev/sda            ata  disk                20G
-#   |-/dev/sda1                                        /dev/sda1 /dev/sda       part                 8M
-#   `-/dev/sda2                                        /dev/sda2 /dev/sda       part  crypto_LUKS   20G
-#     `-/dev/mapper/cr_ata-QEMU_HARDDISK_QM00001-part2 /dev/dm-0 /dev/sda2      crypt LVM2_member   20G
-#       |-/dev/mapper/system-swap                      /dev/dm-1 /dev/dm-0      lvm   swap           2G [SWAP]
-#       |-/dev/mapper/system-root                      /dev/dm-2 /dev/dm-0      lvm   btrfs       12.6G /
-#       `-/dev/mapper/system-home                      /dev/dm-3 /dev/dm-0      lvm   xfs          5.4G /home
-# where /dev/mapper/cr_ata-QEMU_HARDDISK_QM00001-part2 is the (only) PV of a VG 'system'
-# that contains the LVs /dev/system/swap /dev/system/home /dev/system/root
-# To make such LVM storage objects visible for LVM tools like pvscan vgscan lvscan (cf. the LVM related code below)
-# so that those LVM storage objects can be properly removed their parent LUKS volume needs to be opened:
-local crypto_LUKS_kernel_devices luks_device luks_mapping_name
-# The luks_mapping_names where 'cryptsetup luksOpen' succeeded need to be later closed again (see below):
-local luks_mapping_names=""
-crypto_LUKS_kernel_devices="$( lsblk -nlpo KNAME,FSTYPE | grep ' crypto_LUKS$' | cut -s -d ' ' -f1 | tr -s '[:space:]' ' ' )"
-for luks_device in $crypto_LUKS_kernel_devices ; do
-    luks_mapping_name=luks-$( basename $luks_device )
-    LogUserOutput "Enter the password to open LUKS device $luks_device temporarily as $luks_mapping_name (or skip with [Ctrl]+[C])"
-    if ! cryptsetup luksOpen $luks_device $luks_mapping_name 0<&6 1>&7 2>&8 ; then
-        DebugPrint "LUKS device $luks_device not opened"
-        continue
-    fi
-    DebugPrint "LUKS device $luks_device temporarily opened as $luks_mapping_name"
-    luks_mapping_names+="$luks_mapping_name "
-done
-
+local disk_to_be_wiped
 # Wiping LVM storage objects:
 # The only way to get rid of LVM stuff is to deconstruct the LVM stuff
 # with LVM tools step by step from LVs to VGs to PVs.
@@ -91,7 +63,8 @@ detected_VGs="$( vgscan -y | grep 'Found volume group' |cut -s -d '"' -f2 | tr -
 detected_PVs="$( pvscan -y | grep -o 'PV /dev/[^ ]*' | cut -s -d ' ' -f2 | tr -s '[:space:]' ' ' )"
 # From the detected LVs VGs PVs remove only those that belong to one of the disks that will be wiped
 # i.e. keep LVs VGs PVs on disks that will not be wiped (e.g. a separated storage disk with LVM on it).
-local belongs_to_a_disk_to_be_wiped disk_to_be_wiped devices_belonging_to_disk detected_LV detected_VG detected_PV
+local belongs_to_a_disk_to_be_wiped devices_belonging_to_disk
+local detected_LV detected_VG detected_PV
 # Remove detected LVs ('for' does nothing when $detected_LVs is empty):
 #for detected_LV in $detected_LVs ; do
 #    belongs_to_a_disk_to_be_wiped="no"
@@ -166,24 +139,6 @@ for detected_PV in $detected_PVs ; do
     else
         LogPrintError "Failed to remove LVM physical volume $detected_PV ('pvremove $detected_PV' failed)"
     fi
-done
-
-# The luks_mapping_names where 'cryptsetup luksOpen' had succeeded above need to be closed again.
-# Leaving LUKS volumes open leads to errors later when "parted -s $disk mklabel $label" is called
-# in the diskrestore.sh script because then 'parted' fails with the following error message:
-#   Partitions ... have been written, but we have been unable to inform the kernel of the change,
-#   probably because it/they are in use. As a result, the old partition(s) will remain in use.
-#   You should probably reboot now before making further changes.
-# In this case it works to reboot the recovery system and then a second "rear recover" usually succeeds
-# because after plain wiping a disk with LUKS volumes the LUKS metadata/signatures are no longer there
-# so that LUKS cannot be in use in the rebooted recovery system and "parted -s $disk mklabel $label" can succeed.
-# But we like to do all in one single "rear recover" run so we need to clean up LUKS storage objects properly:
-for luks_mapping_name in $luks_mapping_names ; do
-    if ! cryptsetup luksClose $luks_mapping_name ; then
-        LogPrintError "Failed to close LUKS device $luks_device (still opened as $luks_mapping_name)"
-        continue
-    fi
-    DebugPrint "Closed LUKS device $luks_device (was temporarily opened as $luks_mapping_name)"
 done
 
 # Wipe RAID plus LVM plus LUKS metadata.


### PR DESCRIPTION
* Type: **Minor Bug Fix** / **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2715
https://github.com/rear/rear/pull/2703#issuecomment-979928423
https://github.com/rear/rear/pull/2514#issuecomment-743483945

* How was this pull request tested?
I tested some "rear mkbackup" / "rear recover"
with the same two VMs as in
https://github.com/rear/rear/pull/2714

* Brief description of the changes in this pull request:

In layout/recreate/default/120_confirm_wipedisk_disks.sh
skip disks that do not exist on the bare hardware in the recovery system
cf. https://github.com/rear/rear/issues/2715
and exclude disks that are write-protected and
cf. https://github.com/rear/rear/pull/2703#issuecomment-979928423
show what disks will be wiped in any case to the user.
In layout/recreate/default/150_wipe_disks.sh do no longer
open (and close) LUKS volumes because encrypted volumes
contain meaningless data unless opened and unencrypted so there is no need
to wipe anything inside an encrypted LUKS container, cf. "Regarding LUKS"
in https://github.com/rear/rear/pull/2514#issuecomment-743483945