### PR TITLE
Increase USER_INPUT_INTERRUPT_TIMEOUT default from 10 to 30 seconds

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -267,7 +267,7 @@ PROGRESS_WAIT_SECONDS="1"
 # his particular input when the default is not the right one.
 # USER_INPUT_TIMEOUT is set to a default value here only
 # if not already set so that the user can set it also like
-#   export USER_INPUT_TIMEOUT=30
+#   export USER_INPUT_TIMEOUT=120
 # directly before he calls "rear ...":
 test "$USER_INPUT_TIMEOUT" || USER_INPUT_TIMEOUT=300
 #
@@ -276,13 +276,16 @@ test "$USER_INPUT_TIMEOUT" || USER_INPUT_TIMEOUT=300
 # when a predefined input value is specified for a particular UserInput() call
 # via a matching USER_INPUT_user_input_ID variable (see below).
 # The minimum waiting time to interrupt an automated input is one second.
-# The default is 10 seconds to give the user a better chance to recognize
-# an automated input and be able to actually hit a key to interrupt.
+# The default interrupt timeout must be sufficiently long for the user
+# to read and understand the possibly unexpected UserInput() message
+# and then some more time to make a decision whether or not
+# the automated action is actually the right one and
+# if not a bit more time to hit a key to interrupt.
 # USER_INPUT_INTERRUPT_TIMEOUT is set to a default value here only
 # if not already set so that the user can set it also like
-#   export USER_INPUT_INTERRUPT_TIMEOUT=5
+#   export USER_INPUT_INTERRUPT_TIMEOUT=10
 # directly before he calls "rear ...":
-test "$USER_INPUT_INTERRUPT_TIMEOUT" || USER_INPUT_INTERRUPT_TIMEOUT=10
+test "$USER_INPUT_INTERRUPT_TIMEOUT" || USER_INPUT_INTERRUPT_TIMEOUT=30
 #
 # USER_INPUT_PROMPT specifies the default prompt text that is shown
 # if no prompt was specified for a particular UserInput() call.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -4,9 +4,19 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 #
-# Here we define and describe all configuration variables and set them to a default.
+# Here we describe all configuration variables and set them to a default.
+# Do not change anything here.
+# Set in etc/rear/local.conf or etc/rear/site.conf only those variables
+# where you need a different value than the default which is set here
+# (in particular configuration variables for OUTPUT and BACKUP).
 #
-# Do not change them here. Set them in your site.conf or local.conf file as needed.
+# Some variables are set to a default value here via
+#   VAR="${VAR:-default value}"
+# so VAR gets the default value assigned only if VAR is unset or null
+# which means you can set VAR to a non-empty value via
+#   export VAR="value"
+# directly before you call "rear ..."
+# provided you do not overwrite that in your local.conf or site.conf file.
 #
 # Many variables are bash arrays that should be set carefully.
 # Use VAR=() to set an empty array.
@@ -265,11 +275,7 @@ PROGRESS_WAIT_SECONDS="1"
 # the default action ("just proceed") is actually the right one
 # in his particular case and finally even more time to enter
 # his particular input when the default is not the right one.
-# USER_INPUT_TIMEOUT is set to a default value here only
-# if not already set so that the user can set it also like
-#   export USER_INPUT_TIMEOUT=120
-# directly before he calls "rear ...":
-test "$USER_INPUT_TIMEOUT" || USER_INPUT_TIMEOUT=300
+USER_INPUT_TIMEOUT="${USER_INPUT_TIMEOUT:-300}"
 #
 # USER_INPUT_INTERRUPT_TIMEOUT specifies the default timeout in seconds
 # for how long UserInput() waits for the user to interrupt an automated input
@@ -281,30 +287,18 @@ test "$USER_INPUT_TIMEOUT" || USER_INPUT_TIMEOUT=300
 # and then some more time to make a decision whether or not
 # the automated action is actually the right one and
 # if not a bit more time to hit a key to interrupt.
-# USER_INPUT_INTERRUPT_TIMEOUT is set to a default value here only
-# if not already set so that the user can set it also like
-#   export USER_INPUT_INTERRUPT_TIMEOUT=10
-# directly before he calls "rear ...":
-test "$USER_INPUT_INTERRUPT_TIMEOUT" || USER_INPUT_INTERRUPT_TIMEOUT=30
+USER_INPUT_INTERRUPT_TIMEOUT="${USER_INPUT_INTERRUPT_TIMEOUT:-30}"
 #
 # USER_INPUT_PROMPT specifies the default prompt text that is shown
 # if no prompt was specified for a particular UserInput() call.
