### PR TITLE
Do not leak the SSH_ROOT_PASSWORD value into the log file

### DIFF
--- a/usr/share/rear/build/default/500_ssh_setup.sh
+++ b/usr/share/rear/build/default/500_ssh_setup.sh
@@ -14,7 +14,7 @@ local sshd_config_file="$ROOTFS_DIR/etc/ssh/sshd_config"
 if [[ -f "$sshd_config_file" ]]; then
     # Enable root login with a password only if SSH_ROOT_PASSWORD is set
     local password_authentication_value=no
-    [[ -n "$SSH_ROOT_PASSWORD" ]] && password_authentication_value=yes
+    { test "$SSH_ROOT_PASSWORD" ; } 2>/dev/null && password_authentication_value=yes
 
     # List of setting overrides required for the rescue system's sshd - see sshd_config(5)
     # Each list element must be a string of the form 'keyword [value]' or a comment '#...'.

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -9,7 +9,7 @@ has_binary ssh || has_binary sshd || return 0
 # Do nothing when not any SSH file should be copied into the recovery system:
 if is_false "$SSH_FILES" ; then
     # Print an info if SSH_ROOT_PASSWORD is set but that cannot work when SSH_FILES is set to a 'false' value:
-    test "$SSH_ROOT_PASSWORD" && LogPrintError "SSH_ROOT_PASSWORD cannot work when SSH_FILES is set to a 'false' value"
+    { test "$SSH_ROOT_PASSWORD" ; } 2>/dev/null && LogPrintError "SSH_ROOT_PASSWORD cannot work when SSH_FILES is set to a 'false' value"
     return 0
 fi
 
@@ -85,15 +85,16 @@ fi
 echo "ssh:23:respawn:/etc/scripts/run-sshd" >>$ROOTFS_DIR/etc/inittab
 
 # Print an info if there is no authorized_keys file for root and no SSH_ROOT_PASSWORD set:
-if ! test -f "$ROOT_HOME_DIR/.ssh/authorized_keys" -o "$SSH_ROOT_PASSWORD" ; then
+{ if ! test -f "$ROOT_HOME_DIR/.ssh/authorized_keys" -o "$SSH_ROOT_PASSWORD" ; then
     LogPrintError "To log into the recovery system via ssh set up $ROOT_HOME_DIR/.ssh/authorized_keys or specify SSH_ROOT_PASSWORD"
-fi
+  fi
+} 2>/dev/null
 
 # Set the SSH root password; if pw is encrypted just copy it otherwise use openssl (for backward compatibility)
 # Encryption syntax is detected as a '$D$' or '$Dx$' prefix in the password, where D is a single digit and x is one lowercase character.
 # For more information on encryption IDs, check out the NOTES section of the man page for crypt(3).
 # The extglob shell option is required for this to work.
-if test "$SSH_ROOT_PASSWORD" ; then
+{ if test "$SSH_ROOT_PASSWORD" ; then
     case "$SSH_ROOT_PASSWORD" in
         (\$[0-9]?([a-z])\$*)
             echo "root:$SSH_ROOT_PASSWORD:::::::" > $ROOTFS_DIR/etc/shadow
@@ -102,5 +103,5 @@ if test "$SSH_ROOT_PASSWORD" ; then
             echo "root:$( echo $SSH_ROOT_PASSWORD | openssl passwd -1 -stdin ):::::::" > $ROOTFS_DIR/etc/shadow
             ;;
     esac
-fi
-
+  fi
+} 2>/dev/null

--- a/usr/share/rear/restore/YUM/default/970_set_root_password.sh
+++ b/usr/share/rear/restore/YUM/default/970_set_root_password.sh
@@ -20,11 +20,12 @@ set -e -u -o pipefail
 
 # As fallback use 'root' as root password in the target system.
 # A non-empty fallback is needed because 'passwd' does not accept empty input:
