### PR TITLE
Improved comments in default.conf

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -40,7 +40,7 @@
 #
 # In case of doubt inspect the scripts how exactly a particular variable works.
 
-##
+####
 # TMPDIR
 #
 # Relax-and-Recover needs a (temporary) working area where it builds in particular
@@ -64,8 +64,9 @@
 # produces when creating the image (see file-hierarchy(7)). In particular,
 # /tmp can be a tmpfs, and thus restricted by the available RAM/swap.
 export TMPDIR="${TMPDIR-/var/tmp}"
+####
 
-##
+####
 # ROOT_HOME_DIR
 #
 # According to the Filesystem Hierarchy Standard
@@ -75,7 +76,9 @@ export TMPDIR="${TMPDIR-/var/tmp}"
 # ~root is not included into double (or single) quotes so it can be
 # later expanded to actual root home directory.
 ROOT_HOME_DIR=~root
+####
 
+####
 # You can override autodetection and specify the kernel for the rescue/recovery system:
 KERNEL_FILE=""
 # The kernel configuration is used to collect the kernel binary and modules.
@@ -113,7 +116,9 @@ KERNEL_CMDLINE=""
 # - Check net.ifnames and biosdevname kernel parameter as it may impact
 #   the network interface name during recovery/migration.
 COPY_KERNEL_PARAMETERS=( 'net.ifnames' 'biosdevname' )
+####
 
+####
 # These variables are used to include arch/os/version specific stuff:
 # machine architecture, OS independent
 REAL_MACHINE="$( uname -m )"
@@ -135,6 +140,7 @@ esac
 # Architecture, e.g. Linux-i386
 ARCH="$( uname -s )-$MACHINE" 2>>/dev/null
 REAL_ARCH="$( uname -s )-$REAL_MACHINE" 2>>/dev/null
+####
 
 # Short hostname
 HOSTNAME="$( hostname -s 2>/dev/null || uname -n | cut -d. -f1 )"
@@ -143,6 +149,7 @@ HOSTNAME="$( hostname -s 2>/dev/null || uname -n | cut -d. -f1 )"
 # NOTE: This may not be dynamic, else deal with .bash_history in rescue system
 LOGFILE="$LOG_DIR/rear-$HOSTNAME.log"
 
+####
 # Operating System, e.g. GNU/Linux
 OS="$( uname -o )"
 # Vendors are SUSE, Red Hat, Debian, Ubuntu, etc.
@@ -160,6 +167,7 @@ OS_VERSION=none
 # that are not yet supported by ReaR you may specify appropriate
 # supported values that could make it work even for your system.
 # See the SetOSVendorAndVersion function in the config-functions.sh script.
+####
 
 # Keep the build area after we are done (ternary).
 # Useful to inspect the ReaR recovery system content in $TMPDIR/rear.XXXXXXXXXXXXXXX/rootfs/
@@ -176,6 +184,7 @@ OS_VERSION=none
 #   TMPDIR (see above) by cron or other automated jobs in case of errors.
 KEEP_BUILD_DIR=""
 
+####
 # No default workflows. This variable is filled in where the workflows are defined
 # without the empty string as initial value WORKFLOWS and LOCKLESS_WORKFLOWS would
 # be unbound variables that would result an error exit if 'set -eu' is used:
@@ -197,10 +206,9 @@ LOCKLESS_WORKFLOWS=( 'checklayout' 'dump' 'help' )
 # at the end copied to a final possibly used-defined LOGFILE,
 # see /usr/sbin/rear and https://github.com/rear/rear/issues/1102
 SIMULTANEOUS_RUNNABLE_WORKFLOWS=( 'mkbackuponly' 'restoreonly' )
+####
 
-##
 # MESSAGE_PREFIX
-#
 # Get messages of Relax-and-Recover output functions prefixed with ${MESSAGE_PREFIX}.
 # Other output (e.g. from programs that are called) is not prefixed.
 # By default MESSAGE_PREFIX is empty but the user can set it e.g. to MESSAGE_PREFIX="$$: "
@@ -209,9 +217,8 @@ SIMULTANEOUS_RUNNABLE_WORKFLOWS=( 'mkbackuponly' 'restoreonly' )
 # messages (cf. SIMULTANEOUS_RUNNABLE_WORKFLOWS)
 MESSAGE_PREFIX=""
 
-##
+####
 # PROGRESS_MODE
-#
 # How progress messages are shown (cf. lib/progresssubsystem.nosh).
 # PROGRESS_MODE can be "ANSI" (default/fallback) or "plain".
 # When there is a tty on stdout messages via the progress subsystem
@@ -225,10 +232,8 @@ MESSAGE_PREFIX=""
 # would mix up on one same line which results illegible and meaningless
 # output on the terminal
 PROGRESS_MODE="ANSI"
-
-##
-# PROGRESS_WAIT_SECONDS
 #
+# PROGRESS_WAIT_SECONDS
 # The number of seconds between subsequent progress messages that are output
 # via the progress subsystem while a longer task (usually backup or restore) runs.
 # The default/fallback is 1 second. Setting e.g. PROGRESS_WAIT_SECONDS="5" can be
@@ -236,8 +241,9 @@ PROGRESS_MODE="ANSI"
 # continuing after the task (e.g. backup or restore) had finished by half that time
 # on average up to at most the whole amount of PROGRESS_WAIT_SECONDS
 PROGRESS_WAIT_SECONDS="1"
+####
 
-##
+####
 # Relax-and-Recover UserInput function default behaviour
 #
 # see the UserInput function decription in
@@ -319,6 +325,7 @@ test "$USER_INPUT_MAX_CHARS" || USER_INPUT_MAX_CHARS=0
 # Then the "Edit disk mapping" choice will be selected automatically.
 # In this case the USER_INPUT_INTERRUPT_TIMEOUT is crucial because
 # otherwise one would be caught in an endless "Edit disk mapping" loop.
+####
 
 # Default backup and output targets:
 BACKUP=REQUESTRESTORE
@@ -327,6 +334,7 @@ OUTPUT=ISO
 # Default cdrom size in MB (probably it is actually MiB?):
 CDROM_SIZE=20
 
+####
 # The CHECK_CONFIG_FILES array lists files where changes
 # require the ReaR rescue/recovery system to be recreated.
 # Testing whether or not those files changed is implemented in the checklayout workflow
@@ -335,15 +343,15 @@ CDROM_SIZE=20
 # does not automatically recreate the rescue/recovery system.
 # Files matching FILES_TO_PATCH_PATTERNS are added to this list automatically.
 CHECK_CONFIG_FILES=( '/etc/drbd/' '/etc/drbd.conf' '/etc/lvm/lvm.conf' '/etc/multipath.conf' '/etc/rear/' '/etc/udev/udev.conf' )
-
+#
 # FILES_TO_PATCH_PATTERNS is a space-separated list of shell glob patterns.
 # Files that match are eligible for a final migration of UUIDs and other
 # identifiers after recovery (if the layout recreation process has led
 # to a change of an UUID or a device name and a corresponding change needs
 # to be performed on restored configuration files ).
 # See finalize/GNU/Linux/280_migrate_uuid_tags.sh
