### PR TITLE
s390x (IBM Z) disk formatting fixes

### DIFF
--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -29,8 +29,8 @@ BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 # Of course the rear bash scripts can be installed on any architecture just as any binaries can be installed on any architecture.
 # But the meaning of architecture dependent packages should be on what architectures they will work.
 # Therefore only those architectures that are actually supported are explicitly listed.
-# This avoids that rear can be "just installed" on architectures that are actually not supported (e.g. ARM or IBM z Systems):
-ExclusiveArch: %ix86 x86_64 ppc ppc64 ppc64le ia64
+# This avoids that rear can be "just installed" on architectures that are actually not supported (e.g. ARM):
+ExclusiveArch: %ix86 x86_64 ppc ppc64 ppc64le ia64 s390x
 # Furthermore for some architectures it requires architecture dependent packages (like syslinux for x86 and x86_64)
 # so that rear must be architecture dependent because ifarch conditions never match in case of "BuildArch: noarch"
 # see the GitHub issue https://github.com/rear/rear/issues/629

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -487,6 +487,17 @@ DISKS_TO_BE_WIPED=""
 ####
 
 ####
+# Formatting DASDs (S/390 specific)
+# DASD (Direct Access Storage Device) denotes a disk drive on the S/390 architecture.
+# DASDs need to be formatted before use (even before creating a partition table on them).
+# By default ReaR will format the DASDs that are going to be used to recreate the system
+# (are referenced in disklayout.conf) before recreating the disk layout.
+# This can be suppressed by setting FORMAT_DASDS="false". It can be useful when one intends
+# to use already formatted DASDs as recovery target.
+FORMAT_DASDS=""
+####
+
+####
 # Resizing partitions in MIGRATION_MODE during "rear recover"
 #
 # AUTORESIZE_PARTITIONS

--- a/usr/share/rear/layout/prep-for-mount/Linux-s390/205_s390_enable_disk.sh
+++ b/usr/share/rear/layout/prep-for-mount/Linux-s390/205_s390_enable_disk.sh
@@ -1,0 +1,1 @@
+../../prepare/Linux-s390/205_s390_enable_disk.sh

--- a/usr/share/rear/layout/prepare/Linux-s390/090_include_dasd_code.sh
+++ b/usr/share/rear/layout/prepare/Linux-s390/090_include_dasd_code.sh
@@ -1,0 +1,17 @@
+# Generate code for low-level formatting of a DASD
+
+dasd_format_code() {
+    local device size blocksize layout dasdtype dasdcyls
+
+    device="$1"
+    size="$2"
+    blocksize="$3"
+    layout="$4"
+    dasdtype="$5"
+    dasdcyls="$6"
+
+    has_binary dasdfmt || Error "Cannot find 'dasdfmt' command"
+
+    LogPrint 'dasdfmt:' $device ', blocksize:' $blocksize ', layout:' $layout
+    echo "dasdfmt -b $blocksize -d $layout -y $device"
+}

--- a/usr/share/rear/layout/prepare/Linux-s390/205_s390_enable_disk.sh
+++ b/usr/share/rear/layout/prepare/Linux-s390/205_s390_enable_disk.sh
@@ -2,45 +2,36 @@
 # Before we can compare or map DASD devices we must enable them.
 # This operation is only needed during "rear recover".
 
