### PR TITLE
Make get_serial_console_devices() fail-safe if no serial device node exists

### DIFF
--- a/usr/share/rear/lib/serial-functions.sh
+++ b/usr/share/rear/lib/serial-functions.sh
@@ -12,7 +12,7 @@ function get_serial_console_devices () {
     # cf. "Beware of the emptiness" in https://github.com/rear/rear/wiki/Coding-Style
     # see https://github.com/rear/rear/issues/2914#issuecomment-1396659184
     # and return 0 because it is no error when no serial device node exists
-    test "$( echo -n /dev/ttyQS[0-9]* /dev/hvsi[0-9]* )" || return 0
+    test "$( echo -n /dev/ttyS[0-9]* /dev/hvsi[0-9]* )" || return 0
     # Use plain 'sort' which results /dev/ttyS0 /dev/ttyS1 /dev/ttyS10 ... /dev/ttyS19 /dev/ttyS2 /dev/ttyS20 ...
     # to get at least /dev/ttyS0 and /dev/ttyS1 before the other /dev/ttyS* devices because
     # we cannot use "sort -V" which would result /dev/ttyS0 /dev/ttyS1 ... /dev/ttyS9 /dev/ttyS10 ...

--- a/usr/share/rear/lib/serial-functions.sh
+++ b/usr/share/rear/lib/serial-functions.sh
@@ -1,13 +1,24 @@
 
 # Get available serial devices:
 function get_serial_console_devices () {
-    test "$SERIAL_CONSOLE_DEVICES" && echo $SERIAL_CONSOLE_DEVICES || ls /dev/ttyS[0-9]* /dev/hvsi[0-9]* | sort
+    # Via SERIAL_CONSOLE_DEVICES the user specifies which ones to use (and no others):
+    if test "$SERIAL_CONSOLE_DEVICES" ; then
+        echo $SERIAL_CONSOLE_DEVICES
+        return 0
+    fi
+    # Test if there is /dev/ttyS[0-9]* or /dev/hvsi[0-9]*
+    # because when there is neither /dev/ttyS[0-9]* nor /dev/hvsi[0-9]*
+    # the ls command below would become plain 'ls' because of 'nullglob'
+    # cf. "Beware of the emptiness" in https://github.com/rear/rear/wiki/Coding-Style
+    # see https://github.com/rear/rear/issues/2914#issuecomment-1396659184
+    # and return 0 because it is no error when no serial device node exists
+    test "$( echo -n /dev/ttyQS[0-9]* /dev/hvsi[0-9]* )" || return 0
     # Use plain 'sort' which results /dev/ttyS0 /dev/ttyS1 /dev/ttyS10 ... /dev/ttyS19 /dev/ttyS2 /dev/ttyS20 ...
     # to get at least /dev/ttyS0 and /dev/ttyS1 before the other /dev/ttyS* devices because
     # we cannot use "sort -V" which would result /dev/ttyS0 /dev/ttyS1 ... /dev/ttyS9 /dev/ttyS10 ...
     # because in older Linux distributions 'sort' does not support '-V' e.g. SLES10 with GNU coreutils 5.93
     # (SLES11 with GNU coreutils 8.12 supports 'sort -V') but if 'sort' fails there is no output at all
-    # cf. "Maintain backward compatibility" at https://github.com/rear/rear/wiki/Coding-Style
+    # cf. "Maintain backward compatibility" in https://github.com/rear/rear/wiki/Coding-Style
     # Furthermore 'sort' results that /dev/hvsi* devices appear before /dev/ttyS* devices
     # so the create_grub2_serial_entry function in lib/bootloader-functions.sh
     # which uses by default the first one and skips the rest will result that
@@ -16,7 +27,8 @@ function get_serial_console_devices () {
     # that have the HVSI driver loaded (a console driver for IBM's p5 servers)
     # cf. https://lwn.net/Articles/98442/
     # and it seems right that when special console drivers are loaded
-    # then their devices should be preferred by default.
+    # then their devices should be preferred by default:
+    ls /dev/ttyS[0-9]* /dev/hvsi[0-9]* | sort
 }
 
 # Get the serial device speed for those device nodes that belong to actual serial devices.


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2914

* How was this pull request tested?
Seems to work well as far as I could test it
on my QEMU/KVM virtual machine.

* Brief description of the changes in this pull request:

In lib/serial-functions.sh make the
get_serial_console_devices() function
fail-safe if no serial device node exists.