### PR TITLE
Add fully automated restore to REQUESTRESTORE

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2847,6 +2847,15 @@ because the disks and filesystems of the target system are mounted there.
 # This command is shown to the user and added to the predefined bash history
 # in the ReaR recovery system to make the manual backup restore easier:
 REQUESTRESTORE_COMMAND=
+#
+# Set the finished and abort files to enable non-interactive REQUESTRESTORE mode.
+# ReaR will wait for the finished file to appear and continue with the recovery,
+# or abort the recovery if the abort file appears. The content of the abort file is
+# shown and logged as abort reason.
+# Instead of the manual prompt ReaR will simply show an info message and the disk
+# usage of the target filesystems.
+REQUESTRESTORE_FINISHED_FILE=${REQUESTRESTORE_FINISHED_FILE:-}
+REQUESTRESTORE_ABORT_FILE=${REQUESTRESTORE_ABORT_FILE:-}
 ####
 
 ####

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2849,6 +2849,7 @@ because the disks and filesystems of the target system are mounted there.
 REQUESTRESTORE_COMMAND=
 #
 # Set the finished and abort files to enable non-interactive REQUESTRESTORE mode.
+# Without these variables, ReaR will prompt the user to continue with the recovery.
 # ReaR will wait for the finished file to appear and continue with the recovery,
 # or abort the recovery if the abort file appears. The content of the abort file is
 # shown and logged as abort reason.

--- a/usr/share/rear/lib/filesystems-functions.sh
+++ b/usr/share/rear/lib/filesystems-functions.sh
@@ -242,6 +242,17 @@ function xfs_parse
 
 # return the total used disk space of the target file systems
 function total_target_fs_used_disk_space() {
-    df --total --local -h --exclude-type=tmpfs --exclude-type=devtmpfs \
-        $(mount | grep "$TARGET_FS_ROOT" | cut -f 1 -d " ") | awk 'END{print $3}'
+    # get all mounted file systems for TARGET_FS_ROOT that are mounted on a local device (starting with /)
+    # and exclude virtual filesystems like tmpfs, devtmpfs, sysfs, none
+    # and return the 3rd column of the last line of the df output that looks like this:
+    # Filesystem                         Size  Used Avail Use% Mounted on
+    # /dev/mapper/ubuntu--vg-ubuntu--lv  5.6G  4.2G  1.2G  78% /mnt/local
+    # /dev/sda2                          1.7G  277M  1.4G  17% /mnt/local/boot
+    # /dev/sda1                          537M  6.1M  531M   2% /mnt/local/boot/efi
+    # total                              7.8G  4.4G  3.1G  60% -
+    #
+    # shellcheck disable=SC2046
+    df --total --local -h \
+        --exclude-type=tmpfs --exclude-type=devtmpfs --exclude-type=sysfs --exclude-type=none \
+        $(mount | sed -n -e "\#^/.*$TARGET_FS_ROOT#s/ .*//p") | sed -E -n -e '$s/[^ ]+ +[^ ]+ +([^ ]+).*/\1/p'
 }

--- a/usr/share/rear/lib/filesystems-functions.sh
+++ b/usr/share/rear/lib/filesystems-functions.sh
@@ -242,5 +242,6 @@ function xfs_parse
 
 # return the total used disk space of the target file systems
 function total_target_fs_used_disk_space() {
-    df --total --local -h --exclude-type=tmpfs --exclude-type=devtmpfs $(mount | grep "$TARGET_FS_ROOT" | cut -f 1 -d " ") | awk 'END{print $3}'
+    df --total --local -h --exclude-type=tmpfs --exclude-type=devtmpfs \
+        $(mount | grep "$TARGET_FS_ROOT" | cut -f 1 -d " ") | awk 'END{print $3}'
 }

--- a/usr/share/rear/lib/filesystems-functions.sh
+++ b/usr/share/rear/lib/filesystems-functions.sh
@@ -239,3 +239,8 @@ function xfs_parse
   # Output xfs options for further use
   echo "$xfs_opts"
 }
