### PR TITLE
Replace subshell redirection by group command redirection

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -371,7 +371,10 @@ extract_partitions() {
 }
 
 Log "Saving disks and their partitions"
-(   for disk in /sys/block/* ; do
+
+# Begin of group command that appends its stdout to DISKLAYOUT_FILE:
+{
+    for disk in /sys/block/* ; do
         blockd=${disk#/sys/block/}
         if [[ $blockd = hd* || $blockd = sd* || $blockd = cciss* || $blockd = vd* || $blockd = xvd* || $blockd = dasd* || $blockd = nvme* || $blockd = mmcblk* ]] ; then
 
@@ -423,7 +426,8 @@ Log "Saving disks and their partitions"
             fi
         fi
     done
-) >> $DISKLAYOUT_FILE
+} 1>>$DISKLAYOUT_FILE
+# End of group command that appends its stdout to DISKLAYOUT_FILE
 
 # parted and partprobe are required in the recovery system if disklayout.conf contains at least one 'disk' or 'part' entry
 # see the create_disk and create_partitions functions in layout/prepare/GNU/Linux/100_include_partition_code.sh

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -75,8 +75,8 @@ if service docker status ; then
     fi
 fi
 
-# Begin of the subshell that appends its stdout to DISKLAYOUT_FILE:
-(
+# Begin of group command that appends its stdout to DISKLAYOUT_FILE:
+{
     echo "# Filesystems (only $supported_filesystems are supported)."
     echo "# Format: fs <device> <mountpoint> <fstype> [uuid=<uuid>] [label=<label>] [<attributes>]"
     # Read the output of the read_filesystems_command:
@@ -514,8 +514,6 @@ fi
             echo "# Attributes cannot be determined because no executable 'lsattr' and/or 'findmnt' command(s) found that supports 'FSROOT'."
         fi
 
-        # This needs to be done inside the subshell (that appends its stdout to DISKLAYOUT_FILE)
-        # because outside the subshell the inside the subshell set variables would be lost:
         if test "$btrfs_subvolume_sles_setup_devices" ; then
             # Save the updated BTRFS_SUBVOLUME_SLES_SETUP array variable that is needed in recover mode into the rescue.conf file:
             cat - <<EOF >> "$ROOTFS_DIR/etc/rear/rescue.conf"
@@ -536,8 +534,8 @@ EOF
     # End btrfs subvolume layout if a btrfs filesystem exists:
     fi
 
-) >> $DISKLAYOUT_FILE
-# End of the subshell that appends its stdout to DISKLAYOUT_FILE.
+} >> $DISKLAYOUT_FILE
+# End of group command that appends its stdout to DISKLAYOUT_FILE
 
 # mkfs is required in the recovery system if disklayout.conf contains at least one 'fs' entry
 # see the create_fs function in layout/prepare/GNU/Linux/130_include_filesystem_code.sh

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -534,7 +534,7 @@ EOF
     # End btrfs subvolume layout if a btrfs filesystem exists:
     fi
 
-} >> $DISKLAYOUT_FILE
+} 1>>$DISKLAYOUT_FILE
 # End of group command that appends its stdout to DISKLAYOUT_FILE
 
 # mkfs is required in the recovery system if disklayout.conf contains at least one 'fs' entry


### PR DESCRIPTION
* Type: **Bug Fix** / **Cleanup**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2927#issuecomment-1440044143

* How was this pull request tested?
not yet tested by me

* Brief description of the changes in this pull request:

In layout/save/GNU/Linux/230_filesystem_layout.sh
and layout/save/GNU/Linux/200_partition_layout
and layout/save/GNU/Linux/240_swaps_layout.sh
replaced the subshell that appends its stdout to DISKLAYOUT_FILE
by a group command with redirection
```
{
    ...
} 1>>$DISKLAYOUT_FILE
```
cf. usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
https://github.com/rear/rear/blob/rear-2.7/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh#L375