### PR TITLE
Detect by UUIDs if restored config files do not match what was recreated

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -326,13 +326,24 @@ OUTPUT=ISO
 # Default cdrom size in MB (probably it is actually MiB?):
 CDROM_SIZE=20
 
-# The CHECK_CONFIG_FILES array lists files where changes
-# require the ReaR rescue/recovery system to be recreated.
+# The CHECK_CONFIG_FILES array lists files where changes require
+# that an up-to-date ReaR rescue/recovery system must be created anew.
 # Testing whether or not those files changed is implemented in the checklayout workflow
 # which exits with non-zero exit code when the disk layout or those files changed
 # (cf. https://github.com/rear/rear/issues/1134) but the checklayout workflow
 # does not automatically recreate the rescue/recovery system.
-CHECK_CONFIG_FILES=( '/etc/drbd/' '/etc/drbd.conf' '/etc/lvm/lvm.conf' '/etc/multipath.conf' '/etc/rear/' '/etc/udev/udev.conf' )
+# CHECK_CONFIG_FILES is also used in finalize/GNU/Linux/280_migrate_uuid_tags.sh
+# to check during "rear recover" if each UUID that was in at least one of the
+# config files in CHECK_CONFIG_FILES at the time when disklayout.conf was created
+# is also in at least one of the restored config files in CHECK_CONFIG_FILES
+# (i.e. to detect if restored config files do not match what was recreated).
+# Therefore all relevant config files that contain UUIDs should be specified here
+# (some files in /etc/ contain UUIDs but are not relevant like /etc/lvm/cache/.cache).
+# To find files in /etc/ that contain UUIDs on block devices one may use a command like
+#   for uuid in $( lsblk -no UUID,PTUUID,PARTUUID ) ; do find /etc -type f | xargs grep -il $uuid ; done | sort -u
+# which may show files in /etc/ that contain UUIDs which are not used in disklayout.conf
+# so one has to decide what is actually relevant for "rear recover":
+CHECK_CONFIG_FILES=( '/etc/fstab' '/etc/crypttab' '/etc/drbd/' '/etc/drbd.conf' '/etc/lvm/lvm.conf' '/etc/multipath.conf' '/etc/rear/' '/etc/udev/udev.conf' )
 
 ##
 # Relax-and-Recover recovery system update during "rear recover"

--- a/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
+++ b/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
@@ -42,6 +42,8 @@ pushd $TARGET_FS_ROOT >/dev/null
 local config_files=()
 local obj
 for obj in "${CHECK_CONFIG_FILES[@]}" ; do