+
+# return the total used disk space of the target file systems
+function total_target_fs_used_disk_space() {
+    df --total --local -h --exclude-type=tmpfs --exclude-type=devtmpfs $(mount | grep "$TARGET_FS_ROOT" | cut -f 1 -d " ") | awk 'END{print $3}'
+}

--- a/usr/share/rear/restore/NFS4SERVER/default/400_restore_with_nfs_server.sh
+++ b/usr/share/rear/restore/NFS4SERVER/default/400_restore_with_nfs_server.sh
@@ -1,27 +1,34 @@
-local check_file abort_file nfs_connections used_space duration start runtime
+local nfs_connections duration start runtime \
+    check_file="$TARGET_FS_ROOT/$NFS4SERVER_RESTORE_FINISHED_FILE" \
+    abort_file="$TARGET_FS_ROOT/$NFS4SERVER_RESTORE_ABORT_FILE"
 
-check_file="$TARGET_FS_ROOT/$NFS4SERVER_RESTORE_FINISHED_FILE"
-abort_file="$TARGET_FS_ROOT/$NFS4SERVER_RESTORE_ABORT_FILE"
-
-LogPrint "Mount the nfs share: 'mount -t nfs <ip>:/ <destination>' and restore all files to mounted destination."
-LogPrint "Create the <destination>/$NFS4SERVER_RESTORE_FINISHED_FILE file when the restore is completed and umount the share."
+LogPrint "Mount the nfs share: 'mount -t nfs <ip>:/ <destination>' and$LF" \
+    "restore all files to mounted destination."
+LogPrint "Create the <destination>/$NFS4SERVER_RESTORE_FINISHED_FILE file$LF" \
+    "when the restore is completed and umount the share."
 
 rm -f "$check_file" "$abort_file" || Error "Couldn't delete restore finished file $check_file or abort file $abort_file"
 
-LogPrint "Waiting until $check_file was created and there is no active connection on the NFS port 2049."
+LogPrint "Waiting until $check_file was created and there is no$LF" \
+    "active connection on the NFS port 2049."
 
 (( start = SECONDS ))
 nfs_connections=1
+ProgressStart "Restoring data"
 while [ ! -f "$check_file" ] || [ "$nfs_connections" -gt 0 ]; do
     if [ -f "$abort_file" ]; then
-        echo ""
+        ProgressError
         Error "Restore aborted by abort file $abort_file. Reason given:$LF$(< "$abort_file"))"
     fi
+    sleep "$PROGRESS_WAIT_SECONDS"
     (( duration = SECONDS - start ))
     printf -v runtime "%02d:%02d" $(( duration/60 )) $(( duration % 60 ))
     ProgressInfo "Waiting for $runtime minutes, total used storage space: $(total_target_fs_used_disk_space)"
-    sleep 5
     nfs_connections=$(ss -tanpH state established "( sport = 2049 )" | wc -l)
 done
+ProgressStop
+(( duration = SECONDS - start ))
+printf -v runtime "%02d:%02d" $(( duration/60 )) $(( duration % 60 ))
+LogPrint "Restored $(total_target_fs_used_disk_space) in $runtime minutes."
 
 rm -f "$check_file" || Error "Couldn't delete restore finished file $check_file"

--- a/usr/share/rear/restore/REQUESTRESTORE/default/200_prompt_user_to_start_restore.sh
+++ b/usr/share/rear/restore/REQUESTRESTORE/default/200_prompt_user_to_start_restore.sh
@@ -5,44 +5,45 @@
 
 LogPrint "$REQUESTRESTORE_TEXT"
 
-if contains_visible_char "$REQUESTRESTORE_FINISHED_FILE" && contains_visible_char "$REQUESTRESTORE_ABORT_FILE"; then
-    local used_space runtime start duration \
+if contains_visible_char "$REQUESTRESTORE_FINISHED_FILE" && \
+    contains_visible_char "$REQUESTRESTORE_ABORT_FILE"; then
+
+    local runtime start duration \
         check_file="$TARGET_FS_ROOT/$REQUESTRESTORE_FINISHED_FILE" \
         abort_file="$TARGET_FS_ROOT/$REQUESTRESTORE_ABORT_FILE"
     rm $verbose -f "$check_file" "$abort_file" || \
         Error "Couldn't delete restore finished file $check_file or abort file $abort_file"
     LogPrint "Waiting for $check_file file to signal when the restore is completed and recovery can proceed."
     (( start = SECONDS ))
