### PR TITLE
Implement basic 'barrel' support

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -481,6 +481,8 @@ test "$MIGRATION_MODE" || MIGRATION_MODE=''
 # (here it works because the ReaR disk ID is same on the replacement hardware).
 # In any case there is a user confirmation dialog before disks will be wiped.
 # With DISKS_TO_BE_WIPED="false" no disk will be wiped.
+# DISKS_TO_BE_WIPED has no influence what disks will get completely overwritten
+# by the actual disk layout recreation code (e.g. the diskrestore.sh script).
 DISKS_TO_BE_WIPED=""
 ####
 

--- a/usr/share/rear/layout/recreate/default/150_wipe_disks.sh
+++ b/usr/share/rear/layout/recreate/default/150_wipe_disks.sh
@@ -1,15 +1,16 @@
 
-# Skip it when the user has explicitly specified to not wipe disks:
+# Skip wiping disks when the user has explicitly specified to not wipe disks
+# or when the user selected "Skip wiping disks" in layout/recreate/default/120_confirm_wipedisk_disks.sh
 is_false "$DISKS_TO_BE_WIPED" && return 0
 
-# The disks that will be completely wiped are those disks
+# The disks that will be wiped are those disks
 # where in diskrestore.sh the create_disk_label function is called
 # (the create_disk_label function calls "parted -s $disk mklabel $label")
 # for those that exist as disks on the bare hardware for example like
 #   create_disk_label /dev/sda gpt
 #   create_disk_label /dev/sdb msdos
 #   create_disk_label /dev/md127 gpt
-# so in this example DISKS_TO_BE_WIPED="/dev/sda /dev/sdb "
+# so in this example by default DISKS_TO_BE_WIPED="/dev/sda /dev/sdb "
 # or if the user has specified DISKS_TO_BE_WIPED use only the existing block devices therein
 # cf. layout/recreate/default/120_confirm_wipedisk_disks.sh
 

--- a/usr/share/rear/layout/recreate/default/200_run_layout_code.sh
+++ b/usr/share/rear/layout/recreate/default/200_run_layout_code.sh
@@ -29,10 +29,23 @@ unset choices
 choices[0]="Rerun disk recreation script ($LAYOUT_CODE)"
 choices[1]="View '$rear_workflow' log file ($RUNTIME_LOGFILE)"
 choices[2]="Edit disk recreation script ($LAYOUT_CODE)"
-choices[3]="View original disk space usage ($original_disk_space_usage_file)"
-choices[4]="Use Relax-and-Recover shell and return back to here"
-choices[5]="Abort '$rear_workflow'"
+choices[3]="Again wipe those disks: $DISKS_TO_BE_WIPED"
+choices[4]="Show what is currently on the disks ('lsblk' block devices list)"
+choices[5]="View original disk space usage ($original_disk_space_usage_file)"
+choices[6]="Use Relax-and-Recover shell and return back to here"
+choices[7]="Abort '$rear_workflow'"
 prompt="The disk layout recreation script failed"
+# Do not show choice to wipe disks when whiping disks is switched off:
+is_false "$DISKS_TO_BE_WIPED" && choices[3]="n/a"
+# When 'barrel' is used to recreate the storage layout different choices must be shown:
+BARREL_DEVICEGRAPH_DIR="$VAR_DIR/layout/barrel"
+BARREL_DEVICEGRAPH_FILE=$BARREL_DEVICEGRAPH_DIR/devicegraph.xml
+if is_true "$BARREL_DEVICEGRAPH" ; then
+    DebugPrint "Recreating storage layout with 'barrel' devicegraph ($BARREL_DEVICEGRAPH_FILE)"
+    choices[0]="Rerun 'barrel load devicegraph' ($BARREL_DEVICEGRAPH_FILE)"
+    choices[2]="Switch to recreating with disk recreation script ($LAYOUT_CODE)"
+fi
+
 choice=""
 # When USER_INPUT_LAYOUT_CODE_RUN has any 'true' value be liberal in what you accept and
 # assume choices[0] 'Rerun disk recreation script' was actually meant:
@@ -50,12 +63,34 @@ confirm_choice=""
 is_true "$USER_INPUT_LAYOUT_MIGRATED_CONFIRMATION" && USER_INPUT_LAYOUT_MIGRATED_CONFIRMATION="${confirm_choices[0]}"
 
 # Run the disk layout recreation code (diskrestore.sh)