-# USER_INPUT_PROMPT is set to a default value here only
-# if not already set so that the user can set it also like
-#   export USER_INPUT_PROMPT="$HOSTNAME input"
-# directly before he calls "rear ...":
-test "$USER_INPUT_PROMPT" || USER_INPUT_PROMPT='enter your input'
+USER_INPUT_PROMPT="${USER_INPUT_PROMPT:-enter your input}"
 #
 # USER_INPUT_MAX_CHARS specifies the default maximum characters until
 # the UserInput function truncates further input and returns.
 # With the default USER_INPUT_MAX_CHARS=0 input is not truncated and it
 # also makes correcting the input possible (before [Enter] is pressed)
 # cf. https://github.com/rear/rear/issues/2622
-# USER_INPUT_MAX_CHARS is set to a default value here only
-# if not already set so that the user can set it also like
-#   export USER_INPUT_MAX_CHARS=200
-# directly before he calls "rear ...":
-test "$USER_INPUT_MAX_CHARS" || USER_INPUT_MAX_CHARS=0
+USER_INPUT_MAX_CHARS="${USER_INPUT_MAX_CHARS:-0}"
 #
 # USER_INPUT_user_input_ID variables can be used to predefine automated
 # input for UserInput() calls with the matching user_input_ID value.
@@ -400,11 +394,7 @@ FILES_TO_PATCH_PATTERNS="[b]oot/{grub.conf,menu.lst,device.map} [e]tc/grub.* \
 # curl should be added to the REQUIRED_PROGS array like
 #   REQUIRED_PROGS+=( curl )
 #
-# RECOVERY_UPDATE_URL is set to a default value here only
-# if not already set so that the user can set it also via
-#   export RECOVERY_UPDATE_URL="http://my_internal_server/host123_rear_config.tgz"
-# directly before he calls "rear recover":
-test "$RECOVERY_UPDATE_URL" || RECOVERY_UPDATE_URL=""
+RECOVERY_UPDATE_URL="${RECOVERY_UPDATE_URL:-}"
 ####
 
 ####
@@ -444,11 +434,7 @@ test "$RECOVERY_UPDATE_URL" || RECOVERY_UPDATE_URL=""
 # By setting MIGRATION_MODE='true' one can enfore MIGRATION_MODE.
 # The by-default empty MIGRATION_MODE results that MIGRATION_MODE
 # is set via the above described autodetection during "rear recover".
-# MIGRATION_MODE is set to a default value here only
-# if not already set so that the user can set it also via
-#   export MIGRATION_MODE='true'
-# directly before he calls "rear recover":
-test "$MIGRATION_MODE" || MIGRATION_MODE=''
+MIGRATION_MODE="${MIGRATION_MODE:-}"
 ####
 
 ####
@@ -486,7 +472,7 @@ test "$MIGRATION_MODE" || MIGRATION_MODE=''
 # With DISKS_TO_BE_WIPED="false" no disk will be wiped.
 # DISKS_TO_BE_WIPED has no influence what disks will get completely overwritten
 # by the actual disk layout recreation code (e.g. the diskrestore.sh script).
-DISKS_TO_BE_WIPED=""
+DISKS_TO_BE_WIPED="${DISKS_TO_BE_WIPED:-}"
 ####
 
 ####
@@ -669,11 +655,7 @@ WRITE_PROTECTED_FS_LABEL_PATTERNS=()
 #
 # The by-default empty MKFS_XFS_OPTIONS results that the mkfs.xfs options are set
 # via the above described default according to the stored 'xfs_info' output.
-# MKFS_XFS_OPTIONS is set to a default value here only
-# if not already set so that the user can set it also via
-#   export MKFS_XFS_OPTIONS="..."
-# directly before he calls "rear recover":
-test "$MKFS_XFS_OPTIONS" || MKFS_XFS_OPTIONS=''
+MKFS_XFS_OPTIONS="${MKFS_XFS_OPTIONS:-}"
 ####
 
 ####