+    ProgressStart "Restoring data"
     until test -f "$check_file" ; do
-        test -f "$abort_file" && \
+        if test -f "$abort_file" ; then
+            ProgressError
             Error "Restore aborted by abort file $abort_file. Reason given:$LF$(< "$abort_file"))"
+        fi
+        sleep "$PROGRESS_WAIT_SECONDS"
         (( duration = SECONDS - start ))
         printf -v runtime "%02d:%02d" $(( duration/60 )) $(( duration % 60 ))
         ProgressInfo "Waiting for $runtime minutes, total used storage space: $(total_target_fs_used_disk_space)"
-        sleep 5
     done
+    ProgressStop
     (( duration = SECONDS - start ))
     printf -v runtime "%02d:%02d" $(( duration/60 )) $(( duration % 60 ))
-    LogPrint "${LF}Restored $(total_target_fs_used_disk_space) in $runtime minutes."
+    LogPrint "Restored $(total_target_fs_used_disk_space) in $runtime minutes."
     rm $verbose -f "$check_file" || Error "Couldn't delete restore finished file $check_file"
 else
     if [[ "$REQUESTRESTORE_COMMAND" ]]; then
-        LogPrint "Use the following command to restore the backup to your system in '$TARGET_FS_ROOT':
+        LogPrint "Use the following command to restore the backup to your system in '$TARGET_FS_ROOT':$LF$LF$REQUESTRESTORE_COMMAND$LF"
 
-        $REQUESTRESTORE_COMMAND
-    "
-
-        LogPrint "Please restore your backup in the provided shell, use the shell history to
-    access the above command and, when finished, type exit in the shell to continue
-    recovery.
-    "
+        LogPrint "Please restore your backup in the provided shell, use the shell history to$LF" \
+            "access the above command and, when finished, type exit in the shell to continue$LF" \
+            "recovery.$LF"
         rear_shell "Did you restore the backup to $TARGET_FS_ROOT ? Are you ready to continue recovery ?" \
             "$REQUESTRESTORE_COMMAND"
     else
-        LogPrint "Please restore your backup in the provided shell and, when finished, type exit
-    in the shell to continue recovery."
+        LogPrint "Please restore your backup in the provided shell and, when finished, type exit$LF" \
+            "in the shell to continue recovery."
 
         rear_shell "Did you restore the backup to $TARGET_FS_ROOT ? Are you ready to continue recovery ?"
     fi
 fi
-

--- a/usr/share/rear/restore/REQUESTRESTORE/default/200_prompt_user_to_start_restore.sh
+++ b/usr/share/rear/restore/REQUESTRESTORE/default/200_prompt_user_to_start_restore.sh
@@ -5,21 +5,44 @@
 
 LogPrint "$REQUESTRESTORE_TEXT"
 
