### PR TITLE
Better user messages for finalize/default/060_compare_files.sh

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -342,7 +342,7 @@ CDROM_SIZE=20
 # (cf. https://github.com/rear/rear/issues/1134) but the checklayout workflow
 # does not automatically recreate the rescue/recovery system.
 # Files matching FILES_TO_PATCH_PATTERNS are added to this list automatically.
-CHECK_CONFIG_FILES=( '/etc/drbd/' '/etc/drbd.conf' '/etc/lvm/lvm.conf' '/etc/multipath.conf' '/etc/rear/' '/etc/udev/udev.conf' )
+CHECK_CONFIG_FILES=( '/etc/drbd/' '/etc/drbd.conf' '/etc/lvm/lvm.conf' '/etc/multipath.conf' '/etc/udev/udev.conf' "$CONFIG_DIR" )
 #
 # FILES_TO_PATCH_PATTERNS is a space-separated list of shell glob patterns.
 # Files that match are eligible for a final migration of UUIDs and other

--- a/usr/share/rear/finalize/default/060_compare_files.sh
+++ b/usr/share/rear/finalize/default/060_compare_files.sh
@@ -23,15 +23,17 @@ local md5sum_stdout
 if ! md5sum_stdout="$( chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum )" ; then
     LogPrintError "Restored files in $TARGET_FS_ROOT do not fully match the recreated system"
     LogPrintError "(files in the backup are not same as when the ReaR rescue/recovery system was made)"
-    # Add two spaces indentation for better readability what the 'md5sum' stdout lines are.
     # This 'sed' call must not be done in the above command substitution as a pipe
     # because then the command substitution exit status would be the one of 'sed'.
-    # Also prefix the reported files in the 'md5sum' stdout lines with '/mnt/local'
-    # (so an implicit condition is that only files '/path/...' appear as 'md5sum' stdout lines)
+    # Prefix the reported files in the 'md5sum' stdout lines with '/mnt/local'
     # because this is the right path for the user in the currently running ReaR recovery system
     # for the restored files that do not match the md5sums that were saved at "rear mkrescue" time,
-    # cf. https://github.com/rear/rear/pull/2954#issuecomment-1467645338 and subsequent comments:
-    LogPrintError "$( sed -e "s|^|  $TARGET_FS_ROOT|" <<< "$md5sum_stdout" )"
+    # cf. https://github.com/rear/rear/pull/2954#issuecomment-1467645338 and subsequent comments.
+    # The 'md5sum' stdout lines that report files start with '/' because
+    # var/lib/rear/layout/config/files.md5sum contains file names with full path.
+    # Prefix all 'md5sum' stdout lines with two spaces indentation
+    # for better readability what the 'md5sum' stdout lines are:
+    LogPrintError "$( sed -e "s|^/|$TARGET_FS_ROOT/|" -e 's/^/  /' <<< "$md5sum_stdout" )"
     LogPrintError "Manually check if those changed files cause issues in your recreated system"
     return 1
 fi

--- a/usr/share/rear/finalize/default/060_compare_files.sh
+++ b/usr/share/rear/finalize/default/060_compare_files.sh
@@ -6,7 +6,7 @@ local md5sum_output
 # The exit status of the assignment is the exit status of the command substitution
 # which is usually the exit status of 'md5sum' that is forwared by 'chroot'
 # except 'chroot' fails (e.g. with 127 if 'md5sum' cannot be found):
-if ! md5sum_output="$( chroot $TARGET_FS_ROOT md5sum -c --quiet 2>&1 )" ; then
+if ! md5sum_output="$( chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum 2>&1 )" ; then
     LogPrintError "Error: Restored files do not match the recreated system in $TARGET_FS_ROOT"
     # Add two spaces indentation for better readability what the md5sum output lines are.
     # This 'sed' call must not be done in the above command substitution as a pipe

--- a/usr/share/rear/finalize/default/060_compare_files.sh
+++ b/usr/share/rear/finalize/default/060_compare_files.sh
@@ -23,10 +23,11 @@ local md5sum_stdout
 if ! md5sum_stdout="$( chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum )" ; then
     LogPrintError "Restored files do not fully match the recreated system in $TARGET_FS_ROOT"
     LogPrintError "(files in the backup are not same as when the ReaR rescue/recovery system was made)"
-    # Add two spaces indentation for better readability what the 'md5sum' output lines are.
+    # Add two spaces indentation for better readability what the 'md5sum' stdout lines are.
     # This 'sed' call must not be done in the above command substitution as a pipe
     # because then the command substitution exit status would be the one of 'sed'.
-    # Also prefix the reported files in the 'md5sum' output lines with '/mnt/local'
+    # Also prefix the reported files in the 'md5sum' stdout lines with '/mnt/local'
+    # (so an implicit condition is that only files '/path/...' appear as 'md5sum' stdout lines)
     # because this is the right path for the user in the currently running ReaR recovery system
     # for the restored files that do not match the md5sums that were saved at "rear mkrescue" time,
     # cf. https://github.com/rear/rear/pull/2954#issuecomment-1467645338 and subsequent comments:

--- a/usr/share/rear/finalize/default/060_compare_files.sh
+++ b/usr/share/rear/finalize/default/060_compare_files.sh
@@ -11,6 +11,6 @@ if ! md5sum_output="$( chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layou
     # Add two spaces indentation for better readability what the md5sum output lines are.
     # This 'sed' call must not be done in the above command substitution as a pipe
     # because then the command substitution exit status would be the one of 'sed'.
-    LogPrintError "$( sed -e 's/^/  /' <<< "$md5sum_out" )"
+    LogPrintError "$( sed -e 's/^/  /' <<< "$md5sum_output" )"
     return 1
 fi

--- a/usr/share/rear/finalize/default/060_compare_files.sh
+++ b/usr/share/rear/finalize/default/060_compare_files.sh
@@ -5,10 +5,13 @@ test -s $VAR_DIR/layout/config/files.md5sum || return 0
 local md5sum_output
 # The exit status of the assignment is the exit status of the command substitution
 # which is usually the exit status of 'md5sum' that is forwared by 'chroot'
-# except 'chroot' fails (e.g. with 127 if 'md5sum' cannot be found):
+# except 'chroot' fails (e.g. with 127 if 'md5sum' cannot be found).
+# Because the redirections are done before chroot is run
+# (in chroot plain 'md5sum -c --quiet' is run with redirected stdin and stderr)
+# the 'md5sum' stdin comes from VAR_DIR/layout/config/files.md5sum in the recovery system:
 if ! md5sum_output="$( chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum 2>&1 )" ; then
     LogPrintError "Error: Restored files do not match the recreated system in $TARGET_FS_ROOT"
-    # Add two spaces indentation for better readability what the md5sum output lines are.
+    # Add two spaces indentation for better readability what the 'md5sum' output lines are.
     # This 'sed' call must not be done in the above command substitution as a pipe
     # because then the command substitution exit status would be the one of 'sed'.
     LogPrintError "$( sed -e 's/^/  /' <<< "$md5sum_output" )"

--- a/usr/share/rear/finalize/default/060_compare_files.sh
+++ b/usr/share/rear/finalize/default/060_compare_files.sh
@@ -1,6 +1,9 @@
-if [ -e $VAR_DIR/layout/config/files.md5sum ] ; then
-    if ! chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 ) 2>> >( tee -a "$RUNTIME_LOGFILE" 1>&8 ) ; then
-        LogPrintError "Error: Restored files do not match the recreated system in $TARGET_FS_ROOT"
-        return 1
-    fi
+
+# Skip when there are no checksums:
+test -s $VAR_DIR/layout/config/files.md5sum || return 0
+
+LogPrint "Checking if restored files may not match the recreated system"
+if ! chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 ) 2>> >( tee -a "$RUNTIME_LOGFILE" 1>&8 ) ; then
+    LogPrintError "Error: Restored files do not match the recreated system in $TARGET_FS_ROOT"
+    return 1
 fi

--- a/usr/share/rear/finalize/default/060_compare_files.sh
+++ b/usr/share/rear/finalize/default/060_compare_files.sh
@@ -2,8 +2,15 @@
 # Skip when there are no checksums:
 test -s $VAR_DIR/layout/config/files.md5sum || return 0
 
-LogPrint "Checking if restored files may not match the recreated system"
-if ! chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum 1>> >( tee -a "$RUNTIME_LOGFILE" 1>&7 ) 2>> >( tee -a "$RUNTIME_LOGFILE" 1>&8 ) ; then
+local md5sum_output
+# The exit status of the assignment is the exit status of the command substitution
+# which is usually the exit status of 'md5sum' that is forwared by 'chroot'
+# except 'chroot' fails (e.g. with 127 if 'md5sum' cannot be found):
+if ! md5sum_output="$( chroot $TARGET_FS_ROOT md5sum -c --quiet 2>&1 )" ; then
     LogPrintError "Error: Restored files do not match the recreated system in $TARGET_FS_ROOT"
+    # Add two spaces indentation for better readability what the md5sum output lines are.
+    # This 'sed' call must not be done in the above command substitution as a pipe
+    # because then the command substitution exit status would be the one of 'sed'.
+    LogPrintError "$( sed -e 's/^/  /' <<< "$md5sum_out" )"
     return 1
 fi

--- a/usr/share/rear/finalize/default/060_compare_files.sh
+++ b/usr/share/rear/finalize/default/060_compare_files.sh
@@ -2,18 +2,31 @@
 # Skip when there are no checksums:
 test -s $VAR_DIR/layout/config/files.md5sum || return 0
 
-local md5sum_output
+LogPrint "Checking if certain restored files are consistent with the recreated system"
+DebugPrint "See $VAR_DIR/layout/config/files.md5sum what files are checked"
+local md5sum_stdout
 # The exit status of the assignment is the exit status of the command substitution
 # which is usually the exit status of 'md5sum' that is forwared by 'chroot'
 # except 'chroot' fails (e.g. with 127 if 'md5sum' cannot be found).
 # Because the redirections are done before chroot is run
