### PR TITLE
Exclusions for Veritas

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1736,7 +1736,7 @@ COPY_AS_IS=( $SHARE_DIR $VAR_DIR )
 # Furthermore having dev/watchdog* during "rear mkrescue" may even trigger a system "crash" that is
 # caused by TrendMicro ds_am module touching dev/watchdog in ReaR's build area (/var/tmp/rear.XXX/rootfs).
 # See https://github.com/rear/rear/issues/2798
-COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/\* dev/.udev dev/shm dev/shm/\* dev/oracleasm dev/mapper dev/watchdog\* )
+COPY_AS_IS_EXCLUDE=( $VAR_DIR/output/\* dev/.udev dev/shm dev/shm/\* dev/oracleasm dev/mapper dev/watchdog\* dev/vx dev/dmpconfig)
 # Array of user names that are trusted owners of files where RequiredSharedObjects calls ldd (cf. COPY_AS_IS)
 # and where a ldd test is run inside the recovery system that tests all binaries for 'not found' libraries.
 # The default is 'root' plus those standard system users that have a 'bin' or 'sbin' or 'root' home directory


### PR DESCRIPTION
Added 2 exclusions to avoid errors when Veritas sw is installed

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested?
On our servers

* Brief description of the changes in this pull request:
Excluded 2 special paths under /dev