-# The [] around the first letter make sure that shopt -s nullglob removes this file from the list if it does not exist
-
+# The [] around the first letter make sure that
+# 'shopt -s nullglob' removes this file from the list if it does not exist:
 FILES_TO_PATCH_PATTERNS="[b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* \
                          [b]oot/grub/{grub.conf,grub.cfg,menu.lst,device.map} \
                          [b]oot/grub2/{grub.conf,grub.cfg,menu.lst,device.map} \
@@ -356,8 +364,9 @@ FILES_TO_PATCH_PATTERNS="[b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* \
                          [e]tc/sysconfig/rawdevices \
                          [e]tc/security/pam_mount.conf.xml \
                          [b]oot/efi/*/*/grub.cfg"
+####
 
-##
+####
 # Relax-and-Recover recovery system update during "rear recover"
 #
 # see https://github.com/rear/rear/issues/841
@@ -393,8 +402,9 @@ FILES_TO_PATCH_PATTERNS="[b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* \
 #   export RECOVERY_UPDATE_URL="http://my_internal_server/host123_rear_config.tgz"
 # directly before he calls "rear recover":
 test "$RECOVERY_UPDATE_URL" || RECOVERY_UPDATE_URL=""
+####
 
-##
+####
 # MIGRATION_MODE recovery during "rear recover"
 #
 # There is some basic autodetection during "rear recover" when
@@ -436,8 +446,9 @@ test "$RECOVERY_UPDATE_URL" || RECOVERY_UPDATE_URL=""
 #   export MIGRATION_MODE='true'
 # directly before he calls "rear recover":
 test "$MIGRATION_MODE" || MIGRATION_MODE=''
+####
 
-##
+####
 # Wiping disks during "rear recover" before recreating the disk layout:
 #
 # The intent is that disks where the disk layout will be recreated
@@ -471,8 +482,9 @@ test "$MIGRATION_MODE" || MIGRATION_MODE=''
 # In any case there is a user confirmation dialog before disks will be wiped.
 # With DISKS_TO_BE_WIPED="false" no disk will be wiped.
 DISKS_TO_BE_WIPED=""
+####
 
-##
+####
 # Resizing partitions in MIGRATION_MODE during "rear recover"
 #
 # AUTORESIZE_PARTITIONS
@@ -562,8 +574,9 @@ AUTORESIZE_PARTITIONS=''
 AUTORESIZE_EXCLUDE_PARTITIONS=( boot swap efi )
 AUTOSHRINK_DISK_SIZE_LIMIT_PERCENTAGE=2
 AUTOINCREASE_DISK_SIZE_THRESHOLD_PERCENTAGE=10
+####
 
-##
+####
 # Write-protection during "rear recover"
 # for OUTPUT=USB and OUTPUT=RAWDISK
 #
@@ -604,8 +617,9 @@ WRITE_PROTECTED_IDS=()
 # For OUTPUT=USB the file system label of the ReaR data partition on the ReaR recovery system disk
 # is automatically added to WRITE_PROTECTED_FS_LABEL_PATTERNS during "rear mkrescue/mkbackup".
 WRITE_PROTECTED_FS_LABEL_PATTERNS=()
+####
 
-##
+####
 # Creating XFS filesystems during "rear recover"
 #
 # MKFS_XFS_OPTIONS
@@ -644,8 +658,9 @@ WRITE_PROTECTED_FS_LABEL_PATTERNS=()
 #   export MKFS_XFS_OPTIONS="..."
 # directly before he calls "rear recover":
 test "$MKFS_XFS_OPTIONS" || MKFS_XFS_OPTIONS=''
+####
 
-##
+####
 # Support for TCG Opal 2-compliant Self-Encrypting Disks
 # (see doc/user-guide/13-tcg-opal-support.adoc)
 #
@@ -712,11 +727,12 @@ OPAL_PBA_DEBUG_PASSWORD=''
 # installed. To test the PBA system on a machine without any Opal 2-compliant disk, set OPAL_PBA_DEBUG_DEVICE_COUNT=1.
 # Used to debug the PBA system.
 OPAL_PBA_DEBUG_DEVICE_COUNT=""
+####
 
-##
+####
 # Output/backup locations
 ##
-
+#
 # The URL defines the remote share as <scheme>://<host>/<share> like these examples:
 # nfs://host.domain/path/path/path
 # cifs://server.domain/share
@@ -726,14 +742,14 @@ OPAL_PBA_DEBUG_DEVICE_COUNT=""
 # Additional options to the mount command are given using *_OPTIONS
 # Alternatively, you can provide your own mount/unmount commands, in that case
 # Relax-and-Recover will append its mountpoint to the command.
-
+#
 # Specify the location of the backup (see text above):
 BACKUP_URL=
 # BACKUP_OPTIONS variable contains the mount options, do not confuse with BACKUP_PROG_OPTIONS
 BACKUP_OPTIONS=
 BACKUP_MOUNTCMD=
 BACKUP_UMOUNTCMD=
-
+##
 # Specify the location of the output:
 # When OUTPUT_URL is not specified it inherits the BACKUP_URL value
 # and then also OUTPUT_OPTIONS inherits the BACKUP_OPTIONS value
@@ -747,6 +763,7 @@ OUTPUT_OPTIONS=
 OUTPUT_MOUNTCMD=
 OUTPUT_UMOUNTCMD=
 OUTPUT_PREFIX="$HOSTNAME"
+####
 
 # Keep an older copy of the output (mv $OUTPUT_PREFIX $OUTPUT_PREFIX.old before we copy the new version)
 # empty means only keep current output:
@@ -762,8 +779,8 @@ OUTPUT_PREFIX_PXE=""
 # Example: OUTPUT_LFTP_OPTIONS="set ftp:ssl-force true; set ftp:ssl-protect-data true;"
 OUTPUT_LFTP_OPTIONS=""
 
-##
-# OUTPUT=RAMDISK stuff
+####
+# OUTPUT=RAMDISK
 ##
 # With OUTPUT=RAMDISK the ReaR rescue/recovery system initramfs/initrd
 # is created but nothing additional is done to make it bootable.
@@ -777,9 +794,10 @@ OUTPUT_LFTP_OPTIONS=""
 # the kernel at the output location will be kernel-$RAMDISK_SUFFIX
 # the initramfs at the output location will be initramfs-$RAMDISK_SUFFIX.img
 RAMDISK_SUFFIX="$HOSTNAME"
+####
 
-##
-# OUTPUT=ISO stuff
+####
+# OUTPUT=ISO
 ##
 # OUTPUT=ISO produces files suitable for booting with SYSLINUX/ISOLINUX and assumes that the result
 # will be written sequentially to a read-only medium with limited size (e.g. optical medium like CD-ROM).
@@ -935,9 +953,10 @@ ISO_DEFAULT="boothd"
 # (e.g. when the device with the ISO is the first one in the BIOS boot order list).
 # The default ISO_RECOVER_MODE="" results the normal behaviour:
 ISO_RECOVER_MODE=""
+####
 
-##
-# OUTPUT=USB stuff
+####
+# OUTPUT=USB
 ##
 #
 # OUTPUT=USB is only supported on PC-compatible (Linux-i386/x86/x86_64) architecture
@@ -1130,9 +1149,10 @@ USB_RETAIN_BACKUP_NR=2
 # Variable will probably be filled automatically
 # if an USB device was manually mounted to avoid recursive backups:
 AUTOEXCLUDE_USB_PATH=()
+####
 
-##
-# OUTPUT=RAWDISK stuff
+####
+# OUTPUT=RAWDISK
 ##
 # RAWDISK produces a bootable image file named "rear-$HOSTNAME.raw", which
 # - supports UEFI boot if syslinux/EFI or Grub 2/EFI is installed,
@@ -1186,9 +1206,10 @@ RAWDISK_INSTALL_GPT_PARTITION_NAME=''
 # The image's partitions are still mounted at this stage and can be examined. The
 # ReaR workflow continues when exiting the shell.
 RAWDISK_DEBUG='no'
+####
 
-##
-# PXE stuff
+####
+# OUTPUT=PXE
 ##
 # PXE produces files suitable for booting with pxelinux.
 #
@@ -1237,19 +1258,34 @@ PXE_CONFIG_GRUB_STYLE=
 # purposes only.
 # Default is empty which means prompting what to do next and after a timeout boot next option defined by BIOS
 PXE_RECOVER_MODE=
+####
 
-# Certain operation might need longer time to kick in and more retries might be desirable.
+####
+# OUTPUT=OBDR
+##
+#
+COPY_AS_IS_OBDR=( )
+COPY_AS_IS_EXCLUDE_OBDR=( )
+REQUIRED_PROGS_OBDR=( lsscsi sg_wr_mode )
+# OBDR block size, known to work with 2048
+OBDR_BLOCKSIZE=2048
+####
+
+# Certain operations might need longer time to kick in and more retries might be desirable.
 # REAR_SLEEP_DELAY (in sec.) is general delay for operation.
 REAR_SLEEP_DELAY=1
 # REAR_MAX_RETRIES is maximum number of attempts that should be executed before operation is aborted.
 # Maximum timeout for operation calculates as REAR_SLEEP_DELAY * REAR_MAX_RETRIES
-# This retries / timeout operation is currently implemented only in get_disk_size (),
+# This retries / timeout operation is currently implemented only in get_disk_size(),
 # so if you have trouble with error messages like:
-# 'Could not determine size of disk <device> ...' tweaking of REAR_SLEEP_DELAY and REAR_MAX_RETRIES might help.
+# 'Could not determine size of disk <device> ...'
+# tweaking of REAR_SLEEP_DELAY and REAR_MAX_RETRIES might help.
 REAR_MAX_RETRIES=5
 
-##
-# Internal BACKUP stuff
+####
+# Internal BACKUP methods like
+# BACKUP=NETFS
+# ...
 ##
 # These settings apply to all cases of internal Relax-and-Recover backup.
 #
@@ -1449,9 +1485,13 @@ FULLBACKUPDAY=()
 # By default an existing full backup is considered to be too old
 # when it is older than 7 days ago:
 FULLBACKUP_OUTDATED_DAYS="7"
+####
 
-##
-# UDEV workflow stuff
+# Tape block size, default is to leave it up to the tape-device:
+TAPE_BLOCKSIZE=
+
+####
+# UDEV workflow
 ##
 # Define the default WORKFLOW for the udev handler (empty to disable)
 UDEV_WORKFLOW=mkrescue
@@ -1464,7 +1504,9 @@ UDEV_SUSPEND=y
 #
 # Turn the UID led on during udev workflow
 UDEV_UID_LED=y
+####
 
+####
 # Program files (as found in PATH) to include in the rescue/recovery system:
 # These progs are optional, if they are missing, nothing happens
 PROGS=( )
@@ -1514,6 +1556,7 @@ umount
 uniq
 wc
 )