-local root_password="root"
-# If SSH_ROOT_PASSWORD is specified used that as root password in the target system:
-test "$SSH_ROOT_PASSWORD" && root_password="$SSH_ROOT_PASSWORD"
-# If YUM_ROOT_PASSWORD is specified used that as root password in the target system:
-test "$YUM_ROOT_PASSWORD" && root_password="$YUM_ROOT_PASSWORD"
+{ local root_password="root"
+  # If SSH_ROOT_PASSWORD is specified used that as root password in the target system:
+  test "$SSH_ROOT_PASSWORD" && root_password="$SSH_ROOT_PASSWORD"
+  # If YUM_ROOT_PASSWORD is specified used that as root password in the target system:
+  test "$YUM_ROOT_PASSWORD" && root_password="$YUM_ROOT_PASSWORD"
+} 2>/dev/null
 
 # Set the root password in the target system.
 # Use a login shell in between so that one has in the chrooted environment
@@ -32,7 +33,7 @@ test "$YUM_ROOT_PASSWORD" && root_password="$YUM_ROOT_PASSWORD"
 # the commands inside 'chroot' as one would type them in a normal working shell.
 # In particular one can call programs (like 'passwd') by their basename without path
 # cf. https://github.com/rear/rear/issues/862#issuecomment-274068914
-chroot $TARGET_FS_ROOT /bin/bash --login -c "echo -e '$root_password\n$root_password' | passwd root"
+{ chroot $TARGET_FS_ROOT /bin/bash --login -c "echo -e '$root_password\n$root_password' | passwd root" ; } 2>/dev/null
 
 # Restore the ReaR default bash flags and options (see usr/sbin/rear):
 apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"

--- a/usr/share/rear/restore/ZYPPER/default/970_set_root_password.sh
+++ b/usr/share/rear/restore/ZYPPER/default/970_set_root_password.sh
@@ -19,11 +19,12 @@ set -e -u -o pipefail
 
 # As fallback use 'root' as root password in the target system.
 # A non-empty fallback is needed because 'passwd' does not accept empty input:
-local root_password="root"
-# If SSH_ROOT_PASSWORD is specified used that as root password in the target system:
-test "$SSH_ROOT_PASSWORD" && root_password="$SSH_ROOT_PASSWORD"
-# If ZYPPER_ROOT_PASSWORD is specified used that as root password in the target system:
-test "$ZYPPER_ROOT_PASSWORD" && root_password="$ZYPPER_ROOT_PASSWORD"
+{ local root_password="root"
+  # If SSH_ROOT_PASSWORD is specified used that as root password in the target system:
+  test "$SSH_ROOT_PASSWORD" && root_password="$SSH_ROOT_PASSWORD"
+  # If ZYPPER_ROOT_PASSWORD is specified used that as root password in the target system:
+  test "$ZYPPER_ROOT_PASSWORD" && root_password="$ZYPPER_ROOT_PASSWORD"
+} 2>/dev/null
 
 # Set the root password in the target system.
 # Use a login shell in between so that one has in the chrooted environment
@@ -31,7 +32,7 @@ test "$ZYPPER_ROOT_PASSWORD" && root_password="$ZYPPER_ROOT_PASSWORD"
 # the commands inside 'chroot' as one would type them in a normal working shell.
 # In particular one can call programs (like 'passwd') by their basename without path
 # cf. https://github.com/rear/rear/issues/862#issuecomment-274068914
-chroot $TARGET_FS_ROOT /bin/bash --login -c "echo -e '$root_password\n$root_password' | passwd root"
+{ chroot $TARGET_FS_ROOT /bin/bash --login -c "echo -e '$root_password\n$root_password' | passwd root" ; } 2>/dev/null
 
 # Restore the ReaR default bash flags and options (see usr/sbin/rear):
 apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"


### PR DESCRIPTION
Do not leak the SSH_ROOT_PASSWORD value into the log file:
In build/default/500_ssh_setup.sh
rescue/default/500_ssh.sh
restore/YUM/default/970_set_root_password.sh
restore/ZYPPER/default/970_set_root_password.sh
run commands that deal with SSH_ROOT_PASSWORD
in a confidential way via
```
{ confidential_command ; } 2>/dev/null
```
see https://github.com/rear/rear/issues/2967

This fixes by the way also ZYPPER_ROOT_PASSWORD and YUM_ROOT_PASSWORD, see
https://github.com/rear/rear/issues/2967#issuecomment-1545593787
