### PR TITLE
Recognise `-b`/`--bios` options in `format` workflow

### DIFF
--- a/usr/share/rear/lib/format-workflow.sh
+++ b/usr/share/rear/lib/format-workflow.sh
@@ -19,7 +19,7 @@ WORKFLOW_format () {
 
     # Parse options
     # (do not use OPTS here because that is readonly in the rear main script):
-    format_workflow_opts="$( getopt -n "$PROGRAM format" -o "efhy" -l "efi,force,help,yes" -- "$@" )"
+    format_workflow_opts="$( getopt -n "$PROGRAM format" -o "befhy" -l "bios,efi,force,help,yes" -- "$@" )"
     if (( $? != 0 )) ; then
         LogPrintError "Use '$PROGRAM format -- --help' for more information."
         # TODO: Use proper exit codes cf. https://github.com/rear/rear/issues/1134


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* How was this pull request tested? Directly by invoking `rear format -- -b/--bios <device>`.

* Brief description of the changes in this pull request:

Found while testing #2825.

According to `rear format -- --help`, this workflow should recognise both `-b` and `--bios` options. This PR fixes the following error message:
```console
# rear format -- -b /dev/vdb
Use 'rear format -- --help' for more information.
rear format failed, check /var/log/rear/rear-<redacted>.log for details
```

