### PR TITLE
Improvements of the Makefile distribution targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ localstatedir = /var
 specfile = packaging/rpm/$(name).spec
 dscfile = packaging/debian/$(name).dsc
 
+rpmdefines =    --define="_topdir $(BUILD_DIR)/rpmbuild" \
+		--define="debug_package %{nil}"
 
 ifeq ($(shell id -u),0)
 RUNASUSER := runuser -u nobody --
@@ -245,19 +247,17 @@ srpm: dist/$(name)-$(distversion).tar.gz
 	mkdir -p $(BUILD_DIR)
 	cp dist/$(name)-$(distversion).tar.gz $(BUILD_DIR)/
 	rpmbuild -ts --clean --nodeps \
-		--define="_topdir $(BUILD_DIR)/rpmbuild" \
 		--define="_sourcedir $(CURDIR)/dist" \
 		--define="_srcrpmdir $(CURDIR)/dist" \
-		--define "debug_package %{nil}" \
+		$(rpmdefines) \
 		$(BUILD_DIR)/$(name)-$(distversion).tar.gz
 
 rpm: srpm
 	@echo -e "\033[1m== Building RPM package $(name)-$(distversion) ==\033[0;0m"
 	rpmbuild --rebuild --clean \
-		--define="_topdir $(BUILD_DIR)/rpmbuild" \
 		--define="_rpmdir $(CURDIR)/dist" \
 		--define "_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
-		--define "debug_package %{nil}" \
+		$(rpmdefines) \
 		dist/$(name)-$(version)-*.src.rpm
 
 deb: dist/$(name)-$(distversion).tar.gz

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ dscfile = packaging/debian/$(name).dsc
 effectivespecfile = $(BUILD_DIR)/$(name)-$(distversion)/$(specfile)
 
 rpmdefines =    --define="_topdir $(BUILD_DIR)/rpmbuild" \
+		--define="rpmrelease $(rpmrelease)" \
 		--define="debug_package %{nil}"
 
 ifeq ($(shell id -u),0)
@@ -212,7 +213,6 @@ dist/$(name)-$(distversion).tar.gz:
 	sed -i \
 		-e 's#^Source:.*#Source: $(name)-${distversion}.tar.gz#' \
 		-e 's#^Version:.*#Version: $(version)#' \
-		-e 's#^%define rpmrelease.*#%define rpmrelease $(rpmrelease)#' \
 		-e 's#^%setup.*#%setup -q -n $(name)-$(distversion)#' \
 		$(effectivespecfile)
 	sed -i \

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ else
 RUNASUSER :=
 endif
 
-.PHONY: doc dump package
+.PHONY: doc dump package dist/$(name)-$(distversion).tar.gz
 
 all:
 	@echo "Nothing to build. Use 'make help' for more information."

--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -1,4 +1,3 @@
-%define rpmrelease %{nil}
 %define debug_package %{nil}
 
 ### Work-around the fact that openSUSE/SLES _always_ defined both :-/


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested?
`make srpm` and `make rpm`

* Brief description of the changes in this pull request:
Several improvements to the Makefile targets that generate distribution packages:
  * The dist tarball (dist/$(name)-$(distversion).tar.gz) has been considered always up to date by make, and thus not remade when any of the files changed. This has caused "make srpm" (and other targets depending on the dist tarball - "make rpm", "make deb" etc.) to build packages without newer changes to the sources.
  Fix by marking dist/$(name)-$(distversion).tar.gz as a phony target that will be always rebuilt.
  * The source RPM has been specified as a glob pattern: `dist/$(name)-$(version)-*.src.rpm`. This breaks when there are multiple source RPMs under dist/ - leftovers from previous builds. It forces us to use clean or package-clean always before using "make rpm", which is not ideal.
Fix by determining the actual full package name (with the dist tag) by parsing the spec file and using that.
  * Do not `%define` rpmrelease in the spec file, define it on the command line in Makefile instead. Allows us to eliminate one `sed` transform of the spec file to set rpmrelease to the desired value.
