### PR TITLE
fixed pxe file cp and permissions for sshfs target

### DIFF
--- a/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
+++ b/usr/share/rear/output/PXE/default/800_copy_to_tftp.sh
@@ -32,14 +32,17 @@ else
     [[ ! -d "$PXE_TFTP_LOCAL_PATH" ]] && mkdir $v -m 750 "$PXE_TFTP_LOCAL_PATH" >&2
 fi
 
-
-cp -pL $v "$KERNEL_FILE" "$PXE_TFTP_LOCAL_PATH/$PXE_KERNEL" || Error "Failed to copy KERNEL_FILE '$KERNEL_FILE'"
-cp -a $v "$TMP_DIR/$REAR_INITRD_FILENAME" "$PXE_TFTP_LOCAL_PATH/$PXE_INITRD" || Error "Failed to copy initrd '$REAR_INITRD_FILENAME'"
+# Follow symbolic links to ensure the real content gets copied
+# but do not preserve mode,ownership,timestamps (i.e. no -p option) because that may fail (on sshfs) like
+# "cp: failed to preserve ownership for '/tmp/rear-efi.XXXXXXXXXX/EFI/BOOT/kernel': Operation not permitted"
+cp -L $v "$KERNEL_FILE" "$PXE_TFTP_LOCAL_PATH/$PXE_KERNEL" || Error "Failed to copy KERNEL_FILE '$KERNEL_FILE'"
+cp -L $v "$TMP_DIR/$REAR_INITRD_FILENAME" "$PXE_TFTP_LOCAL_PATH/$PXE_INITRD" || Error "Failed to copy initrd '$REAR_INITRD_FILENAME'"
 echo "$VERSION_INFO" >"$PXE_TFTP_LOCAL_PATH/$PXE_MESSAGE"
 # files must be readable for others for PXE
-chmod 444 "$PXE_TFTP_LOCAL_PATH/$PXE_KERNEL"
-chmod 444 "$PXE_TFTP_LOCAL_PATH/$PXE_INITRD"
-chmod 444 "$PXE_TFTP_LOCAL_PATH/$PXE_MESSAGE"
+# files should be writebale by owner or overwriting it on later runs will fail
+chmod 644 "$PXE_TFTP_LOCAL_PATH/$PXE_KERNEL"
+chmod 644 "$PXE_TFTP_LOCAL_PATH/$PXE_INITRD"
+chmod 644 "$PXE_TFTP_LOCAL_PATH/$PXE_MESSAGE"
 
 if [[ ! -z "$PXE_TFTP_URL" ]] && [[ "$PXE_RECOVER_MODE" = "unattended" ]] ; then
     # If we have chosen for "unattended" recover mode then we also copy the


### PR DESCRIPTION
* Type: **Bug Fix**
* Impact: **Normal**
* How was this pull request tested?
```
OUTPUT=PXE
OUTPUT_PREFIX_PXE=$HOSTNAME
PXE_TFTP_PREFIX=$HOSTNAME.
PXE_TFTP_URL=sshfs://wingcon@172.200.200.1/tmp/test
PXE_CONFIG_URL=sshfs://wingcon@172.200.200.1/tmp/test/
PXE_RECOVER_MODE="manual"
PXE_CREATE_LINKS="IP"

BACKUP=BORG
USB_DEVICE=/dev/disk/by-label/REAR-000
USB_DEVICE_FILESYSTEM_LABEL=REAR-000
USB_DEVICE_PARTED_LABEL=gpt
USB_DEVICE_FILESYSTEM=ext4
USB_UEFI_PART_SIZE="512"
CLONE_USERS=(root)
CLONE_GROUPS=(root)
CLONE_ALL_USERS_GROUPS="false"
BORGBACKUP_REPO="/borg"
BORGBACKUP_UMASK="0002"
BORGBACKUP_ENC_TYPE="repokey"
export BORG_RELOCATED_REPO_ACCESS_IS_OK="yes"
export BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK="yes"
export TMPDIR="/wsp_var/tmp/"
USE_RESOLV_CONF="no"
USE_DHCLIENT=no
USE_STATIC_NETWORKING=1
USE_SERIAL_CONSOLE=y
COPY_KERNEL_PARAMETERS=( 'net.ifnames' 'biosdevname', 'console' )
REAR_INITRD_COMPRESSION="fast"
USING_UEFI_BOOTLOADER=1
USB_BOOTLOADER=grub
GRUB2_DEFAULT_BOOT="1"
MODULES=( 'no_modules' )
FIRMWARE_FILES=( 'no' )
EXCLUDE_RUNTIME_LOGFILE="yes"

```
* Brief description of the changes in this pull request:

* prevent cp error "failed to preserve ownership" for sshfs
* prevent issue with write permissions trying to override image on later runs

Please note that atm PXE config is always written in syslinux style and never for grub.