### PR TITLE
Fix SC2091 in 310_network_devices.sh

### DIFF
--- a/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
+++ b/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
@@ -239,7 +239,7 @@ function map_network_interface () {
     local network_interface=$1
     local mapped_as=$2
 
-    if $( printf "%s\n" "${MAPPED_NETWORK_INTERFACES[@]}" | grep -qw ^$network_interface ) ; then
+    if printf "%s\n" "${MAPPED_NETWORK_INTERFACES[@]}" | grep -qw "^$network_interface" ; then
         # There is an error in the code. This means a handle_* function has
         # been called on an already mapped interface, which shouldn't happen.
         BugError "'$network_interface' is already mapped."


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/commit/15567ede425401b008e5b1680db36a2c62752b8f#r68281832

* How was this pull request tested?
Not tested by me.

* Brief description of the changes in this pull request:

In rescue/GNU/Linux/310_network_devices.sh fix
SC2091: Remove surrounding $() to avoid executing output
in the line
```
if $( printf "%s\n" "${MAPPED_NETWORK_INTERFACES[@]}" | grep -qw ^$network_interface ) ; then
```
cf. https://github.com/rear/rear/commit/15567ede425401b008e5b1680db36a2c62752b8f#r68281832
that reads
```
I do not understand why $(...) command substitution is used here.
It looks as if it could be just removed but I am uncertain.
Perhaps I overlook some obscure magic?
But grep -q won't ouput anything so $(...) would execute nothing?
```
