### PR TITLE
Set USB_DEVICE_PARTED_LABEL to match format-workflow.sh

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -977,16 +977,13 @@ USB_DEVICE=
 # USB_DEVICE_PARTED_LABEL is set to 'msdos' or 'gpt' accordingly.
 # When no format workflow option -b/--bios or -e/--efi was specified
 # it means hybrid boot supporting BIOS and UEFI by default
-# so USB_DEVICE_PARTED_LABEL must be set to 'gpt'
+# and then USB_DEVICE_PARTED_LABEL is set to 'gpt'
 # see https://github.com/rear/rear/issues/2698
-# so we set 'gpt' as default here because USB_DEVICE_PARTED_LABEL
-# could be needed in prep/USB/Linux-i386/340_find_mbr_bin.sh
-# which tries to autodetect what the actual USB device partition type is
-# but it uses USB_DEVICE_PARTED_LABEL as fallback when autodetection fails
-# which means when the format workflow option -b/--bios was used
-# the matching USB_DEVICE_PARTED_LABEL=msdos should be set in etc/rear/local.conf
-# otherwise things could go wrong in prep/USB/Linux-i386/340_find_mbr_bin.sh
-USB_DEVICE_PARTED_LABEL=gpt
+# For "rear mkrescue/mkbackup" USB_DEVICE_PARTED_LABEL
+# is set in prep/USB/Linux-i386/340_find_mbr_bin.sh
+# which tries to autodetect what the USB disk partition type is
+# but uses a specified USB_DEVICE_PARTED_LABEL if autodetection fails.
+USB_DEVICE_PARTED_LABEL=
 #
 # The label that is set for the ReaR data partition via the format workflow.
 # That label must be used for settings like

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -969,16 +969,22 @@ ISO_RECOVER_MODE=""
 USB_DEVICE=
 #
 # USB_DEVICE_PARTED_LABEL is the partition type (i.e. what is used for 'parted mklabel')
-# that is used when formatting a medium for use with ReaR via the format workflow.
+# that is used when formatting a medium for use with ReaR via the format workflow and
+# when SYSLINUX/EXTLINUX is used as booloader used for the USB medium (see USB_BOOTLOADER below).
 # It can be 'msdos' to create a MBR partition table or 'gpt' to create a GUID partition table (GPT).
-# It is set depending on the format workflow option -b/--bios or -e/--efi
-# so setting USB_DEVICE_PARTED_LABEL in etc/rear/local.conf has no effect.
+# It is set depending on the format workflow option -b/--bios or -e/--efi as follows:
 # When a format workflow option -b/--bios or -e/--efi was specified
 # USB_DEVICE_PARTED_LABEL is set to 'msdos' or 'gpt' accordingly.
 # When no format workflow option -b/--bios or -e/--efi was specified
 # it means hybrid boot supporting BIOS and UEFI by default
 # so USB_DEVICE_PARTED_LABEL must be set to 'gpt'
 # see https://github.com/rear/rear/issues/2698
+# so we set 'gpt' as default here because USB_DEVICE_PARTED_LABEL
+# is needed in prep/USB/Linux-i386/340_find_mbr_bin.sh
+# which means when the format workflow option -b/--bios was used
+# the matching USB_DEVICE_PARTED_LABEL=msdos must be set in etc/rear/local.conf
+# otherwise things would go wrong in prep/USB/Linux-i386/340_find_mbr_bin.sh
+USB_DEVICE_PARTED_LABEL=gpt
 #
 # The label that is set for the ReaR data partition via the format workflow.
 # That label must be used for settings like
@@ -1079,6 +1085,21 @@ USB_DEVICE_BOOT_LABEL="REARBOOT"
 # For details see output/USB/Linux-i386/300_create_extlinux.sh
 USB_BIOS_BOOT_DEFAULT=""
 #