+# or recreate storage layout with 'barrel' devicegraph
 # again and again until it succeeds or the user aborts:
 while true ; do
-    # Run LAYOUT_CODE in a sub-shell because it sets 'set -e'
-    # so that it exits the running shell in case of an error
-    # but that exit must not exit this running bash here:
-    ( source $LAYOUT_CODE )
+    if is_true "$BARREL_DEVICEGRAPH" ; then
+        # See https://github.com/rear/rear/pull/2382#discussion_r417852393
+        # and https://github.com/rear/rear/pull/2382#discussion_r417998820
+        # and https://github.com/rear/rear/pull/2382#discussion_r418018571
+        # that explains the reasoning behind the stdin stdout stderr redirection plus process substitution in
+        #   COMMAND 0<&6 1>> >( tee -a $RUNTIME_LOGFILE 1>&7 ) 2>> >( tee -a $RUNTIME_LOGFILE 1>&8 )
+        # which is used to show 'barrel' messges on the user's terminal and also have them in the log file.
+        # It is also used to be on the save side if 'barrel' behaves interactively (regardless of '--yes').
+        # Quoting "$BARREL_MAPPING_FILE" is needed because 'test -s' would falsely succeed with an empty argument:
+        if test -s "$BARREL_MAPPING_FILE" ; then
+            # barrel --verbose --yes --prefix /mnt/local load devicegraph --name /etc/barrel-devicegraph.xml --mapping /etc/barrel-mapping.json
+            barrel --verbose --yes --prefix $TARGET_FS_ROOT load devicegraph --name $BARREL_DEVICEGRAPH_FILE --mapping $BARREL_MAPPING_FILE 0<&6 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 ) 2>> >( tee -a "$RUNTIME_LOGFILE" 1>&8 )
+        else
+            # barrel --verbose --yes --prefix /mnt/local load devicegraph --name /etc/barrel-devicegraph.xml
+            barrel --verbose --yes --prefix $TARGET_FS_ROOT load devicegraph --name $BARREL_DEVICEGRAPH_FILE 0<&6 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 ) 2>> >( tee -a "$RUNTIME_LOGFILE" 1>&8 )
+        fi
+    else
+        # After switching to recreating with disk recreation script
+        # change choices[0] from "Run ..." to "Rerun ...":
+        choices[0]="Rerun disk recreation script ($LAYOUT_CODE)"
+        # Run LAYOUT_CODE in a sub-shell because it sets 'set -e'
+        # so that it exits the running shell in case of an error
+        # but that exit must not exit this running bash here:
+        ( source $LAYOUT_CODE )
+    fi
     # One must explicitly test whether or not $? is zero in a separated bash command
     # because with bash 3.x and bash 4.x code like
     #   # ( set -e ; cat qqq ; echo "hello" ) && echo ok || echo failed
@@ -91,6 +126,19 @@ while true ; do
         # When LAYOUT_CODE succeeded in migration mode
         # let the user explicitly confirm the recreated (and usually migrated) disk layout
         # before continuing the "rear recover" workflow with restoring the backup.
+        # Show the recreated disk layout to the user on his terminal (and also in the log file):
+        LogPrint "Recreated storage layout:"
+        # First try the command (which works on SLES12 and SLES15)
+        #   lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,LABEL,SIZE,MOUNTPOINT
+        # but on older systems (like SLES11) that do not support all that lsblk things
+        # cf. https://github.com/rear/rear/pull/2626#issuecomment-856700823
+        # try the simpler command
+        #   lsblk -io NAME,KNAME,FSTYPE,LABEL,SIZE,MOUNTPOINT
+        # and as fallback try 'lsblk -i' and finally try plain 'lsblk'.
+        # In contrast to the lsblk commands in layout/save/GNU/Linux/100_create_layout_file.sh
+        # skip UUID and WWN because they are not scrictly needed to check if things look OK
+        # but those columns make the output lines too long for a normal terminal:
+        { lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,LABEL,SIZE,MOUNTPOINT || lsblk -io NAME,KNAME,FSTYPE,LABEL,SIZE,MOUNTPOINT || lsblk -i || lsblk ; } 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 ) 2>> >( tee -a "$RUNTIME_LOGFILE" 1>&8 )
         # Run an inner while loop with a user dialog so that the user can inspect the recreated disk layout
         # and perhaps even manually fix the recreated disk layout if it is not what the user wants
         # (e.g. by using the Relax-and-Recover shell and returning back to this user dialog):
