### PR TITLE
Implement non-interactive mode

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -203,7 +203,7 @@ To use Relax-and-Recover you always call the main script '/usr/sbin/rear':
 ----
 # rear help
 
-Usage: rear [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-C CONFIG] [-r KERNEL] [--] COMMAND [ARGS...]
+Usage: rear [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-C CONFIG] [-r KERNEL] [-n|--non-interactive] [--] COMMAND [ARGS...]
 
 Relax-and-Recover comes with ABSOLUTELY NO WARRANTY; for details see
 the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
@@ -220,7 +220,7 @@ Available options:
  -S                     step-by-step mode; acknowledge each script individually
  -v                     verbose mode; show more output
  -V --version           version information
- -n --non-interactive   non-interactive mode; aborts when any user input is required
+ -n --non-interactive   non-interactive mode; aborts when any user input is required (experimental)
 
 List of commands:
  checklayout     check if the disk layout has changed

--- a/README.adoc
+++ b/README.adoc
@@ -209,17 +209,18 @@ Relax-and-Recover comes with ABSOLUTELY NO WARRANTY; for details see
 the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 Available options:
- -h --help           usage information
- -c DIR              alternative config directory; instead of /etc/rear
- -C CONFIG           additional config file; absolute path or relative to config directory
- -d                  debug mode; log debug messages
- -D                  debugscript mode; log every function call (via 'set -x')
- --debugscripts SET  same as -d -v -D but debugscript mode with 'set -SET'
- -r KERNEL           kernel version to use; current: '3.12.49-3-default'
- -s                  simulation mode; show what scripts rear would include
- -S                  step-by-step mode; acknowledge each script individually
- -v                  verbose mode; show more output
- -V --version        version information
+ -h --help              usage information
+ -c DIR                 alternative config directory; instead of /etc/rear
+ -C CONFIG              additional config file; absolute path or relative to config directory
+ -d                     debug mode; log debug messages
+ -D                     debugscript mode; log every function call (via 'set -x')
+ --debugscripts SET     same as -d -v -D but debugscript mode with 'set -SET'
+ -r KERNEL              kernel version to use; current: '3.12.49-3-default'
+ -s                     simulation mode; show what scripts rear would include
+ -S                     step-by-step mode; acknowledge each script individually
+ -v                     verbose mode; show more output
+ -V --version           version information
+ -n --non-interactive   non-interactive mode; aborts when any user input is required
 
 List of commands:
  checklayout     check if the disk layout has changed

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -12,7 +12,7 @@ rear - bare metal disaster recovery and system migration tool
 
 
 == SYNOPSIS
-*rear* [*-h*|*--help*] [*-V*|*--version*] [*-dsSv*] [*-D*|*--debugscripts* _SET_] [*-c* _DIR_] [*-C* _CONFIG_] [*-r* _KERNEL_] [--] _COMMAND_ [_ARGS_...]
+*rear* [*-h*|*--help*] [*-V*|*--version*] [*-dsSv*] [*-D*|*--debugscripts* _SET_] [*-c* _DIR_] [*-C* _CONFIG_] [*-r* _KERNEL_] [*-n*|*--non-interactive*] [--] _COMMAND_ [_ARGS_...]
 
 
 == DESCRIPTION
@@ -82,6 +82,9 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 -v::
     *verbose mode* (show messages what ReaR is doing on the terminal)
+
+-n --non-interactive::
+    *non-interactive mode* (aborts when any user input is required, experimental)
 
 -V --version::
     version information

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -130,6 +130,7 @@ DEBUG=""
 DEBUGSCRIPTS=""
 DEBUGSCRIPTS_ARGUMENT="x"
 DEBUG_OUTPUT_DEV="null"
+NON_INTERACTIVE=""
 DISPENSABLE_OUTPUT_DEV="null"
 KEEP_BUILD_DIR=""
 KERNEL_VERSION=""
@@ -141,7 +142,7 @@ WORKFLOW=""
 
 # Parse options
 help_note_text="Use '$PROGRAM --help' or 'man $PROGRAM' for more information."
