### PR TITLE
Update and extend Packit build targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,10 +3,9 @@ jobs:
 - job: copr_build
   metadata:
     targets:
-    - fedora-29-x86_64
-    - fedora-30-x86_64
-    - fedora-31-x86_64
-    - fedora-rawhide-x86_64
+    - fedora-all
+    - centos-stream-8-x86_64
+    - centos-stream-9-x86_64
   trigger: pull_request
 specfile_path: packaging/rpm/rear.spec
 synced_files:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,6 +6,8 @@ jobs:
     - fedora-all
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
+    - opensuse-leap-15.3-x86_64
+    - opensuse-tumbleweed-x86_64
   trigger: pull_request
 - job: production_build
   metadata:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -7,6 +7,13 @@ jobs:
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
   trigger: pull_request
+- job: production_build
+  metadata:
+    scratch: True
+    targets:
+    - fedora-latest-stable
+    - epel-all
+  trigger: pull_request
 specfile_path: packaging/rpm/rear.spec
 synced_files:
 - .packit.yaml


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested?
Packit will test it, see the Checks tab.

* Brief description of the changes in this pull request:
Update build targets for Packit (the Fedora ones were obsolete). Add Koji scratch builds (Koji is the Fedora build system) as an alternative to the usual Copr builds, and EPEL and CentOS Stream build targets in order to produce packages for CentOS / RHEL. Add openSUSE Leap and Tumbleweed build targets (using Copr).

This will greatly increase the diversity of systems that we perform test RPM builds for.