@@ -127,8 +175,13 @@ while true ; do
         choice="$( UserInput -I LAYOUT_CODE_RUN -p "$prompt" -D "${choices[0]}" "${choices[@]}" )" && wilful_input="yes" || wilful_input="no"
         case "$choice" in
             (${choices[0]})
-                # Rerun disk recreation script:
-                is_true "$wilful_input" && LogPrint "User reruns disk recreation script" || LogPrint "Rerunning disk recreation script by default"
+                if is_true "$BARREL_DEVICEGRAPH" ; then
+                    # Rerun 'barrel load devicegraph':
+                    is_true "$wilful_input" && LogPrint "User runs 'barrel load devicegraph'" || LogPrint "Running 'barrel load devicegraph' by default"
+                else
+                    # Rerun or run (after switching to recreating with disk recreation script) disk recreation script:
+                    is_true "$wilful_input" && LogPrint "User runs disk recreation script" || LogPrint "Running disk recreation script by default"
+                fi
                 # Only break the inner while loop (i.e. the user dialog loop):
                 break
                 ;;
@@ -137,18 +190,52 @@ while true ; do
                 less $RUNTIME_LOGFILE 0<&6 1>&7 2>&8
                 ;;
             (${choices[2]})
-                # Run 'vi' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
-                vi $LAYOUT_CODE 0<&6 1>&7 2>&8
+                if is_true "$BARREL_DEVICEGRAPH" ; then
+                    BARREL_DEVICEGRAPH="false"
+                    choices[0]="Run disk recreation script ($LAYOUT_CODE)"
+                    choices[2]="Edit disk recreation script ($LAYOUT_CODE)"
+                    LogPrint "Switched to recreating with disk recreation script ($LAYOUT_CODE)"
+                    is_false "$DISKS_TO_BE_WIPED" || LogPrint "You may need to wipe disks again before running the disk recreation script"
+                else
+                    # Run 'vi' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+                    vi $LAYOUT_CODE 0<&6 1>&7 2>&8
+                fi
                 ;;
             (${choices[3]})
+                if is_false "$DISKS_TO_BE_WIPED" ; then
+                    LogPrint "Not applicable (DISKS_TO_BE_WIPED is 'false')" 
+                else
+                    # Again wipe disks:
+                    # Before wiping disks umount all and turn off all swap
+                    # because after 'barrel' recreated storage layout things are mounted and swap is on:
+                    umount -v -a 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 ) 2>> >( tee -a "$RUNTIME_LOGFILE" 1>&8 )
+                    swapoff -v -a 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 ) 2>> >( tee -a "$RUNTIME_LOGFILE" 1>&8 )
+                    Source $SHARE_DIR/layout/recreate/default/150_wipe_disks.sh
+                fi
+                ;;
+            (${choices[4]})
+                LogPrint "This is currently on the disks:"
+                # First try the command (which works on SLES12 and SLES15)
+                #   lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,LABEL,SIZE,MOUNTPOINT
+                # but on older systems (like SLES11) that do not support all that lsblk things
+                # cf. https://github.com/rear/rear/pull/2626#issuecomment-856700823
+                # try the simpler command
+                #   lsblk -io NAME,KNAME,FSTYPE,LABEL,SIZE,MOUNTPOINT
+                # and as fallback try 'lsblk -i' and finally try plain 'lsblk'.
+                # In contrast to the lsblk commands in layout/save/GNU/Linux/100_create_layout_file.sh
+                # skip UUID and WWN because they are not scrictly needed to check if things look OK
+                # but those columns make the output lines too long for a normal terminal:
+                { lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,LABEL,SIZE,MOUNTPOINT || lsblk -io NAME,KNAME,FSTYPE,LABEL,SIZE,MOUNTPOINT || lsblk -i || lsblk ; } 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 ) 2>> >( tee -a "$RUNTIME_LOGFILE" 1>&8 )
+                ;;
+            (${choices[5]})
                 # Run 'less' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
                 less $original_disk_space_usage_file 0<&6 1>&7 2>&8
                 ;;
-            (${choices[4]})
+            (${choices[6]})
                 # rear_shell runs 'bash' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
                 rear_shell "" "$rear_shell_history"
                 ;;
