### PR TITLE
superseded: non-interactive mode for ReaR

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -209,17 +209,18 @@ Relax-and-Recover comes with ABSOLUTELY NO WARRANTY; for details see
 the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 Available options:
- -h --help           usage information
- -c DIR              alternative config directory; instead of /etc/rear
- -C CONFIG           additional config file; absolute path or relative to config directory
- -d                  debug mode; log debug messages
- -D                  debugscript mode; log every function call (via 'set -x')
- --debugscripts SET  same as -d -v -D but debugscript mode with 'set -SET'
- -r KERNEL           kernel version to use; current: '3.12.49-3-default'
- -s                  simulation mode; show what scripts rear would include
- -S                  step-by-step mode; acknowledge each script individually
- -v                  verbose mode; show more output
- -V --version        version information
+ -h --help              usage information
+ -c DIR                 alternative config directory; instead of /etc/rear
+ -C CONFIG              additional config file; absolute path or relative to config directory
+ -d                     debug mode; log debug messages
+ -D                     debugscript mode; log every function call (via 'set -x')
+ --debugscripts SET     same as -d -v -D but debugscript mode with 'set -SET'
+ -r KERNEL              kernel version to use; current: '3.12.49-3-default'
+ -s                     simulation mode; show what scripts rear would include
+ -S                     step-by-step mode; acknowledge each script individually
+ -v                     verbose mode; show more output
+ -V --version           version information
+ -n --non-interactive   non-interactive mode; aborts when any user input is required
 
 List of commands:
  checklayout     check if the disk layout has changed

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -12,7 +12,7 @@ rear - bare metal disaster recovery and system migration tool
 
 
 == SYNOPSIS
-*rear* [*-h*|*--help*] [*-V*|*--version*] [*-dsSv*] [*-D*|*--debugscripts* _SET_] [*-c* _DIR_] [*-C* _CONFIG_] [*-r* _KERNEL_] [--] _COMMAND_ [_ARGS_...]
+*rear* [*-h*|*--help*] [*-V*|*--version*] [*-dsSv*] [*-D*|*--debugscripts* _SET_] [*-c* _DIR_] [*-C* _CONFIG_] [*-r* _KERNEL_] [*-n*|*--non-interactive*] [--] _COMMAND_ [_ARGS_...]
 
 
 == DESCRIPTION
@@ -82,6 +82,9 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 -v::
     *verbose mode* (show messages what ReaR is doing on the terminal)
+
+-n --non-interactive::
+    *non-interactive mode* (aborts when any user input is required, experimental)
 
 -V --version::
     version information

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -130,6 +130,7 @@ DEBUG=""
 DEBUGSCRIPTS=""
 DEBUGSCRIPTS_ARGUMENT="x"
 DEBUG_OUTPUT_DEV="null"
+NON_INTERACTIVE=""
 DISPENSABLE_OUTPUT_DEV="null"
 KEEP_BUILD_DIR=""
 KERNEL_VERSION=""
@@ -141,7 +142,7 @@ WORKFLOW=""
 
 # Parse options
 help_note_text="Use '$PROGRAM --help' or 'man $PROGRAM' for more information."
-if ! OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVr:" -l "help,version,debugscripts:" -- "$@" )" ; then
+if ! OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVrn:" -l "help,version,non-interactive,debugscripts:" -- "$@" )" ; then
     echo "$help_note_text"
     exit 1
 fi
@@ -158,6 +159,9 @@ while true ; do
             ;;
         (-v)
             VERBOSE=1
+            ;;
+        (-n|--non-interactive)
+            NON_INTERACTIVE=1
             ;;
         (-c)
             if [[ "$2" == -* ]] ; then

--- a/usr/share/rear/lib/help-workflow.sh
+++ b/usr/share/rear/lib/help-workflow.sh
@@ -17,23 +17,24 @@ fi
 
 # Output the help text to the original STDOUT but keep STDERR in the log file:
 cat 1>&7 <<EOF
-Usage: $PROGRAM [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-C CONFIG] [-r KERNEL] [--] COMMAND [ARGS...]
+Usage: $PROGRAM [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-C CONFIG] [-r KERNEL] [-n|--non-interactive] [--] COMMAND [ARGS...]
 
 $PRODUCT comes with ABSOLUTELY NO WARRANTY; for details see
 the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 Available options:
- -h --help           usage information (this text)
- -c DIR              alternative config directory; instead of $CONFIG_DIR
- -C CONFIG           additional config files; absolute path or relative to config directory
- -d                  debug mode; run many commands verbosely with debug messages in log file (also sets -v)
- -D                  debugscript mode; log executed commands via 'set -x' (also sets -v and -d)
- --debugscripts SET  same as -d -v -D but debugscript mode with 'set -SET'
- -r KERNEL           kernel version to use; currently '$KERNEL_VERSION'
- -s                  simulation mode; show what scripts are run (without executing them)
- -S                  step-by-step mode; acknowledge each script individually
- -v                  verbose mode; show messages what $PRODUCT is doing on the terminal or show verbose help
- -V --version        version information
+ -h --help              usage information (this text)
+ -c DIR                 alternative config directory; instead of $CONFIG_DIR
+ -C CONFIG              additional config files; absolute path or relative to config directory
+ -d                     debug mode; run many commands verbosely with debug messages in log file (also sets -v)
+ -D                     debugscript mode; log executed commands via 'set -x' (also sets -v and -d)
+ --debugscripts SET     same as -d -v -D but debugscript mode with 'set -SET'
+ -r KERNEL              kernel version to use; currently '$KERNEL_VERSION'
+ -s                     simulation mode; show what scripts are run (without executing them)
+ -S                     step-by-step mode; acknowledge each script individually
+ -v                     verbose mode; show messages what $PRODUCT is doing on the terminal or show verbose help
+ -V --version           version information
+ -n --non-interactive   non-interactive mode; aborts when any user input is required (experimental)
 
 List of commands:
 EOF

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -151,7 +151,6 @@ if automatic_recovery ; then
               "Go to Relax-and-Recover shell"
             )
     echo -e "\nLaunching 'rear recover' automatically\n"
-    # The recover workflow is always verbose (see usr/sbin/rear):
     if rear $rear_debug_options recover ; then
         echo -e "\n'rear recover' finished successfully\n"
         choices+=( "Reboot" )
@@ -188,8 +187,7 @@ if unattended_recovery ; then
               "Go to Relax-and-Recover shell"
             )
     echo -e "\nLaunching 'rear recover' automatically in unattended mode\n"
-    # The recover workflow is always verbose (see usr/sbin/rear):
-    if rear $rear_debug_options recover ; then
+    if rear $rear_debug_options --non-interactive recover ; then
         echo -e "\n'rear recover' finished successfully\n"
         echo -e "\nRebooting in 30 seconds (Ctrl-C to interrupt)\n"
         sleep 30

--- a/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
+++ b/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
@@ -20,6 +20,9 @@ elif test $qlist_ret -eq 2; then
             Error "CommVault 'qlogin -u $GALAXY11_USER -clp GALAXY11_PASSWORD' failed with exit code $? (retry on command line to see error messages)"
 		fi
 	else
+        is_true "$NON_INTERACTIVE" && \
+            Error "Login is not possible in non-interactive mode. Set variables GALAXY11_USER and GALAXY11_PASSWORD."
+        
 		# try to logon manually
 		Print "Please logon to your Commvault CommServe with suitable credentials:"
 		qlogin $(test "$GALAXY11_Q_ARGUMENTFILE" && echo "-af $GALAXY11_Q_ARGUMENTFILE") 0<&6 1>&7 2>&8 || \


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type:  **Enhancement**

* Impact: **Normal**

* How was this pull request tested?
manually on Ubu2204 and OL8

* Brief description of the changes in this pull request:

This PR adds a non-interactive mode in ReaR.
This mode is intended when ReaR is started with an external automation tool like Ansible and there is no possibility to do an user input.
If a user input is needed, ReaR should abort with an error and not get stuck in user input loop.
The `UserInput` function has been modified so that it returns the dafault value in non-interactive mode otherwise an error is thrown.
In the scripts the mode can be checked and handled with the variable `NON_INTERACTIVE`.
For example, see `usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh`:
```
is_true "$NON_INTERACTIVE" && \
            Error "Login is not possible in non-interactive mode. Set variables GALAXY11_USER and GALAXY11_PASSWORD."
```

The non-interactive mode mode can be activated with the command line option `-n` or `--non-interactive`.
