### PR TITLE
Prepare for Issue #1040: add a fancy GitHub Action for 'shellcheck' for all pushes and PRs

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,61 @@
+name: Shellcheck Lint
+
+on:
+  push:
+    branches:
+      # Run workflow on every push
+      - '**'        # matches every branch
+
+  pull_request:
+    branches:
+      # Run workflow on every push
+      - '**'        # matches every branch
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Shellcheck Lint
+
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      # Required to access files of this repository
+      - uses: actions/checkout@v2
+
+      # Download Shellcheck and add it to the workflow path
+      - name: Download Shellcheck
+        run: |
+          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv
+          chmod +x shellcheck-stable/shellcheck
+      # Verify that Shellcheck can be executed
+      - name: Check Shellcheck Version
+        run: |
+          shellcheck-stable/shellcheck --version
+
+      # Run Shellcheck on repository
+      # ---
+      # https://github.com/koalaman/shellcheck
+      # ---
+      # Excluded checks:
+      # https://www.shellcheck.net/wiki/SC1091 -- Not following: /etc/rc.status was...
+      # https://www.shellcheck.net/wiki/SC1090 -- Can't follow non-constant source. ..
+      # ---
+      - name: Run Shellcheck
+        run: |
+          set +e
+          find  ./*/ -type f | while read -r sh; do
+            if [ "$(file --brief --mime-type "$sh")" == 'text/x-shellscript' ]; then
+              echo "shellcheck'ing $sh"
+              if ! shellcheck --color=always --severity=warning --exclude=SC1091,SC1090 "$sh"; then
+                touch some_scripts_have_failed_shellcheck
+              fi
+            fi
+          done
+          if [ -f ./some_scripts_have_failed_shellcheck ]; then
+            echo "Shellcheck failed for one or more shellscript(s)"
+            exit 1
+          fi
+

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       # Required to access files of this repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Download Shellcheck and add it to the workflow path
       - name: Download Shellcheck

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -53,7 +53,7 @@ jobs:
           find  ./*/ -type f | while read -r sh; do
             if [ "$(file --brief --mime-type "$sh")" == 'text/x-shellscript' ]; then
               echo "shellcheck'ing $sh"
-              if ! shellcheck --color=always --severity=warning --exclude=SC1091,SC1090 "$sh"; then
+              if ! shellcheck-stable/shellcheck --color=always --severity=warning --exclude=SC1091,SC1090 "$sh"; then
                 touch some_scripts_have_failed_shellcheck
               fi
             fi

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,14 +2,18 @@ name: Shellcheck Lint
 
 on:
   push:
-    branches:
+    paths:
       # Run workflow on every push
-      - '**'        # matches every branch
+      # only if a file within the specified paths has been changed:
+      - 'tests/**'
+      - 'usr/**'
 
   pull_request:
-    branches:
+    paths:
       # Run workflow on every push
-      - '**'        # matches every branch
+      # only if a file within the specified paths has been changed:
+      - 'tests/**'
+      - 'usr/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **High**

* Reference to related issue (URL):
This is a preparation for future PRs from me to solve #1040

* How was this pull request tested?
See GitHub Action in my forked repo for this PR:
https://github.com/thomasmerz/rear/runs/5069429307?check_suite_focus=true

* Brief description of the changes in this pull request:
This PR introduces a GitHub Action that will `shellcheck` all scripts in dirs "test" and "usr" for committer's and also repo-owner's convenience. All warnings including and above "severity=warning" will be reported and made transparent.