### PR TITLE
Pipe as many 'y' as asked for into "lvm lvcreate"

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,10 +3,9 @@ jobs:
 - job: copr_build
   metadata:
     targets:
-    - fedora-29-x86_64
-    - fedora-30-x86_64
-    - fedora-31-x86_64
-    - fedora-rawhide-x86_64
+    - fedora-all
+    - centos-stream-8-x86_64
+    - centos-stream-9-x86_64
   trigger: pull_request
 specfile_path: packaging/rpm/rear.spec
 synced_files:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,6 +6,8 @@ jobs:
     - fedora-all
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
+    - opensuse-leap-15.3-x86_64
+    - opensuse-tumbleweed-x86_64
   trigger: pull_request
 - job: production_build
   metadata:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -7,6 +7,13 @@ jobs:
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
   trigger: pull_request
+- job: production_build
+  metadata:
+    scratch: True
+    targets:
+    - fedora-latest-stable
+    - epel-all
+  trigger: pull_request
 specfile_path: packaging/rpm/rear.spec
 synced_files:
 - .packit.yaml

--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -42,6 +42,8 @@ Requires: syslinux
 # (in addition to the default installed bootloader grub2) while on ppc ppc64 the
 # default installed bootloader yaboot is also used to make the bootable ISO image.
 
+BuildRequires: make
+
 ### Mandatory dependencies on all distributions:
 Requires: binutils
 Requires: ethtool

--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -162,6 +162,9 @@ fi
 %{__rm} -rf %{buildroot}
 %{__make} install DESTDIR="%{buildroot}"
 
+%check
+%{__make} validate
+
 %files
 # defattr: is required for SLES 11 and RHEL/CentOS 5 builds on openSUSE Build Service (#2135)
 %defattr(-, root, root, 0755)

--- a/usr/share/rear/build/GNU/Linux/005_create_symlinks.sh
+++ b/usr/share/rear/build/GNU/Linux/005_create_symlinks.sh
@@ -8,7 +8,6 @@
 ln -sf $v bin/init $ROOTFS_DIR/init >&2
 ln -sf $v bin $ROOTFS_DIR/sbin >&2
 ln -sf $v bash $ROOTFS_DIR/bin/sh >&2
-ln -sf $v vi $ROOTFS_DIR/bin/vim >&2
 ln -sf $v true $ROOTFS_DIR/bin/pam_console_apply >&2 # RH/Fedora with udev needs this
 ln -sf $v ../bin $ROOTFS_DIR/usr/bin >&2
 ln -sf $v ../bin $ROOTFS_DIR/usr/sbin >&2

--- a/usr/share/rear/build/OPALPBA/Linux-i386/106_remove_files_copied_unconditionally.sh
+++ b/usr/share/rear/build/OPALPBA/Linux-i386/106_remove_files_copied_unconditionally.sh
@@ -5,7 +5,6 @@
 
 # Remove symlinks whose targets have been excluded on the PBA system
 local symlinks_to_remove=(
-    bin/vim
     var/lib/rear
 )
 

--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -227,6 +227,12 @@ LIBS+=(
 )
 
 COPY_AS_IS+=( /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/termcap /etc/terminfo /lib*/terminfo /usr/share/terminfo /etc/netconfig /etc/mke2fs.conf /etc/*-release /etc/localtime /etc/magic /usr/share/misc/magic /etc/dracut.conf /etc/dracut.conf.d /usr/lib/dracut /sbin/modprobe.ksplice-orig /etc/sysctl.conf /etc/sysctl.d /etc/e2fsck.conf )
+
+# Needed by vi on Fedora and derived distributions
+# where vi is a shell script that executes /usr/libexec/vi
+# see https://github.com/rear/rear/pull/2822
+COPY_AS_IS+=( /usr/libexec/vi )
+
 # Required by curl with https:
 # There are stored the distribution provided certificates
 # installed from packages, nothing confidential.

--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -292,7 +292,7 @@ create_lvmvol() {
     # instead we input as many 'y' as asked for by "lvm lvcreate"
     # see https://github.com/rear/rear/issues/513
     # and https://github.com/rear/rear/issues/2820
-    # and suppress needless "yes: standard output: Broken pipe" sderr messages
+    # and suppress needless "yes: standard output: Broken pipe" stderr messages
     # that appear at least with newer 'yes' in coreutils-8.32 in openSUSE Leap 15.3
     cat >> "$LAYOUT_CODE" <<EOF
 $ifline

--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -289,18 +289,23 @@ create_lvmvol() {
 
     # In SLES11 "man lvcreate" does not show '-y' or '--yes'
     # so we cannot use "lvm lvcreate -y ..."
+    # see https://github.com/rear/rear/issues/2820#issuecomment-1161934013
     # instead we input as many 'y' as asked for by "lvm lvcreate"
     # see https://github.com/rear/rear/issues/513
     # and https://github.com/rear/rear/issues/2820
+    # plus be safe against possible 'set -o pipefail' non-zero exit code of 'yes' via '( yes || true ) | ...'
+    # see https://github.com/rear/rear/issues/2820#issuecomment-1162804476
+    # because 'yes' may get terminated by SIGPIPE when plain 'yes | ...' is used
+    # see https://github.com/rear/rear/issues/2820#issuecomment-1162772415
     # and suppress needless "yes: standard output: Broken pipe" stderr messages
     # that appear at least with newer 'yes' in coreutils-8.32 in openSUSE Leap 15.3
     cat >> "$LAYOUT_CODE" <<EOF
 $ifline
     LogPrint "Creating LVM volume '$vg/$lvname' (some properties may not be preserved)"
     $warnraidline
-    if ! yes 2>/dev/null | lvm lvcreate $lvopts $vg ; then
+    if ! ( yes 2>/dev/null || true ) | lvm lvcreate $lvopts $vg ; then
         LogPrintError "Failed to create LVM volume '$vg/$lvname' with lvcreate $lvopts $vg"
-        if yes 2>/dev/null | lvm lvcreate $fallbacklvopts $vg ; then
+	if ( yes 2>/dev/null || true ) | lvm lvcreate $fallbacklvopts $vg ; then
             LogPrintError "Created LVM volume '$vg/$lvname' using fallback options lvcreate $fallbacklvopts $vg"
         else
             LogPrintError "Also failed to create LVM volume '$vg/$lvname' with lvcreate $fallbacklvopts $vg"


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):

https://github.com/rear/rear/issues/513
https://github.com/rear/rear/commit/5bc24808da0a5d2b6d711c428fef0aa415f2fc01
https://github.com/rear/rear/issues/2820

* How was this pull request tested?
 
Not yet tested

* Brief description of the changes in this pull request:

In layout/prepare/GNU/Linux/110_include_lvm_code.sh
input as many 'y' as asked for by "lvm lvcreate" via a "yes" pipe
see https://github.com/rear/rear/issues/513
and https://github.com/rear/rear/issues/2820
and suppress needless "yes: standard output: Broken pipe" stderr messages
