### PR TITLE
Always include loaded kernel modules

### DIFF
--- a/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
+++ b/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
@@ -127,7 +127,7 @@ for dummy in "once" ; do
 
     # Finally the fallback cases, i.e. when the user has specified
     # MODULES=() which means the currently loaded kernel modules get included in the recovery system
-    # plus the modules that get added above plus kernel modules for certain kernel drivers like
+    # plus the kernel modules in MODULES_LOAD plus kernel modules for certain kernel drivers like
     # storage drivers, network drivers, crypto drivers, virtualization drivers, and some extra drivers
     # (see rescue/GNU/Linux/230_storage_and_network_modules.sh
     #  and rescue/GNU/Linux/240_kernel_modules.sh)

--- a/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
+++ b/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
@@ -173,9 +173,14 @@ for dummy in "once" ; do
         modinfo $module 1>/dev/null || continue
         # Continue with the next module if the current one is a kernel builtin module
         # cf. https://github.com/rear/rear/issues/2414#issuecomment-668632798
+        # and have the grep search value with a leading '/' and a trailing '.'
+        # to avoid false substring matches of wrong kernel builtin modules
+        # that would falsely skip non-builtin modules from being included
+        # cf. https://github.com/rear/rear/pull/2728#issuecomment-995799489
+        # and https://github.com/rear/rear/pull/2728#issuecomment-996103272
         # Quoting the grep search value is mandatory here ($module might be empty or blank),
         # cf. "Beware of the emptiness" in https://github.com/rear/rear/wiki/Coding-Style
-        grep -q "$( echo $module | tr '_-' '..' )" /lib/modules/$KERNEL_VERSION/modules.builtin && continue
+        grep -q "/$( echo $module | tr '_-' '..' )\." /lib/modules/$KERNEL_VERSION/modules.builtin && continue
         # Resolve module dependencies:
         # Get the module file plus the module files of other needed modules.
         # This is currently only a "best effort" attempt because

--- a/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
+++ b/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
@@ -135,6 +135,10 @@ for dummy in "once" ; do
     # MODULES=( 'moduleX' 'moduleY' ) where additional kernel modules can be specified
     # to be included in the recovery system in addition to the ones via an empty MODULES=() setting:
     LogPrint "Copying kernel modules as specified by MODULES"
+    # Kernel modules that should be loaded during recovery system startup must be always copied into the recovery system:
+    MODULES+=( "${MODULES_LOAD[@]}" )
+    # Kernel modules that are currently loaded are always copied into the recovery system:
+    MODULES+=( $( lsmod | tail -n +2 | cut -d ' ' -f 1 ) )
     # Before ReaR version 2.5 the below added modules had been added via conf/GNU/Linux.conf
     # which is sourced in usr/sbin/rear before user config files like etc/rear/local.conf
     # so that the user had to specify MODULES+=( 'moduleX' 'moduleY' )
@@ -160,8 +164,7 @@ for dummy in "once" ; do
                zlib zlib-inflate zlib-deflate
                libcrc32c crc32c crc32c-intel )
     # Include the modules in MODULES plus their dependant modules.
-    # Kernel modules that should be loaded during recovery system startup must be always copied into the recovery system:
-    for module in "${MODULES_LOAD[@]}" "${MODULES[@]}" ; do
+    for module in "${MODULES[@]}" ; do
         # Strip trailing ".o" if there:
         module=${module#.o}
         # Strip trailing ".ko" if there:


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2727

* How was this pull request tested?
Seems to work OK for me - but I can only do a few generic tests.
In particular with `MODULES=( 'loaded_modules' 'wireguard' )`
I get exactly only the loaded kernel modules but no 'wireguard'.

* Brief description of the changes in this pull request:
In build/GNU/Linux/400_copy_modules.sh also
for MODULES=() or MODULES=( 'moduleX' 'moduleY' )
include the currently loaded kernel modules.
