### PR TITLE
Replace `mkinitrd` with `dracut` on Fedora and RHEL

### DIFF
--- a/usr/share/rear/finalize/Fedora/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Fedora/i386/550_rebuild_initramfs.sh
@@ -60,7 +60,7 @@ INITRD_MODULES="${OLD_INITRD_MODULES[*]} ${NEW_INITRD_MODULES[*]}"
 Log "New INITRD_MODULES='$INITRD_MODULES'"
 
 # Do not quote $INITRD_MODULES otherwise printf could not split words as separated arguments on separated lines:
-WITH_INITRD_MODULES=$( printf '%s\n' $INITRD_MODULES | awk '{printf "--with=%s ", $1}' )
+WITH_INITRD_MODULES=$( printf '%s\n' $INITRD_MODULES | awk '{printf "--add-drivers=%s ", $1}' )
 
 # Recreate any initrd or initramfs image under $TARGET_FS_ROOT/boot/ with new drivers
 # Images ignored:
@@ -71,19 +71,19 @@ for INITRD_IMG in $( ls $TARGET_FS_ROOT/boot/initramfs-*.img $TARGET_FS_ROOT/boo
     # Do not use KERNEL_VERSION here because that is readonly in the rear main script:
     kernel_version=$( basename $( echo $INITRD_IMG ) | cut -f2- -d"-" | sed s/"\.img"// )
     INITRD=$( echo $INITRD_IMG | egrep -o "/boot/.*" )
-    LogPrint "Running mkinitrd..."
-    # Run mkinitrd directly in chroot without a login shell in between (see https://github.com/rear/rear/issues/862).
-    # We need the mkinitrd binary in the chroot environment i.e. the mkinitrd binary in the recreated system.
-    # Normally we would use a login shell like: chroot $TARGET_FS_ROOT /bin/bash --login -c 'type -P mkinitrd'
+    LogPrint "Running dracut..."
+    # Run dracut directly in chroot without a login shell in between (see https://github.com/rear/rear/issues/862).
+    # We need the dracut binary in the chroot environment i.e. the dracut binary in the recreated system.
+    # Normally we would use a login shell like: chroot $TARGET_FS_ROOT /bin/bash --login -c 'type -P dracut'
     # because otherwise there is no useful PATH (PATH is only /bin) so that 'type -P' won't find it
     # but we cannot use a login shell because that contradicts https://github.com/rear/rear/issues/862
     # so that we use a plain (non-login) shell and set a (hopefully) reasonable PATH:
-    local mkinitrd_binary=$( chroot $TARGET_FS_ROOT /bin/bash -c 'PATH=/sbin:/usr/sbin:/usr/bin:/bin type -P mkinitrd' )
-    # If there is no mkinitrd in the chroot environment plain 'chroot $TARGET_FS_ROOT' will hang up endlessly
+    local dracut_binary=$( chroot $TARGET_FS_ROOT /bin/bash -c 'PATH=/sbin:/usr/sbin:/usr/bin:/bin type -P dracut' )
+    # If there is no dracut in the chroot environment plain 'chroot $TARGET_FS_ROOT' will hang up endlessly
     # and then "rear recover" cannot be aborted with the usual [Ctrl]+[C] keys.
     # Use plain $var because when var contains only blanks test "$var" results true because test " " results true:
-    if test $mkinitrd_binary ; then
-        if chroot $TARGET_FS_ROOT $mkinitrd_binary -v -f $WITH_INITRD_MODULES $INITRD $kernel_version ; then
+    if test $dracut_binary ; then
+        if chroot $TARGET_FS_ROOT $dracut_binary -v -f $WITH_INITRD_MODULES $INITRD $kernel_version ; then
             LogPrint "Updated initrd with new drivers for kernel $kernel_version."
         else
             LogPrint "WARNING:
@@ -94,7 +94,7 @@ and decide yourself, whether the system will boot or not.
         fi
     else
         LogPrint "WARNING:
-Cannot create initrd (found no mkinitrd in the recreated system).
+Cannot create initrd (found no dracut in the recreated system).
 Check the recreated system (mounted at $TARGET_FS_ROOT)
 and decide yourself, whether the system will boot or not.
 "


### PR DESCRIPTION
#### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL): https://bugzilla.redhat.com/show_bug.cgi?id=2096900

* How was this pull request tested?

RHEL 9 VM without this patch that failed to regenerate the `initrd` and same VM with this patch that regenerated the `initrd` successfully.

* Brief description of the changes in this pull request:

For a long time, `mkinitrd` was a wrapper script around `dracut` in Fedora and RHEL that maintained backwards compatibility with the real (but rather obsolete) `mkinitrd`.

Dracut 054 removed the `mkinitrd` wrapper script [1] so now we have to execute `dracut` directly.  Fortunately, ReaR did not use almost anything from `mkinitrd`'s interface (with the exception of `--with`) so the transition is quite straightforward.

Without this patch the initrd regeneration in the finalize stage of recovery fails on RHEL 9 and Fedora 33 or newer.

[1] https://github.com/dracutdevs/dracut/pull/1285

