### PR TITLE
Support for http sources when using PXE

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1138,6 +1138,11 @@ PXE_TFTP_URL=
 # prefix for PXE files, e.g. the hostname
 PXE_TFTP_PREFIX=$HOSTNAME.
 #
+# Optional HTTP download source for PXE (URL style)
+# for example PXE_HTTP_URL="http://pxe-over-http-srv:7777"
+# If set an additional pxe boot option in the pxeconfig for this client is provided ('rear-http') which uses this url as base path for the kernel and initrd files. 
+PXE_HTTP_URL=
+#
 # Create pxelinux config symlinks for MAC addresses or for IP addresses ? [MAC|IP|'']
 PXE_CREATE_LINKS=MAC
 #

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -782,6 +782,34 @@ function make_pxelinux_config {
     echo "    append initrd=$PXE_INITRD root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE $PXE_RECOVER_MODE"
     echo "say ----------------------------------------------------------"
 
+    # start with optional rear http entry if specified
+    if [[ ! -z $PXE_HTTP_URL ]] ; then    
+        case "$PXE_RECOVER_MODE" in
+        "automatic")
+            echo "say rear-automatic-http - Recover $HOSTNAME (HTTP) with auto-recover kernel option"
+            echo "label rear-automatic-http"
+            echo "MENU label ^Automatic Recover $HOSTNAME (HTTP)"
+            ;;
+        "unattended")
+            echo "say rear-unattended-http - Recover $HOSTNAME (HTTP) with unattended kernel option"
+            echo "label rear-unattended-http"
+            echo "MENU label ^Unattended Recover $HOSTNAME (HTTP)"
+            ;;
+        *)
+            echo "say rear-http - Recover $HOSTNAME (HTTP)"
+            echo "label rear-http"
+            echo "MENU label ^Recover $HOSTNAME (HTTP)"
+            ;;
+        esac
+        echo "TEXT HELP"
+        echo "Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)"
+        echo "${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}"
+        echo "ENDTEXT"
+        echo "    kernel $PXE_HTTP_URL""/""$PXE_KERNEL"
+        echo "    append initrd=$PXE_HTTP_URL""/""$PXE_INITRD root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE $PXE_RECOVER_MODE"
+        echo "say ----------------------------------------------------------"
+    fi
+
     # start the the other entries like local,...
     echo "say local - Boot from next boot device"
     echo "label local"

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -805,8 +805,8 @@ function make_pxelinux_config {
         echo "Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)"
         echo "${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}"
         echo "ENDTEXT"
-        echo "    kernel $PXE_HTTP_URL""/""$PXE_KERNEL"
-        echo "    append initrd=$PXE_HTTP_URL""/""$PXE_INITRD root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE $PXE_RECOVER_MODE"
+        echo "    kernel $PXE_HTTP_URL/$PXE_KERNEL"
+        echo "    append initrd=$PXE_HTTP_URL/$PXE_INITRD root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE $PXE_RECOVER_MODE"
         echo "say ----------------------------------------------------------"
     fi
 


### PR DESCRIPTION

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: Enhancement

* Impact: Normal

* Reference to related issue (URL): https://github.com/rear/rear/issues/2733

* How was this pull request tested? yes in my own environment with 2 different virtual machines.

* Brief description of the changes in this pull request:

Due to the performance issues involved when using TFTP for file transfer modern PXE server support HTTP(s) downloads as well.
Since it is necessary for rear to mount the upload target during creating of the rescue information HTTP targets are not supported. Hence the url specified via $PXE_TFTP_URL used for nfs, sshfs upload and TFTP download may differ from the HTTP source offered by the same PXE server.

Therefore the change introduces a new config variable $PXE_HTTP_URL to specify explicitly the HTTP download source for PXE.
If the variable is set the PXE config file will generate an additional 3rd boot option besides the unchanged standard option "rear" (via TFTP) and "local". Namely "rear-http" which includes the HTTP url information to download the kernel and initrd data.