+# Booloader used for the USB medium.
+# At the moment only empty/unset and "grub" is supported.
+# USB_BOOTLOADER="grub" uses GRUB2 as bootloader for USB with BIOS. GRUB Legacy is not supported.
+# Default is using GRUB2 for EFI other then elilo, extlinux for ext, syslinux otherwise:
+USB_BOOTLOADER=
+#
+# USB EFI booting can benefit with a better search string than the default:
+# GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --label REAR-EFI
+# as hardcoded in script output/USB/Linux-i386/100_create_efiboot.sh
+# Only to be used by experts. An example of a different setup could be:
+# GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --label REAR-EFI --hint hd0,msdos1"
+# or
+# GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --file /EFI/BOOT/BOOTX64.efi"
+GRUB2_SEARCH_ROOT_COMMAND=""
+#
 # Resulting files that should be copied onto the USB stick:
 USB_FILES=()
 #
@@ -1106,24 +1127,9 @@ USB_SUFFIX=""
 # and this setting is ignored when USB_SUFFIX is set (see above).
 USB_RETAIN_BACKUP_NR=2
 #
-# Booloader used for the USB medium.
-# At the moment only empty/unset and "grub" is supported.
-# USB_BOOTLOADER="grub" uses GRUB2 as bootloader for USB with BIOS. GRUB Legacy is not supported.
-# Default is using GRUB2 for EFI other then elilo, extlinux for ext, syslinux otherwise:
-USB_BOOTLOADER=
-#
 # Variable will probably be filled automatically
 # if an USB device was manually mounted to avoid recursive backups:
 AUTOEXCLUDE_USB_PATH=()
-
-# USB EFI booting can benefit with a better search string than the default:
-# GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --label REAR-EFI
-# as hardcoded in script output/USB/Linux-i386/100_create_efiboot.sh
-# Only to be used by experts. An example of a different setup could be:
-# GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --label REAR-EFI --hint hd0,msdos1"
-# or
-# GRUB2_SEARCH_ROOT_COMMAND="search --no-floppy --set=root --file /EFI/BOOT/BOOTX64.efi"
-GRUB2_SEARCH_ROOT_COMMAND=""
 
 ##
 # OUTPUT=RAWDISK stuff

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -968,14 +968,17 @@ ISO_RECOVER_MODE=""
 # (see also USB_DEVICE_FILESYSTEM_LABEL below):
 USB_DEVICE=
 #
-# The partition type that is used when formatting a medium for use with ReaR via the format workflow.
+# USB_DEVICE_PARTED_LABEL is the partition type (i.e. what is used for 'parted mklabel')
+# that is used when formatting a medium for use with ReaR via the format workflow.
 # It can be 'msdos' to create a MBR partition table or 'gpt' to create a GUID partition table (GPT).
-# When UEFI is used the format workflow will create a GUID partition table in any case.
-# A MBR partition table limits the maximum usable storage space on the medium to 2TB.
-# For larger medium sizes use 'gpt'. If you must use a MBR partition table on a medium > 2TB
-# set USB_DEVICE_FILESYSTEM_PERCENTAGE appropriately so that what is used for ReaR does not exceed
-# what works with a MBR partition table but then you cannot use the remaining space on the medium:
-USB_DEVICE_PARTED_LABEL=msdos
+# It is set depending on the format workflow option -b/--bios or -e/--efi
+# so setting USB_DEVICE_PARTED_LABEL in etc/rear/local.conf has no effect.
+# When a format workflow option -b/--bios or -e/--efi was specified
+# USB_DEVICE_PARTED_LABEL is set to 'msdos' or 'gpt' accordingly.
+# When no format workflow option -b/--bios or -e/--efi was specified
+# it means hybrid boot supporting BIOS and UEFI by default
+# so USB_DEVICE_PARTED_LABEL must be set to 'gpt'
+# see https://github.com/rear/rear/issues/2698
 #
 # The label that is set for the ReaR data partition via the format workflow.
 # That label must be used for settings like

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -980,10 +980,12 @@ USB_DEVICE=
 # so USB_DEVICE_PARTED_LABEL must be set to 'gpt'
 # see https://github.com/rear/rear/issues/2698
 # so we set 'gpt' as default here because USB_DEVICE_PARTED_LABEL
