### PR TITLE
Add yes to REQUIRED_PROGS

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -5,6 +5,8 @@ ip
 less
 parted
 readlink
+# For noninteractive confirmation in lvm commands during layout recreation
+yes
 )
 
 PROGS+=(


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):
#2827 
* How was this pull request tested?
Created LVM on an empty disk (`mpatha`) and mounted it
```bash
parted --script -a optimal /dev/mapper/mpatha -- mklabel gpt mkpart extra ext2 1M -1M set 1 lvm on
pvcreate --yes /dev/mapper/mpatha1
vgcreate sigvg  /dev/mapper/mpatha1
lvcreate -y -n  sig_lv  sigvg -L 1G
mkfs.xfs /dev/sigvg/sig_lv
mkdir /home/foo
echo "/dev/sigvg/sig_lv                             /home/foo                   xfs     defaults        0 0" >> /etc/fstab
mount /home/foo
```
ran `rear mkbackup`
and then filled the disk with signatures 
```bash
EXTRADISK=/dev/mapper/mpatha1
EXTRAFS=( $(lsblk -ln -o mountpoint $EXTRADISK) )
for f in "${EXTRAFS[@]}"; do
    umount $f
done
EXTRADEVS=( $(lsblk -lnp -o name $EXTRADISK | tac) )
for d in "${EXTRADEVS[@]}"; do
    EXTRATYPE=$(lsblk -ln -o type "$d")
    if [ lvm == "$EXTRATYPE" ]; then
        wipefs -a $d
        lvremove -y $d
    fi
done
lvcreate -y sigvg -n xfsloglv -l 100%FREE
LOOPFILE=loopbackfile.img
dd if=/dev/zero of=$LOOPFILE bs=100M count=10
LOOPDEV=$(losetup -f)
losetup -f $LOOPFILE
MKFSOUT=$(mkfs.xfs -l logdev=/dev/sigvg/xfsloglv,size=2048b "$LOOPDEV")
losetup -d $LOOPDEV
BSIZE=$(echo $MKFSOUT | sed "s/.*\/dev\/sigvg\/xfsloglv bsize=\([^ ]*\)[ ]*.*/\1/")
dd if=/dev/sigvg/xfsloglv of=/dev/sigvg/xfsloglv bs=$BSIZE seek=1
lvremove -y /dev/sigvg/xfsloglv
vgremove -y /dev/sigvg
pvremove -y $EXTRADISK
```
and restored from the backup in migration mode

* Brief description of the changes in this pull request:
Since PR #2827 we have been piping the output of `yes` to `lvcreate`, but `yes` has not been added to the rescue system. Fix that.
(We could have added it to `REQUIRED_PROGS` only if lvm is present, but let's not complicate it and add it always.)