### PR TITLE
fix bconsole CLI argument format

### DIFF
--- a/usr/share/rear/prep/BAREOS/default/500_check_BAREOS_bconsole_results.sh
+++ b/usr/share/rear/prep/BAREOS/default/500_check_BAREOS_bconsole_results.sh
@@ -8,11 +8,19 @@ if [ "$BEXTRACT_DEVICE" -o "$BEXTRACT_VOLUME" ]; then
    return
 fi
 
+# Check bconsole version and use appropriate CLI switch
+BCONSOLE_VERSION=$(bconsole --version | awk -F '.' '{print $1}')
+if [ "$BCONSOLE_VERSION" -ge 22 ]; then
+	BCONSOLE_XC="--xc"
+else
+	BCONSOLE_XC="-xc"
+fi
+
 #
 # See if we can ping the director
 #
 # is the director server present? Fetch from /etc/bareos/bconsole.conf file
-BAREOS_DIRECTOR=$(bconsole -xc | grep -i address | awk '{ print $3 }')
+BAREOS_DIRECTOR=$(bconsole "$BCONSOLE_XC" | grep -i address | awk '{ print $3 }')
 [ "${BAREOS_DIRECTOR}" ]
 StopIfError "Director not configured in bconsole"
 


### PR DESCRIPTION
Use appropriate CLI argument format depending on the installed bconsole version.

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix** / **New Feature** / **Enhancement** / **Other?**
Bug Fix

* Impact: **Low** / **Normal** / **High** / **Critical** / **Urgent**
Normal

* Reference to related issue (URL):
#2900 

* How was this pull request tested?
Manually, on multiple KVM hosts running Bareos 22 and Bareos 21 release.

* Brief description of the changes in this pull request:
Bareos 22 introduced breaking change in how the CLI tools (such as bconsole) parse the arguments. This pull request fixes the issue when calling the `bconsole -xc` command.

Before bconsole configuration export command is called, the script will check the bconsole version and will use the appropriate argument format later on.

If bconsole is called with incorrect argument format, the utility will terminate with 113 exit code, and `rear mkrescue` will fail as well.