-if ! OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVr:" -l "help,version,debugscripts:" -- "$@" )" ; then
+if ! OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVrn:" -l "help,version,non-interactive,debugscripts:" -- "$@" )" ; then
     echo "$help_note_text"
     exit 1
 fi
@@ -158,6 +159,9 @@ while true ; do
             ;;
         (-v)
             VERBOSE=1
+            ;;
+        (-n|--non-interactive)
+            NON_INTERACTIVE=1
             ;;
         (-c)
             if [[ "$2" == -* ]] ; then

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -129,9 +129,7 @@ if is_true "$FORMAT_EFI" ; then
     while ! is_positive_integer $USB_UEFI_PART_SIZE ; do
         # When USB_UEFI_PART_SIZE is empty, do not falsely complain about "Invalid EFI partition size":
         test "$USB_UEFI_PART_SIZE" && LogPrintError "Invalid EFI system partition size USB_UEFI_PART_SIZE='$USB_UEFI_PART_SIZE' (must be positive integer)"
-        USB_UEFI_PART_SIZE="$( UserInput -I USB_DEVICE_EFI_PARTITION_MIBS -p "Enter size for EFI system partition on $RAW_USB_DEVICE in MiB (default 512 MiB)" )"
-        # Plain 'Enter' defaults to 512 MiB (same as the default value in default.conf):
-        test "$USB_UEFI_PART_SIZE" || USB_UEFI_PART_SIZE="512"
+        USB_UEFI_PART_SIZE="$( UserInput -I USB_DEVICE_EFI_PARTITION_MIBS -D "$USB_UEFI_PART_SIZE" -p "Enter size for EFI system partition on $RAW_USB_DEVICE in MiB (default $USB_UEFI_PART_SIZE MiB)" )"
     done
 
     # Round UEFI partition size to nearest block size to make the 2nd partition (the data partition) also align to the block size:

--- a/usr/share/rear/layout/prep-for-mount/default/600_show_unprocessed.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/600_show_unprocessed.sh
@@ -29,8 +29,8 @@ while read status name type junk ; do
         # hopefully only uppercase letters and digits are sufficient to distinguish different missing components:
         current_missing_component_alnum_uppercase="$( echo "$missing_component" | tr -d -c '[:alnum:]' | tr '[:lower:]' '[:upper:]' )"
         test "$current_missing_component_alnum_uppercase" || current_missing_component_alnum_uppercase="COMPONENT"
-        user_input_ID="ADD_CODE_TO_RECREATE_MISSING_$current_missing_component_alnum_uppercase"
-        case "$( UserInput -I $user_input_ID -p "Manually add code that mounts $missing_component" -D "${choices[3]}" "${choices[@]}" )" in
+        local user_input_ID="ADD_CODE_TO_RECREATE_MISSING_$current_missing_component_alnum_uppercase"
+        case "$( UserInput -I "$user_input_ID" -p "Manually add code that mounts $missing_component" -D "${choices[3]}" "${choices[@]}" )" in
             (${choices[0]})
                 # Run 'less' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
                 less $LAYOUT_CODE 0<&6 1>&7 2>&8

--- a/usr/share/rear/layout/prepare/GNU/Linux/150_include_drbd_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/150_include_drbd_code.sh
@@ -22,7 +22,7 @@ EOF
     # Ask if we need to become primary.
     # When USER_INPUT_DRBD_RESOURCE_BECOMES_PRIMARY has any 'true' value be liberal in what you accept and assume exactly 'yes' was actually meant:
     is_true "$USER_INPUT_DRBD_RESOURCE_BECOMES_PRIMARY" && USER_INPUT_DRBD_RESOURCE_BECOMES_PRIMARY="yes"
-    user_input="$( UserInput -I DRBD_RESOURCE_BECOMES_PRIMARY -p "Type 'yes' if you want DRBD resource $resource to become primary" )"
+    user_input="$( UserInput -I DRBD_RESOURCE_BECOMES_PRIMARY -D no -p "Type 'yes' if you want DRBD resource $resource to become primary" )"
     if [ "$user_input" = "yes" ] ; then
         cat >> "$LAYOUT_CODE" <<-EOF
         if ! drbdadm role $resource &>/dev/null ; then

