### PR TITLE
Removed need for /usr/lib64

### DIFF
--- a/doc/user-guide/16-Rubrik-CDM.adoc
+++ b/doc/user-guide/16-Rubrik-CDM.adoc
@@ -64,17 +64,6 @@ Bare Metal Recovery is performed by first restoring the ReaR ISO file from Rubri
 * Recovery from a replica CDM cluster is only supported with CDM v4.2.1 and higher.
 * Care must be taken with SUSE systems on DHCP. They tend to request the same IP as the original host. If this is not the desired behavior the system will have to be adjusted after booting from the ReaR ISO.  
 * If multiple restores are performed using the same temporary IP, the temporary IP must first be deleted from Servers & Apps -> Linux and Unix Servers and re-added upon each reuse.
-* ReaR's `ldd` check of other binaries or libraries may result in libraries not being found. This can generally be fixed by adding the path to those libraries to the `LD_LIBRARY_PATH` variable in `/etc/rear/local.conf`. Do this by adding the following line in `/etc/rear/local.conf`:
-+
-  export LD_LIBRARY_PATH-"$LD_LIBRARY_PATH:<path>"
-+
-To make CentoOS v7.7 work the following line was needed:
-+
-  export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib64/bind9-export"
-+
-To make CentOS v8.0 work the following line was needed:
-+
-  export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib64/bind9-export:/usr/lib64/eog:/usr/lib64/python3.6/site-packages:/usr/lib64/samba:/usr/lib64/firefox"
 
 == Troubleshooting
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1883,7 +1883,7 @@ LUKS_CRYPTSETUP_OPTIONS="--iter-time 2000 --use-random"
 # ReaR support for Rubrik Cloud Data Management (CDM).
 # ReaR will copy the Rubrk RBS agent and required OS binaries to its ISO for incluson on boot.
 # ReaR will start the Rubrik RBS agent when 'rear recover' is run.
-COPY_AS_IS_CDM=( /etc/rubrik /usr/bin/rubrik /var/log/rubrik /etc/pki /usr/lib64 )
+COPY_AS_IS_CDM=( /etc/rubrik /usr/bin/rubrik /var/log/rubrik /etc/pki )
 COPY_AS_IS_EXCLUDE_CDM=( /var/log/rubrik/* )
 PROGS_CDM=( /usr/bin/rubrik/backup_agent_main /usr/bin/rubrik/bootstrap_agent_main openssl uuidgen )
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement** 

* Impact: **High**

* Reference to related issue (URL):

#2685
#2266
#2700
#2314 

* How was this pull request tested?

Deployed a RHEL 7.9 system on vSphere, ran `rear mkrescue` with no errors. Performed BMR on using the created ISO image on a 2nd empty vSphere VM and was able to recover the original system successfully.

* Brief description of the changes in this pull request:

Removed the need to include /usr/lib64 with the Rubrik CDM image. Rubrik CDM v6 and higher does not seem to need the libraries in this directory anymore. This will also reduce the image size when CDM is being used and fix boot problems due to an image that is too large. 