### PR TITLE
Include `dmsetup` and `dmeventd` unconditionally

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -164,6 +164,25 @@ sysctl
 blockdev
 lsblk
 clear
+
+# Older releases of os-prober (1.74 and below) use dmsetup as a fallback
+# solution for mounting when grub-mount is missing.
+#
+# However, dmsetup was included in the rescue image if and only if LVM,
+# multipath or encryption were detected.  Thus, BIOS machines that do
+# not use these but still have dmsetup present, would block indefinitely
+# on the "Installing GRUB2 boot loader..." step.
+#
+# GRUB2 installation is performed in a chroot after the data have already
+# been recovered.  ReaR would call grub-mkconfig which calls os-prober
+# which then executes dmsetup.  However, it would never receive the expected
+# response in the form of releasing a System V semaphore by dmsetup executed
+# by udevd outside the chroot as rescue system would not have dmsetup present.
+#
+# see https://github.com/rear/rear/pull/2748
+# related https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=853927
+dmsetup
+dmeventd
 )
 
 # the lib* serves to cover both 32bit and 64bit libraries!


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL): None

* How was this pull request tested?

Successful recovery of a RHEL 8.5 VM with BIOS without encryption, LVM
or multipath with this patch applied and unsuccessful recovery of the same
machine without it.  RHEL 8.5 has `os-prober` 1.74 and does not ship
`grub-mount` binary.

* Brief description of the changes in this pull request:

Changes usr/share/rear/conf/GNU/Linux.conf

Older releases of `os-prober` (1.74 and below) use `dmsetup` as a fallback
solution for mounting when `grub-mount` is missing.

However, `dmsetup` was included in the rescue image if and only if LVM,
multipath or encryption were detected.  Thus, BIOS machines that do
not use these but still have `dmsetup` present, would block indefinitely
on the "Installing GRUB2 boot loader..." step.

GRUB2 installation is performed in a chroot after the data have already
been recovered.  ReaR would call `grub-mkconfig` which calls `os-prober`
which then executes `dmsetup`.  However, it would never receive the response
trough host's udev as the rescue system would not have `dmsetup` present
to send it.

EDIT: reworded the description (thanks @pcahyna for suggestions!)
EDIT2: usr/share/rear/conf/GNU/Linux.conf is now being changed.