--- a/usr/share/rear/layout/prepare/default/200_recreate_hpraid.sh
+++ b/usr/share/rear/layout/prepare/default/200_recreate_hpraid.sh
@@ -55,8 +55,8 @@ while read type name junk ; do
     # hopefully only uppercase letters and digits are sufficient to distinguish different controllers:
     controller_basename_alnum_uppercase="$( basename "$name" | tr -d -c '[:alnum:]' | tr '[:lower:]' '[:upper:]' )"
     test "$controller_basename_alnum_uppercase" || controller_basename_alnum_uppercase="CONTROLLER"
-    user_input_ID="HP_SMART_ARRAY_$controller_basename_alnum_uppercase"
-    input_value="$( UserInput -I $user_input_ID -p "$prompt" -D 'YES' )" && wilful_input="yes" || wilful_input="no"
+    local user_input_ID="HP_SMART_ARRAY_$controller_basename_alnum_uppercase"
+    input_value="$( UserInput -I "$user_input_ID" -p "$prompt" -D 'YES' )" && wilful_input="yes" || wilful_input="no"
     if is_true "$input_value" ; then
         is_true "$wilful_input" && LogPrint "User confirmed recreating HP Smart Array controller '$name'" || LogPrint "Recreating HP Smart Array controller '$name' by default"
         echo "# Recreate HP Smart Array controller '$name'" >>$LAYOUT_CODE

--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -291,10 +291,10 @@ while read keyword orig_device orig_size junk ; do
     # hopefully only uppercase letters and digits are sufficient to distinguish different devices:
     current_orig_device_basename_alnum_uppercase="$( basename "$preferred_orig_device_name" | tr -d -c '[:alnum:]' | tr '[:lower:]' '[:upper:]' )"
     test "$current_orig_device_basename_alnum_uppercase" || current_orig_device_basename_alnum_uppercase="DISK"
-    user_input_ID="LAYOUT_MIGRATION_REPLACEMENT_$current_orig_device_basename_alnum_uppercase"
+    local user_input_ID="LAYOUT_MIGRATION_REPLACEMENT_$current_orig_device_basename_alnum_uppercase"
     until IsInArray "$choice" "${regular_choices[@]}" ; do
         # Default input is the first regular choice which is the first of the possible targets:
-        choice="$( UserInput -I $user_input_ID -p "$prompt" -D 1 "${regular_choices[@]}" "$rear_shell_choice" )" && wilful_input="yes" || wilful_input="no"
+        choice="$( UserInput -I "$user_input_ID" -p "$prompt" -D 1 "${regular_choices[@]}" "$rear_shell_choice" )" && wilful_input="yes" || wilful_input="no"
         test "$rear_shell_choice" = "$choice" && rear_shell
     done
     # Continue with next original device when the user selected to not map it:

--- a/usr/share/rear/layout/prepare/default/600_show_unprocessed.sh
+++ b/usr/share/rear/layout/prepare/default/600_show_unprocessed.sh
@@ -29,8 +29,8 @@ while read status name type junk ; do
         # hopefully only uppercase letters and digits are sufficient to distinguish different missing components:
         current_missing_component_alnum_uppercase="$( echo "$missing_component" | tr -d -c '[:alnum:]' | tr '[:lower:]' '[:upper:]' )"
         test "$current_missing_component_alnum_uppercase" || current_missing_component_alnum_uppercase="COMPONENT"