-format_s390_disk() {
-    LogPrint "run dasdfmt"
-    while read line ; do
-        LogPrint 'dasdfmt:' "$line"
-        # example format command: dasdfmt -b 4096 -d cdl -y /dev/dasda
-        # where
-        #  b is the block size
-        #  d is the layout: 
-        #   cdl - compatible disk layout (can be shared with zos and zvm apps)
-        #   ldl - linux disk layout
-        #  y - answer yes
-        device=$( echo $line | awk '{ print $7 }' )
-        blocksize=$( echo $line | awk '{ print $3 }' )
-        layout=$( echo $line | awk '{ print tolower($5) }' )
-        if [[ "$layout" == "ldl" ]] ; then
-            # listDasdLdl contains devices such as /dev/dasdb that are formatted as LDL
-            # LDL formatted disks are already partitioned and should not be partitioned with parted or fdasd , it will fail
-            # this var, listDasdLdl, is used by 100_include_partition_code.sh to exclude writing partition code to diskrestore.sh for LDL disks
-            listDasdLdl+=( $device )
-            LogPrint "LDL disk '$device' will not be partitioned (LDL disks are already partitioned)"
-        fi
-        LogPrint 'dasdfmt:' $device ', blocksize:' $blocksize ', layout:' $layout
-        # dasd format
-        dasdfmt -b $blocksize -d $layout -y $device
-    done < <( grep "^dasdfmt " "$LAYOUT_FILE" )
-}
-
+DISK_MAPPING_HINTS=()
 
 enable_s390_disk() {
+    local keyword device bus len newname
+
     LogPrint "run chccwdev"
-    while read line ; do
-        LogPrint 'dasd channel:' "$line"
-        device=$( echo $line | awk '{ print $4 }' )
-        bus=$( echo $line | awk '{ print $2 }' )
-        channel=$( echo $line | awk '{ print $5 }' )
-        LogPrint 'chccwdev:' $device ', bus:' $bus ', channel:' $channel
-        # dasd channel enable
-        chccwdev -e $bus
-    done < <( grep "^dasd_channel " "$LAYOUT_FILE" )
+    while read len device bus ; do
+        # this while loop must be outside the pipeline so that variables propagate outside
+        # (pipelines run in subshells)
+        LogPrint "Enabling DASD $device with virtual device number $bus"
+        if chccwdev -e $bus ; then
+            newname=$(lsdasd $bus | awk "/$bus/ { print \$3}" )
+            if ! test $newname ; then
+                LogPrintError "New device with virtual device number $bus not found among online DASDs"
+                continue
+            fi
+            if [ "$newname" != "$device" ]; then
+                LogPrint "original DASD '$device' changed name to '$newname'"
+                test "$MIGRATION_MODE" || MIGRATION_MODE='true'
+            fi
+            DISK_MAPPING_HINTS+=( "/dev/$device /dev/$newname" )
+        else
+            LogPrintError "Failed to enable $bus"
+        fi
+    done < <( grep "^dasd_channel " "$LAYOUT_FILE" | while read keyword bus device; do
+                  # add device name length, so that "dasdb" sorts properly before "dasdaa"
+                  # we need to create devices in the same order as the kernel orders them (by minor number)
+                  # - this increases the chance that they will get identical names
+                  echo ${#device} $device $bus
+                  done | sort -k1n -k2 )
 }
 
 # May need to look at $OS_VENDOR also as DASD disk layout is distro specific:
@@ -49,7 +40,6 @@ case $OS_MASTER_VENDOR in
         # "Fedora" also handles Red Hat
         # "Debian" also handles Ubuntu
         enable_s390_disk
-        format_s390_disk
         ;;
     (*)
         LogPrintError "No code for DASD disk device enablement on $OS_MASTER_VENDOR"

--- a/usr/share/rear/layout/prepare/Linux-s390/360_generate_dasd_format_code.sh
+++ b/usr/share/rear/layout/prepare/Linux-s390/360_generate_dasd_format_code.sh
@@ -27,6 +27,13 @@ EOF
 
 while read component disk size label junk; do
     if [ "$label" == dasd ]; then
+        # Ignore excluded components.
+        # Normally they are removed in 520_exclude_components.sh,
+        # but we run before it, so we must skip them here as well.
+        if IsInArray "$disk" "${EXCLUDE_RECREATE[@]}" ; then
+            Log "Excluding $disk from DASD reformatting."
+            continue
+        fi
         # dasd has more fields - junk is not junk anymore
         read blocksize layout dasdtype dasdcyls junk2 <<<$junk
         dasd_format_code "$disk" "$size" "$blocksize" "$layout" "$dasdtype" "$dasdcyls" >> "$DASD_FORMAT_CODE" || \

--- a/usr/share/rear/layout/prepare/Linux-s390/360_generate_dasd_format_code.sh
+++ b/usr/share/rear/layout/prepare/Linux-s390/360_generate_dasd_format_code.sh
@@ -1,0 +1,44 @@
+# DASD_FORMAT_CODE is the script to recreate the dasd formatting (dasdformat.sh).
+
+local component disk size label junk
+local blocksize layout dasdtype dasdcyls junk2
+
+
+save_original_file "$DASD_FORMAT_CODE"
+
+# Initialize
+
+echo '#!/bin/bash' >"$DASD_FORMAT_CODE"
+
+# Show the current output of lsdasd, it can be useful for identifying disks
+# (in particular it shows the Linux device name <-> virtual device number mapping,
+# formatted / unformatted status and the number/size of blocks when formatted )
+echo "# Current output of 'lsdasd':" >>"$DASD_FORMAT_CODE"
+lsdasd | sed -e 's/^/# /' >>"$DASD_FORMAT_CODE"
+
+cat <<EOF >>"$DASD_FORMAT_CODE"
+
+LogPrint "Start DASD format restoration."
+
+set -e
+set -x
+
+EOF
+
+while read component disk size label junk; do
+    if [ "$label" == dasd ]; then
+        # dasd has more fields - junk is not junk anymore
+        read blocksize layout dasdtype dasdcyls junk2 <<<$junk
+        dasd_format_code "$disk" "$size" "$blocksize" "$layout" "$dasdtype" "$dasdcyls" >> "$DASD_FORMAT_CODE" || \
+            LogPrintError "Error producing DASD format code for $disk"
+    fi
+done < <(grep "^disk " "$LAYOUT_FILE")
+
+cat <<EOF >>"$DASD_FORMAT_CODE"
+
+set +x
+set +e
+
+LogPrint "DASD(s) formatted."
+
+EOF

--- a/usr/share/rear/layout/prepare/Linux-s390/370_confirm_dasd_format_code.sh
+++ b/usr/share/rear/layout/prepare/Linux-s390/370_confirm_dasd_format_code.sh
@@ -1,0 +1,57 @@
+#
+# In migration mode let the user confirm the
+# DASD format code (dasdformat.sh) script.
+#
+
+# Skip if not in migration mode:
+is_true "$MIGRATION_MODE" || return 0
+
+rear_workflow="rear $WORKFLOW"
+original_disk_space_usage_file="$VAR_DIR/layout/config/df.txt"
+rear_shell_history="$( echo -e "cd $VAR_DIR/layout/\nvi $DASD_FORMAT_CODE\nless $DASD_FORMAT_CODE" )"
+unset choices
+choices[0]="Confirm DASD format script and continue '$rear_workflow'"
+choices[1]="Edit DASD format script ($DASD_FORMAT_CODE)"
+choices[2]="View DASD format script ($DASD_FORMAT_CODE)"
+choices[3]="View original disk space usage ($original_disk_space_usage_file)"
+choices[4]="Use Relax-and-Recover shell and return back to here"
+choices[5]="Abort '$rear_workflow'"
+prompt="Confirm or edit the DASD format script"
+choice=""
+wilful_input=""
+# When USER_INPUT_DASD_FORMAT_CODE_CONFIRMATION has any 'true' value be liberal in what you accept and
+# assume choices[0] 'Confirm DASD format' was actually meant:
+is_true "$USER_INPUT_DASD_FORMAT_CODE_CONFIRMATION" && USER_INPUT_DASD_FORMAT_CODE_CONFIRMATION="${choices[0]}"
+while true ; do
+    choice="$( UserInput -I DASD_FORMAT_CODE_CONFIRMATION -p "$prompt" -D "${choices[0]}" "${choices[@]}" )" && wilful_input="yes" || wilful_input="no"
+    case "$choice" in
+        (${choices[0]})
+            # Confirm DASD format file and continue:
+            is_true "$wilful_input" && LogPrint "User confirmed DASD format script" || LogPrint "Continuing '$rear_workflow' by default"
+            break
+            ;;
+        (${choices[1]})
+            # Run 'vi' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+            vi $DASD_FORMAT_CODE 0<&6 1>&7 2>&8
+            ;;
+        (${choices[2]})
+            # Run 'less' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+            less $DASD_FORMAT_CODE 0<&6 1>&7 2>&8
+            ;;
+        (${choices[3]})
+            # Run 'less' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+            less $original_disk_space_usage_file 0<&6 1>&7 2>&8
+            ;;
+        (${choices[4]})
+            # rear_shell runs 'bash' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+            rear_shell "" "$rear_shell_history"
+            ;;
+        (${choices[5]})
+            abort_dasd_format
+            Error "User chose to abort '$rear_workflow' in ${BASH_SOURCE[0]}"
+            ;;
+    esac
+done
+
+chmod +x $DASD_FORMAT_CODE
+

--- a/usr/share/rear/layout/prepare/Linux-s390/370_confirm_dasd_format_code.sh
+++ b/usr/share/rear/layout/prepare/Linux-s390/370_confirm_dasd_format_code.sh
@@ -4,6 +4,8 @@
 # DASD format code (dasdformat.sh) script.
 #
 
+is_false "$FORMAT_DASDS" && return 0
+
 # Show the user confirmation dialog in any case but when not in migration mode
 # automatically proceed with less timeout USER_INPUT_INTERRUPT_TIMEOUT (by default 10 seconds)
 # to avoid longer delays (USER_INPUT_TIMEOUT is by default 300 seconds) in case of unattended recovery:
@@ -19,8 +21,9 @@ choices[0]="Confirm DASD format script and continue '$rear_workflow'"
 choices[1]="Edit DASD format script ($DASD_FORMAT_CODE)"
 choices[2]="View DASD format script ($DASD_FORMAT_CODE)"
 choices[3]="View original disk space usage ($original_disk_space_usage_file)"
-choices[4]="Use Relax-and-Recover shell and return back to here"
-choices[5]="Abort '$rear_workflow'"
+choices[4]="Confirm what is currently on the DASDs, skip formatting them and continue '$rear_workflow'"
+choices[5]="Use Relax-and-Recover shell and return back to here"
+choices[6]="Abort '$rear_workflow'"
 prompt="Confirm or edit the DASD format script"
 choice=""
 wilful_input=""
@@ -48,10 +51,14 @@ while true ; do
             less $original_disk_space_usage_file 0<&6 1>&7 2>&8
             ;;
         (${choices[4]})
+            # Confirm what is on the disks and continue without formatting
+            FORMAT_DASDS="false"
+            ;;
+        (${choices[5]})
             # rear_shell runs 'bash' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
             rear_shell "" "$rear_shell_history"
             ;;
-        (${choices[5]})
+        (${choices[6]})
             abort_dasd_format
             Error "User chose to abort '$rear_workflow' in ${BASH_SOURCE[0]}"
             ;;

--- a/usr/share/rear/layout/prepare/Linux-s390/370_confirm_dasd_format_code.sh
+++ b/usr/share/rear/layout/prepare/Linux-s390/370_confirm_dasd_format_code.sh
@@ -1,10 +1,15 @@
+# adapted from 100_confirm_layout_code.sh
 #
-# In migration mode let the user confirm the
+# Let the user confirm the
 # DASD format code (dasdformat.sh) script.
 #
 
-# Skip if not in migration mode:
-is_true "$MIGRATION_MODE" || return 0
+# Show the user confirmation dialog in any case but when not in migration mode
+# automatically proceed with less timeout USER_INPUT_INTERRUPT_TIMEOUT (by default 10 seconds)
+# to avoid longer delays (USER_INPUT_TIMEOUT is by default 300 seconds) in case of unattended recovery:
+# (taken from 120_confirm_wipedisk_disks.sh)
+local timeout="$USER_INPUT_TIMEOUT"
+is_true "$MIGRATION_MODE" || timeout="$USER_INPUT_INTERRUPT_TIMEOUT"
 
 rear_workflow="rear $WORKFLOW"
 original_disk_space_usage_file="$VAR_DIR/layout/config/df.txt"
@@ -23,7 +28,7 @@ wilful_input=""
 # assume choices[0] 'Confirm DASD format' was actually meant:
 is_true "$USER_INPUT_DASD_FORMAT_CODE_CONFIRMATION" && USER_INPUT_DASD_FORMAT_CODE_CONFIRMATION="${choices[0]}"
 while true ; do
-    choice="$( UserInput -I DASD_FORMAT_CODE_CONFIRMATION -p "$prompt" -D "${choices[0]}" "${choices[@]}" )" && wilful_input="yes" || wilful_input="no"
+    choice="$( UserInput -I DASD_FORMAT_CODE_CONFIRMATION -t "$timeout" -p "$prompt" -D "${choices[0]}" "${choices[@]}" )" && wilful_input="yes" || wilful_input="no"
     case "$choice" in
         (${choices[0]})
             # Confirm DASD format file and continue:

--- a/usr/share/rear/layout/prepare/Linux-s390/400_run_dasd_format_code.sh
+++ b/usr/share/rear/layout/prepare/Linux-s390/400_run_dasd_format_code.sh
@@ -4,6 +4,12 @@
 # again and again until it succeeds or the user aborts.
 #
 
+# Skip DASD formatting when the user has explicitly specified to not format them
+# or when the user selected "Confirm what is currently on the DASDs, skip formatting them"
+# in 370_confirm_dasd_format_code.sh
+
+is_false "$FORMAT_DASDS" && return 0
+
 function lsdasd_output () {
     lsdasd 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 )
 }