+    # Strip leading slash because we need relative file and directory names inside TARGET_FS_ROOT:
+    obj=${obj#/}
     if test -d "$obj" ; then
         config_files+=( $( find "$obj" -type f ) )
     elif test -e "$obj" ; then

--- a/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
+++ b/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
@@ -1,4 +1,3 @@
-# migrate fs_uuid_mapping
 
 # Check if UUIDs in disklayout.conf still appear in the restored config files.
 # During "rear mkrescue/mkbackup/mkbackuponly/savelayout" various layout/save/ scripts
@@ -19,12 +18,8 @@
 # for those UUIDs that were adapted to the actually recreated UUIDs by the mapping code.
 # One reason for this check is that the subsequent UUID mapping code cannot work
 # when restored config files have different UUIDs than those in disklayout.conf because
-# FS_UUID_MAP contains UUIDs that were changed during disk layout recreation in the form
-#   disklayout_conf_UUID recreated_UUID device
-# (see layout/prepare/GNU/Linux/131_include_filesystem_code.sh)
-# from which a sed script is created below that replaces disklayout_conf_UUID by recreated_UUID
-# but this sed script cannot work when restored config files have different UUIDs
-# than those in disklayout.conf because the UUIDs in disklayout.conf will not match.
+# it adapts disklayout.conf UUIDs in restored config files to the actually recreated UUIDs
+# which cannot work when restored config files do not contain the disklayout.conf UUIDs.
 # The main reason for this check is that normally UUIDs get recreated as stored in disklayout.conf
 # because nowadays tools (e.g. mkfs) can set UUIDs so normally the UUID mapping code has nothing to do.
 # But when restored config files have different UUIDs than those in disklayout.conf
@@ -68,6 +63,16 @@ for uuid in $DISKLAYOUT_UUIDS_IN_CONFIG_FILES ; do
 done
 # Go back from the restored files directory:
 popd >/dev/null
+
+# UUID mapping:
+# UUIDs that were recreated different than what is stored in disklayout.conf
+# need to be adapted in restored config files:
+# FS_UUID_MAP is /var/lib/rear/layout/fs_uuid_mapping which contains UUIDs
+# that were changed during disk layout recreation in the form
+#   disklayout_conf_UUID recreated_UUID device
+# (see layout/prepare/GNU/Linux/131_include_filesystem_code.sh)
+# from which a sed script is created that replaces disklayout_conf_UUID by recreated_UUID
+# in restored config files.
 
 # skip if no mappings
 test -s "$FS_UUID_MAP" || return 0

--- a/usr/share/rear/layout/save/GNU/Linux/100_create_layout_file.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/100_create_layout_file.sh
@@ -7,6 +7,9 @@ mkdir -p $v $VAR_DIR/layout
 mkdir -p $v $VAR_DIR/recovery
 mkdir -p $v $VAR_DIR/layout/config
 
+# Use a new VAR_DIR/layout/config/disklayout.uuids from scratch:
+rm -f $VAR_DIR/layout/config/disklayout.uuids
+
 # We need directory for XFS options only if XFS is in use:
 if test "$( mount -t xfs )" ; then
     LAYOUT_XFS_OPT_DIR="$VAR_DIR/layout/xfs"

--- a/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
@@ -184,7 +184,10 @@ mdadm --detail --scan --config=partitions | while read array raiddevice junk ; d
 
     line=( $( grep "UUID :" $mdadm_details ) )
     uuid=${line[2]}
-    test $uuid && raid_layout_entry+=" uuid=$uuid"
+    if test $uuid ; then
+        raid_layout_entry+=" uuid=$uuid"
+        echo "$uuid" >> $VAR_DIR/layout/config/disklayout.uuids
+    fi
 
     # A "Layout :" line in the detailed mdadm output normally looks like
     #          Layout : near=2

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -129,6 +129,7 @@ local lvs_exit_code
         fi
         # With the above example the output is:
         # lvmdev /dev/system /dev/sda1 7wwpcO-KmNN-qsTE-7sp7-JBJS-vBdC-Zyt1W7 41940992
+        echo "$uuid" >> $VAR_DIR/layout/config/disklayout.uuids
         echo "lvmdev /dev/$vgrp $pdev $uuid $size"
 
     done

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -179,6 +179,7 @@ fi
                     fi
                 fi
                 uuid=$( $tunefs -l $device | tr -d '[:blank:]' | grep -i 'UUID:' | cut -d ':' -f 2 )
+                echo "$uuid" >> $VAR_DIR/layout/config/disklayout.uuids
                 echo -n " uuid=$uuid"
                 label=$( e2label $device )
                 echo -n " label=$label"
@@ -213,10 +214,12 @@ fi
             (vfat)
                 label=$(blkid_label_of_device $device)
                 uuid=$(blkid_uuid_of_device $device)
+                echo "$uuid" >> $VAR_DIR/layout/config/disklayout.uuids
                 echo -n " uuid=$uuid label=$label"
                 ;;
             (xfs)
                 uuid=$(xfs_admin -u $device | cut -d'=' -f 2 | tr -d " ")
+                echo "$uuid" >> $VAR_DIR/layout/config/disklayout.uuids
                 label=$(xfs_admin -l $device | cut -d'"' -f 2)
                 echo -n " uuid=$uuid label=$label "
                 # Save current XFS file system options.
@@ -227,6 +230,7 @@ fi
                 ;;
             (reiserfs)
                 uuid=$(debugreiserfs $device | grep "UUID" | cut -d":" -f "2" | tr -d " ")
+                echo "$uuid" >> $VAR_DIR/layout/config/disklayout.uuids
                 label=$(debugreiserfs $device | grep "LABEL" | cut -d":" -f "2" | tr -d " ")
                 echo -n " uuid=$uuid label=$label"
                 ;;
@@ -234,6 +238,7 @@ fi
                 # Remember devices and mountpoints of the btrfs filesystems for the btrfs subvolume layout stuff below:
                 btrfs_devices_and_mountpoints="$btrfs_devices_and_mountpoints $device,$mountpoint"
                 uuid=$( btrfs filesystem show $device | grep -o 'uuid: .*' | cut -d ':' -f 2 | tr -d '[:space:]' )
+                echo "$uuid" >> $VAR_DIR/layout/config/disklayout.uuids
                 label=$( btrfs filesystem show $device | grep -o 'Label: [^ ]*' | cut -d ':' -f 2 | tr -d '[:space:]' )
                 test "none" = "$label" && label=
                 echo -n " uuid=$uuid label=$label"

--- a/usr/share/rear/layout/save/GNU/Linux/240_swaps_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/240_swaps_layout.sh
@@ -44,6 +44,7 @@ Log "Saving Swap information."
 	   done
         fi
 
+        echo "$uuid" >> $VAR_DIR/layout/config/disklayout.uuids
         echo "swap $filename uuid=$uuid label=$label"
     done < /proc/swaps
 ) >> $DISKLAYOUT_FILE

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -126,6 +126,7 @@ while read target_name junk ; do
         # and https://github.com/rear/rear/issues/2509
         LogPrintError "Error: No 'uuid' value for LUKS$version volume $target_name in $source_device (mounting it or booting the recreated system may fail)"
     fi
+    echo "$uuid" >> $VAR_DIR/layout/config/disklayout.uuids
 
     echo "crypt /dev/mapper/$target_name $source_device type=$luks_type cipher=$cipher key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE
 

--- a/usr/share/rear/layout/save/default/600_snapshot_files.sh
+++ b/usr/share/rear/layout/save/default/600_snapshot_files.sh
@@ -1,14 +1,44 @@
-# Save a hash of files that would warrant a new rescue image when changed.
-if [ "$WORKFLOW" = "checklayout" ] ; then
-    return 0
-fi
 
-config_files=()
+# During "rear mkrescue/mkbackup/mkbackuponly/savelayout"
+# save md5sum of config files in CHECK_CONFIG_FILES
+# which is needed for comparison by "rear checklayout":
+
+# During "rear checklayout" do not save new md5sum of files in CHECK_CONFIG_FILES because
+# the old ones are needed for comparison in layout/compare/default/510_compare_files.sh
+test "$WORKFLOW" = "checklayout" && return 0
+
+local config_files=()
+local obj
 for obj in "${CHECK_CONFIG_FILES[@]}" ; do
-    if [ -d "$obj" ] ; then
+    if test -d "$obj" ; then
         config_files+=( $( find "$obj" -type f ) )
-    elif [ -e "$obj" ] ; then
-        config_files+=( "$obj")
+    elif test -e "$obj" ; then
+        config_files+=( "$obj" )
     fi
 done
+
 md5sum "${config_files[@]}" > $VAR_DIR/layout/config/files.md5sum
+
+# During "rear mkrescue/mkbackup/mkbackuponly/savelayout"
+# save which UUIDs in disklayout.conf appear in a config file in CHECK_CONFIG_FILES
+# which is needed for comparison during "rear recover":
+
+# Nothing to do when there are no UUIDs in disklayout.conf:
+test -s $VAR_DIR/layout/config/disklayout.uuids || return 0
+
+local uuid
+local uuids_in_config_files=""
+# Ignore duplicates (a UUID may appear more than once in disklayout.conf):
+for uuid in $( sort -u $VAR_DIR/layout/config/disklayout.uuids ) ; do
+    grep -q "$uuid" "${config_files[@]}" && uuids_in_config_files+=" $uuid"
+done
+# Remove duplicates (a UUID may appear in more than one config file) and
+# have all as a single line of UUIDs separated by space (i.e. remove newlines):
+uuids_in_config_files="$( for uuid in $uuids_in_config_files ; do echo "$uuid" ; done | sort -u | tr '\n' ' ' )"
+# Store the UUIDs in disklayout.conf that appear in a config file in CHECK_CONFIG_FILES in the rescue configuration:
+if test "$uuids_in_config_files" ; then
+    { echo "# The following line was added by layout/save/default/600_snapshot_files.sh"
+      echo "DISKLAYOUT_UUIDS_IN_CONFIG_FILES='$uuids_in_config_files'"
+      echo ""
+    } >> "$ROOTFS_DIR/etc/rear/rescue.conf"
+fi


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2787
https://github.com/rear/rear/issues/2785

* How was this pull request tested?
Curently only a "rear mkrescue" test on my homeoffice laptop

* Brief description of the changes in this pull request:

During "rear mkrescue/mkbackup/mkbackuponly/savelayout"
save which UUIDs in disklayout.conf appear
in a config file in CHECK_CONFIG_FILES
which is used for comparison during "rear recover"
if those UUIDs in disklayout.conf still appear
in a restored config file in CHECK_CONFIG_FILES
in the recreated system under /mnt/local

The main reason is to avoid false alarm
when UUIDs in disklayout.conf do not appear in a config file
on the original system - then those UUIDs do not need to
be checked in the recreated system.