-        user_input_ID="ADD_CODE_TO_RECREATE_MISSING_$current_missing_component_alnum_uppercase"
-        case "$( UserInput -I $user_input_ID -p "Manually add code that recreates $missing_component" -D "${choices[3]}" "${choices[@]}" )" in
+        local user_input_ID="ADD_CODE_TO_RECREATE_MISSING_$current_missing_component_alnum_uppercase"
+        case "$( UserInput -I "$user_input_ID" -p "Manually add code that recreates $missing_component" -D "${choices[3]}" "${choices[@]}" )" in
             (${choices[0]})
                 # Run 'less' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user:
                 less $LAYOUT_CODE 0<&6 1>&7 2>&8

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -1095,8 +1095,6 @@ function UserInput () {
     local automated_input_interrupt_timeout=10
     # Avoid stderr if USER_INPUT_INTERRUPT_TIMEOUT is not set or empty and ignore wrong USER_INPUT_INTERRUPT_TIMEOUT:
     test "$USER_INPUT_INTERRUPT_TIMEOUT" -ge 1 2>/dev/null && automated_input_interrupt_timeout=$USER_INPUT_INTERRUPT_TIMEOUT
-    # set timeouts to low but acceptable 3 seconds for non-interactive mode:
-    is_true "$NON_INTERACTIVE" && timeout=3 && automated_input_interrupt_timeout=3
     local default_prompt="enter your input"
     local prompt="$default_prompt"
     # Avoid stderr if USER_INPUT_PROMPT is not set or empty:
@@ -1170,8 +1168,13 @@ function UserInput () {
     test "$( echo $user_input_ID | tr -c -d '[:lower:]' )" && BugError "UserInput: Option '-I' argument '$user_input_ID' must not contain lower case letters"
     declare $user_input_ID="dummy" 2>/dev/null || BugError "UserInput: Option '-I' argument '$user_input_ID' not a valid variable name"
     # Check the non-interactive mode and throw an error if default_input was not set
-    if is_true "$NON_INTERACTIVE" && is_true "${USER_INPUT_SEEN_WITH_TIMEOUT[$user_input_ID]}" 2>/dev/null; then
-        Error "UserInput: non-interactive mode and repeat input for '$user_input_ID' requested while the previous attempt was answered with the default or timed out"
+    if is_true "$NON_INTERACTIVE" ; then
+        if is_true "${USER_INPUT_SEEN_WITH_TIMEOUT[$user_input_ID]}" 2>/dev/null; then
+            Error "UserInput: non-interactive mode and repeat input for '$user_input_ID' requested while the previous attempt was answered with the default or timed out"
+        fi
+        # set timeouts to low but acceptable 3 seconds for non-interactive mode:
+        timeout=3
+        automated_input_interrupt_timeout=3
     fi
     # Shift away the options and arguments:
     shift "$(( OPTIND - 1 ))"

--- a/usr/share/rear/lib/help-workflow.sh
+++ b/usr/share/rear/lib/help-workflow.sh
@@ -17,23 +17,24 @@ fi
 
 # Output the help text to the original STDOUT but keep STDERR in the log file:
 cat 1>&7 <<EOF
-Usage: $PROGRAM [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-C CONFIG] [-r KERNEL] [--] COMMAND [ARGS...]
+Usage: $PROGRAM [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-C CONFIG] [-r KERNEL] [-n|--non-interactive] [--] COMMAND [ARGS...]
 
 $PRODUCT comes with ABSOLUTELY NO WARRANTY; for details see
 the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 Available options:
- -h --help           usage information (this text)
- -c DIR              alternative config directory; instead of $CONFIG_DIR
- -C CONFIG           additional config files; absolute path or relative to config directory
- -d                  debug mode; run many commands verbosely with debug messages in log file (also sets -v)
- -D                  debugscript mode; log executed commands via 'set -x' (also sets -v and -d)
- --debugscripts SET  same as -d -v -D but debugscript mode with 'set -SET'
- -r KERNEL           kernel version to use; currently '$KERNEL_VERSION'
- -s                  simulation mode; show what scripts are run (without executing them)
- -S                  step-by-step mode; acknowledge each script individually
- -v                  verbose mode; show messages what $PRODUCT is doing on the terminal or show verbose help
- -V --version        version information
+ -h --help              usage information (this text)
+ -c DIR                 alternative config directory; instead of $CONFIG_DIR
+ -C CONFIG              additional config files; absolute path or relative to config directory
+ -d                     debug mode; run many commands verbosely with debug messages in log file (also sets -v)
+ -D                     debugscript mode; log executed commands via 'set -x' (also sets -v and -d)
+ --debugscripts SET     same as -d -v -D but debugscript mode with 'set -SET'
+ -r KERNEL              kernel version to use; currently '$KERNEL_VERSION'
+ -s                     simulation mode; show what scripts are run (without executing them)
+ -S                     step-by-step mode; acknowledge each script individually
+ -v                     verbose mode; show messages what $PRODUCT is doing on the terminal or show verbose help
+ -V --version           version information
+ -n --non-interactive   non-interactive mode; aborts when any user input is required (experimental)
 
 List of commands:
 EOF

--- a/usr/share/rear/prep/default/040_check_backup_and_output_scheme.sh
+++ b/usr/share/rear/prep/default/040_check_backup_and_output_scheme.sh
@@ -24,10 +24,10 @@ if test "$BACKUP_URL" ; then
                    # to provide a ready for use mean of final power to the user to enforce what ReaR must do:
                    prompt="Proceed regardless that '$WORKFLOW' could be destructive with a '$backup_scheme' BACKUP_URL ?"
                    workflow_uppercase="$( tr '[:lower:]' '[:upper:]' <<< $WORKFLOW )"
-                   user_input_ID="BACKUP_URL_ISO_PROCEED_$workflow_uppercase"
+                   local user_input_ID="BACKUP_URL_ISO_PROCEED_$workflow_uppercase"
                    input_value=""
                    wilful_input=""
-                   input_value="$( UserInput -I $user_input_ID -p "$prompt" -D 'No' )" && wilful_input="yes" || wilful_input="no"
+                   input_value="$( UserInput -I "$user_input_ID" -p "$prompt" -D 'No' )" && wilful_input="yes" || wilful_input="no"
                    if ! is_true "$input_value" ; then
                        if is_true "$wilful_input" ; then
                            LogPrint "User confirmed to not proceed '$WORKFLOW' with a '$backup_scheme' BACKUP_URL"

--- a/usr/share/rear/restore/BORG/default/300_load_archives.sh
+++ b/usr/share/rear/restore/BORG/default/300_load_archives.sh
@@ -63,13 +63,15 @@ while true ; do
         LogUserOutput "[0] Show all archives again"
     fi
 
+    local abort_choice
+    (( abort_choice = archive_cache_lines_total + 1 ))
     # Show "Exit" option.
     UserOutput ""
-    LogUserOutput "[$(( archive_cache_lines_total + 1 ))]" Exit
+    LogUserOutput "[$abort_choice]" Exit
     UserOutput ""
 
     # Read user input.
-    choice="$( UserInput -I BORGBACKUP_ARCHIVE_TO_RECOVER -p "Choose archive to recover from" )"
+    choice="$( UserInput -I BORGBACKUP_ARCHIVE_TO_RECOVER -D "$abort_choice" -p "Choose archive to recover from" )"
 
     # Evaluate user selection and save archive name to restore.
     # Valid pick
@@ -79,7 +81,7 @@ while true ; do
             | awk '{ print $1 }' )
         break
     # Exit
-    elif [[ $choice -eq $(( archive_cache_lines_total + 1 )) ]]; then
+    elif [[ $choice -eq $abort_choice ]]; then
         Error "Operation aborted by user"
     fi
 done

--- a/usr/share/rear/restore/BORG/default/300_load_archives.sh
+++ b/usr/share/rear/restore/BORG/default/300_load_archives.sh
@@ -71,7 +71,7 @@ while true ; do
     UserOutput ""
 
     # Read user input.
-    choice="$( UserInput -I BORGBACKUP_ARCHIVE_TO_RECOVER -D "$abort_choice" -p "Choose archive to recover from" )"
+    choice="$( UserInput -I BORGBACKUP_ARCHIVE_TO_RECOVER -D "$archive_cache_lines_total" -p "Choose archive to recover from" )"
 
     # Evaluate user selection and save archive name to restore.
     # Valid pick

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -151,7 +151,6 @@ if automatic_recovery ; then
               "Go to Relax-and-Recover shell"
             )
     echo -e "\nLaunching 'rear recover' automatically\n"
