### PR TITLE
Protect against colons in pvdisplay output

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -70,14 +70,20 @@ local lvs_exit_code
     # Get physical_device configuration.
     # Format: lvmdev <volume_group> <device> [<uuid>] [<size(bytes)>]
     header_printed="no"
-    # Example output of "lvm pvdisplay -c":
-    #   /dev/sda1:system:41940992:-1:8:8:-1:4096:5119:2:5117:7wwpcO-KmNN-qsTE-7sp7-JBJS-vBdC-Zyt1W7
+    # Set pvdisplay separator to '|' to prevent issues with a colon in the path under /dev/disk/by-path
+    # that contains a ':' in the SCSI slot name.
+    # Example output of "lvm pvdisplay -C --separator '|' --noheadings --nosuffix --units=b -o pv_name,vg_name,pv_size,pv_uuid"
+    # on a system where LVM is configured to show the /dev/disk/by-path device names instead of the usual
+    # /dev/sda etc. (by using a setting like
+    # filter = [ "r|/dev/disk/by-path/.*-usb-|", "a|/dev/disk/by-path/pci-.*-nvme-|", "a|/dev/disk/by-path/pci-.*-scsi-|", "a|/dev/disk/by-path/pci-.*-ata-|", "a|/dev/disk/by-path/pci-.*-sas-|", "a|loop|", "r|.*|" ]
+    # in /etc/lvm/lvm.conf):
+    #   /dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:1:0-part1|system|107340627968|7wwpcO-KmNN-qsTE-7sp7-JBJS-vBdC-Zyt1W7
     # There are two leading blanks in the output (at least on SLES12-SP4 with LVM 2.02.180).
-    lvm pvdisplay -c | while read line ; do
+    lvm pvdisplay -C --separator '|' --noheadings --nosuffix --units=b -o pv_name,vg_name,pv_size,pv_uuid | while read line ; do
 
-        # With the above example pdev=/dev/sda1
+        # With the above example pdev=/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:1:0-part1
         # (the "echo $line" makes the leading blanks disappear)
-        pdev=$( echo $line | cut -d ":" -f "1" )
+        pdev=$( echo $line | cut -d "|" -f "1" )
 
         # Skip lines that are not describing physical devices
         # i.e. lines where pdev does not start with a leading / character:
@@ -91,11 +97,11 @@ local lvs_exit_code
         fi
 
         # With the above example vgrp=system
-        vgrp=$( echo $line | cut -d ":" -f "2" )
-        # With the above example size=41940992
-        size=$( echo $line | cut -d ":" -f "3" )
+        vgrp=$( echo $line | cut -d "|" -f "2" )
+        # With the above example size=107340627968
+        size=$( echo $line | cut -d "|" -f "3" )
         # With the above example uuid=7wwpcO-KmNN-qsTE-7sp7-JBJS-vBdC-Zyt1W7
-        uuid=$( echo $line | cut -d ":" -f "12" )
+        uuid=$( echo $line | cut -d "|" -f "4" )
 
         # Translate pdev through diskbyid_mappings file:
         pdev=$( get_device_mapping $pdev )


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): fixes #1958

* How was this pull request tested?
  * full back-up and recovery on RHEL 8.7 / x86_64 (BIOS) with SATA disk, LVM in default configuration
  * full back-up and recovery on RHEL 8.7 / x86_64 (BIOS) with SATA disk, LVM configured to show `/dev/disk/by-path` device symlinks instead of the usual `/dev/sd*` device nodes by using this line in /etc/lvm/lvm.conf:
  `filter = [ "r|/dev/disk/by-path/.*-usb-|", "a|/dev/disk/by-path/pci-.*-nvme-|", "a|/dev/disk/by-path/pci-.*-scsi-|", "a|/dev/disk/by-path/pci-.*-ata-|", "a|/dev/disk/by-path/pci-.*-sas-|", "a|loop|", "r|.*|" ]`.
This case breaks with the original code already during `rear savelayout` and is fixed by this change.

* Brief description of the changes in this pull request:

LVM can be configured to show device names under `/dev/disk/by-path` in command output. These names often contain colons that separate fields like channel and target (for example `/dev/disk/by-path/pci-*-scsi-0:0:1:0-*`, similarly the `pci-*` part, which contains colon-separated PCI bus and device numbers). Since the "`pvdisplay -c`" output also uses colons as field separators and does not escape embedded colons in any way, embedded colons break parsing of this output.

As a fix, use the pipe character '`|`' as the field separator in pvdisplay output. (This would break if a PV device has a '`|`' in its name, but this is very much less likely than having a '`:`' .)

I did a survey of how similar problems are handled in other tools. Some Solaris tools (ipadm, dladm, zoneadm) have a special switch (`-p`) to request machine-parseable format. This format has colon-separated fields, and embedded colons are escaped by backslash to allow parsing by the shell "read" command (this escaping is the key functionality missing in the pvdisplay command). zfs has a `-H` option which uses an alternative parseable format: in addition to omitting headers it separates the fields by a single TAB character. This would be in principle ideal for our purpose (TABs are unlikely to occur in the values), but in our case the output is processed via an unquoted "echo" command, which would not preserve the TAB character. (This is needed to remove the two leading spaces in the output, not sure what their purpose is.) I believe that using `|` as the separator is the best choice in our situation.

Also, configure explicitly what fields to output - "`pvdisplay -c`" prints many fields, but I have not found documentation about what fields is it using exactly, so one had to guess what the output means. Using "`pvdisplay -C`" and selecting the fields explicitly is much clearer.

This also changes the PV size field to match documentation, the comment says that size is in bytes, but it actually was not in bytes. As nothing is actually using the PV size field, this inconsistency has not caused any problem in practice, and no code needs adjusting for the change.

Fix provided by a customer in https://bugzilla.redhat.com/show_bug.cgi?id=2091163 .