### PR TITLE
Fix vi in the rescue system on Fedora and RHEL 9

### DIFF
--- a/usr/share/rear/build/GNU/Linux/005_create_symlinks.sh
+++ b/usr/share/rear/build/GNU/Linux/005_create_symlinks.sh
@@ -8,7 +8,6 @@
 ln -sf $v bin/init $ROOTFS_DIR/init >&2
 ln -sf $v bin $ROOTFS_DIR/sbin >&2
 ln -sf $v bash $ROOTFS_DIR/bin/sh >&2
-ln -sf $v vi $ROOTFS_DIR/bin/vim >&2
 ln -sf $v true $ROOTFS_DIR/bin/pam_console_apply >&2 # RH/Fedora with udev needs this
 ln -sf $v ../bin $ROOTFS_DIR/usr/bin >&2
 ln -sf $v ../bin $ROOTFS_DIR/usr/sbin >&2

--- a/usr/share/rear/build/OPALPBA/Linux-i386/106_remove_files_copied_unconditionally.sh
+++ b/usr/share/rear/build/OPALPBA/Linux-i386/106_remove_files_copied_unconditionally.sh
@@ -5,7 +5,6 @@
 
 # Remove symlinks whose targets have been excluded on the PBA system
 local symlinks_to_remove=(
-    bin/vim
     var/lib/rear
 )
 

--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -227,6 +227,12 @@ LIBS+=(
 )
 
 COPY_AS_IS+=( /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/termcap /etc/terminfo /lib*/terminfo /usr/share/terminfo /etc/netconfig /etc/mke2fs.conf /etc/*-release /etc/localtime /etc/magic /usr/share/misc/magic /etc/dracut.conf /etc/dracut.conf.d /usr/lib/dracut /sbin/modprobe.ksplice-orig /etc/sysctl.conf /etc/sysctl.d /etc/e2fsck.conf )
+
+# Needed by vi on Fedora and derived distributions
+# where vi is a shell script that executes /usr/libexec/vi
+# see https://github.com/rear/rear/pull/2822
+COPY_AS_IS+=( /usr/libexec/vi )
+
 # Required by curl with https:
 # There are stored the distribution provided certificates
 # installed from packages, nothing confidential.


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL): https://bugzilla.redhat.com/show_bug.cgi?id=2097437

* How was this pull request tested?
without the change:
```
# echo 'PROGS+=( timeout )' >> /etc/rear/local.conf
# rear -d mkrescue
...
Testing that the recovery system in /var/tmp/rear.sewWahfi7dNgMlf/rootfs contains a usable system
...
# chroot /var/tmp/rear.sewWahfi7dNgMlf/rootfs timeout 10 vi +q
# echo $?
124
```
with the change, the return code is 0 and manually executing vi in the chroot works properly.

* Brief description of the changes in this pull request:

In recent Fedora and RHEL 9, `vi` is a shell script that executes `vim` if found, so linking `vim` to `vi` leads to an infinite loop. Fix by removing the symlink (I find it more confusing than helpful anyway, and it is good to reduce the amount of special handling) and adding `/usr/libexec/vi` (the real executable, executed by `vi` if `vim` is not found) to `COPY_AS_IS`.

One could add vim as well, but I am afraid that it would bloat the rescue ramdisk in case vim is compiled with a rich set of features.