-# (in chroot plain 'md5sum -c --quiet' is run with redirected stdin and stderr)
-# the 'md5sum' stdin comes from VAR_DIR/layout/config/files.md5sum in the recovery system:
-if ! md5sum_output="$( chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum 2>&1 )" ; then
-    LogPrintError "Error: Restored files do not match the recreated system in $TARGET_FS_ROOT"
+# (in chroot plain 'md5sum -c --quiet' is run with redirected stdin)
+# the 'md5sum' stdin comes from VAR_DIR/layout/config/files.md5sum in the recovery system.
+# The 'md5sum' stdout messages like
+#   testy/bar: FAILED
+#   testy/blub: FAILED open or read
+# provide sufficient information so we do not output 'md5sum' stderr messages like
+#   md5sum: testy/blub: No such file or directory
+#   md5sum: WARNING: 1 line is improperly formatted
+#   md5sum: WARNING: 1 listed file could not be read
+#   md5sum: WARNING: 1 computed checksum did NOT match
+# on the user's terminal but have them only in the log file as usual for stderr:
+if ! md5sum_stdout="$( chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum )" ; then
+    LogPrintError "Restored files do not fully match the recreated system in $TARGET_FS_ROOT"
+    LogPrintError "(files in the backup are not same as when the ReaR rescue/recovery system was made)"
     # Add two spaces indentation for better readability what the 'md5sum' output lines are.
     # This 'sed' call must not be done in the above command substitution as a pipe
     # because then the command substitution exit status would be the one of 'sed'.
-    LogPrintError "$( sed -e 's/^/  /' <<< "$md5sum_output" )"
+    LogPrintError "$( sed -e 's/^/  /' <<< "$md5sum_stdout" )"
+    LogPrintError "Manually check if those changed files cause issues in your recreated system"
     return 1
 fi

--- a/usr/share/rear/finalize/default/060_compare_files.sh
+++ b/usr/share/rear/finalize/default/060_compare_files.sh
@@ -21,7 +21,7 @@ local md5sum_stdout
 #   md5sum: WARNING: 1 computed checksum did NOT match
 # on the user's terminal but have them only in the log file as usual via stderr:
 if ! md5sum_stdout="$( chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum )" ; then
-    LogPrintError "Restored files do not fully match the recreated system in $TARGET_FS_ROOT"
+    LogPrintError "Restored files in $TARGET_FS_ROOT do not fully match the recreated system"
     LogPrintError "(files in the backup are not same as when the ReaR rescue/recovery system was made)"
     # Add two spaces indentation for better readability what the 'md5sum' stdout lines are.
     # This 'sed' call must not be done in the above command substitution as a pipe

--- a/usr/share/rear/finalize/default/060_compare_files.sh
+++ b/usr/share/rear/finalize/default/060_compare_files.sh
@@ -12,21 +12,25 @@ local md5sum_stdout
 # (in chroot plain 'md5sum -c --quiet' is run with redirected stdin)
 # the 'md5sum' stdin comes from VAR_DIR/layout/config/files.md5sum in the recovery system.
 # The 'md5sum' stdout messages like
-#   testy/bar: FAILED
-#   testy/blub: FAILED open or read
+#   /path/to/this: FAILED
+#   /path/to/that: FAILED open or read
 # provide sufficient information so we do not output 'md5sum' stderr messages like
-#   md5sum: testy/blub: No such file or directory
+#   md5sum: /path/to/that: No such file or directory
 #   md5sum: WARNING: 1 line is improperly formatted
 #   md5sum: WARNING: 1 listed file could not be read
 #   md5sum: WARNING: 1 computed checksum did NOT match
-# on the user's terminal but have them only in the log file as usual for stderr:
+# on the user's terminal but have them only in the log file as usual via stderr:
 if ! md5sum_stdout="$( chroot $TARGET_FS_ROOT md5sum -c --quiet < $VAR_DIR/layout/config/files.md5sum )" ; then
     LogPrintError "Restored files do not fully match the recreated system in $TARGET_FS_ROOT"
     LogPrintError "(files in the backup are not same as when the ReaR rescue/recovery system was made)"
     # Add two spaces indentation for better readability what the 'md5sum' output lines are.
     # This 'sed' call must not be done in the above command substitution as a pipe
     # because then the command substitution exit status would be the one of 'sed'.
-    LogPrintError "$( sed -e 's/^/  /' <<< "$md5sum_stdout" )"
+    # Also prefix the reported files in the 'md5sum' output lines with '/mnt/local'
+    # because this is the right path for the user in the currently running ReaR recovery system
+    # for the restored files that do not match the md5sums that were saved at "rear mkrescue" time,
+    # cf. https://github.com/rear/rear/pull/2954#issuecomment-1467645338 and subsequent comments:
+    LogPrintError "$( sed -e "s|^|  $TARGET_FS_ROOT|" <<< "$md5sum_stdout" )"
     LogPrintError "Manually check if those changed files cause issues in your recreated system"
     return 1
 fi


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2952#issuecomment-1458094671

* How was this pull request tested?
see https://github.com/rear/rear/pull/2954#issuecomment-1463864769

* Brief description of the changes in this pull request:

In finalize/default/060_compare_files.sh show what will be done so the user understands what possibly subsequent error messages mean
