### PR TITLE
skip LVM PVs mounted on /dev/loop

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -85,6 +85,7 @@ local lvs_exit_code
 
         # Skip physical volumes that are created on loop back devices
         # i.e. /dev/loop0p2:cinder_volume:996853760:-1:8:8:-1:4096:121686:41046:80640:something
+        # See https://github.com/rear/rear/issues/2853
         [[ "$pdev" = /dev/loop* ]] && continue
 
         # Output lvmdev header only once to DISKLAYOUT_FILE:

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -82,9 +82,10 @@ local lvs_exit_code
         # Skip lines that are not describing physical devices
         # i.e. lines where pdev does not start with a leading / character:
         test "${pdev#/}" = "$pdev" && continue
-        if [[ "${pdev}" =~ '/dev/loop' ]]; then
-            continue
-        fi
+
+        # Skip physical volumes that are created on loop back devices
+        # i.e. /dev/loop0p2:cinder_volume:996853760:-1:8:8:-1:4096:121686:41046:80640:something
+        [[ "$pdev" = /dev/loop* ]] && continue
 
         # Output lvmdev header only once to DISKLAYOUT_FILE:
         if is_false $header_printed ; then

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -82,7 +82,7 @@ local lvs_exit_code
         # Skip lines that are not describing physical devices
         # i.e. lines where pdev does not start with a leading / character:
         test "${pdev#/}" = "$pdev" && continue
-        if [[ "${pdev}" =~ '/dev/loop' ]] then
+        if [[ "${pdev}" =~ '/dev/loop' ]]; then
             continue
         fi
 

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -82,6 +82,9 @@ local lvs_exit_code
         # Skip lines that are not describing physical devices
         # i.e. lines where pdev does not start with a leading / character:
         test "${pdev#/}" = "$pdev" && continue
+        if [[ "${pdev}" =~ '/dev/loop' ]] then
+            continue
+        fi
 
         # Output lvmdev header only once to DISKLAYOUT_FILE:
         if is_false $header_printed ; then


### PR DESCRIPTION
* Type: **Bug Fix** / **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2853

* How was this pull request tested?

* Brief description of the changes in this pull request:

Skip physical volumes that are created on loop back devices like
```
/dev/loop0p2:cinder_volume:996853760:-1:8:8:-1:4096:121686:41046:80640:something
```
