### PR TITLE
Exclude dev/watchdog* from recovery system

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1653,7 +1653,12 @@ COPY_AS_IS=( $SHARE_DIR $VAR_DIR )
 # We let them being recreated by device mapper in the recovery system during the recovery process.
 # Copying them into the recovery system would let "rear recover" avoid the migration process.
 # See https://github.com/rear/rear/pull/1393 for details.
-COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/\* dev/.udev dev/shm dev/shm/\* dev/oracleasm dev/mapper )
+# /dev/watchdog /dev/watchdog\* functionality is not wanted in the ReaR rescue/recovery system
+# because we do not want any automated reboot while disaster recovery happens via "rear recover".
+# Furthermore having dev/watchdog* during "rear mkrescue" may even trigger a system "crash" that is
+# caused by TrendMicro ds_am module touching dev/watchdog in ReaR's build area (/var/tmp/rear.XXX/rootfs).
+# See https://github.com/rear/rear/issues/2798
+COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/\* dev/.udev dev/shm dev/shm/\* dev/oracleasm dev/mapper dev/watchdog\* )
 # Array of user names that are trusted owners of files where RequiredSharedObjects calls ldd (cf. COPY_AS_IS)
 # and where a ldd test is run inside the recovery system that tests all binaries for 'not found' libraries.
 # The default is 'root' plus those standard system users that have a 'bin' or 'sbin' or 'root' home directory


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Critical**
("critical" because it is related to system crash in some cases)

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2798

* How was this pull request tested?
See https://github.com/rear/rear/issues/2798#issuecomment-1126145771
and https://github.com/rear/rear/issues/2798#issuecomment-1127721378

* Brief description of the changes in this pull request:

In default.conf add dev/watchdog\* to COPY_AS_IS_EXCLUDE
because /dev/watchdog /dev/watchdog\* functionality
is not wanted in the ReaR rescue/recovery system
because we do not want any automated reboot
while disaster recovery happens via "rear recover".
Furthermore having dev/watchdog* during "rear mkrescue"
may even trigger a system "crash" that is caused by
TrendMicro ds_am module touching dev/watchdog
in ReaR's build area (/var/tmp/rear.XXX/rootfs).
