### PR TITLE
Avoid SC2068 and SC2145 in finalize/Fedora/i386/550_rebuild_initramfs.sh

### DIFF
--- a/usr/share/rear/finalize/Fedora/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Fedora/i386/550_rebuild_initramfs.sh
@@ -52,7 +52,7 @@ Log "Original OLD_INITRD_MODULES=( ${OLD_INITRD_MODULES[*]} )"
 # To achieve this, we list the old modules twice in the variable NEW_INITRD_MODULES and then add the new modules.
 # Then we use "uniq -u" to filter out the modules which only appear once in the list.
 # The resulting array contains only the new modules:
-NEW_INITRD_MODULES=( ${OLD_INITRD_MODULES[@]} ${OLD_INITRD_MODULES[@]} $( cat $TMP_DIR/storage_drivers ) )
+NEW_INITRD_MODULES=( "${OLD_INITRD_MODULES[@]}" "${OLD_INITRD_MODULES[@]}" $( cat $TMP_DIR/storage_drivers ) )
 NEW_INITRD_MODULES=( $( tr " " "\n" <<< "${NEW_INITRD_MODULES[*]}" | sort | uniq -u ) )
 
 # Concatenate the old and new modules into a string:

--- a/usr/share/rear/finalize/Fedora/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Fedora/i386/550_rebuild_initramfs.sh
@@ -47,7 +47,7 @@ if [ -f $VAR_DIR/recovery/initrd_modules ]; then
     OLD_INITRD_MODULES=()
 fi
 
-Log "Original OLD_INITRD_MODULES='${OLD_INITRD_MODULES[@]}'"
+Log "Original OLD_INITRD_MODULES are ${OLD_INITRD_MODULES[*]}"
 # To see what has been added by the migration process, the new modules are added to the
 # end of the list. To achieve this, we list the old modules twice in the variable
 # NEW_INITRD_MODULES and then add the new modules. Then we use "uniq -u" to filter out
@@ -58,10 +58,10 @@ NEW_INITRD_MODULES=( ${OLD_INITRD_MODULES[@]} ${OLD_INITRD_MODULES[@]} $( cat $T
 # uniq INITRD_MODULES
 NEW_INITRD_MODULES=( $(tr " " "\n" <<< "${NEW_INITRD_MODULES[*]}" | sort | uniq -u) )
 
-Log "New INITRD_MODULES='${OLD_INITRD_MODULES[@]} ${NEW_INITRD_MODULES[@]}'"
+Log "New INITRD_MODULES are ${OLD_INITRD_MODULES[*]} ${NEW_INITRD_MODULES[*]}"
 INITRD_MODULES="${OLD_INITRD_MODULES[@]} ${NEW_INITRD_MODULES[@]}"
 
-WITH_INITRD_MODULES=$( printf '%s\n' ${INITRD_MODULES[@]} | awk '{printf "--with=%s ", $1}' )
+WITH_INITRD_MODULES=$( printf '%s\n' ${INITRD_MODULES[*]} | awk '{printf "--with=%s ", $1}' )
 
 # Recreate any initrd or initramfs image under $TARGET_FS_ROOT/boot/ with new drivers
 # Images ignored:
@@ -88,7 +88,7 @@ for INITRD_IMG in $( ls $TARGET_FS_ROOT/boot/initramfs-*.img $TARGET_FS_ROOT/boo
     # and then "rear recover" cannot be aborted with the usual [Ctrl]+[C] keys.
     # Use plain $var because when var contains only blanks test "$var" results true because test " " results true:
     if test $mkinitrd_binary ; then
-        if chroot $TARGET_FS_ROOT $mkinitrd_binary -v -f ${WITH_INITRD_MODULES[@]} $INITRD $kernel_version >&2 ; then
+        if chroot $TARGET_FS_ROOT $mkinitrd_binary -v -f ${WITH_INITRD_MODULES[*]} $INITRD $kernel_version ; then
             LogPrint "Updated initrd with new drivers for kernel $kernel_version."
         else
             LogPrint "WARNING:

--- a/usr/share/rear/finalize/Fedora/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Fedora/i386/550_rebuild_initramfs.sh
@@ -67,11 +67,6 @@ WITH_INITRD_MODULES=$( printf '%s\n' $INITRD_MODULES | awk '{printf "--with=%s "
 # kdump images as they are build by kdump
 # initramfs rescue images (>= Rhel 7), which need all modules and are created by new-kernel-pkg
 # initrd-plymouth.img (>= Rhel 7), which contains only files needed for graphical boot via plymouth
-# The unalias originates from https://github.com/rear/rear/commit/d029e0dbe98b9fed496d8f3857bef132c8f165ad
-# This is the only place in ReaR where unalias is called and it unaliases ls also for all subsequent scripts.
-# TODO: Explain why this unalias is needed here and why it is also needed in all subsequent scripts:
-unalias ls 2>/dev/null
-
 for INITRD_IMG in $( ls $TARGET_FS_ROOT/boot/initramfs-*.img $TARGET_FS_ROOT/boot/initrd-*.img | egrep -v '(kdump|rescue|plymouth)' ) ; do
     # Do not use KERNEL_VERSION here because that is readonly in the rear main script:
     kernel_version=$( basename $( echo $INITRD_IMG ) | cut -f2- -d"-" | sed s/"\.img"// )


### PR DESCRIPTION
* Type: **Cleanup**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1040

* How was this pull request tested?

I don't use Fedora so cannot test it.
@pcahyna @rmetrich 
please have a look if my changes make sense.

* Brief description of the changes in this pull request:

In finalize/Fedora/i386/550_rebuild_initramfs.sh
avoid ShellCheck
SC2068: Double quote array expansions to avoid re-splitting elements
https://github.com/koalaman/shellcheck/wiki/SC2068
and avoid
SC2145: Argument mixes string and array. Use * or separate argument
https://github.com/koalaman/shellcheck/wiki/SC2145
cf. https://github.com/rear/rear/issues/1040#issuecomment-1062945160