-            (${choices[5]})
+            (${choices[7]})
                 abort_recreate
                 Error "User chose to abort '$rear_workflow' in ${BASH_SOURCE[0]}"
                 ;;

--- a/usr/share/rear/layout/save/default/550_barrel_devicegraph.sh
+++ b/usr/share/rear/layout/save/default/550_barrel_devicegraph.sh
@@ -1,0 +1,90 @@
+# This file is part of Relax-and-Recover,
+# licensed under the GNU General Public License.
+# Refer to the included COPYING for full text of license.
+
+# Skip it when the user has explicitly specified to not use barrel:
+is_false "$BARREL_DEVICEGRAPH" && return 0
+
+# Skip it when there is no 'barrel' program
+# but error out when the user has explicitly specified to use barrel:
+if has_binary barrel ; then
+    LogPrint "Also saving storage layout as 'barrel' devicegraph"
+else
+    is_true "$BARREL_DEVICEGRAPH" && Error "Cannot find 'barrel' command (BARREL_DEVICEGRAPH is 'true')"
+    DebugPrint "Skip saving storage layout as 'barrel' devicegraph (no 'barrel' command)"
+    return 0
+fi
+
+BARREL_DEVICEGRAPH_DIR="$VAR_DIR/layout/barrel"
+mkdir -p $v $BARREL_DEVICEGRAPH_DIR
+
+# Let barrel save the whole storage layout (as a devicegraph):
+BARREL_DEVICEGRAPH_FILE=$BARREL_DEVICEGRAPH_DIR/devicegraph.xml
+if barrel $v save devicegraph --name $BARREL_DEVICEGRAPH_FILE 0<&6 1>&7 2>&8 ; then
+    DebugPrint "Saved 'barrel' devicegraph in $BARREL_DEVICEGRAPH_FILE"
+else
+    is_true "$BARREL_DEVICEGRAPH" && Error "barrel failed to save devicegraph in $BARREL_DEVICEGRAPH_FILE (BARREL_DEVICEGRAPH is 'true')"
+    LogPrintError "barrel failed to save devicegraph' in $BARREL_DEVICEGRAPH_FILE"
+    return 1
+fi
+
+# When 'barrel save devicegraph' succeeded
+# include all possibly needed programs to recreate the storage layout during "rear recover":
+
+# barrel requires getconf otherwise it fails with
+#   Probing...error: Command not found: "/usr/bin/getconf PAGESIZE"
+REQUIRED_PROGS+=( barrel getconf )
+
+# barrel uses libstorage-ng which can call the following programs, see
+# https://github.com/openSUSE/libstorage-ng/blob/master/storage/Utils/StorageDefines.h
+# In a libstorage-ng sources directory run (here for libstorage-ng-4.4.17)
+# # grep -o 'bin/[^"]*' storage/Utils/StorageDefines.h | cut -d '/' -f2-
+#  sh echo cat uname getconf
+#  parted
+#  mdadm
+#  pvcreate pvremove pvresize pvs lvcreate lvremove lvresize lvchange lvs vgcreate vgremove vgextend vgreduce vgs vgchange
+#  cryptsetup
+#  multipath multipathd
+#  dmsetup dmraid
+#  btrfs
+#  wipefs
+#  bcache
+#  mount umount
+#  swapon swapoff
+#  dd
+#  blkid lsscsi
+#  ls df test stat
+#  losetup
+#  lsattr chattr
+#  dasdview
+#  udevadm rpcbind efibootmgr
+#  ntfsresize xfs_growfs resize_reiserfs resize2fs fatresize tune2fs reiserfstune xfs_admin jfs_tune
+#  ntfslabel fatlabel swaplabel exfatlabel
+#  dumpe2fs
+#  mkswap
+#  mkfs.xfs mkfs.jfs mkfs.fat mkfs.ntfs mkreiserfs mke2fs mkfs.btrfs mkfs.f2fs mkfs.exfat mkfs.udf
+#  dot display
+# We include all of them if they are installed
+# except getconf that is already in REQUIRED_PROGS above
+# and except generic programs like sh echo cat uname parted mount umount dd ls df test stat
+# and except dot and display which are programs for drawing graphs and display images on an X server:
+PROGS+=( mdadm
+         pvcreate pvremove pvresize pvs lvcreate lvremove lvresize lvchange lvs vgcreate vgremove vgextend vgreduce vgs vgchange
+         cryptsetup
+         multipath multipathd
+         dmsetup dmraid
+         btrfs
+         wipefs
+         bcache
+         swapon swapoff
+         blkid lsscsi
+         losetup
+         lsattr chattr
+         dasdview
+         udevadm rpcbind efibootmgr
+         ntfsresize xfs_growfs resize_reiserfs resize2fs fatresize tune2fs reiserfstune xfs_admin jfs_tune
+         ntfslabel fatlabel swaplabel exfatlabel
+         dumpe2fs
+         mkswap
+         mkfs.xfs mkfs.jfs mkfs.fat mkfs.ntfs mkreiserfs mke2fs mkfs.btrfs mkfs.f2fs mkfs.exfat mkfs.udf )
+


