### PR TITLE
By default let "rear recover" wipe disks that get completely recreated

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -468,9 +468,9 @@ test "$MIGRATION_MODE" || MIGRATION_MODE=''
 # replacement hardware then DISKS_TO_BE_WIPED="/dev/sda ..." may destroy the ReaR disk
 # unless that disk is (by default automatically) listed in WRITE_PROTECTED_IDS
 # (here it works because the ReaR disk ID is same on the replacement hardware).
-# In any case there is a user confirmation dialog for the disks that will be wiped.
-# Currently by default no disk is wiped to avoid issues until this feature was more tested:
-DISKS_TO_BE_WIPED='false'
+# In any case there is a user confirmation dialog before disks will be wiped.
+# With DISKS_TO_BE_WIPED='false' no disk will be wiped.
+DISKS_TO_BE_WIPED=''
 
 ##
 # Resizing partitions in MIGRATION_MODE during "rear recover"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -449,7 +449,7 @@ test "$MIGRATION_MODE" || MIGRATION_MODE=''
 # This is currently new and experimental functionality,
 # see https://github.com/rear/rear/pull/2514
 #
-# An empty DISKS_TO_BE_WIPED='' means that disks will be automatically wiped.
+# An empty DISKS_TO_BE_WIPED="" means that disks will be automatically wiped.
 # The disks that will be automatically wiped are those disks
 # where in diskrestore.sh the create_disk_label function is called
 # i.e. disks where the whole partitioning will be recreated from scratch.
@@ -469,8 +469,8 @@ test "$MIGRATION_MODE" || MIGRATION_MODE=''
 # unless that disk is (by default automatically) listed in WRITE_PROTECTED_IDS
 # (here it works because the ReaR disk ID is same on the replacement hardware).
 # In any case there is a user confirmation dialog before disks will be wiped.
-# With DISKS_TO_BE_WIPED='false' no disk will be wiped.
-DISKS_TO_BE_WIPED=''
+# With DISKS_TO_BE_WIPED="false" no disk will be wiped.
+DISKS_TO_BE_WIPED=""
 
 ##
 # Resizing partitions in MIGRATION_MODE during "rear recover"


### PR DESCRIPTION
* Type: **New Feature**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2514
https://github.com/rear/rear/issues/799

* How was this pull request tested?
I used `DISKS_TO_BE_WIPED=""` a lot on my openSUSE test VMs

* Brief description of the changes in this pull request:

In ReaR 2.7 default.conf has DISKS_TO_BE_WIPED='false'
so no disk is wiped to avoid possible regressions
until this new feature was more tested by interested users, see
https://github.com/rear/rear/blob/master/doc/rear-release-notes.txt

Now after ReaR 2.7 release I like to have this feature tested
by default by users who use our GitHub master code.