-# is needed in prep/USB/Linux-i386/340_find_mbr_bin.sh
+# could be needed in prep/USB/Linux-i386/340_find_mbr_bin.sh
+# which tries to autodetect what the actual USB device partition type is
+# but it uses USB_DEVICE_PARTED_LABEL as fallback when autodetection fails
 # which means when the format workflow option -b/--bios was used
-# the matching USB_DEVICE_PARTED_LABEL=msdos must be set in etc/rear/local.conf
-# otherwise things would go wrong in prep/USB/Linux-i386/340_find_mbr_bin.sh
+# the matching USB_DEVICE_PARTED_LABEL=msdos should be set in etc/rear/local.conf
+# otherwise things could go wrong in prep/USB/Linux-i386/340_find_mbr_bin.sh
 USB_DEVICE_PARTED_LABEL=gpt
 #
 # The label that is set for the ReaR data partition via the format workflow.

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -32,6 +32,25 @@ local current_partition_number=1
 # current start byte of the next partition to add
 local current_partition_start_byte=$(( USB_PARTITION_ALIGN_BLOCK_SIZE * MiB_bytes ))
 
+### Create partition table section
+
+# Initialize USB disk via "parted mklabel" (create partition table)
+# When a format workflow option -b/--bios or -e/--efi was specified set USB_DEVICE_PARTED_LABEL accordingly
+# cf. https://github.com/rear/rear/pull/2828#issuecomment-1164590100
+# and when no format workflow option -b/--bios or -e/--efi was specified
+# then rear/lib/format-workflow.sh sets both FORMAT_BIOS and FORMAT_EFI to 'y'
+# cf. https://github.com/rear/rear/commit/9591fbf77c0c12329738625fcb83bb1d9b419b51
+# to get hybrid boot supporting BIOS and UEFI from the same medium by default
+# see https://github.com/rear/rear/pull/2705
+# so the ordering of the two settings below is crucial
+# to ensure a GUID partition table is set up for hybrid boot:
+is_true "$FORMAT_BIOS" && USB_DEVICE_PARTED_LABEL="msdos"
+is_true "$FORMAT_EFI" && USB_DEVICE_PARTED_LABEL="gpt"
+LogPrint "Creating partition table of type $USB_DEVICE_PARTED_LABEL on $RAW_USB_DEVICE"
+if ! parted -s $RAW_USB_DEVICE mklabel $USB_DEVICE_PARTED_LABEL ; then
+    Error "Failed to create $USB_DEVICE_PARTED_LABEL partition table on $RAW_USB_DEVICE"
+fi
+
 # Flag for the partition wherefrom is booted which is the boot partition if exists
 # or the data partition as fallback when there is no boot partition:
 local boot_partition_flag="$USB_BOOT_PARTITION_FLAG"
@@ -49,16 +68,6 @@ if ! test $boot_partition_flag ; then
             Error "USB_DEVICE_PARTED_LABEL='$USB_DEVICE_PARTED_LABEL' (neither 'msdos' nor 'gpt')"
             ;;
     esac
-fi
-
-### Create partition table section
-
-# Initialize USB disk via "parted mklabel" (create partition table)
-# If not set use fallback value 'msdos' (same as the default value in default.conf):
-test "msdos" = "$USB_DEVICE_PARTED_LABEL" -o "gpt" = "$USB_DEVICE_PARTED_LABEL" || USB_DEVICE_PARTED_LABEL="msdos"
-LogPrint "Creating partition table of type $USB_DEVICE_PARTED_LABEL on $RAW_USB_DEVICE"
-if ! parted -s $RAW_USB_DEVICE mklabel $USB_DEVICE_PARTED_LABEL ; then
-    Error "Failed to create $USB_DEVICE_PARTED_LABEL partition table on $RAW_USB_DEVICE"
 fi
 
 ### Create partitions section

--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -3,16 +3,29 @@
 # because it sets a hardcoded label REAR-EFI in format/USB/default/300_format_usb_disk.sh
 # for the VFAT EFI filesystem that is needed here.
 