### PR DESCRIPTION
* Type: **New Feature**

* Impact: **High**

High impact only on systems where 'barrel' exists.

There should be no change (and no impact) on other systems
regarding the actual disk layout recreation via diskrestore.sh
(i.e. nothing of the actual disk layout recreation
via diskrestore.sh is changed).

There are visible changes on all systems
regarding the choices in the user dialogs
during "rear recover" that are improved
so that users have now more options what to do
and what should happen during "rear recover".
There was no change what the default choice is
so the default behaviour of "rear recover" is same as before
unless BARREL_DEVICEGRAPH is explicitly set to true by the user.

In particular users can now additionally choose:

"Skip wiping disks"
Before there was no way to do that without changing
/etc/rear/local.conf and restarting "rear recover".

"Again wipe the disks in DISKS_TO_BE_WIPED"
Before there was no way to do that during "rear recover".
The only way was to abort "rear recover" and restart it.

"Show what is currently on the disks ('lsblk' block devices list)"
Before there was no easy way to see what is currently on the disks.
The only way was to use the ReaR shell and manually type
e.g. an appropriate 'lsblk' command.

"Confirm what is currently on the disks and continue 'rear recover'"
Before there was no way to do that.
The only way was to fix diskrestore.sh and re-run it until all is OK
or do something via ReaR shell and re-run barrel until all is OK.
But the user might also fix things (in particular smaller things)
by only using the ReaR shell and then confirm what he created
on his disks and continue with restoring the backup.

Those additional options during "rear recover" became useful
and needed by me while I did my various tests with 'barrel'
so those additional options during "rear recover" are a direct
consequence of the added support for a second method how to
recreate the disk layout - in particular when I first used
'barrel' and then switched back to 'diskrastore.sh' where
I needed to "Again wipe the disks in DISKS_TO_BE_WIPED"
and where I liked to see what is currently on the disks.

The BARREL_DEVICEGRAPH and BARREL_MAPPING_FILE config variables
are curently not documented in default.conf because the names
and semantics of 'barrel' config variables may change during
the currently ongoing development of 'barrel' support.

* Reference to related issue (URL):

https://github.com/rear/rear/issues/2863

* How was this pull request tested?

Several tests on my SLES15 SP4 test VM
with the default SUSE storage structure:
```
# lsblk -ipo NAME,TRAN,TYPE,FSTYPE,SIZE,MOUNTPOINTS
NAME        TRAN TYPE FSTYPE   SIZE MOUNTPOINTS
/dev/sda    ata  disk           20G 
|-/dev/sda1      part            8M 
|-/dev/sda2      part btrfs   12.6G /var
|                                   /root
|                                   /usr/local
|                                   /tmp
|                                   /srv
|                                   /boot/grub2/x86_64-efi
|                                   /opt
|                                   /boot/grub2/i386-pc
|                                   /.snapshots
|                                   /
|-/dev/sda3      part xfs      5.4G /home
`-/dev/sda4      part swap       2G [SWAP]
```

* Brief description of the changes in this pull request:

In layout/recreate/default/200_run_layout_code.sh
added the new storage layout recreation method
`Recreating storage layout with 'barrel' devicegraph`
as optional alternative to recreating with diskrestore.sh
when the config variable BARREL_DEVICEGRAPH is 'true'
plus an option to switch from 'barrel' back to diskrestore.sh.

Additionally there are the new options
`Show what is currently on the disks ('lsblk' block devices list)`
and
`Again wipe those disks ...` in DISKS_TO_BE_WIPED
to check after a failed attempt what was recreated and
to redo the recreation from scratch on clean disks.