+####
 
 # Special library files to include in the rescue/recovery system:
 # Needed programs in the recovery system should be specified via
@@ -1538,6 +1581,7 @@ wc
 # cf. https://github.com/rear/rear/issues/2743
 LIBS=()
 
+####
 # Kernel modules to include in the rescue/recovery system:
 # The default MODULES=( 'all_modules' ) results that
 # all files in the /lib/modules/$KERNEL_VERSION directory
@@ -1604,6 +1648,7 @@ MODULES_LOAD=()
 # specified for MODULES e.g. also for MODULES=( 'all_modules' ).
 # By default we exclude scsi_debug - see issue #626:
 EXCLUDE_MODULES=( scsi_debug )
+####
 
 # Firmware files to include in the rescue/recovery system.
 # The FIRMWARE_FILES array contains filename globbing patterns
@@ -1631,6 +1676,7 @@ FIRMWARE_FILES=()
 # See also issue https://github.com/rear/rear/issues/2074 for the details
 UDEV_NET_MAC_RULE_FILES=( /etc/udev/rules.d/*persistent*{names,net,cd}.rules /etc/udev/rules.d/*eno-fix.rules )
 
+####
 # Files and directories to copy as-is (with tar) into the ReaR recovery system.
 # As its name tells COPY_AS_IS is primarily meant to "only copy as is".
 # In particular tar does not follow symlinks when copying
@@ -1697,7 +1743,9 @@ COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/\* dev/.udev dev/shm dev/shm/\* dev/oraclea
 # cf. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/5/html/deployment_guide/s1-users-groups-standard-users
 # When TRUSTED_FILE_OWNERS is empty all file owners are trusted.
 TRUSTED_FILE_OWNERS=( 'root' 'bin' 'daemon' 'sync' 'shutdown' 'halt' 'operator' )
+####
 
+####
 # Including and setting keyboard mappings in the ReaR recovery system,
 # cf. https://github.com/rear/rear/pull/1781
 # KEYMAPS_DEFAULT_DIRECTORY specifies the default directory for keyboard mapping files.
@@ -1753,7 +1801,9 @@ KEYMAPS_DIRECTORIES=""
 # Be default (i.e. when KEYMAP is not set or empty) the keymap of the original system
 # while "rear mkrescue/mkbackup" was run is also used in the recovery system:
 KEYMAP=""
+####
 
+####
 # Users and groups to copy into the ReaR recovery system.
 # Users and groups must exist in the original system (i.e. one cannot create new ones).
 # Specified users and groups that do not exist in the original system are ignored.
@@ -1785,6 +1835,7 @@ CLONE_ALL_USERS_GROUPS="true"
 # users and groups there and not with the users and groups of the original system.
 # Therefore special users and groups can be added via CLONE_USERS and CLONE_GROUPS
 # or even CLONE_ALL_USERS_GROUPS="all" can be specified.
+####
 
 # A terminal login password as a salted hash.
 # If empty, a root login into the ReaR recovery system via the system console or a serial terminal
@@ -1800,7 +1851,7 @@ CLONE_ALL_USERS_GROUPS="true"
 #          in the log file when ReaR runs in debugscript mode.
 TTY_ROOT_PASSWORD=''
 
-##
+####
 # SSH_FILES
 # SSH_ROOT_PASSWORD
 # SSH_UNPROTECTED_PRIVATE_KEYS
@@ -1893,6 +1944,7 @@ SSH_ROOT_PASSWORD=
 # in $TMPDIR/rear.XXXXXXXXXXXXXXX/rootfs/ and use COPY_AS_IS_EXCLUDE
 # to exclude unwanted files from the recovery system.
 SSH_UNPROTECTED_PRIVATE_KEYS='no'
+####
 
 ##
 # NON_FATAL_BINARIES_WITH_MISSING_LIBRARY
@@ -1942,10 +1994,12 @@ NON_FATAL_BINARIES_WITH_MISSING_LIBRARY=''
 # and skel/default/etc/scripts/system-setup scripts.
 EXCLUDE_MD5SUM_VERIFICATION=''
 
+####
 # Time synchronisation, could be NTP, CHRONY, NTPDATE, RDATE or empty:
 TIMESYNC=
 # Set a timesync source, mostly needed for NTPDATE and RDATE:
 TIMESYNC_SOURCE=
+####
 
 # Define a default LANG_RECOVER. At least TSM seems to need it to correctly restore foreign language sets.
 # You may redefine it e.g. like LANG_RECOVER=de_DE@euro but be careful because there could be weird failures
@@ -1981,7 +2035,7 @@ LANG_RECOVER=C
 # For details, see the cryptsetup(8) manual page of your particular Linux distribution.
 LUKS_CRYPTSETUP_OPTIONS="--iter-time 2000 --use-random"
 
-##
+####
 # BACKUP=CDM (Rubrik CDM; Cloud Data Management)
 ##
 # ReaR support for Rubrik Cloud Data Management (CDM).
@@ -1990,10 +2044,10 @@ LUKS_CRYPTSETUP_OPTIONS="--iter-time 2000 --use-random"
 COPY_AS_IS_CDM=( /etc/rubrik /usr/bin/rubrik /var/log/rubrik /etc/pki )
 COPY_AS_IS_EXCLUDE_CDM=( /var/log/rubrik/* )
 PROGS_CDM=( /usr/bin/rubrik/backup_agent_main /usr/bin/rubrik/bootstrap_agent_main openssl uuidgen )
+####
 
-
-##
-# BACKUP=FDRUPSTREAM stuff
+####
+# BACKUP=FDRUPSTREAM
 ##
 # ReaR support for FDR/Upstream is limited to disaster recovery only.
 # ReaR will not perform an FDR/Upstream backup.
@@ -2023,21 +2077,23 @@ CHECK_CONFIG_FILES_FDRUPSTREAM=(
 "$FDRUPSTREAM_DATA_PATH/*/parms/*"
 )
 PROGS_FDRUPSTREAM=()
+####
 
-##
-# BACKUP=NBKDC stuff
+####
+# BACKUP=NBKDC
 ##
 # (NovaStor DataCenter: http://www.novastor.com)
 # Agent installation will be detected automatically in:
 #  prep/NBKDC/default/400_prep_nbkdc.sh
 # ReaR will not perform the backup, this will be triggered by NovaStor DataCenter
-##
+#
 NBKDC_DIR=/opt/NovaStor/DataCenter
 COPY_AS_IS_NBKDC=()
 COPY_AS_IS_EXCLUDE_NBKDC=()
+####
 
-##
-# BACKUP=GALAXY stuff
+####
+# BACKUP=GALAXY
 ##
 # Note: This is for Galaxy 5 (tested) und probably 6 (untested)
 #
@@ -2048,9 +2104,10 @@ GALAXY_PORT=8401
 GALAXY_LOGONID=
 GALAXY_INSTANCE=
 GALAXY_BACKUPSET=
+####
 
-##
-# BACKUP=GALAXY7 stuff
+####
+# BACKUP=GALAXY7
 ##
 # Note: This is for Galaxy 7 (tested) and maybe also for 6 (untested)
 #
@@ -2064,8 +2121,10 @@ GALAXY7_BACKUPSET=
 # and also use this file to store the logon credentials to Galaxy. This file will be
 # automatically included in COPY_AS_IS
 GALAXY7_Q_ARGUMENTFILE=
-##
-# BACKUP=GALAXY10 stuff
+####
+
+####
+# BACKUP=GALAXY10
 ##
 # Note: This is for Galaxy 10 (tested)
 #
@@ -2079,9 +2138,10 @@ GALAXY10_BACKUPSET=
 # and also use this file to store the logon credentials to Galaxy. This file will be
 # automatically included in COPY_AS_IS
 GALAXY10_Q_ARGUMENTFILE=
+####
 
-##
-# BACKUP=TSM stuff
+####
+# BACKUP=TSM
 ##
 #
 COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
@@ -2114,19 +2174,10 @@ TSM_ARCHIVE_MGMT_CLASS=
 # Say "y", "Yes" or "1" to remove the ISO file from local system (in the ISO_DIR location)
 # if TSM server confirms the backup was successful (to preserve space on the local system)
 TSM_RM_ISOFILE=
+####
 
-##
-# OUTPUT=OBDR stuff
-##
-#
-COPY_AS_IS_OBDR=( )
-COPY_AS_IS_EXCLUDE_OBDR=( )
-REQUIRED_PROGS_OBDR=( lsscsi sg_wr_mode )
-# OBDR block size, known to work with 2048
-OBDR_BLOCKSIZE=2048
-
-##
-# BACKUP=NBU stuff (Symantec/Veritas NetBackup)
+####
+# BACKUP=NBU (Symantec/Veritas NetBackup)
 ##
 #
 COPY_AS_IS_NBU=( /usr/openv/bin/vnetd /usr/openv/bin/vopied /usr/openv/lib /usr/openv/netbackup /usr/openv/var/auth/[mn]*.txt /opt/VRTSpbx /etc/vx/VxICS /etc/vx/vrtslog.conf )
@@ -2134,9 +2185,10 @@ COPY_AS_IS_EXCLUDE_NBU=( /usr/openv/netbackup/logs "/usr/openv/netbackup/bin/bpj
 # See https://github.com/rear/rear/issues/2105 why /usr/openv/netbackup/sec/at/lib/ is needed:
 NBU_LD_LIBRARY_PATH="/usr/openv/lib:/usr/openv/netbackup/sec/at/lib/"
 PROGS_NBU=( )
+####
 
-##
-# BACKUP=AVA stuff (EMC Avamar)
+####
+# BACKUP=AVA (EMC Avamar)
 ##
 #
 # AVA_ROOT_DIR is relocatable - default location is either /usr/local/avamar or /opt/avamar
@@ -2144,9 +2196,10 @@ AVA_ROOT_DIR=/opt/avamar
 COPY_AS_IS_AVA=( $AVA_ROOT_DIR/* /var/avamar/avagent.cfg /var/avamar/cid.bin /etc/init.d/functions /etc/rc.d/init.d/avagent )
 COPY_AS_IS_EXCLUDE_AVA=( "$AVA_ROOT_DIR/var/*" )
 PROGS_AVA=( )
+####
 
-##
-# BACKUP=DP stuff (Micro Focus Data Protector)
+####
+# BACKUP=DP (Micro Focus Data Protector)
 ##
 # With COPY_AS_IS_DP=( ... /etc/opt/omni/client ) in particular the client certificate files
 # localhost_cert.pem and localhost_key.pem in the /etc/opt/omni/client/sscertificates/ directory
@@ -2163,8 +2216,9 @@ PROGS_AVA=( )
 COPY_AS_IS_DP=( /opt/omni /etc/opt/omni/client )
 COPY_AS_IS_EXCLUDE_DP=( /opt/omni/bin/telemetry /opt/omni/Depot /opt/omni/databases /opt/omni/jre /opt/omni/newconfig /opt/omni/bin/drim /opt/omni/AppServer /opt/omni/RS_idb /opt/omni/reporting )
 DP_LD_LIBRARY_PATH="/opt/omni/lib:/opt/omni/lib64"
+####
 
-##
+####
 # BACKUP=NSR (EMC Networker; Legato)
 ##
 #
@@ -2213,17 +2267,19 @@ NSR_CLIENT_MODE=
 #                                           recovery action (is allowed to perform recovery
 #                                           actions on its own).
 NSR_CLIENT_REQUESTRESTORE=
+####
 
-##
-# BACKUP=SESAM  (SEP Sesam: http://www.sep.de)
+####
+# BACKUP=SESAM (SEP Sesam: http://www.sep.de)
 # path to sesam installation will be detected automatically in:
 #  prep/SESAM/default/400_prep_sesam.sh
 ##
 COPY_AS_IS_SESAM=()
 COPY_AS_IS_EXCLUDE_SESAM=()
+####
 
-##
-# BACKUP=BACULA stuff (www.bacula.org stuff)
+####
+# BACKUP=BACULA (www.bacula.org stuff)
 ##
 # If empty BACULA_CONF_DIR and BACULA_BIN_DIR
 # are automatically set in prep/BACULA/default/400_prep_bacula.sh
@@ -2244,9 +2300,10 @@ BEXTRACT_VOLUME=
 # name of a tape device or a disk block device as configured for bacula-sd.
 #  eg. Ultrium-1 or /dev/sda1
 BEXTRACT_DEVICE=
+####
 
-##
-# BACKUP=BORG stuff (https://borgbackup.readthedocs.io)
+####
+# BACKUP=BORG (https://borgbackup.readthedocs.io)
 ##
 # Copy Borg stuff 1:1
 COPY_AS_IS_BORG=( )
@@ -2389,8 +2446,9 @@ BORGBACKUP_TIMESTAMP=
 #
 # For full list and description see:
 # https://borgbackup.readthedocs.io/en/stable/usage/general.html#environment-variables
+####
 
-##
+####
 # BACKUP=BLOCKCLONE
 ##
 # If set to "yes" partitions will be created 1:1
@@ -2419,9 +2477,10 @@ BLOCKCLONE_PARTITIONS_CONF_FILE="partition_layout.conf"
 BLOCKCLONE_ALLOW_MOUNTED="no"
 # Try unmounting device first (only meaningful when BLOCKCLONE_ALLOW_MOUNTED="yes")
 BLOCKCLONE_TRY_UNMOUNT="no"
+####
 
-##
-# BACKUP=BAREOS stuff (bareos.org)
+####
+# BACKUP=BAREOS (bareos.org)
 ##
 COPY_AS_IS_BAREOS=( /etc/bareos /var/spool/bareos )
 COPY_AS_IS_EXCLUDE_BAREOS=( /var/lib/bareos )
@@ -2446,9 +2505,10 @@ BEXTRACT_DEVICE=
 # Leave unset, if you have only one fileset for your client (this is almost always the case)
 # E.g. BAREOS_FILESET=Full
 # BAREOS_FILESET=
+####
 
-##
-# BACKUP=DUPLICITY stuff
+####
+# BACKUP=DUPLICITY
 ##
 # DUPLICITY is a cloud based external backup method
 # The program duply is wrapper script around duplicity which makes it much easier to use
@@ -2460,7 +2520,7 @@ BEXTRACT_DEVICE=
 # BACKUP_PROG="duply"
 DUPLY_PROFILE=""
 #
-#######################################################################
+##
 # Extension for DUPLICITY
 #
 # BACKUP=DUPLICITY
@@ -2566,10 +2626,10 @@ BACKUP_DUPLICITY_NAME="rear-backup"
 # Mountpoints and directories to restore via DIRECTORY_ENTRIES_TO_RECOVER
 # if defined, used by restore/default/900_create_missing_directories.sh
 #
-#######################################################################
+####
 
-##
-# BACKUP=NETFS stuff
+####
+# BACKUP=NETFS
 ##
 # NETFS is an internal backup method that saves the backup into a mounted directory.
 # This is usually a network share, but can also be used to create a backup to a local
@@ -2608,9 +2668,10 @@ NETFS_KEEP_OLD_BACKUP_COPY=
 # Furthermore BUILD_DIR (i.e. usually /tmp/rear.XXXXXXXXXXXXXXX cf. TMPDIR above) and
 # ISO_DIR are automatically excluded cf. rescue/NETFS/default/610_save_capabilities.sh
 NETFS_RESTORE_CAPABILITIES=( 'No' )
+####
 
-##
-# BACKUP=RSYNC method
+####
+# BACKUP=RSYNC
 ##
 # RSYNC backup method uses rsync (using ssh or rsync) to make a backup to a remote network server
 # prefix directory to create on the remote network filesystem
@@ -2629,20 +2690,10 @@ RSYNC_PROTOCOL_VERSION=
 # You can use this variable to add your own options, e.g.
 # BACKUP_RSYNC_OPTIONS+=( --devices --acls )
 BACKUP_RSYNC_OPTIONS=( --sparse --archive --hard-links --numeric-ids --stats )
-############
+####
 
-# Tape block size, default is to leave it up to the tape-device:
-TAPE_BLOCKSIZE=
-
-# Disable ping:
-# Some environments don't allow to ping the backup host,
-# even though the backup software is reachable
-# e.g. in a DMZ. since most backup methods check the host availability,
-# you can disable ping by unsetting the PING variable [BOOL]
-PING=
-
-##
-# BACKUP=REQUESTRESTORE stuff
+####
+# BACKUP=REQUESTRESTORE
 ##
 # This mode interrupts "rear recover" after formatting and mounting the filesystems
 # and expects the backup data was properly restored to continue "rear recover"
@@ -2661,8 +2712,9 @@ instead of '/' because the hard disks of the recovered system are mounted there.
 # This command is shown to the user and added to the predefined bash history
 # in the ReaR recovery system to make the manual backup restore easier:
 REQUESTRESTORE_COMMAND=
+####
 
-##
+####
 # BACKUP=RBME
 ##
 # This mode allows restoring a RBME backup from NFS shares.
@@ -2678,8 +2730,9 @@ RBME_BACKUP=
 # If the RBME hostname is different from the system hostname, configure it here
 # Example: RBME_HOSTNAME="$HOSTNAME-bcp"
 RBME_HOSTNAME=$HOSTNAME
+####
 
-##
+####
 # BACKUP=ZYPPER
 ##
 # It is not an usual file-based backup/restore method
@@ -2781,8 +2834,9 @@ ZYPPER_ROOT_PASSWORD='root'
 # ZYPPER_NETWORK_SETUP_COMMANDS=( 'YAST' 'ip route add default via 192.168.100.1' 'systemctl enable sshd.service' )
 ZYPPER_NETWORK_SETUP_COMMANDS=()
 # End of BACKUP=ZYPPER default setings.
+####
 
-##
+####
 # BACKUP=YUM
 ##
 # This method is very similar to the ZYPPER method, above, but for systems that use the YUM package manager (RHEL, CentOS, etc)
@@ -2828,32 +2882,46 @@ YUM_BACKUP_SELINUX_CONTEXTS="no"
 ##
 RECREATE_USERS_GROUPS="no"
 # End of BACKUP=YUM default setings.
+####
 
-
-##
+####
 # BACKUP=EXTERNAL
 ##
 # Custom command backup stuff.
 #
 # Examples for external backup. In this mode your external program must do EVERYTHING
 # In the example below we backup / to the vms host via tar and netcat
-# NOTE: The EXTERNAL_* commands can be also defined as an array () to better protect
-# arguments with blanks
-# NOTE: The EXTERNAL_* commands will be run inside eval like this:
+# The EXTERNAL_* commands can be also defined as an array to better protect arguments with blanks.
+# The EXTERNAL_* commands will be run inside eval like this:
 # eval "${EXTERNAL_BACKUP[@]}"
 #
-# Command to backup the required data
-# This example saves the data via SSH to a remote system called vms
-EXTERNAL_BACKUP="tar -c -l -z / | ssh vms 'cat >rear64/backup.tar.gz'"
-# Command to restore the data (by default $TARGET_FS_ROOT is '/mnt/local')
-EXTERNAL_RESTORE="ssh vms cat rear64/backup.tar.gz | tar -C $TARGET_FS_ROOT -x -z"
-# The following exit codes from EXTERNAL_* should not abort the backup or recovery
-# This example is useful for rsync
-EXTERNAL_IGNORE_ERRORS=( 23 24 )
-# Command to verify the availability of the backup resource, will be executed only if PING=1
-EXTERNAL_CHECK="ssh vms date >/dev/null"
+# Example command to backup the required data:
+# This example saves the data via SSH to a remote system called vms:
+# EXTERNAL_BACKUP="tar -c -l -z / | ssh vms 'cat >rear64/backup.tar.gz'"
+#
+# Example command to restore the data (by default $TARGET_FS_ROOT is '/mnt/local'):
+# EXTERNAL_RESTORE="ssh vms cat rear64/backup.tar.gz | tar -C $TARGET_FS_ROOT -x -z"
+#
+# When the backup command in EXTERNAL_BACKUP or the restore command in EXTERNAL_RESTORE
+# exits with a non-zero exit code that is listed in EXTERNAL_IGNORE_ERRORS
+# it will not let "rear mkbackup" or "rear recover" abort with an error
+# but only show a warning message.
+# This example is useful when rsync is used in EXTERNAL_BACKUP or EXTERNAL_RESTORE:
+# EXTERNAL_IGNORE_ERRORS=( 23 24 )
+#
+# Example command to verify the availability of the backup resource.
+# It will be executed only if PING=1
+# EXTERNAL_CHECK="ssh vms date >/dev/null"
+####
 
-##
+# Disable ping:
+# Some environments don't allow to ping the backup host,
+# even though the backup software is reachable
+# e.g. in a DMZ. since most backup methods check the host availability,
+# you can disable ping by unsetting the PING variable [BOOL]
+PING=
+
+####
 # BACKUP_RESTORE_MOVE_AWAY
 #
 # Move away restored files or directories that should not have been restored:
@@ -2922,8 +2990,9 @@ readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/moved_away_after_backup_re
 # Nevertheless that information from the last boot on the original system
 # could be still of interest for the user so that it is not deleted:
 BACKUP_RESTORE_MOVE_AWAY_FILES=( /boot/grub/grubenv /boot/grub2/grubenv )
+####
 
-##
+####
 # DIRECTORY_ENTRIES_TO_RECOVER
 #
 # Create still missing directories and symbolic links
@@ -2973,8 +3042,9 @@ BACKUP_RESTORE_MOVE_AWAY_FILES=( /boot/grub/grubenv /boot/grub2/grubenv )
 # DIRECTORY_ENTRIES_TO_RECOVER=( '/path/to/mytmpdir 1770 myowner mygroup' '/var/mytmpdir -> /path/to/mytmpdir' )
 # By default the DIRECTORY_ENTRIES_TO_RECOVER array is empty:
 DIRECTORY_ENTRIES_TO_RECOVER=()
+####
 
-##
+####
 # How to exclude something ----- EXCLUDES -------
 #
 # You cannot exclude a device (e.g. /dev/sdg) directly. Instead you have to exclude everything
@@ -2983,25 +3053,25 @@ DIRECTORY_ENTRIES_TO_RECOVER=()
 #
 # Furthermore, you have to exclude MD devices and LVM2 volume groups separately
 # as there is no automatic detection of these dependencies.
-
+#
 # Exclude filesystems by specifying their mountpoints. Will be automatically added to the
 # $BACKUP_PROG_EXCLUDE array during backup to prevent the excluded filesystems' data to
 # be backed up
 # examples: /tmp
 #           /media/bigdisk
 EXCLUDE_MOUNTPOINTS=()
-
+#
 # Exclude MD devices
 # examples: /dev/md0
 #           /dev/md/0
 EXCLUDE_MD=()
-
+#
 # Exclude LVM2 volume groups. This will automatically exclude also the creation of the
 # corresponding physical and logical volumes that belong to the excluded volume group.
 # You must also exclude the corresponding mountpoints in EXCLUDE_MOUNTPOINTS (see above)
 # otherwise "rear recover" would try to recreate the filesystems onto non-existing LVs.
 EXCLUDE_VG=()
-
+#
 # Exclude any component from the recovery image.
 # Some component types need a prefix:
 # - filesystems: "fs:/var/cache"
@@ -3010,22 +3080,21 @@ EXCLUDE_VG=()
 # Volume groups look like: "/dev/system".
 # If in doubt about the correct syntax, consult /var/lib/rear/layout/disktodo.conf
 EXCLUDE_COMPONENTS=()
-
-####
+#
 # Only include LVM2 volume groups - the opposite of EXCLUDE_VG (handy if you only want vg00 to be included)
 # EXCLUDE_VG and EXCLUDE_MOUNTPOINTS will get populated automatically, if needed
 # syntax : e.g. ONLY_INCLUDE_VG=( "vg00" "vg01" )
 ONLY_INCLUDE_VG=()
-
+#
 # Automatically exclude disks that are not used by mounted filesystems
 AUTOEXCLUDE_DISKS=y
-
+#
 # Automatically exclude multipath disks and their dependent components
 AUTOEXCLUDE_MULTIPATH=y
-
+#
 # Automatically exclude automounter paths from the backup
 AUTOEXCLUDE_AUTOFS=
-
+#
 # Automatically exclude filesystems with mountpoints that are sub-directories
 # of the directories that are specified in the AUTOEXCLUDE_PATH array.
 # This is different from EXCLUDE_MOUNTPOINTS, which accepts only mountpoints.
@@ -3041,60 +3110,68 @@ AUTOEXCLUDE_AUTOFS=
 # sub-directories below /media /run[/media] /mnt and /tmp
 # see https://github.com/rear/rear/issues/2239
 AUTOEXCLUDE_PATH=( /media /run /mnt /tmp )
-
-#### New Style include/excludes
+#
+## New Style include/excludes
 # Exclude components from being backed up, recreation information is active
 EXCLUDE_BACKUP=()
-
+#
 # Exclude components during component recreation
 # will be added to EXCLUDE_BACKUP (it is not backed up)
 # recreation information gathered, but commented out
 EXCLUDE_RECREATE=()
-
+#
 # Exclude components during the backup restore phase
 # Only used to exclude files from the restore.
 EXCLUDE_RESTORE=()
-
+#
 # Exclude block devices from being viable mapping options that can be selected
 # by the user during 'rear recover' (cf. layout/prepare/default/300_map_disks.sh).
 # The EXCLUDE_DEVICE_MAPPING array contains 'case' patterns that must match
 # the basename of block devices in the /sys/block/ directory:
 EXCLUDE_DEVICE_MAPPING=( 'loop*' 'ram*' 'zram*' )
-
+#
 # Exclude RUNTIME_LOGFILE (useful for debugging) from initramfs
 EXCLUDE_RUNTIME_LOGFILE='no'
+####
 
-################ ---- various warnings
+####
+# various warnings
 #
 # Warnings can be also disabled by unsetting these variables
 WARN_MISSING_VOL_ID=1
+####
 
-################ ---- enable/disable features
+####
+# enable/disable features
 #
 # To enable cfg2html, if present on the system, set to 'y', 'Y' or '1'
 USE_CFG2HTML=
 # The SKIP_CFG2HTML variable is no longer supported since ReaR 1.18
+####
 
+####
 # IP addresses that are present on the system but must be excluded when
 # building the network configuration used in recovery mode; this is typically
 # used when floating IP addresses are used on the system
 EXCLUDE_IP_ADDRESSES=()
-
+#
 # Network interfaces that are present on the system but must be excluded when
 # building the network configuration used in recovery mode
 EXCLUDE_NETWORK_INTERFACES=()
-
+#
 # Simplify bonding setups by configuring always the first active device of a
 # bond, except when mode is 4 (IEEE 802.3ad policy)
 SIMPLIFY_BONDING=no
-
+#
 # Simplify bridge setups by configuring always the first active device of a bridge
 SIMPLIFY_BRIDGE=no
-
+#
 # Simplify team setups by configuring always the first active device of a team,
 # except when runner is 'lacp' (IEEE 802.3ad policy)
 SIMPLIFY_TEAMING=no
+#####
 
+####
 # Serial console support for the ReaR rescue/recovery system:
 # By default serial consoles get enabled if serial devices are found and
 # then matching kernel command line parameters like 'console=ttyS0,9600 console=ttyS1,9600'
@@ -3129,15 +3206,18 @@ SERIAL_CONSOLE_DEVICE_SYSLINUX=
 # provided USE_SERIAL_CONSOLE is turned on.
 # By default (when empty) the first one of SERIAL_CONSOLE_DEVICES is used for GRUB:
 SERIAL_CONSOLE_DEVICE_GRUB=
+####
 
-# Say "y", "Yes", etc, to enable or "n", "No" etc. to disable the DHCP client protocol or leave empty to autodetect.
+####
+# Say "y", "Yes", etc, to enable or "n", "No" etc.
+# to disable the DHCP client protocol or leave empty to autodetect.
 # When enabled, lets the rescue/recovery system run dhclient to get an IP address
 # instead of using the same IP address as the original system:
 USE_DHCLIENT=
-
+#
 # Say "y", "Yes", etc, to enable static networking (overrules USE_DHCLIENT):
 USE_STATIC_NETWORKING=
-
+#
 # USE_RESOLV_CONF specifies what to use as /etc/resolv.conf in the recovery system:
 # Relax-and-Recover does no to replicate in the ReaR recovery system
 # whatever complicated DNS setup there is on the original system
@@ -3165,7 +3245,7 @@ USE_STATIC_NETWORKING=
 # generated by /bin/dhclient-script regardless what its content was before
 # (for details see usr/share/rear/build/GNU/Linux/630_verify_resolv_conf_file.sh):
 USE_RESOLV_CONF=()
-
+#
 # Commands to prepare network devices setup in the rescue/recovery system
 # provided the kernel command line does not contain the 'noip' parameter.
 # Each command is a quoted fixed string to get the commands separated from each other
@@ -3187,8 +3267,9 @@ USE_RESOLV_CONF=()
 # i.e. the default is an automated network devices setup in the rescue/recovery system
 # that should match the network devices setup in the currently running system:
 NETWORKING_PREPARATION_COMMANDS=()
+####
 
-##
+####
 # GRUB_RESCUE [ GRUB_RESCUE_USER ]
 #
 # Add a ReaR rescue/recovery system to the bootloader of the currently running system.
@@ -3238,10 +3319,9 @@ GRUB_RESCUE_USER=""
 # For background information see https://github.com/rear/rear/pull/942
 # and https://github.com/rear/rear/issues/703
 # starting at https://github.com/rear/rear/issues/703#issuecomment-235506494
+####
 
-##
 # REBUILD_INITRAMFS
-#
 # Whether or not the initramfs/initrd should be rebuild during "rear recover"
 # in the recreated system.
 # The default REBUILD_INITRAMFS="yes" rebuilds the initramfs/initrd in any case
@@ -3259,9 +3339,7 @@ GRUB_RESCUE_USER=""
 # see https://github.com/rear/rear/issues/1321
 REBUILD_INITRAMFS="yes"
 
-##
 # BOOTLOADER
-#
 # What kind of bootloader is used on the original system
 # (i.e. the bootloader that should be reinstalled during "rear recover").
 # The by default empty BOOTLOADER means that ReaR will try to autodetect
@@ -3278,9 +3356,7 @@ REBUILD_INITRAMFS="yes"
 # With an unknown or unsupported bootloader value setting ReaR would fail:
 BOOTLOADER=""
 
-##
 # GRUB2_INSTALL_DEVICES
-#
 # When GRUB2 is used as bootloader GRUB2_INSTALL_DEVICES is a string of devices
 # where GRUB2 should be installed like GRUB2_INSTALL_DEVICES="/dev/sda /dev/sdb".
 # When GRUB2_INSTALL_DEVICES is specified, GRUB2 will be installed
@@ -3311,7 +3387,7 @@ BOOTLOADER=""
 # to the right device directly before he calls "rear recover":
 test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
 
-##
+####
 # GRUB2_MODULES_UEFI_LOAD
 # List of modules that will be included into Grub2 based UEFI boot loader (the core image).
 # When empty ReaR will use the defaults of grub-mkstandalone
@@ -3326,8 +3402,7 @@ test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
 # Incorrect use of this variable can lead to unusable ReaR recovery system.
 # When you modify this variable, verify that your ReaR recovery system works.
 GRUB2_MODULES_UEFI_LOAD=()
-
-##
+#
 # GRUB2_MODULES_UEFI
 # List of modules that will be installed into Grub2 based UEFI boot loader ramdisk.
 # Those will not be preloaded in the core image, but will be available for autoloading
@@ -3338,8 +3413,7 @@ GRUB2_MODULES_UEFI_LOAD=()
 # Incorrect use of this variable can lead to unusable ReaR recovery system.
 # When you modify this variable, verify that your ReaR recovery system works.
 GRUB2_MODULES_UEFI=()
-
-##
+#
 # GRUB2_DEFAULT_BOOT
 # The default GRUB2 menu entry to boot
 # when GRUB2 is used as bootloader for the ReaR recovery system.
@@ -3353,14 +3427,15 @@ GRUB2_MODULES_UEFI=()
 # exit             : Exit to EFI shell
 #                    Exit (possibly continue bootchain)
 GRUB2_DEFAULT_BOOT="chainloader"
-
-##
+#
 # GRUB2_TIMEOUT
 # The timeout in seconds to automatically boot GRUB2_DEFAULT_BOOT
 # when GRUB2 is used as bootloader for the ReaR recovery system.
 GRUB2_TIMEOUT="$USER_INPUT_TIMEOUT"
+####
 
-##
+####
+#
 # USING_UEFI_BOOTLOADER
 #
 # UEFI (Secure booting) support is partly available in ReaR (at least for Fedora, RHEL)
@@ -3374,8 +3449,7 @@ GRUB2_TIMEOUT="$USER_INPUT_TIMEOUT"
 # instead of '0' also any value that is recognized as 'no' by the is_false function can be used
 # instead of '1' also any value that is recognized as 'yes' by the is_true function can be used
 USING_UEFI_BOOTLOADER=
-
-##
+#
 # UEFI_BOOTLOADER
 #
 # When a filename (with path) is specified in UEFI_BOOTLOADER in /etc/rear/local.conf
@@ -3395,8 +3469,8 @@ USING_UEFI_BOOTLOADER=
 # and then ReaR autodetects from EFI variables in /sys/firmware/efi/vars
 # or /sys/firmware/efi/efivars what to use as UEFI bootloader.
 UEFI_BOOTLOADER=""
-
-##
+#
+#
 # SECURE_BOOT_BOOTLOADER
 #
 # When using Secure Boot set full path of your signed boot loader here.
@@ -3407,8 +3481,9 @@ UEFI_BOOTLOADER=""
 #
 # c.f. https://github.com/rear/rear/pull/1385
 SECURE_BOOT_BOOTLOADER=""
+####
 
-##
+####
 # EFI_STUB
 # Enforce EFISTUB booting.
 # If enabled and OS is currently using some boot loader (Grub, Grub2, elilo, ...), restored
@@ -3417,17 +3492,16 @@ SECURE_BOOT_BOOTLOADER=""
 # ReaR will trigger some basic check if kernel currently used, is EFISTUB capable and will
 # end with error if EFISTUB support is not available in detected Linux kernel.
 EFI_STUB="no"
-
+#
 # Full path to Systemd boot loader that will be used to boot ReaR rescue system.
 OUTPUT_EFISTUB_SYSTEMD_BOOTLOADER="/usr/lib/systemd/boot/efi/systemd-bootx64.efi"
-
+#
 # Options passed to efibootmgr --unicode ...
 # E.g. EFI_STUB_EFIBOOTMGR_ARGS="initrd=initramfs-linux.img root=/dev/sda2"
 EFI_STUB_EFIBOOTMGR_ARGS=
+###
 
-##
 # REAR_INITRD_COMPRESSION
-#
 # What compression to use when creating the initramfs/initrd for the ReaR rescue/recovery system.
 # By default and also as fallback an initrd.cgz with gzip default compression is created.
 # The default is known to work well in practice.
@@ -3455,12 +3529,11 @@ EFI_STUB_EFIBOOTMGR_ARGS=
 # see https://github.com/rear/rear/pull/1182#issuecomment-282252770
 REAR_INITRD_COMPRESSION=""
 
-##
+####
 # advanced handling of Relax-and-Recover result (boot image)
 ##
-# Relax-and-Recover can do something with the resulting files, here we say what
+# Relax-and-Recover can do something with the resulting files, here we say what:
 #
-
 # The list of resulting files that make up the DR environment.
 # RESULT_FILES array elements get added as needed by various scripts.
 # For example such an automatically added RESULT_FILES array element
@@ -3469,33 +3542,37 @@ REAR_INITRD_COMPRESSION=""
 # specified via OUTPUT_URL (or inherited from BACKUP_URL).
 # Initially this array is empty, but a user could specify additional files:
 RESULT_FILES=()
-
+#
 # we can send a mail with the resulting files. We even support multiple recipients,
 # each array variable is one recipient. When you set this variable to a value without
 # using an array, it will still work.
 RESULT_MAILTO=()
-
+#
 # set the sender, your local sendmail will expand this to a FQDN if you don't
 # supply a full name here.
 RESULT_MAILFROM=root
-
+#
 # set the subject to empty here, later script will fill in our default
 RESULT_MAILSUBJECT=
-
+#
 # path to your sendmail
 RESULT_SENDMAIL="$( type -p sendmail || echo /usr/lib/sendmail )"
-
+#
 # extra sendmail options. On my system -t makes sendmail read the recipients
 # from the mail headers
 # Use array to properly handle args with spaces ("some arg")
 RESULT_SENDMAIL_OPTIONS=( -oi -t )
+####
 
-################ ---- ia64 specific stuff
+####
+# ia64 specific stuff
 #
 # full path to elilo.efi file. Leave empty to use automatic search for it
 ELILO_BIN=
+####
 
-################ ---- custom scripts
+####
+# Custom scripts
 #
 # The scripts can be defined as an array to better handle spaces in parameters.
 # The scripts are called like this:
@@ -3517,23 +3594,23 @@ ELILO_BIN=
 # or
 #   PRE_RECOVERY_COMMANDS=( 'echo Hello' )
 #   PRE_RECOVERY_COMMANDS+=( 'sleep 3' )
-
+#
 # Those get called at the very beginning of "rear recover".
 # The PRE_RECOVERY_COMMANDS are called directly before the PRE_RECOVERY_SCRIPT.
 # Nothing was recreated and you have only the plain ReaR rescue/recovery system:
 PRE_RECOVERY_COMMANDS=()
 PRE_RECOVERY_SCRIPT=
-
+#
 # Those get called at the very end of "rear recover".
 # The POST_RECOVERY_COMMANDS are called directly after the POST_RECOVERY_SCRIPT.
 # Use $TARGET_FS_ROOT (by default '/mnt/local') to access the recreated target system.
 POST_RECOVERY_SCRIPT=
 POST_RECOVERY_COMMANDS=()
-
+#
 # PRE_BACKUP_SCRIPT and POST_BACKUP_SCRIPT are called at the beginning and
 # at the end of the backup part in the mkbackup/mkbackuponly workflow like this:
 #   eval "${PRE_BACKUP_SCRIPT[@]}"
-
+#
 # For example:
 # When a database is running on a filesystem which is included in the backup
 # you may need to stop a database service before backup via PRE_BACKUP_SCRIPT
@@ -3546,12 +3623,13 @@ POST_RECOVERY_COMMANDS=()
 # When only POST_BACKUP_SCRIPT is set without a PRE_BACKUP_SCRIPT
 # then POST_BACKUP_SCRIPT is not run in case of an error exit during backup.
 # POST_BACKUP_SCRIPT is run if there is some error but no error exit during backup.
-
+#
 # Called at the beginning of the backup part in the mkbackup/mkbackuponly workflow:
 PRE_BACKUP_SCRIPT=
-
+#
 # Called at the end of the backup part in the mkbackup/mkbackuponly workflow:
 POST_BACKUP_SCRIPT=
+####
 
 # Some external backup software request user input
 # (e.g. to enter paths to exclude or date and time values for point in time restore).
@@ -3565,8 +3643,10 @@ POST_BACKUP_SCRIPT=
 # directly before he calls "rear ...":
 test "$WAIT_SECS" || WAIT_SECS="$USER_INPUT_TIMEOUT"
 
-# to force adding multipath related executables so a recovered system would be able to boot via SAN disks only
-# instead of the internal ones (no success guaranteed although). E.g. in case the destination has no internal disks.
+# To force adding multipath related executables
+# so a recovered system would be able to boot via SAN disks only
+# instead of the internal ones (no success guaranteed although).
+# E.g. in case the destination has no internal disks.
 # making the variable (y,Y,1) to enable
 BOOT_OVER_SAN=
 
@@ -3580,27 +3660,33 @@ BOOT_OVER_SAN=
 # See http://stackoverflow.com/questions/9879688/difference-between-cacert-and-capath-in-curl
 REAR_CAPATH="/etc/rear/cert"
 
-####################
+####
 # DRLM (Disaster Recovery Linux Manager) Variables
-
+#
 # Specify if ReaR is managed from DRLM (y/n) [ default (n) ].
 DRLM_MANAGED=n
-
-# Specify the DRLM certificate location. DRLM can provide the certificate with it's 'instclient' workflow or you can get it from
+#
+# Specify the DRLM certificate location.
+# DRLM can provide the certificate with it's 'instclient' workflow or you can get it from
 # /etc/drlm/cert/*.crt on a DRLM server.
-# By default is defined with '--capath' curl option (see: man curl). Take care on using (-k|--insecure) only use it on trusted networks.
+# By default is defined with '--capath' curl option (see: man curl).
+# Take care on using (-k|--insecure) only use it on trusted networks.
 # DRLM use a RESTful API and in future more REST required options could be added.
 DRLM_REST_OPTS="--capath $REAR_CAPATH"
-
-# Specify DRLM Server name or ip address. This name must be the same as defined in CN of the certificate (DRLM server hostname by default).
-# If is not possible because you're using other DRLM server for recovery or system migration, get the certificate from the new DRLM server
-# or use (-k or --insecure) on DRLM_REST_OPTS.
+#
+# Specify DRLM Server name or ip address.
+# This name must be the same as defined in CN of the certificate (DRLM server hostname by default).
+# If is not possible because you're using other DRLM server for recovery or system migration,
+# get the certificate from the new DRLM server or use (-k or --insecure) on DRLM_REST_OPTS.
 DRLM_SERVER=""
-
-# Specify DRLM Client name. The hostname is used by default, but must be set to the DRLM client name if is different.
+#
+# Specify DRLM Client name.
+# The hostname is used by default, but must be set to the DRLM client name if is different.
 # The client hostname is the recommended but not mandatory.
 DRLM_ID="$HOSTNAME"
-
-# DRLM_REST_OPTS, DRLM_SERVER and DRLM_ID variables can be changed in /etc/rear/local.conf and also can be updated at runtime.
-#  e.g.
-#       rear recover SERVER=1.1.1.1 REST_OPTS="-k" ID=client01
+#
+# DRLM_REST_OPTS, DRLM_SERVER and DRLM_ID variables can be changed
+# in /etc/rear/local.conf and also can be updated at runtime.
+# e.g.
+#   rear recover SERVER=1.1.1.1 REST_OPTS="-k" ID=client01
+####

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2887,7 +2887,7 @@ RECREATE_USERS_GROUPS="no"
 ####
 # BACKUP=EXTERNAL
 ##
-# Custom command backup stetup.
+# Custom command backup setup.
 # In this mode your external program must do all what is needed in its own.
 #
 # The EXTERNAL_BACKUP EXTERNAL_RESTORE and EXTERNAL_CHECK commands
@@ -2921,9 +2921,10 @@ RECREATE_USERS_GROUPS="no"
 
 # Disable ping:
 # Some environments don't allow to ping the backup host,
-# even though the backup software is reachable e.g. in a DMZ.
+# even though the backup service is reachable e.g. in a DMZ.
 # Several backup methods check the backup host availability
-# when you enable ping tests by setting the PING variable [BOOL].
+# when you enable ping tests by setting the PING variable
+# to any non-empty value (see 'Boolean variables' above).
 # Currently ping tests that check the PING variable
 # are implemented for those BACKUP=... methods:
 # BAREOS DUPLICITY EXTERNAL NETFS RSYNC GALAXY GALAXY7 GALAXY10 NBU NSR TSM

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2279,7 +2279,7 @@ COPY_AS_IS_EXCLUDE_SESAM=()
 ####
 
 ####
-# BACKUP=BACULA (www.bacula.org stuff)
+# BACKUP=BACULA (www.bacula.org)
 ##
 # If empty BACULA_CONF_DIR and BACULA_BIN_DIR
 # are automatically set in prep/BACULA/default/400_prep_bacula.sh
@@ -2887,38 +2887,46 @@ RECREATE_USERS_GROUPS="no"
 ####
 # BACKUP=EXTERNAL
 ##
-# Custom command backup stuff.
+# Custom command backup stetup.
+# In this mode your external program must do all what is needed in its own.
 #
-# Examples for external backup. In this mode your external program must do EVERYTHING
-# In the example below we backup / to the vms host via tar and netcat
-# The EXTERNAL_* commands can be also defined as an array to better protect arguments with blanks.
-# The EXTERNAL_* commands will be run inside eval like this:
+# The EXTERNAL_BACKUP EXTERNAL_RESTORE and EXTERNAL_CHECK commands
+# can be also defined as an array to better protect arguments with blanks.
+# Those EXTERNAL_* commands will be run inside eval like this:
 # eval "${EXTERNAL_BACKUP[@]}"
 #
+# In the example below we backup '/' via tar and ssh
+# to a file 'rear/backup.tar.gz' on a remote host 'backup_server'.
+#
 # Example command to backup the required data:
-# This example saves the data via SSH to a remote system called vms:
-# EXTERNAL_BACKUP="tar -c -l -z / | ssh vms 'cat >rear64/backup.tar.gz'"
+# This example saves the data via SSH to a remote system called 'backup_server':
+# EXTERNAL_BACKUP="tar -c -l -z / | ssh backup_server 'cat >rear/backup.tar.gz'"
 #
 # Example command to restore the data (by default $TARGET_FS_ROOT is '/mnt/local'):
-# EXTERNAL_RESTORE="ssh vms cat rear64/backup.tar.gz | tar -C $TARGET_FS_ROOT -x -z"
+# EXTERNAL_RESTORE="ssh backup_server cat rear/backup.tar.gz | tar -C $TARGET_FS_ROOT -x -z"
 #
 # When the backup command in EXTERNAL_BACKUP or the restore command in EXTERNAL_RESTORE
 # exits with a non-zero exit code that is listed in EXTERNAL_IGNORE_ERRORS
 # it will not let "rear mkbackup" or "rear recover" abort with an error
-# but only show a warning message.
-# This example is useful when rsync is used in EXTERNAL_BACKUP or EXTERNAL_RESTORE:
+# but only log a warning message.
+# This example could be useful when rsync is used in EXTERNAL_BACKUP or EXTERNAL_RESTORE
+# to ignore rsync partial transfer issues due to error or vanished source files:
 # EXTERNAL_IGNORE_ERRORS=( 23 24 )
 #
-# Example command to verify the availability of the backup resource.
-# It will be executed only if PING=1
-# EXTERNAL_CHECK="ssh vms date >/dev/null"
+# Example command to verify the availability of the backup resource
+# before making the backup with "rear mkbackup" or "rear mkbackuponly".
+# It will be executed only if PING=1 (see below):
+# EXTERNAL_CHECK="ssh backup_server date >/dev/null"
 ####
 
 # Disable ping:
 # Some environments don't allow to ping the backup host,
-# even though the backup software is reachable
-# e.g. in a DMZ. since most backup methods check the host availability,
-# you can disable ping by unsetting the PING variable [BOOL]
+# even though the backup software is reachable e.g. in a DMZ.
+# Several backup methods check the backup host availability
+# when you enable ping tests by setting the PING variable [BOOL].
+# Currently ping tests that check the PING variable
+# are implemented for those BACKUP=... methods:
+# BAREOS DUPLICITY EXTERNAL NETFS RSYNC GALAXY GALAXY7 GALAXY10 NBU NSR TSM
 PING=
 
 ####


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2870#issuecomment-1261045942

* Brief description of the changes in this pull request:

In default.conf better description
of the BACKUP=EXTERNAL config variables, see
https://github.com/rear/rear/issues/2870#issuecomment-1261045942
and some general improvements of the comments
e.g. removed the colloquial word 'stuff' where not useful
and in particular make blocks of config variables
that belong together more clear by using
```
####
.
.
.
####
```
as indicators where a block begins and ends.