--- a/usr/share/rear/layout/prepare/Linux-s390/400_run_dasd_format_code.sh
+++ b/usr/share/rear/layout/prepare/Linux-s390/400_run_dasd_format_code.sh
@@ -1,0 +1,179 @@
+# adapted from 200_run_layout_code.sh
+#
+# Run the DASD format code (dasdformat.sh)
+# again and again until it succeeds or the user aborts.
+#
+
+function lsdasd_output () {
+    lsdasd 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 )
+}
+
+rear_workflow="rear $WORKFLOW"
+original_disk_space_usage_file="$VAR_DIR/layout/config/df.txt"
+rear_shell_history="$( echo -e "cd $VAR_DIR/layout/\nvi $DASD_FORMAT_CODE\nless $RUNTIME_LOGFILE" )"
+wilful_input=""
+
+unset choices
+choices[0]="Rerun DASD format script ($DASD_FORMAT_CODE)"
+choices[1]="View '$rear_workflow' log file ($RUNTIME_LOGFILE)"
+choices[2]="Edit DASD format script ($DASD_FORMAT_CODE)"
+choices[3]="Show what is currently on the disks ('lsdasd' device list)"
+choices[4]="View original disk space usage ($original_disk_space_usage_file)"
+choices[5]="Use Relax-and-Recover shell and return back to here"
+choices[6]="Confirm what is currently on the disks and continue '$rear_workflow'"
+choices[7]="Abort '$rear_workflow'"
+prompt="DASD format choices"
+
+choice=""
+# When USER_INPUT_DASD_FORMAT_CODE_RUN has any 'true' value be liberal in what you accept and
+# assume choices[0] 'Rerun DASD format script' was actually meant
+# regardless that this likely lets 'rear recover' run an endless loop
+# of failed DASD format attempts but ReaR must obey what the user specified
+# (perhaps it is intended to let 'rear recover' loop here until an admin intervenes):
+is_true "$USER_INPUT_DASD_FORMAT_CODE_RUN" && USER_INPUT_DASD_FORMAT_CODE_RUN="${choices[0]}"
+
+unset confirm_choices
+confirm_choices[0]="Confirm recreated DASD format and continue '$rear_workflow'"
+confirm_choices[1]="Go back one step to redo DASD format"
+confirm_choices[2]="Use Relax-and-Recover shell and return back to here"
+confirm_choices[3]="Abort '$rear_workflow'"
+confirm_prompt="Confirm the recreated DASD format or go back one step"
+confirm_choice=""
+# When USER_INPUT_DASD_FORMAT_MIGRATED_CONFIRMATION has any 'true' value be liberal in what you accept and
+# assume confirm_choices[0] 'Confirm recreated DASD format and continue' was actually meant:
+is_true "$USER_INPUT_DASD_FORMAT_MIGRATED_CONFIRMATION" && USER_INPUT_DASD_FORMAT_MIGRATED_CONFIRMATION="${confirm_choices[0]}"
+
+# Run the DASD format code (dasdformat.sh)
+# again and again until it succeeds or the user aborts
+# or the user confirms to continue with what is currently on the disks
+# (the user may have setup manually what he needs via the Relax-and-Recover shell):
+while true ; do
+    prompt="The DASD format had failed"
+    # After switching to recreating with DASD format script
+    # change choices[0] from "Run ..." to "Rerun ...":
+    choices[0]="Rerun DASD format script ($DASD_FORMAT_CODE)"
+    # Run DASD_FORMAT_CODE in a sub-shell because it sets 'set -e'
+    # so that it exits the running shell in case of an error
+    # but that exit must not exit this running bash here:
+    ( source $DASD_FORMAT_CODE )
+    # One must explicitly test whether or not $? is zero in a separated bash command
+    # because with bash 3.x and bash 4.x code like
+    #   # ( set -e ; cat qqq ; echo "hello" ) && echo ok || echo failed
+    #   cat: qqq: No such file or directory
+    #   hello
+    #   ok
+    # does not work as one may expect (cf. what "man bash" describes for 'set -e').
+    # There is a subtle behavioural difference between bash 3.x and bash 4.x
+    # when a script that has 'set -e' set gets sourced:
+    # With bash 3.x the 'set -e' inside the sourced script is effective:
+    #   # echo 'set -e ; cat qqq ; echo hello' >script.sh
+    #   # ( source script.sh ) && echo ok || echo failed
+    #   cat: qqq: No such file or directory
+    #   failed
+    # With bash 4.x the 'set -e' inside the sourced script gets noneffective:
+    #   # echo 'set -e ; cat qqq ; echo hello' >script.sh
+    #   # ( source script.sh ) && echo ok || echo failed
+    #   cat: qqq: No such file or directory
+    #   hello
+    #   ok
+    # With bash 3.x and bash 4.x testing $? in a separated bash command
+    # keeps the 'set -e' inside the sourced script effective:
+    #   # echo 'set -e ; cat qqq ; echo hello' >script.sh
+    #   # ( source script.sh ) ; (( $? == 0 )) && echo ok || echo failed
+    #   cat: qqq: No such file or directory
+    #   failed
+    # See also https://github.com/rear/rear/pull/1573#issuecomment-344303590
+    if (( $? == 0 )) ; then
+        prompt="DASD format had been successful"
+        # When DASD_FORMAT_CODE succeeded and when not in migration mode
+        # break the outer while loop and continue the "rear recover" workflow
+        # which means continue with restoring the backup:
+        is_true "$MIGRATION_MODE" || break
+        # When DASD_FORMAT_CODE succeeded in migration mode
+        # let the user explicitly confirm the recreated (and usually migrated) format
+        # before continuing the "rear recover" workflow with restoring the backup.
+        # Show the recreated DASD format to the user on his terminal (and also in the log file):
+        LogPrint "Recreated DASD format:"
+        lsdasd_output
+        # Run an inner while loop with a user dialog so that the user can inspect the recreated DASD format
+        # and perhaps even manually fix the recreated DASD format if it is not what the user wants
+        # (e.g. by using the Relax-and-Recover shell and returning back to this user dialog):
+        while true ; do
+            confirm_choice="$( UserInput -I DASD_FORMAT_MIGRATED_CONFIRMATION -p "$confirm_prompt" -D "${confirm_choices[0]}" "${confirm_choices[@]}" )" && wilful_input="yes" || wilful_input="no"
+            case "$confirm_choice" in
+                (${confirm_choices[0]})
+                    # Confirm recreated DASD format and continue:
+                    is_true "$wilful_input" && LogPrint "User confirmed recreated DASD format" || LogPrint "Continuing with recreated DASD format by default"
+                    # Break the outer while loop and continue with restoring the backup:
+                    break 2
+                    ;;
+                (${confirm_choices[1]})
+                    # Go back one step to redo DASD format:
+                    # Only break the inner while loop (i.e. this user dialog loop)
+                    # and  continue with the next user dialog below:
+                    break
+                    ;;
+                (${confirm_choices[2]})
+                    # rear_shell runs 'bash' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+                    rear_shell "" "$rear_shell_history"
+                    ;;
+                (${confirm_choices[3]})
+                    abort_dasd_format
+                    Error "User did not confirm the recreated DASD format but aborted '$rear_workflow' in ${BASH_SOURCE[0]}"
+                    ;;
+            esac
+        done
+    fi
+    # Run an inner while loop with a user dialog so that the user can fix things
+    # when DASD_FORMAT_CODE failed.
+    # Such a fix does not necessarily mean the user must change
+    # the dasdformat.sh script when DASD_FORMAT_CODE failed.
+    # The user might also fix things by only using the Relax-and-Recover shell and
+    # then confirm what is on the disks and continue with restoring the backup
+    # or abort this "rear recover" run to re-try from scratch.
+    while true ; do
+        choice="$( UserInput -I DASD_FORMAT_CODE_RUN -p "$prompt" -D "${choices[0]}" "${choices[@]}" )" && wilful_input="yes" || wilful_input="no"
+        case "$choice" in
+            (${choices[0]})
+                # Rerun or run (after switching to recreating with DASD format script) DASD format script:
+                is_true "$wilful_input" && LogPrint "User runs DASD format script" || LogPrint "Running DASD format script by default"
+                # Only break the inner while loop (i.e. the user dialog loop):
+                break
+                ;;
+            (${choices[1]})
+                # Run 'less' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+                less $RUNTIME_LOGFILE 0<&6 1>&7 2>&8
+                ;;
+            (${choices[2]})
+                # Run 'vi' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+                vi $DASD_FORMAT_CODE 0<&6 1>&7 2>&8
+                ;;
+            (${choices[3]})
+                LogPrint "This is the current list of DASDs:"
+                lsdasd_output
+                ;;
+            (${choices[4]})
+                # Run 'less' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+                less $original_disk_space_usage_file 0<&6 1>&7 2>&8
+                ;;
+            (${choices[5]})
+                # rear_shell runs 'bash' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
+                rear_shell "" "$rear_shell_history"
+                ;;
+            (${choices[6]})
+                # Confirm what is on the disks and continue:
+                # Break the outer while loop and continue with restoring the backup:
+                break 2
+                ;;
+            (${choices[7]})
+                abort_dasd_format
+                Error "User chose to abort '$rear_workflow' in ${BASH_SOURCE[0]}"
+                ;;
+        esac
+    done
+# End of the outer while loop:
+done
+
+# Local functions must be 'unset' because bash does not support 'local function ...'
+# cf. https://unix.stackexchange.com/questions/104755/how-can-i-create-a-local-function-in-my-bashrc
+unset -f lsdasd_output

