### PR TITLE
multipath: fix exclusion of still wanted devices

### DIFF
--- a/usr/share/rear/layout/save/default/335_remove_excluded_multipath_vgs.sh
+++ b/usr/share/rear/layout/save/default/335_remove_excluded_multipath_vgs.sh
@@ -19,9 +19,9 @@ while read lvmdev name mpdev junk ; do
     # Remember, multipath devices from a volume group that is "excluded" should be 'commented out'
     device=$(echo $mpdev | cut -c1-45)
     while read LINE ; do
-        # Now we need to comment all lines that contain "$devices" in the LAYOUT_FILE
+        # Now we need to comment all lines that contain "$device" in the LAYOUT_FILE
         sed -i "s|^$LINE|\#$LINE|" "$LAYOUT_FILE"
-    done < <(grep "$device" $LAYOUT_FILE | grep -v "^#")
+    done < <(grep " $device " $LAYOUT_FILE | grep -v "^#")
     DebugPrint "Disabling multipath device $device belonging to disabled 'lvmdev $name' in $LAYOUT_FILE"
 done < <(grep "^#lvmdev" $LAYOUT_FILE)
 
@@ -31,7 +31,7 @@ done < <(grep "^#lvmdev" $LAYOUT_FILE)
 while read LINE ; do
     # multipath /dev/mapper/360060e8007e2e3000030e2e300002065 /dev/sdae,/dev/sdat,/dev/sdbi,/dev/sdp
     device=$(echo $LINE | awk '{print $2}' | cut -c1-45)
-    num=$(grep "$device" $LAYOUT_FILE | grep -v "^#" | wc -l)
+    num=$(grep " $device " $LAYOUT_FILE | grep -v "^#" | wc -l)
     if [ $num -lt 2 ] ; then
         # If the $device is only seen once (in a uncommented line) then the multipath is not in use
         sed -i "s|^$LINE|\#$LINE|" "$LAYOUT_FILE"


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* How was this pull request tested? On RHEL8 with Upstream ReaR

* Brief description of the changes in this pull request:

The current code excluding multipath devices is broken when a device being excluded matches other devices.
This leads to excluding wanted devices.
This happens when having custom alias for multipath devices *or* there are more than 26 multipath devices and 'mpatha' is getting excluded, which leads to excluding all 'mpathaX' devices are well.

See example below:
- have /boot on a dedicated multipath device 'mpathba'
- have / on a dedicated multipath device 'mpatha' and LVM vg 'rhel'
- have a dedicated multipath device 'mpathb' and LVM vg 'data'
- tell ReaR to only include 'rhel' VG (and not 'data' VG)
- tell ReaR to not auto-exclude multipath devices (otherwise everything
  gets commented out)

~~~
$ lsblk
NAME            MAJ:MIN RM  SIZE RO TYPE  MOUNTPOINT
sda               8:0    0    5G  0 disk
└─mpathba       253:1    0    5G  0 mpath
  └─mpathba1    253:2    0    1G  0 part  /boot
sdb               8:16   0    5G  0 disk
└─mpathba       253:1    0    5G  0 mpath
  └─mpathba1    253:2    0    1G  0 part  /boot
sdc               8:32   0   20G  0 disk
└─mpatha        253:0    0   20G  0 mpath
  ├─mpatha1     253:3    0    1G  0 part
  └─mpatha2     253:4    0   19G  0 part
    ├─rhel-root 253:5    0   10G  0 lvm   /
    └─rhel-swap 253:6    0    2G  0 lvm   [SWAP]
sdd               8:48   0   20G  0 disk
└─mpatha        253:0    0   20G  0 mpath
  ├─mpatha1     253:3    0    1G  0 part
  └─mpatha2     253:4    0   19G  0 part
    ├─rhel-root 253:5    0   10G  0 lvm   /
    └─rhel-swap 253:6    0    2G  0 lvm   [SWAP]
sde               8:64   0    2G  0 disk
└─mpathb        253:7    0    2G  0 mpath
sdf               8:80   0    2G  0 disk
└─mpathb        253:7    0    2G  0 mpath
sr0              11:0    1 1024M  0 rom

$ vgs
  VG   #PV #LV #SN Attr   VSize   VFree
  data   1   0   0 wz--n-  <2.00g <2.00g
  rhel   1   2   0 wz--n- <19.00g <7.00g

$ cat /etc/rear/local.conf
ONLY_INCLUDE_VG=("rhel")
AUTOEXCLUDE_MULTIPATH=n
~~~

With original code:
~~~
$ rear mkrescue
$ grep -v ^# /var/lib/rear/layout/disklayout.conf | grep "mpathba"
--> device excluded even though it hosts /boot
~~~

With the fix:
~~~
$ rear mkrescue
$ grep -v ^# /var/lib/rear/layout/disklayout.conf | grep "mpathba"
fs /dev/mapper/mpathba1 /boot xfs ...
multipath /dev/mapper/mpathba 5368709120 msdos /dev/sda,/dev/sdb
part /dev/mapper/mpathba 1073741824 1048576 primary none /dev/mapper/mpathba1
~~~

The root cause behind this is ReaR excludes 'mpathb' (hosting the 'data'
VG) through using a non-word matching *grep* command, which causes
'mpathba' (hosting /boot) to be excluded as well.