-    # The recover workflow is always verbose (see usr/sbin/rear):
     if rear $rear_debug_options recover ; then
         echo -e "\n'rear recover' finished successfully\n"
         choices+=( "Reboot" )
@@ -188,8 +187,7 @@ if unattended_recovery ; then
               "Go to Relax-and-Recover shell"
             )
     echo -e "\nLaunching 'rear recover' automatically in unattended mode\n"
-    # The recover workflow is always verbose (see usr/sbin/rear):
-    if rear $rear_debug_options recover ; then
+    if rear $rear_debug_options --non-interactive recover ; then
         echo -e "\n'rear recover' finished successfully\n"
         echo -e "\nRebooting in 30 seconds (Ctrl-C to interrupt)\n"
         sleep 30

--- a/usr/share/rear/verify/CDM/default/430_gen_rbs_uuid_for_cdm.sh
+++ b/usr/share/rear/verify/CDM/default/430_gen_rbs_uuid_for_cdm.sh
@@ -13,7 +13,7 @@ is_true "$USER_INPUT_CDM_SAME_AGENT_UUID" && USER_INPUT_SAME_AGENT_UUID="y"
 while true ; do
     # Find out if the IP address has changed from the original. If so generate a new UUID.
     # the default (i.e. the automated response after the timeout) should be 'n':