-is_true $USING_UEFI_BOOTLOADER || return 0
-
-local uefi_bootloader_basename=$( basename "$UEFI_BOOTLOADER" )
+# Do "the right thing" depending on
+# whether or not there is a partition labeled 'REAR-EFI'
+# and whether or not USING_UEFI_BOOTLOADER is 'true':
 local efi_label="REAR-EFI"
 local efi_part="/dev/disk/by-label/$efi_label"
-
+if ! test -b "$efi_part" ; then
+    if ! is_true $USING_UEFI_BOOTLOADER ; then
+        # There is no partition labeled 'REAR-EFI' and USING_UEFI_BOOTLOADER is not 'true':
+        DebugPrint "No EFI boot (no EFI partition '$efi_part' and USING_UEFI_BOOTLOADER is not 'true')"
+        return 0
+    fi
+    # There is no partition labeled 'REAR-EFI' but USING_UEFI_BOOTLOADER is 'true':
+    Error "USING_UEFI_BOOTLOADER is 'true' but no EFI partition '$efi_part' block device (did you prepare with 'rear format'?)"
+fi
+# There is a is a partition labeled 'REAR-EFI':
+if ! is_true $USING_UEFI_BOOTLOADER ; then
+    # There is a is a partition labeled 'REAR-EFI' and USING_UEFI_BOOTLOADER is not 'true':
+    DebugPrint "Skip configuring EFI partition '$efi_part' for EFI boot (USING_UEFI_BOOTLOADER is not 'true')"
+    return 0
+fi
+# There is a is a partition labeled 'REAR-EFI' and USING_UEFI_BOOTLOADER is 'true':
+local uefi_bootloader_basename=$( basename "$UEFI_BOOTLOADER" )
 DebugPrint "Configuring EFI partition '$efi_part' for EFI boot with '$uefi_bootloader_basename'"
-
-# Fail if EFI partition is not present
-test -b "$efi_part" || Error "EFI partition '$efi_part' is no block device (did you use 'rear format -- --efi ...' for correct format?)"
 
 # $BUILD_DIR is not present at this stage so TMPDIR (by default /var/tmp see default.conf) will be used instead.
 # Slackware version of mktemp requires 6 Xs in template and

--- a/usr/share/rear/prep/USB/Linux-i386/340_find_mbr_bin.sh
+++ b/usr/share/rear/prep/USB/Linux-i386/340_find_mbr_bin.sh
@@ -5,18 +5,17 @@ local mbr_image_file
 
 # Choose right MBR image file for right partition table type (issue #1153)
 case "$USB_DEVICE_PARTED_LABEL" in
-    "msdos")
+    (msdos)
         mbr_image_file="mbr.bin"
-    ;;
-    "gpt")
+        ;;
+    (gpt)
         mbr_image_file="gptmbr.bin"
-    ;;
-    *)
-        Error "USB_DEVICE_PARTED_LABEL is incorrectly set, please check your settings."
-    ;;
+        ;;
+    (*)
+        Error "USB_DEVICE_PARTED_LABEL='$USB_DEVICE_PARTED_LABEL' (neither 'msdos' nor 'gpt')"
+        ;;
 esac
 
-SYSLINUX_MBR_BIN=$(find_syslinux_file $mbr_image_file)
+SYSLINUX_MBR_BIN=$( find_syslinux_file $mbr_image_file )
 
-[[ -s "$SYSLINUX_MBR_BIN" ]]
-StopIfError "Could not find file '$mbr_image_file'. Syslinux version 3.08 or newer is required, 4.x prefered!"
+test -s "$SYSLINUX_MBR_BIN" || Error "Could not find SYSLINUX MBR image file '$mbr_image_file' (at least SYSLINUX 3.08 is required, 4.x preferred)"

--- a/usr/share/rear/prep/USB/Linux-i386/340_find_mbr_bin.sh
+++ b/usr/share/rear/prep/USB/Linux-i386/340_find_mbr_bin.sh
@@ -1,10 +1,46 @@
 # The file mbr.bin is only added since syslinux 3.08
 # The extlinux -i option is only added since syslinux 3.20
 
