### PR TITLE
insert missing prefix to fix #2850

### DIFF
--- a/usr/share/rear/output/PXE/default/810_create_pxelinux_cfg.sh
+++ b/usr/share/rear/output/PXE/default/810_create_pxelinux_cfg.sh
@@ -92,7 +92,7 @@ case "$PXE_CREATE_LINKS" in
 		# look at all devices that have link/ether
 		ip l | grep link/ether | \
 			while read link mac junk ; do
-				ln -sf $v "$PXE_CONFIG_FILE" 01-${mac//:/-} >&2
+				ln -sf $v "$PXE_CONFIG_FILE" ${pxe_link_prefix}01-${mac//:/-} >&2
 			done
 		;;
 	"")


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): #2850 

* How was this pull request tested? make rpm; install on 2 LPARs; rear mkrescue

* Brief description of the changes in this pull request:
adds the missing prefix to the symlink so it is found during tftp boot
