### PR TITLE
implement  BORGBACKUP_IGNORE_WARNING

### DIFF
--- a/usr/share/rear/backup/BORG/default/500_make_backup.sh
+++ b/usr/share/rear/backup/BORG/default/500_make_backup.sh
@@ -32,9 +32,9 @@ function check_BORG_create_return_code() {
     fi
 
     if test $borg_create_exit_code -eq 0; then
-        LogUserOutput "[BORG] borg create operation completed successfully"
+        LogUserOutput "[BORG] borg create backup operation completed successfully"
     else
-        LogUserOutput "[BORG] borg create operation completed with 'borg create' exit code $borg_create_exit_code"
+        LogUserOutput "[BORG] borg create backup operation completed with 'borg create' exit code $borg_create_exit_code"
         test $borg_create_exit_code -eq 1 && LogUserOutput "[BORG rc=1] borg create backup operation completed with at least one warning message"
         test $borg_create_exit_code -eq 2 && LogUserOutput "[BORG rc=2] borg create backup operation completed with at least one error message"
         test $borg_create_exit_code -ge 128 && LogUserOutput "[BORG rc=$borg_create_exit_code] borg create backup operation was killed by signal"

--- a/usr/share/rear/backup/BORG/default/500_make_backup.sh
+++ b/usr/share/rear/backup/BORG/default/500_make_backup.sh
@@ -26,7 +26,7 @@ function check_BORG_create_return_code() {
     #
     # Warning (rc=1) can happen if a file changed while backing it up.
     # $BORGBACKUP_IGNORE_WARNING="yes" makes rear ignoring warnings (rc=1).
-    if test "$BORGBACKUP_IGNORE_WARNING" = "yes" && test $borg_create_exit_code -eq 1; then
+    if is_true "$BORGBACKUP_IGNORE_WARNING" && test $borg_create_exit_code -eq 1; then
         LogUserOutput "[BORG rc=1] borg create backup operation completed with at least one warning message that was ignored (see rear log file)"
         return 0
     fi

--- a/usr/share/rear/backup/BORG/default/500_make_backup.sh
+++ b/usr/share/rear/backup/BORG/default/500_make_backup.sh
@@ -104,5 +104,4 @@ else
 fi
 borg_exit_code=$?
 
-check_BORG_create_return_code $borg_exit_code
-StopIfError "Borg failed to create backup archive, borg rc $?!"
+check_BORG_create_return_code $borg_exit_code || Error "Borg failed to create backup archive, borg rc $borg_exit_code"

--- a/usr/share/rear/backup/BORG/default/500_make_backup.sh
+++ b/usr/share/rear/backup/BORG/default/500_make_backup.sh
@@ -12,6 +12,36 @@ if [ ! -r "$TMP_DIR/backup-include.txt" ]; then
     Error "Can't find include list"
 fi
 
+function check_BORG_create_return_code() {
+
+    borg_create_exit_code=$1
+
+    # 'borg_create' function returns one of the following codes:
+    #   0     success
+    #   1     warning (operation reached its normal end, but there were warnings)
+    #   2     error (like a fatal error)
+    #   128+N killed by signal
+    # They corresponde to the borg return codes:
+    # https://borgbackup.readthedocs.io/en/stable/usage/general.html#return-codes
+    #
+    # Warning (rc=1) can happen if a file changed while backing it up.
+    # $BORGBACKUP_IGNORE_WARNING="yes" makes rear ignoring warnings (rc=1).
+    if test "$BORGBACKUP_IGNORE_WARNING" = "yes" && test $borg_create_exit_code -eq 1; then
+        LogUserOutput "[BORG rc=1] borg create backup operation completed with at least one warning message that was ignored (see rear log file)"
+        return 0
+    fi
+
+    if test $borg_create_exit_code -eq 0; then
+        LogUserOutput "[BORG] borg create operation completed successfully"
+    else
+        LogUserOutput "[BORG] borg create operation completed with 'borg create' exit code $borg_create_exit_code"
+        test $borg_create_exit_code -eq 1 && LogUserOutput "[BORG rc=1] borg create backup operation completed with at least one warning message"
+        test $borg_create_exit_code -eq 2 && LogUserOutput "[BORG rc=2] borg create backup operation completed with at least one error message"
+        test $borg_create_exit_code -ge 128 && LogUserOutput "[BORG rc=$borg_create_exit_code] borg create backup operation was killed by signal"
+        return $borg_create_exit_code
+    fi
+}
+
 # Create Borg friendly include list.
 while IFS= read -r include; do
     include_list+=( "$include" )
@@ -72,5 +102,7 @@ elif is_true "$VERBOSE"; then
 else
     borg_create 0<&6
 fi
+borg_exit_code=$?
 
+check_BORG_create_return_code $borg_exit_code
 StopIfError "Borg failed to create backup archive, borg rc $?!"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2338,6 +2338,9 @@ BORGBACKUP_SHOW_RC="no"
 BORGBACKUP_CREATE_SHOW_RC=
 BORGBACKUP_PRUNE_SHOW_RC=
 BORGBACKUP_EXTRACT_SHOW_RC=
+# Should rear ignore Borg WARNINGS
+# See https://borgbackup.readthedocs.io/en/stable/usage/general.html#return-codes
+BORGBACKUP_IGNORE_WARNING="no"
 # Pagination for selecting archives:
 # While restoring how many archives should be shown in each step to the user?
 # If more archives are available, cycle through them.

--- a/usr/share/rear/lib/borg-functions.sh
+++ b/usr/share/rear/lib/borg-functions.sh
@@ -126,6 +126,11 @@ in Borg repository $BORGBACKUP_REPO on ${BORGBACKUP_HOST:-USB}"
     "${BORGBACKUP_OPT_UMASK[@]}" --exclude-from "$TMP_DIR/backup-exclude.txt" \
     "${borg_dst_dev}${BORGBACKUP_REPO}::${BORGBACKUP_ARCHIVE_PREFIX}_$BORGBACKUP_SUFFIX" \
     "${include_list[@]}"
+    rc=$?
+    if test "${BORGBACKUP_IGNORE_WARNING}" = "yes" && test ${rc} -eq 1 ; then
+        exit 0
+    fi
+    exit ${rc}
 }
 
 function borg_prune

--- a/usr/share/rear/lib/borg-functions.sh
+++ b/usr/share/rear/lib/borg-functions.sh
@@ -126,11 +126,9 @@ in Borg repository $BORGBACKUP_REPO on ${BORGBACKUP_HOST:-USB}"
     "${BORGBACKUP_OPT_UMASK[@]}" --exclude-from "$TMP_DIR/backup-exclude.txt" \
     "${borg_dst_dev}${BORGBACKUP_REPO}::${BORGBACKUP_ARCHIVE_PREFIX}_$BORGBACKUP_SUFFIX" \
     "${include_list[@]}"
-    rc=$?
-    if test "${BORGBACKUP_IGNORE_WARNING}" = "yes" && test ${rc} -eq 1 ; then
-        exit 0
-    fi
-    exit ${rc}
+    borg_exit_code=$?
+
+    return ${borg_exit_code}
 }
 
 function borg_prune

