### PR TITLE
OUTPUT=USB: Use target=i386-pc for legacy BIOS GRUB2 install on EFI systems

### DIFF
--- a/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
@@ -51,7 +51,15 @@ if [ ! -d "$usb_boot_dir" ] ; then
     mkdir -p $v "$usb_boot_dir" || Error "Failed to create USB boot dir '$usb_boot_dir'"
 fi
 DebugPrint "Installing GRUB2 as USB bootloader on $RAW_USB_DEVICE"
-$grub_install_binary --boot-directory=$usb_boot_dir --recheck $RAW_USB_DEVICE || Error "Failed to install GRUB2 on $RAW_USB_DEVICE"
+if is_true $USING_UEFI_BOOTLOADER ; then
+    # TODO only call grub-install if legacy boot install is requested
+    # TODO use a switch case based on the target (uname -m) and possibly other info or make this a config option?
+    # Enforce legacy BIOS installation since efi was handled in 100_create_efiboot.sh
+    # see https://github.com/rear/rear/issues/2883
+    $grub_install_binary --target=i386-pc --boot-directory=$usb_boot_dir --recheck $RAW_USB_DEVICE || Error "Failed to install GRUB2 with target=i386-pc on $RAW_USB_DEVICE"
+else
+    $grub_install_binary --boot-directory=$usb_boot_dir --recheck $RAW_USB_DEVICE || Error "Failed to install GRUB2 on $RAW_USB_DEVICE"
+fi
 # grub[2]-install creates the $BUILD_DIR/outputfs/boot/grub[2] sub-directory that is needed
 # to create the GRUB2 config $BUILD_DIR/outputfs/boot/grub[2].cfg in the next step:
 DebugPrint "Creating GRUB2 config for legacy BIOS boot as USB bootloader"

--- a/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
@@ -63,7 +63,7 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     # TODO: use a switch case based on the target (uname -m) and possibly other info?
     # Enforce legacy BIOS installation since EFI was handled in 100_create_efiboot.sh
     # see https://github.com/rear/rear/issues/2883
-    # Set default GRUB2 target only if there is no '--target=' in USB_GRUB2_INSTALL_OPTIONS
+    # Set a GRUB2 target only if there is no '--target=' in USB_GRUB2_INSTALL_OPTIONS
     # (according to "man grub2-install" of grub2-2.06 on openSUSE Leap 15.4
        '--target=TARGET' is the only possible syntax to specify a GRUB2 target)
     # because a GRUB2 target could be already specified like '--target=i386-qemu'

--- a/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
@@ -65,7 +65,7 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     # see https://github.com/rear/rear/issues/2883
     # Set a GRUB2 target only if there is no '--target=' in USB_GRUB2_INSTALL_OPTIONS
     # (according to "man grub2-install" of grub2-2.06 on openSUSE Leap 15.4
-       '--target=TARGET' is the only possible syntax to specify a GRUB2 target)
+    #  '--target=TARGET' is the only possible syntax to specify a GRUB2 target)
     # because a GRUB2 target could be already specified like '--target=i386-qemu'
     # cf. https://github.com/rear/rear/pull/2905#discussion_r1062457353
     [[ "$USB_GRUB2_INSTALL_OPTIONS" == *"--target="* ]] || USB_GRUB2_INSTALL_OPTIONS+=" --target=i386-pc"


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2883

* How was this pull request tested?

not tested by me but see
https://github.com/rear/rear/issues/2883#issuecomment-1302006263

* Brief description of the changes in this pull request:

grub-install defaults to --target x86_64-efi
if the system is booted with EFI
so one cannot install a legacy-bios (or 32bit) grub
without setting the --target parameter
