### PR TITLE
Uptodate Source pointing to GitHub in RPM spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,8 @@ uninstall:
 
 dist: clean validate man dist/$(name)-$(distversion).tar.gz
 
+# most of the sed stuff should be skipped if $(distversion) == $(version)
+# except RELEASE_DATE= and perhaps the Version in $(dscfile)
 dist/$(name)-$(distversion).tar.gz:
 	@echo -e "\033[1m== Building archive $(name)-$(distversion) ==\033[0;0m"
 	rm -Rf build/$(name)-$(distversion)
@@ -171,7 +173,7 @@ dist/$(name)-$(distversion).tar.gz:
 		tar -C build/$(name)-$(distversion) -x
 	@echo -e "\033[1m== Rewriting $(specfile), $(dscfile) and $(rearbin) ==\033[0;0m"
 	sed -i.orig \
-		-e 's#^Source:.*#Source: https://sourceforge.net/projects/rear/files/rear/${version}/$(name)-${distversion}.tar.gz#' \
+		-e 's#^Source:.*#Source: $(name)-${distversion}.tar.gz#' \
 		-e 's#^Version:.*#Version: $(version)#' \
 		-e 's#^%define rpmrelease.*#%define rpmrelease $(rpmrelease)#' \
 		-e 's#^%setup.*#%setup -q -n $(name)-$(distversion)#' \

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ dist/$(name)-$(distversion).tar.gz:
 	mkdir -p dist build/$(name)-$(distversion)
 	tar -c --exclude-from=.gitignore --exclude=.gitignore --exclude=".??*" * | \
 		tar -C build/$(name)-$(distversion) -x
-	@echo -e "\033[1m== Rewriting $(specfile), $(dscfile) and $(rearbin) ==\033[0;0m"
+	@echo -e "\033[1m== Rewriting build/$(name)-$(distversion)/{$(specfile),$(dscfile),$(rearbin)} ==\033[0;0m"
 	sed -i.orig \
 		-e 's#^Source:.*#Source: $(name)-${distversion}.tar.gz#' \
 		-e 's#^Version:.*#Version: $(version)#' \

--- a/packaging/debian/rear.dsc
+++ b/packaging/debian/rear.dsc
@@ -1,6 +1,6 @@
 Format: 1.0
 Source: rear
-Version: 2.00
+Version: 2.7
 Binary: rear
 Maintainer: Gratien Dhaese <gratien.dhaese@gmail.com>
 Architecture: all

--- a/packaging/gentoo/rear.ebuild
+++ b/packaging/gentoo/rear.ebuild
@@ -6,7 +6,7 @@ EAPI=4
 
 DESCRIPTION="Fully automated disaster recovery supporting a broad variety of backup strategies and scenarios"
 HOMEPAGE="http://relax-and-recover.org/"
-SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+SRC_URI="https://github.com/rear/rear/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -18,8 +18,7 @@ License: GPL-3.0
 Group: Applications/File
 URL: http://relax-and-recover.org/
 
-# as GitHub stopped with download section we need to go back to Sourceforge for downloads
-Source: https://sourceforge.net/projects/rear/files/rear/%{version}/rear-%{version}.tar.gz
+Source: https://github.com/rear/rear/archive/%{version}.tar.gz#/rear-%{version}.tar.gz
 
 # BuildRoot: is required for SLES 11 and RHEL/CentOS 5 builds on openSUSE Build Service (#2135)
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):  closes #2945

* How was this pull request tested?
`spectool -g packaging/rpm/rear.spec` downloads the correct tarball

* Brief description of the changes in this pull request:
Change the URL in the Source tag in the RPM spec file to point to the tarball on GitHub instead of SourceForge (where the tarball is not updated anymore).
AFAIK GitHub creates the tarballs automatically from tags.