--- a/usr/share/rear/lib/borg-functions.sh
+++ b/usr/share/rear/lib/borg-functions.sh
@@ -126,9 +126,6 @@ in Borg repository $BORGBACKUP_REPO on ${BORGBACKUP_HOST:-USB}"
     "${BORGBACKUP_OPT_UMASK[@]}" --exclude-from "$TMP_DIR/backup-exclude.txt" \
     "${borg_dst_dev}${BORGBACKUP_REPO}::${BORGBACKUP_ARCHIVE_PREFIX}_$BORGBACKUP_SUFFIX" \
     "${include_list[@]}"
-    borg_exit_code=$?
-
-    return ${borg_exit_code}
 }
 
 function borg_prune


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

##### Pull Request Details:

* Type: **New Feature**

* Impact: **Normal** 

* Reference to related issue (URL):

* How was this pull request tested?
Tested with rear release `2.6` on Debian Bullseye (patched `usr/share/rear/lib/borg-functions.sh` file with this changes)

* Brief description of the changes in this pull request:
This PR implements a new variable `BORGBACKUP_IGNORE_WARNING` which ignores borg warnings.
Borg warnings can happen if a file changed while backing it up described here: https://borgbackup.readthedocs.io/en/stable/usage/general.html#return-codes. Because borg return code is 1 in such case `rear mkbackup` fails.
