### PR TITLE
Add `console=tty0` to cmdline only if no real serial device was found

### DIFF
--- a/usr/share/rear/lib/serial-functions.sh
+++ b/usr/share/rear/lib/serial-functions.sh
@@ -73,12 +73,15 @@ function cmdline_add_console {
             fi
         done
     else
+        local real_consoles=""
         for devnode in $( get_serial_console_devices ) ; do
             # Only add for those device nodes that belong to actual serial devices:
-            speed=$( get_serial_device_speed $devnode ) && cmdline+=" console=${devnode##/dev/},$speed"
+            speed=$( get_serial_device_speed $devnode ) && real_consoles+=" console=${devnode##/dev/},$speed"
         done
+        cmdline+=" $real_consoles"
+
         # Add fallback console if no real serial device was found:
-        test "$speed" || cmdline+=" console=tty0"
+        test "$real_consoles" || cmdline+=" console=tty0"
     fi
 
     # Have a trailing space to be on the safe side


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): None

* How was this pull request tested? RHEL 8.5 VM with a serial console

* Brief description of the changes in this pull request:

Changes `usr/share/rear/lib/serial-functions.sh`.

Without this change `console=tty0` would be added whenever the last
device returned by `get_serial_console_devices` was not classified
as a real serial device even though the previous ones were.

Thus, the `cmdline` on a machine with `ttyS[0-3]` where only `ttyS0`
is real was changed to
```
console=ttyS0,115200 console=tty0
```
In such case, only kernel messages would appear on `ttyS0` [1].

[1] https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html