### PR TITLE
GRUB2_SEARCH_ROOT_COMMAND variable to overrule Grub2 search string

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1063,7 +1063,7 @@ USB_BOOTLOADER=
 # if an USB device was manually mounted to avoid recursive backups:
 AUTOEXCLUDE_USB_PATH=()
 
-# USB EFI booting can benifit with a better search string than the default:
+# USB EFI booting can benefit with a better search string than the default:
 # GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --label REAR-EFI
 # as hardcoded in script output/USB/Linux-i386/100_create_efiboot.sh
 # Only to be used by experts. An example of a different setup could be:

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1063,12 +1063,14 @@ USB_BOOTLOADER=
 # if an USB device was manually mounted to avoid recursive backups:
 AUTOEXCLUDE_USB_PATH=()
 
-# USB EFI booting can benifit with a better search string then the default:
-# GRUB2_SET_USB_ROOT="search --no-floppy --set=root --label REAR-EFI
+# USB EFI booting can benifit with a better search string than the default:
+# GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --label REAR-EFI
 # as hardcoded in script output/USB/Linux-i386/100_create_efiboot.sh
 # Only to be used by experts. An example of a different setup could be:
-# GRUB2_SET_USB_ROOT="search --no-floppy --set=root --label REAR-EFI --hint hd0,msdos1"
-GRUB2_SET_USB_ROOT=""
+# GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --label REAR-EFI --hint hd0,msdos1"
+# or
+# GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --file /EFI/BOOT/BOOTX86.efi"
+GRUB2_SEARCH_ROOT_COMMAND=""
 
 ##
 # OUTPUT=RAWDISK stuff

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1063,6 +1063,13 @@ USB_BOOTLOADER=
 # if an USB device was manually mounted to avoid recursive backups:
 AUTOEXCLUDE_USB_PATH=()
 
