### PR TITLE
New 990_verify_empty_rootfs.sh to verify untouched ROOTFS_DIR at the end of 'prep'

### DIFF
--- a/usr/share/rear/prep/README
+++ b/usr/share/rear/prep/README
@@ -3,13 +3,15 @@ This is the preparation part of ReaR (i.e. the 'prep' stage)
 before starting the rescue/recovery system build phase.
 
 You should not put scripts into this 'prep' stage that modify things
-in $ROOTFS_DIR or $VAR_DIR/recovery and $VAR_DIR/layout because
-scripts for $ROOTFS_DIR belong to the 'rescue' stage and scripts
-for $VAR_DIR/recovery and $VAR_DIR/layout belong to the 'layout' stages.
+in ROOTFS_DIR or in VAR_DIR/recovery and VAR_DIR/layout because
+scripts for ROOTFS_DIR belong to the 'rescue' stage and scripts
+for VAR_DIR/recovery and VAR_DIR/layout belong to the 'layout' stages.
 
-The prep stage is used for preparing and configuring ReaR for the later stages, e.g. auto-detect features or settings.
+The 'prep' stage is used for preparing and configuring ReaR
+for the later stages, e.g. auto-detect features or settings.
 
-Therefore code in prep should not modify ROOTFS_DIR (the rescue system) but only manipulate ReaR variables.
+Therefore code in 'prep' should not modify ROOTFS_DIR (the rescue/recovery system)
+but only manipulate ReaR variables or check and prepare requirements
 so that the 'prep' stage can also be run by workflows which
 do not make a rescue/recovery system.
 

--- a/usr/share/rear/prep/README
+++ b/usr/share/rear/prep/README
@@ -1,7 +1,29 @@
-This is the preparation part of ReaR before starting the rescue build phase.
 
-Please note that you should not put any scripts that reference
-$ROOTFS_DIR or $VAR_DIR/recovery into this section. Scripts for $ROOTFS_DIR
-go to rescue/ and for $VAR_DIR/recovery go to layout/ respectively
+This is the preparation part of ReaR (i.e. the 'prep' stage)
+before starting the rescue/recovery system build phase.
 
-That way we keep only the real prep stuff here in the prep section.
+You should not put scripts into this 'prep' stage that modify things
+in $ROOTFS_DIR or $VAR_DIR/recovery and $VAR_DIR/layout because
+scripts for $ROOTFS_DIR belong to the 'rescue' stage and scripts
+for $VAR_DIR/recovery and $VAR_DIR/layout belong to the 'layout' stages.
+
+We have only the real preparation tasks in the 'prep' stage
+so that the 'prep' stage can also be run by workflows which
+do not make a rescue/recovery system.
+
+Reasoning for ROOTFS_DIR:
+Only those workflows that actually make a rescue/recovery system
+by running the stages 'rescue', 'build', 'pack', and 'output'
+(in particular the workflows mkrescue, mkbackup and mkopalpba)
+should modify something in ROOTFS_DIR.
+In contrast when other workflows that run the 'prep' stage (e.g. mkbackuponly)
+modify something in ROOTFS_DIR then all those modifications will be lost
+because no rescue/recovery system with those modifications is made.
+So the problem is possible inconsistencies between what gets actually used
+during "rear recover" (i.e. the last actually made rescue/recovery system)
+versus what other workflows that run the 'prep' stage may need to have.
+For example mkbackuponly may need a modified rescue/recovery system
+when backup config variables need updated values in the recovery system
+(e.g. an updated value for BACKUP_PROG_EXCLUDE or something similar).
+The prep/default/990_verify_empty_rootfs.sh scrip checks at the end
+of the 'prep' stage that ROOTFS_DIR is unmodified (i.e. still empty).

--- a/usr/share/rear/prep/README
+++ b/usr/share/rear/prep/README
@@ -7,7 +7,9 @@ in $ROOTFS_DIR or $VAR_DIR/recovery and $VAR_DIR/layout because
 scripts for $ROOTFS_DIR belong to the 'rescue' stage and scripts
 for $VAR_DIR/recovery and $VAR_DIR/layout belong to the 'layout' stages.
 