-if [[ "$REQUESTRESTORE_COMMAND" ]]; then
-    LogPrint "Use the following command to restore the backup to your system in '$TARGET_FS_ROOT':
-
-    $REQUESTRESTORE_COMMAND
-"
-
-    LogPrint "Please restore your backup in the provided shell, use the shell history to
-access the above command and, when finished, type exit in the shell to continue
-recovery.
-"
-    rear_shell "Did you restore the backup to $TARGET_FS_ROOT ? Are you ready to continue recovery ?" \
-        "$REQUESTRESTORE_COMMAND"
+if contains_visible_char "$REQUESTRESTORE_FINISHED_FILE" && contains_visible_char "$REQUESTRESTORE_ABORT_FILE"; then
+    local used_space runtime start duration \
+        check_file="$TARGET_FS_ROOT/$REQUESTRESTORE_FINISHED_FILE" \
+        abort_file="$TARGET_FS_ROOT/$REQUESTRESTORE_ABORT_FILE"
+    rm $verbose -f "$check_file" "$abort_file" || \
+        Error "Couldn't delete restore finished file $check_file or abort file $abort_file"
+    LogPrint "Waiting for $check_file file to signal when the restore is completed and recovery can proceed."
+    (( start = SECONDS ))
+    until test -f "$check_file" ; do
+        test -f "$abort_file" && \
+            Error "Restore aborted by abort file $abort_file. Reason given:$LF$(< "$abort_file"))"
+        (( duration = SECONDS - start ))
+        printf -v runtime "%02d:%02d" $(( duration/60 )) $(( duration % 60 ))
+        ProgressInfo "Waiting for $runtime minutes, total used storage space: $(total_target_fs_used_disk_space)"
+        sleep 5
+    done
+    (( duration = SECONDS - start ))
+    printf -v runtime "%02d:%02d" $(( duration/60 )) $(( duration % 60 ))
+    LogPrint "${LF}Restored $(total_target_fs_used_disk_space) in $runtime minutes."
+    rm $verbose -f "$check_file" || Error "Couldn't delete restore finished file $check_file"
 else
-    LogPrint "Please restore your backup in the provided shell and, when finished, type exit
-in the shell to continue recovery."
+    if [[ "$REQUESTRESTORE_COMMAND" ]]; then
+        LogPrint "Use the following command to restore the backup to your system in '$TARGET_FS_ROOT':
 
-    rear_shell "Did you restore the backup to $TARGET_FS_ROOT ? Are you ready to continue recovery ?"
+        $REQUESTRESTORE_COMMAND
+    "
+
+        LogPrint "Please restore your backup in the provided shell, use the shell history to
+    access the above command and, when finished, type exit in the shell to continue
+    recovery.
+    "
+        rear_shell "Did you restore the backup to $TARGET_FS_ROOT ? Are you ready to continue recovery ?" \
+            "$REQUESTRESTORE_COMMAND"
+    else
+        LogPrint "Please restore your backup in the provided shell and, when finished, type exit
+    in the shell to continue recovery."
+
+        rear_shell "Did you restore the backup to $TARGET_FS_ROOT ? Are you ready to continue recovery ?"
+    fi
 fi
+


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* How was this pull request tested?

Manually on Ubuntu 22.04

* Brief description of the changes in this pull request:

Add an automated restore feature to `REQUESTRESTORE`, similar to how `NFS4SERVER` works.

Example:

```
Confirm the recreated disk layout or go back one step
1) Confirm recreated disk layout and continue 'rear recover'
2) Go back one step to redo disk layout recreation
3) Use Relax-and-Recover shell and return back to here
4) Abort 'rear recover'
(default '1' timeout 300 seconds)

User confirmed recreated disk layout
Now you must manually restore your backup.
Ensure the backup data gets restored into /mnt/local (instead of '/')
because the disks and filesystems of the target system are mounted there.

Waiting for /mnt/local/ok file to signal when the restore is completed and recovery can proceed.
Waiting since 02:05, used storage space: 4.3G
Restored 4.4G in 02:10 minutes.
Created SELinux /mnt/local/.autorelabel file : after reboot SELinux will relabel all files
Recreating directories (with permissions) from /var/lib/rear/recovery/directories_permissions_owner_group
```

with a config like this:

```sh
REQUESTRESTORE_FINISHED_FILE=ok
REQUESTRESTORE_ABORT_FILE=bad
```

Without those two variables the behaviour is like before, with a prompt and dropping the user into `rear_shell`.

This will also help with #2988 for this backup method.

I used the following command on another computer to perform the remote restore of a backup created via `BACKUP=NETFS`

```sh
ssh root@192.168.11.52 "tar -C /mnt/local -x -v -z && echo >/mnt/local/ok" </srv/scratch/rear-u2204/backup.tar.gz
```

@codefritzel what do you think?

@rear/contributors please have a look, I'd like to merge this soon