### PR TITLE
For GRUB_RESCUE set 'root=/dev/ram0 vga=normal rw' as for other boot media

### DIFF
--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -229,7 +229,7 @@ else
     fi
       ( echo "          search --no-floppy --fs-uuid --set=root $grub_boot_uuid"
         echo "          echo 'Loading kernel $boot_kernel_file ...'"
-        echo "          linux $grub_boot_dir/$boot_kernel_name $KERNEL_CMDLINE"
+        echo "          linux $grub_boot_dir/$boot_kernel_name root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE"
         echo "          echo 'Loading initrd $boot_initrd_file (may take a while) ...'"
         echo "          initrd $grub_boot_dir/$boot_initrd_name"
         echo "}"


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL): No issue opened right now

* How was this pull request tested?: Local VM

* Brief description of the changes in this pull request:
On RHEL8.5, if you simply add the line `GRUB_RESCUE=y` at `/etc/rear/site.conf` and run `rear -v mkbackup`, you'll see the new entry at the Grub2 menu, but that new boot option will end up with a Panic like the following one:

![image](https://user-images.githubusercontent.com/26822043/163188174-d61045f3-13fb-4e05-a650-04b1317f54dc.png)

The original Grub2 entry looks like the following:

```
menuentry 'Relax-and-Recover' --class os {
          search --no-floppy --fs-uuid --set=root 1c0c73ea-169c-4ed5-a6d0-d0e6501fc0b6
          echo 'Loading kernel /boot/rear-kernel ...'
          linux /rear-kernel selinux=0 unattended console=ttyS0,9600 console=tty0
          echo 'Loading initrd /boot/rear-initrd.cgz (may take a while) ...'
          initrd /rear-initrd.cgz
}
```

Looking at the kernel parameters used at every other boot media generated by ReaR, the `root` parameter generated by the `/usr/share/rear/output/default/940_grub2_rescue.sh` file is using a wrong value, as the correct value should be `root=/dev/ram0`.

That PR is generating the grub entry with this parameter, in addition to the `search --no-floppy --fs-uuid --set=root ...` line. Maybe that line should disappear, but I can't test other O.S.