### PR TITLE
In the UserInput function drain stdin if stdin is a terminal

### DIFF
--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -1188,14 +1188,14 @@ function UserInput () {
     # up to 1000 characters (so it fails if there are more than 1000 characters in stdin)
     # see https://superuser.com/questions/276531/clear-stdin-before-reading
     # That the 'read' timeout can be a fractional number requires bash 4.x
-    # but in general ReaR should still work with bash 3.x so we use '-t1'
+    # but in general ReaR should still work with bash 3.x so we use '-t 1'
     # which causes a one second delay (in interactive mode) which cannot be avoided,
     # see https://github.com/rear/rear/issues/2866#issuecomment-1254908270
     local discard_stdin=""
     if tty -s ; then
         # This 'read' call usually exits with non-zero exit code
         # (unless it gets valid input terminated by ENTER):
-        read -s -t1 -n 1000 discard_stdin
+        read -s -t 1 -n 1000 discard_stdin
     else
         Log "UserInput: stdin not a tty (using stdin as is without draining)"
     fi

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -1197,11 +1197,13 @@ function UserInput () {
     #   stty $old_tty_settings
     # but we do not like to mess around with the user's terminal settings in ReaR.
     # That the 'read' timeout can be a fractional number requires bash 4.x
-    # but in general ReaR should still work with bash 3.x so we use '-t 1'
-    # which causes a one second delay (in interactive mode) which cannot be avoided,
     # see https://github.com/rear/rear/issues/2866#issuecomment-1254908270
-    # and https://github.com/rear/rear/pull/2868#issuecomment-1257988466
-    test -t 0 && read -s -t 1 -n 1000 -d ''
+    # but in general ReaR should still work with bash 3.x so we use '-t 1'
+    # which would cause a one second delay when there is nothing in stdin
+    # until 'read' timed out which we avoid with 'read -t 0' before
+    # and we keep the '-t 1' in the subsequent 'read' to be fail safe
+    # see https://github.com/rear/rear/pull/2868#issuecomment-1259087491
+    test -t 0 && read -t 0 && read -s -t 1 -n 1000 -d ''
     # First of all show the prompt unless an empty prompt was specified (via -p '')
     # so that the prompt can be used as some kind of header line that introduces the user input
     # and separates the following user input from arbitrary other output lines before:

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -1193,6 +1193,8 @@ function UserInput () {
     # see https://github.com/rear/rear/issues/2866#issuecomment-1254908270
     local discard_stdin=""
     if tty -s ; then
+        # This 'read' call usually exits with non-zero exit code
+        # (unless it gets valid input terminated by ENTER):
         read -s -t1 -n 1000 discard_stdin
     else
         Log "UserInput: stdin not a tty (using stdin as is without draining)"

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -1178,27 +1178,22 @@ function UserInput () {
     # so that the user can prepare an automated response for that UserInput call (without digging in the code):
     DebugPrint "UserInput -I $user_input_ID needed in $caller_source"
     # Drain stdin if stdin is a terminal i.e. when 'rear' is run in interactive mode
-    # where stdin is all what the user types on his keyboard.
+    # where stdin is what the user types on his keyboard (except terminal buffer, see below).
     # In this case discard possibly already existing characters (in particular ENTER keystrokes) from stdin
     # to avoid that when the user had accidentally hit ENTER more than once in a previous (UserInput) dialog
     # then those additional ENTER characters would be already in stdin and let this current UserInput dialog
     # proceed unintendedly automatically without an explicit ENTER from the user for this current dialog,
     # see https://github.com/rear/rear/issues/2866
-    # There is no generic way to clear stdin so we 'read' and discard what is already there
-    # up to 1000 characters (so it fails if there are more than 1000 characters in stdin)
-    # see https://superuser.com/questions/276531/clear-stdin-before-reading
-    # That the 'read' timeout can be a fractional number requires bash 4.x
-    # but in general ReaR should still work with bash 3.x so we use '-t 1'
-    # which causes a one second delay (in interactive mode) which cannot be avoided,
-    # see https://github.com/rear/rear/issues/2866#issuecomment-1254908270
-    local discard_stdin=""
-    if tty -s ; then
-        # This 'read' call usually exits with non-zero exit code
-        # (unless it gets valid input terminated by ENTER):
-        read -s -t 1 -n 1000 discard_stdin
-    else
-        Log "UserInput: stdin not a tty (using stdin as is without draining)"
-    fi
+    # There is no generic way to clear stdin (or even clear stdin and terminal buffer)
+    # so we 'read' away what is already there as long as there is something in stdin.
+    # This does not get unfinished lines in the terminal buffer which are not yet in stdin.
+    # Draining also the terminal buffer would require special things with 'stty' like
+    #   old_tty_settings=$( stty -g )
+    #   stty -icanon min 0 time 0
+    #   ... [read away what is there]
+    #   stty $old_tty_settings
+    # but we do not like to mess around with the user's terminal settings here.
+    test -t 0 && while read -t 0 ; do read -s ; done
     # First of all show the prompt unless an empty prompt was specified (via -p '')
     # so that the prompt can be used as some kind of header line that introduces the user input
     # and separates the following user input from arbitrary other output lines before:

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -1192,7 +1192,11 @@ function UserInput () {
     # which causes a one second delay (in interactive mode) which cannot be avoided,
     # see https://github.com/rear/rear/issues/2866#issuecomment-1254908270
     local discard_stdin=""
-    tty -s && read -s -t1 -n 1000 discard_stdin || Log "UserInput: stdin not a tty (using stdin as is without draining)"
+    if tty -s ; then
+        read -s -t1 -n 1000 discard_stdin
+    else
+        Log "UserInput: stdin not a tty (using stdin as is without draining)"
+    fi
     # First of all show the prompt unless an empty prompt was specified (via -p '')
     # so that the prompt can be used as some kind of header line that introduces the user input
     # and separates the following user input from arbitrary other output lines before:


### PR DESCRIPTION
* Type: **Minor Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2866

* How was this pull request tested?
 
Works sufficiently well for me
during "rear recover" with MIGRATION_MODE="true"
(where several user dialogs appear).

* Brief description of the changes in this pull request:

In the UserInput function
in lib/_input-output-functions.sh
drain stdin if stdin is a terminal (i.e. in interactive mode).
