### PR TITLE
New EXCLUDE_IP_ADDRESSES and EXCLUDE_NETWORK_INTERFACES directives

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2963,6 +2963,15 @@ WARN_MISSING_VOL_ID=1
 USE_CFG2HTML=
 # The SKIP_CFG2HTML variable is no longer supported since ReaR 1.18
 
+# IP addresses that are present on the system but must be excluded when
+# building the network configuration used in recovery mode; this is typically
+# used when floating IP addresses are used on the system
+EXCLUDE_IP_ADDRESSES=()
+
+# Network interfaces that are present on the system but must be excluded when
+# building the network configuration used in recovery mode
+EXCLUDE_NETWORK_INTERFACES=()
+
 # Simplify bonding setups by configuring always the first active device of a
 # bond, except when mode is 4 (IEEE 802.3ad policy)
 SIMPLIFY_BONDING=no


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): N/A

* How was this pull request tested? Manually

* Brief description of the changes in this pull request:

These new array variables enable to ignore specific IP addresses or network interfaces when building the network configuration used in the rescue environment.
This is typically useful when floating IP addresses are used. Not ignoring these may lead to outage if the floating IP address is used by another system at time the system is getting recovered.
