### PR TITLE
check for wrong array assignment in user configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist/
 build-stamp
 /var
+/etc/rear/os.conf
 /etc/rear/site.conf
 .DS_Store
 .vscode

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -620,6 +620,7 @@ for config in site local rescue ; do
     fi
 done
 # Finally source additional configuration files if specified on the command line:
+CONFIG_APPEND_FILES_PATHS=()
 if test "$CONFIG_APPEND_FILES" ; then
     # Treat missing additional config files (almost) same as other missing config files
     # which means that missing additional config files do not let ReaR abort with an Error
@@ -659,14 +660,17 @@ if test "$CONFIG_APPEND_FILES" ; then
         if test -r "$config_append_file_path" ; then
             LogPrint "Sourcing additional configuration file '$config_append_file_path'"
             Source "$config_append_file_path" || Error "Failed to Source $config_append_file_path"
+            CONFIG_APPEND_FILES_PATHS+=( "$config_append_file_path" )
         elif test -r "$config_append_file_path.conf" ; then
             LogPrint "Sourcing additional configuration file '$config_append_file_path.conf'"
             Source "$config_append_file_path.conf" || Error "Failed to Source $config_append_file_path.conf"
+            CONFIG_APPEND_FILES_PATHS+=( "$config_append_file_path.conf" )
         else
             LogPrintError "There is '-C $config_append_file' but neither '$config_append_file_path' nor '$config_append_file_path.conf' can be read."
         fi
     done
 fi
+readonly CONFIG_APPEND_FILES_PATHS # nothing else should be able to add more configs
 
 # Now SHARE_DIR CONFIG_DIR VAR_DIR LOG_DIR and KERNEL_VERSION should be set to a fixed value:
 readonly SHARE_DIR CONFIG_DIR VAR_DIR LOG_DIR KERNEL_VERSION

--- a/usr/share/rear/init/default/001_verify_config_arrays.sh
+++ b/usr/share/rear/init/default/001_verify_config_arrays.sh
@@ -1,0 +1,22 @@
+# ensure that all array variables defined in default.conf are still array variables after
+# reading the user configuration, fixes common user config error: https://github.com/rear/rear/issues/2930
+
+array_variables=($(
+    sed -n -e '/^[A-Z_]\+=(/s/=.*//p' "$SHARE_DIR"/conf/default.conf
+))
+
+
+for config in "$CONFIG_DIR"/{site,local,rescue}.conf; do
+    test -r "$config" || continue
+    for var in "${array_variables[@]}"; do
+        mapfile -t var_assignments < <(
+            sed -n -E -e "/$var\+?=/p" "$config"
+            )
+        for line in "${var_assignments[@]}"; do
+            [[ "$line" == *\(* ]] || Error "Missing array assignment like +=(...) for $var in $config:$LF$line$LF"
+        done
+    done
+done
+
+
+unset array_variables

--- a/usr/share/rear/init/default/001_verify_config_arrays.sh
+++ b/usr/share/rear/init/default/001_verify_config_arrays.sh
@@ -6,14 +6,14 @@ array_variables=($(
 ))
 
 
-for config in "$CONFIG_DIR"/{site,local,rescue}.conf; do
+for config in "$CONFIG_DIR"/{site,local,rescue}.conf "${CONFIG_APPEND_FILES_PATHS[@]}"; do
     test -r "$config" || continue
     for var in "${array_variables[@]}"; do
         mapfile -t var_assignments < <(
             sed -n -E -e "/$var\+?=/p" "$config"
             )
         for line in "${var_assignments[@]}"; do
-            [[ "$line" == *\(* ]] || Error "Missing array assignment like +=(...) for $var in $config:$LF$line$LF"
+            [[ "$line" == *$var?(+)=\(* ]] || Error "Missing array assignment like +=(...) for $var in $config:$LF$line$LF"
         done
     done
 done

--- a/usr/share/rear/init/default/001_verify_config_arrays.sh
+++ b/usr/share/rear/init/default/001_verify_config_arrays.sh
@@ -6,16 +6,19 @@
 #       Therefore it is enough to simply take all the currently defined array variables and check
 #       for any wrong assignment in the user configuration
 
-local var_assignments array_variables=($(
-    declare -p | sed -n -E -e '/^declare -a/s/declare [-arxlu]+ ([A-Za-z0-9_-]+)=.*/\1/p'
-))
+local var_assignments array_variables
 
+mapfile -t array_variables < <(
+    declare -p | sed -n -E -e '/^declare -a/s/declare [-arxlu]+ ([A-Za-z0-9_-]+)=.*/\1/p'
+)
+
+declare -p array_variables
 
 for config in "$CONFIG_DIR"/{site,local,rescue}.conf "${CONFIG_APPEND_FILES_PATHS[@]}"; do
     test -r "$config" || continue
     for var in "${array_variables[@]}"; do
         mapfile -t var_assignments < <(
-            sed -n -E -e "/$var\+?=/p" "$config"
+            sed -n -E -e "/(^|\W+)$var\+?=/p" "$config"
             )
         for line in "${var_assignments[@]}"; do
             [[ "$line" == *$var?(+)=\(* ]] || Error "Syntax error: Variable $var not assigned as Bash array in $config:$LF$line$LF"

--- a/usr/share/rear/lib/help-workflow.sh
+++ b/usr/share/rear/lib/help-workflow.sh
@@ -25,7 +25,7 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 Available options:
  -h --help           usage information (this text)
  -c DIR              alternative config directory; instead of $CONFIG_DIR
- -C CONFIG           additional config file; absolute path or relative to config directory
+ -C CONFIG           additional config files; absolute path or relative to config directory
  -d                  debug mode; run many commands verbosely with debug messages in log file (also sets -v)
  -D                  debugscript mode; log executed commands via 'set -x' (also sets -v and -d)
  --debugscripts SET  same as -d -v -D but debugscript mode with 'set -SET'


### PR DESCRIPTION
fixes #2930 

I wrote something that has this effect:

```
rear-sle15sp4:/src/rear # cat /etc/rear/local.conf 
BACKUP_PROG_INCLUDE=( $(findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash') )
COPY_AS_IS=foobar
rear-sle15sp4:/src/rear # rear help
ERROR: Missing array assignment like +=(...) for COPY_AS_IS in /etc/rear/local.conf:
COPY_AS_IS=foobar

Use debug mode '-d' for some debug messages or debugscript mode '-D' for full debug messages with 'set -x' output
Aborting due to an error, check /var/log/rear/rear-rear-sle15sp4.log.lockless for details
Terminated
```

What do you think?