### PR TITLE
Add -f (force) option to wipefs command in 120_include_raid_code.sh

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/120_include_raid_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/120_include_raid_code.sh
@@ -90,7 +90,7 @@ create_raidarray() {
 LogPrint "Creating software RAID $raiddevice"
 test -b $raiddevice && mdadm --stop $raiddevice
 for component_device in ${component_devices[@]} ; do
-    wipefs -af \$component_device
+    wipefs -af \$component_device || wipefs -a \$component_device
 done
 $mdadmcmd >&2
 EOF

--- a/usr/share/rear/layout/prepare/GNU/Linux/120_include_raid_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/120_include_raid_code.sh
@@ -90,7 +90,7 @@ create_raidarray() {
 LogPrint "Creating software RAID $raiddevice"
 test -b $raiddevice && mdadm --stop $raiddevice
 for component_device in ${component_devices[@]} ; do
-    wipefs -a \$component_device
+    wipefs -af \$component_device
 done
 $mdadmcmd >&2
 EOF


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal** 

* Reference to related issue (URL):

https://github.com/rear/rear/issues/2990

* How was this pull request tested?

On a Ubuntu desktop machine using mdadm RAID 1.

* Brief description of the changes in this pull request:

`rear recover` fails during disk layout recreation on my machine unless `wipefs` is called with the `-f` ( or `--force`) option.

rear may currently be a bit over-zealous with its use of `wipefs` when recreating md RAID arrays but if we are going to use `wipefs` then we should be consistent because wipefs uses the force option elsewhere in `rear` and recover failed to work at all for me without this extra -f.