### PR TITLE
Clean up USB backups before creating a new one on the USB drive

### DIFF
--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -98,6 +98,39 @@ case "$WORKFLOW" in
     (*) BugError "Workflow $WORKFLOW should not run this script."
 esac
 
+# Clean up older images of a given system, but keep USB_RETAIN_BACKUP_NR
+# entries for backup and rescue when backup on USB works in default mode.
+# When USB_SUFFIX is set the compliance mode is used where
+# backup on USB works in compliance with backup on NFS which means
+# a fixed backup directory and no automated removal of backups or other stuff
+# see https://github.com/rear/rear/issues/1164
+# Use plain $USB_SUFFIX and not "$USB_SUFFIX" because when USB_SUFFIX contains only blanks
+# test "$USB_SUFFIX" would result true because test " " results true:
+if ! test $USB_SUFFIX ; then
+    backup_count=${USB_RETAIN_BACKUP_NR:-2}
+    rescue_count=${USB_RETAIN_BACKUP_NR:-2}
+    for rear_run in $(ls -dt $BUILD_DIR/outputfs/rear/$HOSTNAME/*); do
+        # This fails when the backup archive name is not
+        # ${BACKUP_PROG_ARCHIVE}${BACKUP_PROG_SUFFIX}${BACKUP_PROG_COMPRESS_SUFFIX}
+        # so that in particular it would fail for incremental/differential backups
+        # but incremental/differential backups on USB require USB_SUFFIX to be set:
+        backup_name=$rear_run/${BACKUP_PROG_ARCHIVE}${BACKUP_PROG_SUFFIX}${BACKUP_PROG_COMPRESS_SUFFIX}
+        if [[ -e $backup_name ]] ; then
+            backup_count=$((backup_count - 1))
+            if (( backup_count < 0 )); then
+                Log "Remove older backup directory $rear_run"
+                rm -rf $v $rear_run >/dev/null
+            fi
+        else
+            rescue_count=$((rescue_count - 1))
+            if (( rescue_count < 0 )); then
+                Log "Remove older rescue directory $rear_run"
+                rm -rf $v $rear_run >/dev/null
+            fi
+        fi
+    done
+fi
+
 USB_REAR_DIR="$BUILD_DIR/outputfs/$USB_PREFIX"
 if [ ! -d "$USB_REAR_DIR" ]; then
     mkdir -p $v "$USB_REAR_DIR" >/dev/null || Error "Could not create USB ReaR dir [$USB_REAR_DIR] !"
@@ -140,39 +173,6 @@ ${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BA
     append initrd=/$USB_PREFIX/$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover
 
 EOF
-
-# Clean up older images of a given system, but keep USB_RETAIN_BACKUP_NR
-# entries for backup and rescue when backup on USB works in default mode.
-# When USB_SUFFIX is set the compliance mode is used where
-# backup on USB works in compliance with backup on NFS which means
-# a fixed backup directory and no automated removal of backups or other stuff
-# see https://github.com/rear/rear/issues/1164
-# Use plain $USB_SUFFIX and not "$USB_SUFFIX" because when USB_SUFFIX contains only blanks
-# test "$USB_SUFFIX" would result true because test " " results true:
-if ! test $USB_SUFFIX ; then
-    backup_count=${USB_RETAIN_BACKUP_NR:-2}
-    rescue_count=${USB_RETAIN_BACKUP_NR:-2}
-    for rear_run in $(ls -dt $BUILD_DIR/outputfs/rear/$HOSTNAME/*); do
-        # This fails when the backup archive name is not
-        # ${BACKUP_PROG_ARCHIVE}${BACKUP_PROG_SUFFIX}${BACKUP_PROG_COMPRESS_SUFFIX}
-        # so that in particular it would fail for incremental/differential backups
-        # but incremental/differential backups on USB require USB_SUFFIX to be set:
-        backup_name=$rear_run/${BACKUP_PROG_ARCHIVE}${BACKUP_PROG_SUFFIX}${BACKUP_PROG_COMPRESS_SUFFIX}
-        if [[ -e $backup_name ]] ; then
-            backup_count=$((backup_count - 1))
-            if (( backup_count < 0 )); then
-                Log "Remove older backup directory $rear_run"
-                rm -rf $v $rear_run >/dev/null
-            fi
-        else
-            rescue_count=$((rescue_count - 1))
-            if (( rescue_count < 0 )); then
-                Log "Remove older rescue directory $rear_run"
-                rm -rf $v $rear_run >/dev/null
-            fi
-        fi
-    done
-fi
 
 # We generate a ReaR syslinux.cfg based on existing ReaR syslinux.cfg files.
 Log "Creating /rear/syslinux.cfg"


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL): No issue created yet

* How was this pull request tested?: VM in a home lab

* Brief description of the changes in this pull request: If you are working with an adjusted free space into your USB drive, creating any content prior to free space may fail, making the process to abort. This PR is changing the order of the cleanup, so it'll the first step to be executed.

