### PR TITLE
Do not leak the GALAXY11_PASSWORD value into the log file

### DIFF
--- a/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
+++ b/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
@@ -10,7 +10,7 @@ let qlist_ret=$?
 if test $qlist_ret -eq 0; then
 	Log "CommVault client logged in automatically"
 elif test $qlist_ret -eq 2; then
-	if { test "$GALAXY11_USER" && test "$GALAXY11_PASSWORD" ; } 2>/dev/null ; then
+	if test "$GALAXY11_USER" && { test "$GALAXY11_PASSWORD" ; } 2>/dev/null ; then
 		# try to login with Credentials from env
 		{ qlogin -u "${GALAXY11_USER}" -clp "${GALAXY11_PASSWORD}" ; } 2>/dev/null || \
 			Error "Could not logon to Commvault CommServe with credentials from GALAXY11_USER ($GALAXY11_USER) and GALAXY11_PASSWORD. Check the log file."

--- a/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
+++ b/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
@@ -10,9 +10,9 @@ let qlist_ret=$?
 if test $qlist_ret -eq 0; then
 	Log "CommVault client logged in automatically"
 elif test $qlist_ret -eq 2; then
-	if [ -n "$GALAXY11_USER" ] && [ -n "$GALAXY11_PASSWORD" ]; then
+	if { test "$GALAXY11_USER" && test "$GALAXY11_PASSWORD" ; } 2>/dev/null ; then
 		# try to login with Credentials from env
-		qlogin -u "${GALAXY11_USER}" -clp "${GALAXY11_PASSWORD}" || \
+		{ qlogin -u "${GALAXY11_USER}" -clp "${GALAXY11_PASSWORD}" ; } 2>/dev/null || \
 			Error "Could not logon to Commvault CommServe with credentials from GALAXY11_USER ($GALAXY11_USER) and GALAXY11_PASSWORD. Check the log file."
 		LogPrint "CommVault client logged in with credentials from GALAXY11_USER ($GALAXY11_USER) and GALAXY11_PASSWORD"
 	else

--- a/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
+++ b/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
@@ -12,9 +12,13 @@ if test $qlist_ret -eq 0; then
 elif test $qlist_ret -eq 2; then
 	if test "$GALAXY11_USER" && { test "$GALAXY11_PASSWORD" ; } 2>/dev/null ; then
 		# try to login with Credentials from env
-		{ qlogin -u "${GALAXY11_USER}" -clp "${GALAXY11_PASSWORD}" ; } 2>/dev/null || \
-			Error "Could not logon to Commvault CommServe with credentials from GALAXY11_USER ($GALAXY11_USER) and GALAXY11_PASSWORD. Check the log file."
-		LogPrint "CommVault client logged in with credentials from GALAXY11_USER ($GALAXY11_USER) and GALAXY11_PASSWORD"
+        # Using "if COMMAND ; then ... ; else echo COMMAND failed with $? ; fi" is mandatory
+        # because "if ! COMMAND ; then echo COMMAND failed with $? ..." shows wrong $? because '!' results $?=0
+		if { qlogin -u "${GALAXY11_USER}" -clp "${GALAXY11_PASSWORD}" ; } 2>/dev/null ; then
+            LogPrint "CommVault client logged in with credentials from GALAXY11_USER '$GALAXY11_USER' and GALAXY11_PASSWORD"
+        else
+            Error "CommVault 'qlogin -u $GALAXY11_USER -clp GALAXY11_PASSWORD' failed with exit code $? (retry on command line to see error messages)"
+		fi
 	else
 		# try to logon manually
 		Print "Please logon to your Commvault CommServe with suitable credentials:"


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Critical**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2156

* How was this pull request tested?
I cannot test it because I do not have the needed backup software

* Brief description of the changes in this pull request:

In
verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
run commands that deal with GALAXY11_PASSWORD
in a confidential way via
```
{ confidential_command ; } 2>/dev/null
```
to not leak the GALAXY11_PASSWORD value into the log file
