### PR TITLE
Skip unneeded /usr/lib*/syslog-ng/loggen/ from the recovery system

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -181,8 +181,10 @@ LIBS+=(
 /lib*/libresolv*
 /usr/lib*/rsyslog/*so
 /lib*/rsyslog/*so
-
-/usr/lib*/syslog-ng/*
+# Only copy *.so files in /usr/lib*/syslog-ng/ and skip /usr/lib*/syslog-ng/loggen/
+# because the loggen program is not included in the recovery system
+# see https://github.com/rear/rear/issues/2743
+/usr/lib*/syslog-ng/*so
 
 ### needed for curl HTTPS
 /lib*/libnsspem.so*


### PR DESCRIPTION
* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2743

* How was this pull request tested?
See https://github.com/rear/rear/issues/2743#issue-1110167131

* Brief description of the changes in this pull request:

Do no longer copy all in `/usr/lib*/syslog-ng/*`
but only copy `*.so` files `/usr/lib*/syslog-ng/*so`
and skip things in `/usr/lib*/syslog-ng/loggen/`
because 'loggen' is not included in the recovery system.
