### PR TITLE
Describe USB_BOOT_PART_SIZE and USB_DEVICE_BOOT_LABEL

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1044,6 +1044,26 @@ USB_PARTITION_ALIGN_BLOCK_SIZE="8"
 # USB_PARTITION_ALIGN_BLOCK_SIZE chunk:
 USB_UEFI_PART_SIZE="1024"
 #
+# USB_BOOT_PART_SIZE specifies the size of an optional boot partition in MiB
+# when formatting a medium by the format workflow.
+# A boot partition is created when USB_BOOT_PART_SIZE is a positive integer.
+# By default we do not create a separated boot partition
+# so by default the ReaR recovery system (kernel and initrd)
+# and the backup archive get stored in the ReaR data partition
+# in a rear/HOSTNAME/TIMESTAMP directory (cf. USB_SUFFIX below):
+USB_BOOT_PART_SIZE="0"
+#
+# The label that is set for a boot partition via the format workflow
+# when a boot partition is created (see USB_BOOT_PART_SIZE above).
+# That label must be used for settings like
+#   OUTPUT_URL=usb:///dev/disk/by-label/$USB_DEVICE_BOOT_LABEL
+#   BACKUP_URL=usb:///dev/disk/by-label/$USB_DEVICE_FILESYSTEM_LABEL
+# to get the ReaR recovery system (kernel and initrd) stored
+# in the boot partition in a rear/HOSTNAME/TIMESTAMP directory
+# while the backup archive gets stored in the ReaR data partition
+# there in a matching rear/HOSTNAME/TIMESTAMP directory:
+USB_DEVICE_BOOT_LABEL="REARBOOT"
+#
 # Default boot option (i.e. what gets booted automatically after some timeout)
 # when EXTLINUX boots the USB stick or USB disk or other disk device on BIOS systems.
 # USB_BIOS_BOOT_DEFAULT="boothd0" boots from 'boothd0' which is usually the same disk


### PR DESCRIPTION
* Type: **Documentation**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2660

* Brief description of the changes in this pull request:

In default.conf describe
USB_BOOT_PART_SIZE and USB_DEVICE_BOOT_LABEL

In particular see
https://github.com/rear/rear/pull/2660#issuecomment-885582656

I do not change the currently
implemented user config variable names
USB_BOOT_PART_SIZE and USB_DEVICE_BOOT_LABEL

By the way:
Regarding where by default the recovery system and backup
get stored for OUTPUT=USB and BACKUP=NETFS see
https://github.com/rear/rear/pull/2660#issuecomment-885622061
and how they can be stored separated
with an optional boot partition see
https://github.com/rear/rear/pull/2660#issuecomment-885643937