+# USB EFI booting can benifit with a better search string then the default:
+# GRUB2_SET_USB_ROOT="search --no-floppy --set=root --label REAR-EFI
+# as hardcoded in script output/USB/Linux-i386/100_create_efiboot.sh
+# Only to be used by experts. An example of a different setup could be:
+# GRUB2_SET_USB_ROOT="search --no-floppy --set=root --label REAR-EFI --hint hd0,msdos1"
+GRUB2_SET_USB_ROOT=""
+
 ##
 # OUTPUT=RAWDISK stuff
 ##

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -622,6 +622,7 @@ function create_grub2_cfg {
             cat << EOF
 menuentry "Relax-and-Recover (BIOS or UEFI without Secure Boot)" --id=rear {
     insmod gzio
+    insmod xzio
     echo 'Loading kernel $grub2_kernel ...'
     linux $grub2_kernel root=UUID=$root_uuid $KERNEL_CMDLINE
     echo 'Loading initial ramdisk $grub2_initrd ...'
@@ -630,6 +631,7 @@ menuentry "Relax-and-Recover (BIOS or UEFI without Secure Boot)" --id=rear {
 
 menuentry "Relax-and-Recover (UEFI and Secure Boot)" --id=rear_secure_boot {
     insmod gzio
+    insmod xzio
     echo 'Loading kernel $grub2_kernel ...'
     linuxefi $grub2_kernel root=UUID=$root_uuid $KERNEL_CMDLINE
     echo 'Loading initial ramdisk $grub2_initrd ...'
@@ -640,6 +642,7 @@ EOF
             cat << EOF
 menuentry "Relax-and-Recover (BIOS or UEFI in legacy BIOS mode)" --id=rear {
     insmod gzio
+    insmod xzio
     echo 'Loading kernel $grub2_kernel ...'
     linux $grub2_kernel root=UUID=$root_uuid $KERNEL_CMDLINE
     echo 'Loading initial ramdisk $grub2_initrd ...'

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -542,15 +542,15 @@ function create_grub2_cfg {
     local grub2_initrd="$2"
     test "$grub2_initrd" || BugError "create_grub2_cfg function called without grub2_initrd argument"
     DebugPrint "Configuring GRUB2 initrd $grub2_initrd"
-    local grub2_set_root_command="$3"
-    if ! test "$grub2_set_root_command" ; then
-        test "$grub2_set_root" && grub2_set_root_command="set root=$grub2_set_root"
+    local grub2_search_root_command="$3"
+    if ! test "$grub2_search_root_command" ; then
+        test "$grub2_set_root" && grub2_search_root_command="set root=$grub2_set_root"
     fi
-    if ! test "$grub2_set_root_command" ; then
-        test "$GRUB2_SET_USB_ROOT" && grub2_set_root_command="$GRUB2_SET_USB_ROOT"
+    if ! test "$grub2_search_root_command" ; then
+        test "$GRUB2_SEARCH_ROOT_COMMAND" && grub2_search_root_command="$GRUB2_SEARCH_ROOT_COMMAND"
     fi
-    test "$grub2_set_root_command" || grub2_set_root_command="search --no-floppy --set=root --file /boot/efiboot.img"
-    DebugPrint "Configuring GRUB2 root device as '$grub2_set_root_command'"
+    test "$grub2_search_root_command" || grub2_search_root_command="search --no-floppy --set=root --file /boot/efiboot.img"
+    DebugPrint "Configuring GRUB2 root device as '$grub2_search_root_command'"
 
     local grub2_default_menu_entry="$GRUB2_DEFAULT_BOOT"
     test "$grub2_default_menu_entry" || grub2_default_menu_entry="chainloader"
@@ -713,7 +713,7 @@ EOF
     # Sleep 3 seconds before the GRUB2 menu replaces what there is on the screen
     # so that the user has a chance to see possible (error) messages on the screen.
     cat << EOF
-$grub2_set_root_command
+$grub2_search_root_command
 insmod all_video
 set gfxpayload=keep
 insmod part_gpt

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -90,10 +90,13 @@ function build_bootx86_efi {
         fi
 
         if [ -n "$gprobe" ]; then
-            # this is unfortunately only a crude approximation of the Grub internal probe_mods() function
+            # This is unfortunately only a crude approximation of the Grub internal probe_mods() function.
+            # $gprobe --target=partmap "$p" | sed -e 's/^/part_/' does not always returns part_msdos
+            # Therefore, we explicit do an echo 'part_msdos' (the sort -u will make sure it is listed only once)
             modules=( $( for p in "${dirs[@]}" ; do
                              $gprobe --target=fs "$p"
                              $gprobe --target=partmap "$p" | sed -e 's/^/part_/'
+                             echo 'part_msdos'
                              $gprobe --target=abstraction "$p"
                          done | sort -u ) )
         fi

--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -82,8 +82,8 @@ EOF
             DebugPrint "Configuring GRUB2 for EFI boot"
             # We need to explicitly set GRUB 2 'root' variable to $efi_label (hardcoded "REAR-EFI")
             # because default $root would point to memdisk, where kernel and initrd are NOT present.
-            # GRUB2_SET_USB_ROOT is used in the create_grub2_cfg() function:
-            [[ -z "$GRUB2_SET_USB_ROOT" ]] && GRUB2_SET_USB_ROOT="search --no-floppy --set=root --label $efi_label"
+            # GRUB2_SEARCH_ROOT_COMMAND is used in the create_grub2_cfg() function:
+            [[ -z "$GRUB2_SEARCH_ROOT_COMMAND" ]] && GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --label $efi_label"
             # Create config for GRUB 2
             create_grub2_cfg $efi_dir/kernel $efi_dir/$REAR_INITRD_FILENAME > $efi_dst/grub.cfg
             # Create bootloader, this overwrite BOOTX64.efi copied in previous step ...

--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -83,7 +83,7 @@ EOF
             # We need to explicitly set GRUB 2 'root' variable to $efi_label (hardcoded "REAR-EFI")
             # because default $root would point to memdisk, where kernel and initrd are NOT present.
             # GRUB2_SET_USB_ROOT is used in the create_grub2_cfg() function:
-            GRUB2_SET_USB_ROOT="search --no-floppy --set=root --label $efi_label"
+            [[ -z "$GRUB2_SET_USB_ROOT" ]] && GRUB2_SET_USB_ROOT="search --no-floppy --set=root --label $efi_label"
             # Create config for GRUB 2
             create_grub2_cfg $efi_dir/kernel $efi_dir/$REAR_INITRD_FILENAME > $efi_dst/grub.cfg
             # Create bootloader, this overwrite BOOTX64.efi copied in previous step ...

--- a/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
@@ -59,6 +59,6 @@ test "$USB_DEVICE_BOOT_LABEL" || USB_DEVICE_BOOT_LABEL="REARBOOT"
 # We need to set the GRUB environment variable 'root' to the partition device with filesystem label USB_DEVICE_BOOT_LABEL
 # because GRUB's default 'root' (or GRUB's 'root' identifcation heuristics) would point to the ramdisk but neither kernel
 # nor initrd are located on the ramdisk but on the partition device with filesystem label USB_DEVICE_BOOT_LABEL.
-# GRUB2_SET_USB_ROOT is used in the create_grub2_cfg() function:
-GRUB2_SET_USB_ROOT="search --no-floppy --set=root --label $USB_DEVICE_BOOT_LABEL"
+# GRUB2_SEARCH_ROOT_COMMAND is used in the create_grub2_cfg() function:
+GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --label $USB_DEVICE_BOOT_LABEL"
 create_grub2_cfg /$USB_PREFIX/kernel /$USB_PREFIX/$REAR_INITRD_FILENAME > $usb_boot_dir/$grub_cfg || Error "Failed to create $usb_boot_dir/$grub_cfg"


### PR DESCRIPTION
Signed-off-by: Gratien D'haese <gratien.dhaese@gmail.com>

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): #2500 

* How was this pull request tested? With an EFI USB disk

* Brief description of the changes in this pull request: The GRUB2_SET_USB_ROOT variable was used locally in script 100_create_efiboot.sh. However, by adding it to the default.conf we are able to overrule the setting which was defined in the 100_create_efiboot.sh script. Now, it can be added to the local.conf file with a more precise setting according the end-user requirements.
Furthermore, we also introduced the `insmod xzio` in the grub.conf file in case we were using the `REAR_INITRD_COMPRESSION=lzma` setting in the local.conf file.