-local mbr_image_file
+# Find out what the actual USB device partition table type is
+# of the USB disk that is the parent device of the USB data partition
+# that is the value of the USB_DEVICE variable.
+# For example
+#   BACKUP_URL=usb:///dev/disk/by-label/REAR-000
+# leads to
+#   USB_DEVICE=/dev/disk/by-label/REAR-000
+# which is a symbolic link e.g. to /dev/sdb3 (on a hybrid UEFI and BIOS dual boot USB disk)
+# so its parent device /dev/sdb is where we need to inspect the partition table type.
+# See the code of the write_protection_ids() function in lib/write-protect-functions.sh
+# how to get the parent device.
+# See the output of
+#   # find usr/sbin/rear usr/share/rear -type f | xargs grep 'Partition Table'
+# for code how to autodetect the partition table type via 'parted ... print'.
+# In summary it goes like this example:
+#   # USB_DEVICE=/dev/disk/by-label/REAR-000
+#   # usb_disk="$( lsblk -inpo PKNAME "$USB_DEVICE" 2>/dev/null | awk NF | head -n1 )"
+#   # echo $usb_disk
+#   /dev/sdb
+#   # usb_disk_label=$( parted -s $usb_disk print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " " )
+#   # echo $usb_disk_label
+#   gpt
+# see https://github.com/rear/rear/pull/2829/files#r906006257
 
-# Choose right MBR image file for right partition table type (issue #1153)
-case "$USB_DEVICE_PARTED_LABEL" in
+local usb_disk usb_disk_label mbr_image_file
+
+usb_disk="$( lsblk -inpo PKNAME "$USB_DEVICE" 2>/dev/null | awk NF | head -n1 )"
+# Older Linux distributions do not contain lsblk (e.g. SLES10)
+# and older lsblk versions do not support the output column PKNAME
+# e.g. lsblk in util-linux 2.19.1 in SLES11 supports NAME and KNAME but not PKNAME
+# see the code of the write_protection_ids() function in lib/write-protect-functions.sh
+# so we use USB_DEVICE_PARTED_LABEL as fallback when the 'lsblk' automatism does not work:
+if test -b "$usb_disk" ; then
+    usb_disk_label=$( parted -s $usb_disk print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " " )
+else
+    usb_disk_label=$USB_DEVICE_PARTED_LABEL
+fi
+
+# Choose the right MBR image file for the partition table type (issue #1153)
+case "$usb_disk_label" in
     (msdos)
         mbr_image_file="mbr.bin"
         ;;
@@ -12,7 +48,7 @@ case "$USB_DEVICE_PARTED_LABEL" in
         mbr_image_file="gptmbr.bin"
         ;;
     (*)
-        Error "USB_DEVICE_PARTED_LABEL='$USB_DEVICE_PARTED_LABEL' (neither 'msdos' nor 'gpt')"
+        Error "Unsupported USB disk partition table type '$usb_disk_label' (neither 'msdos' nor 'gpt')"
         ;;
 esac
 


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):

https://github.com/rear/rear/pull/2828#issuecomment-1164590100

* How was this pull request tested?

Tested on openSUSE Leap 15.3 laptop with BIOS, see
https://github.com/rear/rear/pull/2829#issuecomment-1165460982
and on Red Hat with BIOS, see
https://github.com/rear/rear/pull/2829#issuecomment-1165470884
and on on RHEL 8 with UEFI, see
https://github.com/rear/rear/pull/2829#issuecomment-1165570472
and on openSUSE Leap 15.3 laptop with UEFI, see
https://github.com/rear/rear/pull/2829#issuecomment-1166925033
and subsequent comments

* Brief description of the changes in this pull request:

In format/USB/default/300_format_usb_disk.sh
set USB_DEVICE_PARTED_LABEL to match format-workflow.sh
which means when a format workflow option -b/--bios or -e/--efi was specified
set USB_DEVICE_PARTED_LABEL to "msdos" or "gpt" accordingly
and when no format workflow option -b/--bios or -e/--efi was specified
it means hybrid boot supporting BIOS and UEFI by default
so USB_DEVICE_PARTED_LABEL must be set to "gpt".