### PR TITLE
More failsafe 200_partition_layout.sh

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -115,6 +115,11 @@ extract_partitions() {
         parted -s $device print > $TMP_DIR/parted
         disk_label=$(grep -E "Partition Table|Disk label" $TMP_DIR/parted | cut -d ":" -f "2" | tr -d " ")
     fi
+    # Ensure $disk_label is valid to determine the partition name/type in the next step at 'declare type'
+    # cf. https://github.com/rear/rear/issues/2801#issuecomment-1122015129
+    if ! [[ "$disk_label" = "msdos" || "$disk_label" = "gpt" || "$disk_label" = "gpt_sync_mbr" || "$disk_label" = "dasd" ]] ; then
+        Error "Unsupported partition table '$disk_label' (must be one of 'msdos' 'gpt' 'gpt_sync_mbr' 'dasd')"
+    fi
 
     cp $TMP_DIR/partitions $TMP_DIR/partitions-data
 


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2801#issuecomment-1122015129

* How was this pull request tested?
Not yet tested.

* Brief description of the changes in this pull request:

In layout/save/GNU/Linux/200_partition_layout.sh
ensure the partition name/type entry in disklayout.conf
is always set (and percent encoded if needed)
at least it is set to the fallback value 'rear-noname'
regardless of the 'disk_label' value