@@ -1459,11 +1441,7 @@ BACKUP_PROG_DECRYPT_OPTIONS="/usr/bin/openssl des3 -d -k "
 # But then one must specify the right existing BACKUP_PROG_ARCHIVE
 # for "rear recover" so that the backup can be found and restored
 # (i.e. during "rear recover" a dynamic name does not make sense).
-# BACKUP_PROG_ARCHIVE is set to a default value here only
-# if not already set so that the user can set it also like
-#   export BACKUP_PROG_ARCHIVE="mybackup"
-# directly before he calls "rear ...":
-test "$BACKUP_PROG_ARCHIVE" || BACKUP_PROG_ARCHIVE="backup"
+BACKUP_PROG_ARCHIVE="${BACKUP_PROG_ARCHIVE:-backup}"
 # BACKUP_PROG_EXCLUDE is an array of strings that get written into a backup-exclude.txt file
 # that is used e.g. in 'tar -X backup-exclude.txt' to get things excluded from the backup.
 # Quoting of the BACKUP_PROG_EXCLUDE array members avoids bash pathname expansion
@@ -3530,11 +3508,7 @@ BOOTLOADER=""
 # When GRUB2_INSTALL_DEVICES is not specified, ReaR tries to automatically determine
 # where to install GRUB2 but then the bootloader installation could get wrong.
 # For details see the finalize/Linux-i386/660_install_grub2.sh script.
-# GRUB2_INSTALL_DEVICES is set to a default value here only
-# if not already set so that the user can set it also via
-#   export GRUB2_INSTALL_DEVICES="/dev/sdb"
-# to the right device directly before he calls "rear recover":
-test "$GRUB2_INSTALL_DEVICES" || GRUB2_INSTALL_DEVICES=""
+GRUB2_INSTALL_DEVICES="${GRUB2_INSTALL_DEVICES:-}"
 
 ####
 # GRUB2_MODULES_UEFI_LOAD
@@ -3805,11 +3779,7 @@ POST_BACKUP_SCRIPT=
 # because also this timeout here interrupts a possibly ongoing user input
 # (in particular when the bash builtin 'read -t timeout' is used)
 # see the above explanation where USER_INPUT_TIMEOUT is set.
-# WAIT_SECS is set to a default value here only
-# if not already set so that the user can set it also like
-#   export WAIT_SECS=30
-# directly before he calls "rear ...":
-test "$WAIT_SECS" || WAIT_SECS="$USER_INPUT_TIMEOUT"
+WAIT_SECS="${WAIT_SECS:-$USER_INPUT_TIMEOUT}"
 
 # To force adding multipath related executables
 # so a recovered system would be able to boot via SAN disks only


### PR DESCRIPTION

* Type: **Enhancement**

* Impact: **Normal**

* How was this pull request tested?

In current GitHub master code since DISKS_TO_BE_WIPED="" cf.
https://github.com/rear/rear/pull/2859
there is in layout/recreate/default/120_confirm_wipedisk_disks.sh
a UserInput() dialog like
```
Disks to be wiped: /dev/sda /dev/sdb /dev/sdd
...
Confirm disks to be wiped and continue 'rear recover'
```
which has usually (i.e. when not in MIGRATION_MODE)
a timeout of USER_INPUT_INTERRUPT_TIMEOUT.

During my tests with current GitHub master code
I learned that 10 seconds is far too little time
to read and understand that UserInput message and
then some more time to make a decision whether or not
the automated action is actually the right one.

I.e. 10 seconds was far too little time even for me
where I expected that UserInput dialog but even I
could not actually comprehend what disks will be wiped
and I could not at all make a decision whether or not
those are the right disks.

So the same applies to any UserInput dialog
(in prticular to any unexpected UserInput dialog)
where USER_INPUT_INTERRUPT_TIMEOUT is used
i.e. any UserInput() dialog with a predefined input.

In general a default timeout is useless when it is too short
to let the user understand what is going on and let him
make a decision so in practice such a too short timeout
behaves very user unfiendly.

* Brief description of the changes in this pull request:

In default.conf increased the default USER_INPUT_INTERRUPT_TIMEOUT
from 10 seconds to 30 seconds because 10 seconds is far too little time
to read and understand a possibly unexpected UserInput() message
and then some more time to make a decision whether or not
the automated action is actually the right one.