### PR TITLE
Addendum for issue 2045 for Linux-ppc64le/660_install_grub2.sh

### DIFF
--- a/usr/share/rear/finalize/Linux-ppc64le/660_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/660_install_grub2.sh
@@ -84,18 +84,6 @@ if ! test -d "$TARGET_FS_ROOT/boot/$grub_name" ; then
     fi
 fi
 
-# Make /proc /sys /dev available in TARGET_FS_ROOT
-# so that later things work in the "chroot TARGET_FS_ROOT" environment,
-# cf. https://github.com/rear/rear/issues/1828#issuecomment-398717889
-# and do not umount them when leaving this script because
-# it is better when also after "rear recover" things still
-# work in the "chroot TARGET_FS_ROOT" environment so that
-# the user could more easily adapt things after "rear recover":
-for mount_device in proc sys dev ; do
-    umount $TARGET_FS_ROOT/$mount_device && sleep 1
-    mount --bind /$mount_device $TARGET_FS_ROOT/$mount_device
-done
-
 # Generate GRUB configuration file anew to be on the safe side (this could be even mandatory in MIGRATION_MODE):
 if ! chroot $TARGET_FS_ROOT /bin/bash --login -c "$grub_name-mkconfig -o /boot/$grub_name/grub.cfg" ; then
     LogPrintError "Failed to generate boot/$grub_name/grub.cfg in $TARGET_FS_ROOT - trying to install GRUB2 nevertheless"


### PR DESCRIPTION

* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2045

* How was this pull request tested?
I cannot test it because I don't have PPC hardware.

* Brief description of the changes in this pull request:

In finalize/Linux-ppc64le/660_install_grub2.sh
remove the
"mount --bind <proc|sys|dev> at TARGET_FS_ROOT"
section because that is meanwhile done generically in
finalize/default/110_bind_mount_proc_sys_dev_run.sh
since https://github.com/rear/rear/issues/2045

But there the file
finalize/Linux-ppc64le/..._install_grub2.sh
was accidentally forgotten
(see its initial description).

See
https://github.com/rear/rear/pull/2047
therein see in particular
https://github.com/rear/rear/pull/2047/commits/dd9977f727b4a3a6573361cfafff833f3431f99f
and therein see the change for
finalize/Linux-i386/..._install_grub2.sh
which we supplement now also for
finalize/Linux-ppc64le/..._install_grub2.sh
