### PR TITLE
RPM spec: update build requirement for Fedora to unblock Packit build and run make validate after build

### DIFF
--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -42,6 +42,8 @@ Requires: syslinux
 # (in addition to the default installed bootloader grub2) while on ppc ppc64 the
 # default installed bootloader yaboot is also used to make the bootable ISO image.
 
+BuildRequires: make
+
 ### Mandatory dependencies on all distributions:
 Requires: binutils
 Requires: ethtool

--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -162,6 +162,9 @@ fi
 %{__rm} -rf %{buildroot}
 %{__make} install DESTDIR="%{buildroot}"
 
+%check
+%{__make} validate
+
 %files
 # defattr: is required for SLES 11 and RHEL/CentOS 5 builds on openSUSE Build Service (#2135)
 %defattr(-, root, root, 0755)


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): https://github.com/rear/rear/issues/2757

* How was this pull request tested?
Test with correct filenames and a little change with no impact:
https://github.com/antonvoznia/rear/pull/51
As result the packit build has been passed
https://dashboard.packit.dev/results/copr-builds/362145

Test with incorrect filename:
https://github.com/antonvoznia/rear/pull/52
As result the Packit build has been failed:
https://dashboard.packit.dev/results/copr-builds/362146

* Brief description of the changes in this pull request:
Adding make validate for building stage to check the correctness of the filenames of the scripts.
It is instead of travis CI solution which were actual in past.

