### PR TITLE
Fixed the RAID10 layout support code

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
@@ -231,6 +231,11 @@ mdadm --detail --scan --config=partitions | while read array raiddevice junk ; d
         OIFS=$IFS
         IFS=","
         for layout_option in $layout ; do
+            # When a RAID10 layout option is already set for this RAID array an additional one is not supported:
+            if test $layout_option_setting ; then
+                LogPrintError "Ignoring additional RAID10 layout '$layout_option' for $raiddevice (only one RAID10 layout setting is supported)"
+                continue
+            fi
             layout_option_name=${layout_option%=*}
             layout_option_value=${layout_option#*=}
             # The RAID10 layout option value must be "a small number" where "2 is normal, 3 can be useful"
@@ -243,11 +248,6 @@ mdadm --detail --scan --config=partitions | while read array raiddevice junk ; d
             # Now the RAID10 layout option value is at least a number:
             if ! test $layout_option_value -le 9 ; then
                 LogPrintError "Ignoring RAID10 layout '$layout_option' for $raiddevice (the value is not a small number)"
-                continue
-            fi
-            # When a RAID10 layout option is already set for this RAID array an additional one is not supported:
-            if test $layout_option_setting ; then
-                LogPrintError "Ignoring additional RAID10 layout '$layout_option' for $raiddevice (only one RAID10 layout setting is supported)"
                 continue
             fi
             # Save the RAID10 layout option with the right syntax for the mdadm --layout option value during "rear recover":


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/commit/4dbbb288057189076d82cb8e477cd994a4ce1851
https://github.com/rear/rear/issues/1040#issuecomment-1034870262

* How was this pull request tested?
Not at all tested - I don't have a RAID10 test system right now

* Brief description of the changes in this pull request:

In layout/save/GNU/Linux/210_raid_layout.sh
fixed the RAID10 layout support code as far as possible for now.
Currently only 'near=...' support is (and was) implemented initially via
https://github.com/rear/rear/commit/4dbbb288057189076d82cb8e477cd994a4ce1851

This fix was triggered by ShellCheck
SC2034: param appears unused. Verify use (or export if used externally)
https://github.com/koalaman/shellcheck/wiki/SC2034
SC2066: Since you double quoted this, it will not word split, and the loop will only run once
https://github.com/koalaman/shellcheck/wiki/SC2066
cf. https://github.com/rear/rear/issues/1040#issuecomment-1034870262