--- a/usr/share/rear/layout/prepare/default/010_prepare_files.sh
+++ b/usr/share/rear/layout/prepare/default/010_prepare_files.sh
@@ -7,6 +7,8 @@ LAYOUT_CODE="$VAR_DIR/layout/diskrestore.sh"
 LAYOUT_XFS_OPT_DIR="$VAR_DIR/layout/xfs"
 LAYOUT_XFS_OPT_DIR_RESTORE="$LAYOUT_XFS_OPT_DIR/restore"
 
+DASD_FORMAT_CODE="$VAR_DIR/layout/dasdformat.sh"
+
 FS_UUID_MAP="$VAR_DIR/layout/fs_uuid_mapping"
 LUN_WWID_MAP="$VAR_DIR/layout/lun_wwid_mapping"
 

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -87,6 +87,12 @@ abort_recreate() {
     restore_original_file "$LAYOUT_FILE"
 }
 
+abort_dasd_format() {
+    Log "Error detected during DASD formatting."
+    Log "Restoring saved original $DASD_FORMAT_FILE"
+    restore_original_file "$DASD_FORMAT_FILE"
+}
+
 # Test and log if a component $1 (type $2) needs to be recreated.
 create_component() {
     local device="$1"

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -734,6 +734,18 @@ get_block_size() {
     fi
 }
 
+# Get the number of cylinders of a DASD.
+# The number of cylinders has the advantage of being fixed - size depends on formatting
+# and number of cylinders is valid even for unformatted DASDs, size is not.
+get_dasd_cylinders() {
+    local disk_name="${1##*/}" # /some/path/dasda -> dasda
+    local dasd_cyls
+
+    dasd_cyls=$(dasdview -i /dev/$disk_name | grep cylinders | cut -d ':' -f2 | awk '{print $4}')
+    ### Make sure we always return a number
+    echo $(( dasd_cyls ))
+}
+
 # Get the UUID of a device.
 # Device is something like /dev/sda1.
 blkid_uuid_of_device() {

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -752,6 +752,34 @@ get_dasd_cylinders() {
     echo $(( dasd_cyls ))
 }
 
+# Sometimes we know what the new device for the original device should be in a more reliable way
+# than by looking at disk sizes. THis information is called "mapping hints". Let's pass them
+# to the mapping code using the DISK_MAPPING_HINTS array. Each element of the array has the form
+# "/dev/source /dev/target" (space-separated).
+
+# Output the mapping hint for the original device.
+function get_mapping_hint () {
+    local device="$1"
+    local hint mapping_hint_source mapping_hint_target
+
+    for hint in "${DISK_MAPPING_HINTS[@]}"; do
+        mapping_hint_source=${hint%% *}
+        mapping_hint_target=${hint##* }
+        if [ "${device}" == "${mapping_hint_source}" ] ; then
+            echo "$mapping_hint_target"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Determine if there is a mapping hint for the original device.
+function has_mapping_hint () {
+    local device="$1"
+
+    get_mapping_hint "$device" > /dev/null
+}
+
 # Get the UUID of a device.
 # Device is something like /dev/sda1.
 blkid_uuid_of_device() {


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix** 

* Impact: **High**

* Reference to related issue (URL):

* How was this pull request tested?
Full backup and recovery on RHEL 8 s390x VM with 4 DASDs: 2 in the root VG, one for storing the backup and one that was not included in the backup (`ONLY_INCLUDE_VG=( rootvg )` was set). Verified that the extra VG and the disk with the backup survived recovery and that DASDs were properly mapped during recovery (in a situation where the correct disk mapping is not an identity map).

* Brief description of the changes in this pull request:
The s390x architecture needs some unique handling of disks (called DASDs - Direct Access Storage Devices) during layout restoration. The DASDs need to be enabled, otherwise they are not recognized as block devices, and then to get formatted (at low level), unless they are formatted already, before they can be partitioned. The current code to do this suffers from several problems.
Formatting of the disks is controlled by the `dasdfmt` directive in the disklayout.conf file. This directive is emitted for all dasds, regardless of whether they should be included in the layout. While there is component exclusion code that comments out the "disk" lines for unused disks automatically, the `dasdfmt` lines for unused disks stay in the layout file, which later causes the unused disks to be reformatted unconditionally. Crucially, this includes the disk with the backup (one must use network backup storage because of this). Moreover, when the user is prompted to confirm the disk layout file and layout recreation script, it is too late, because the formatting code is unconditionally executed very early, before the rest of processing of the layout, and is not part of the disklayout.sh script.
As the formatting code runs early, it is also not affected by disk mappings, so when the device names change, formatting will be applied to wrong disks.
Another problem is that obtaining the disk entry from the `lsdasd` command output uses a simple `grep` command. Unfortunately, this breaks for more than 26 DASDs, because `grep dasda` will also match `dasdaa`, `dasdab` etc., so multiple lines will pass through the filter instead of just one and break the format of the disklayout.conf file.

This PR does the following changes:
- Simplify syntax of dasd_channel directive. The previous syntax had some useless fields, like the major:minor number and status.
- Fix obtaining the entry from lsdasd output
- Eliminate the "dasdfmt" directive, merge its fields into the "disk" directive. This has the advantage that the exclusion code eliminates the "disk" lines for unused disks automatically and thus prevents them from being reformatted (in addition to preventing them from being repartitioned). Unfortunately it means that the format of the "disk" directive now depends on the disk label type: `dasd` disks have extra fields that other disk types don't have.
-  Generate the DASD formatting code as a separate script and let the user confirm it before it gets executed. Heavily inspired by the disk wiping code (it is similarly destructive), but executed during the "layout/prepare" stage and not during the "layout/recreate" stage. The reason is that unformatted DASDs do not have their size in bytes known (it depends on format), but other scripts in the "layout/prepare" stage need to know the disk sizes (e.g. for resizing partitions). The script is generated after the mapping code has mapped original to current disk devices, ensuring that we format the correct DASDs. Reformatting can be switched off entirely by setting the `FORMAT_DASDS` variable to a false value.
- The heuristics in disk comparison and mapping script will now be less accurate, because it won't know the current sizes if disks are not formatted. Since the DASDs have permanent identifiers (virtual device number) that can be used to reliably identify disks, pass this information to the mapping code in a variable called DISK_MAPPING_HINTS and use them there in preference to the usual device name and size comparison.
- Since DASD enabling and DASD formatting code are now separate and the former is non-destructive, run it also for "rear mountonly". This fixes "rear mountonly" on s390x.