### PR TITLE
Add Shell linter - Differential-ShellCheck

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,0 +1,39 @@
+---
+
+name: Differential ShellCheck
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+
+      - id: ShellCheck
+        name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@d24099b9f39ddee81dea31eb0e135e0a623cb2b8
+        with:
+          severity: error
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ always() }}
+        name: Upload artifact with ShellCheck defects in SARIF format
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        with:
+          name: Differential ShellCheck SARIF
+          path: ${{ steps.ShellCheck.outputs.sarif }}
+
+...


### PR DESCRIPTION
Differential ShellCheck is a GitHub action that performs differential ShellCheck scans on files changed via PR and reports results directly in PR.

Since this repository contains a lot of shell scripts I think you might find it useful.

Documentation is available at: [@redhat-plumbers-in-action/differential-shellcheck](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme). Let me know If you are missing some feature or setting. I'm always happy to extend functionality.

Examples - [screenshots](https://github.com/redhat-plumbers-in-action/differential-shellcheck/tree/main/docs/images)

---

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): #1040

* How was this pull request tested?

> Manually, status should be showed below.
>
> It is deployed and running on a [few repositories](https://github.com/redhat-plumbers-in-action/differential-shellcheck/network/dependents) already and it's working as expected.

* Brief description of the changes in this pull request:

> Adding workflow that executes `differential-shellcheck` action when PR is opened against `master` branch.

Alternative to: #2754 and #2756

/cc @lzaoral @pcahyna

