### PR TITLE
SYSLINUX timeout configurable 

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1028,6 +1028,10 @@ ISO_DEFAULT="boothd"
 # (e.g. when the device with the ISO is the first one in the BIOS boot order list).
 # The default ISO_RECOVER_MODE="" results the normal behaviour:
 ISO_RECOVER_MODE=""
+#
+# SYSLINUX timeout in 0.1 seconds units (e.g. 100 = 10 seconds) to automatically boot 
+# set this value to 0 to disable
+ISO_SYSLINUX_TIMEOUT="$(( $USER_INPUT_TIMEOUT * 10 ))"
 ####
 
 ####

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -283,7 +283,7 @@ function make_syslinux_config {
         syslinux_menu "TABMSG Press [Tab] to edit options and [F1] for version info"
     fi
 
-    echo "timeout 300"
+    echo "timeout $ISO_SYSLINUX_TIMEOUT"
     echo "#noescape 1"
     syslinux_menu title $PRODUCT v$VERSION
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type:  **Enhancement**

* Impact: **Low**

* How was this pull request tested?
manually on Ubu2204
* Brief description of the changes in this pull request:
This PR makes the SYSLINUX timeout at OUTPUT=ISO configurable.

This setting can save time during tests. Especially if you are too lazy to start the graphical VNC console of a VM. :smiley:

