### PR TITLE
increase USB_UEFI_PART_SIZE to 1024 MiB

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1007,18 +1007,20 @@ USB_PARTITION_ALIGN_BLOCK_SIZE="8"
 # in MiB when formatting a medium by the format workflow.
 # If USB_UEFI_PART_SIZE is empty or invalid (i.e. not an unsigned integer larger than 0)
 # the user must interactively enter a valid value while running the format workflow.
-# The default value of 512 MiB should be sufficiently big and it is in compliance
-# with the 8 MiB partition alignment default value ( 512 = 8 * 64 )
-# and also with higher 2^n MiB partition alignment values
+# The default value of 1024 MiB should be sufficiently big
 # cf. https://github.com/rear/rear/pull/1205
-# Furthermore the default value of 512 MiB results that the FAT filesystem of the ESP
+# in particular when third-party kernel modules and firmware (e.g. from Nvidia) are used
+# cf. https://github.com/rear/rear/issues/2770#issuecomment-1068935688
+# and 1024 MiB is in compliance with the 8 MiB partition alignment value ( 1024 = 8 * 128 )
+# and also with higher 2^n MiB partition alignment values.
+# Furthermore the default value of 1024 MiB results that the FAT filesystem of the ESP
 # will be in compliance with that the ESP should officially use a FAT32 filesystem
 # because mkfs.vfat automatically makes a FAT32 filesystem starting at 512 MiB
 # (a FAT16 ESP works in most cases but causes issues with certain UEFI firmware)
 # cf. https://github.com/rear/rear/issues/2575
 # The value of USB_UEFI_PART_SIZE will be rounded to the nearest
 # USB_PARTITION_ALIGN_BLOCK_SIZE chunk:
-USB_UEFI_PART_SIZE="512"
+USB_UEFI_PART_SIZE="1024"
 #
 # Default boot option (i.e. what gets booted automatically after some timeout)
 # when EXTLINUX boots the USB stick or USB disk or other disk device on BIOS systems.


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):

https://github.com/rear/rear/pull/1205

https://github.com/rear/rear/issues/2770#issuecomment-1068935688

* Brief description of the changes in this pull request:

In default.conf increase USB_UEFI_PART_SIZE to 1024 MiB
cf. https://github.com/rear/rear/pull/1205
in particular to also make things work by default when additional
third-party kernel modules and firmware (e.g. from Nvidia) are used,
cf. https://github.com/rear/rear/issues/2770#issuecomment-1068935688
