### PR TITLE
fix rear mkrescue with sesam 5.x

### DIFF
--- a/usr/share/rear/lib/sesam-functions.sh
+++ b/usr/share/rear/lib/sesam-functions.sh
@@ -12,7 +12,7 @@ fi
 # for later use in build/default/990_verify_rootfs.sh to avoid issues
 # with missing library dependencies during rootfs check
 source $sesam2000ini_file
-SESAM_LD_LIBRARY_PATH=$SM_BIN_SESAM
+SESAM_LD_LIBRARY_PATH=$SM_BIN_SESAM:$SM_BIN_SESAM/python3/:$SM_BIN_SMS
 
 SM_INI="$( grep SM_INI $sesam2000ini_file 2>/dev/null | cut -d '=' -f 2 )"
 test -z "$SM_INI" && return 0


### PR DESCRIPTION
hi,

we are evaluating shipping REAR 2.7 with the next sesam release. It appears that with REAR 2.7, mkrescue
step will fail bcs of missing libraries during functionality check:

```
2022-12-04 12:00:57.066647656 /opt/sesam/bin/sesam/python3/libhogweed.so.6 requires additional libraries (fatal error)
2022-12-04 12:00:57.075641526   linux-vdso.so.1 (0x00007ffc7a5ca000)
                                libnettle.so.8 => not found
```

adding two more directories to the backup module related LD_LIBRARY_PATH fixes this issue.