-    answer="$( UserInput -I CDM_SAME_AGENT_UUID -p "Does this client have the same IP address as the original? (y/n)" -D 'y' -t 300 )"
+    answer="$( UserInput -I CDM_SAME_AGENT_UUID -p "Does this client have the same IP address as the original? (y/n)" -D 'y' )"
     is_true "$answer" && return 0
     if is_false "$answer" ; then
         break

--- a/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
+++ b/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
@@ -20,6 +20,9 @@ elif test $qlist_ret -eq 2; then
             Error "CommVault 'qlogin -u $GALAXY11_USER -clp GALAXY11_PASSWORD' failed with exit code $? (retry on command line to see error messages)"
 		fi
 	else
+        is_true "$NON_INTERACTIVE" && \
+            Error "Login is not possible in non-interactive mode. Set variables GALAXY11_USER and GALAXY11_PASSWORD."
+        
 		# try to logon manually
 		Print "Please logon to your Commvault CommServe with suitable credentials:"
 		qlogin $(test "$GALAXY11_Q_ARGUMENTFILE" && echo "-af $GALAXY11_Q_ARGUMENTFILE") 0<&6 1>&7 2>&8 || \

--- a/usr/share/rear/verify/GALAXY11/default/500_select_backupset.sh
+++ b/usr/share/rear/verify/GALAXY11/default/500_select_backupset.sh
@@ -7,5 +7,5 @@ IFS=$'\n' read -r -d "" -a backupsets < <(
 )
 
 until IsInArray "$GALAXY11_BACKUPSET" "${backupsets[@]}"; do
-	GALAXY11_BACKUPSET=$( UserInput -I GALAXY11_BACKUPSET -p "Select CommVault backupset to use:" "${backupsets[@]}" )
+	GALAXY11_BACKUPSET=$( UserInput -I GALAXY11_BACKUPSET -D "${backupsets[0]}" -p "Select CommVault backupset to use (ENTER for first one):" "${backupsets[@]}" )
 done


### PR DESCRIPTION
supersedes #2979 and should solve everything discussed there. Code is based on the work by @codefritzel and adapted by me.

My considerations and decisions:
* the non-interactive mode is marked *experimental* because it only changes the way how `UserInput` works and there might be some scenarios where it won't work as advertised. I don't want to put a lengthy explanation about the technical details in the help text, hence *experimental* to indicate the current status.
* Without `--non-interactive` nothing should have changed (but I fixed a few places that seemed like they could cause problems)
* With `--non-interactive` the `UserInput` timeouts are hard coded to 3 seconds (short, but not too short) and every `UserInput -I FOO` call can happen only once. If it happens again then it will `Error` out.
* I treat an automated response by `USER_INPUT_FOO` the same as using the default response given via `-D`
* I'd like to keep it this simple till further testing reveals scenarios where multiple calls to the same `UserInput -I FOO` would be successful, and then I'll adjust the code accordingly (no premature optimisation).

Finally, I'd like to merge this rather soon so please look for reasons why this is a really bad idea and leave further improvements to future iterations.

@rear/contributors please have a look.

PS: The `UserInput` function is really hard to understand and to test (via `rear shell`) because it does *so much*, if somebody wants to contribute a unit test then this would be my starting point.