-We have only the real preparation tasks in the 'prep' stage
+The prep stage is used for preparing and configuring ReaR for the later stages, e.g. auto-detect features or settings.
+
+Therefore code in prep should not modify ROOTFS_DIR (the rescue system) but only manipulate ReaR variables.
 so that the 'prep' stage can also be run by workflows which
 do not make a rescue/recovery system.
 

--- a/usr/share/rear/prep/default/990_verify_empty_rootfs.sh
+++ b/usr/share/rear/prep/default/990_verify_empty_rootfs.sh
@@ -1,0 +1,31 @@
+
+# Verify that at the end of the 'prep' stage
+# the ReaR recovery system area (i.e. ROOTFS_DIR)
+# is still empty, see prep/README
+#
+# Only those workflows that actually make a ReaR recovery system via
+#   SourceStage "rescue"
+#   SourceStage "build"
+#   SourceStage "pack"
+#   SourceStage "output"
+# (currently those workflows are mkrescue, mkbackup and mkopalpba)
+# should modify something in ROOTFS_DIR.
+#
+# In contrast when other workflows that run the 'prep' stage (e.g. mkbackuponly)
+# modify something in ROOTFS_DIR then all those modifications will be lost
+# because no ReaR recovery system with those modifications is made.
+# So the problem is possible inconsistencies between what gets actually used
+# during "rear recover" (i.e. the last actually made ReaR recovery system)
+# versus what other workflows that run the 'prep' stage may need to have.
+# For example mkbackuponly may need a modified ReaR recovery system
+# when backup config variables need updated values in the recovery system
+# e.g. an updated value for BACKUP_PROG_EXCLUDE or something similar.
+
+# For now do not error out because currently
+# some 'prep' scripts modify things in ROOTFS_DIR,
+# see https://github.com/rear/rear/issues/2951
+
+test "$( ls -A $ROOTFS_DIR )" || return 0
+LogPrintError "Modified ReaR recovery system area after 'prep' stage ($ROOTFS_DIR not empty)"
+DebugPrint "$( find $ROOTFS_DIR )"
+return 1

--- a/usr/share/rear/prep/default/990_verify_empty_rootfs.sh
+++ b/usr/share/rear/prep/default/990_verify_empty_rootfs.sh
@@ -1,14 +1,11 @@
 
-# Verify that at the end of the 'prep' stage
-# the ReaR recovery system area (i.e. ROOTFS_DIR)
+# Verify at the end of the 'prep' stage
+# that the ReaR recovery system area (i.e. ROOTFS_DIR)
 # is still empty, see prep/README
 #
-# Only those workflows that actually make a ReaR recovery system via
-#   SourceStage "rescue"
-#   SourceStage "build"
-#   SourceStage "pack"
-#   SourceStage "output"
-# (currently those workflows are mkrescue, mkbackup and mkopalpba)
+# Only those workflows that actually make a ReaR recovery system
+# by running the stages 'rescue', 'build', 'pack', and 'output'
+# (in particular the workflows mkrescue, mkbackup and mkopalpba)
 # should modify something in ROOTFS_DIR.
 #
 # In contrast when other workflows that run the 'prep' stage (e.g. mkbackuponly)

--- a/usr/share/rear/prep/default/990_verify_empty_rootfs.sh
+++ b/usr/share/rear/prep/default/990_verify_empty_rootfs.sh
@@ -26,6 +26,6 @@
 # see https://github.com/rear/rear/issues/2951
 
 test "$( ls -A $ROOTFS_DIR )" || return 0
-LogPrintError "Modified ReaR recovery system area after 'prep' stage ($ROOTFS_DIR not empty)"
-DebugPrint "$( find $ROOTFS_DIR )"
+DebugPrint "Modified ReaR recovery system area after 'prep' stage ($ROOTFS_DIR not empty)"
+Debug "$( find $ROOTFS_DIR )"
 return 1


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2951

* How was this pull request tested?
Only a quick test by me:
https://github.com/rear/rear/pull/2953#issuecomment-1456253142

* Brief description of the changes in this pull request:

New prep/default/990_verify_empty_rootfs.sh
to verify that at the end of the 'prep' stage
the ReaR recovery system area (i.e. ROOTFS_DIR) is still empty.
