### PR TITLE
New --expose-secrets option plus SECRET_OUTPUT_DEV

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -130,8 +130,10 @@ DEBUG=""
 DEBUGSCRIPTS=""
 DEBUGSCRIPTS_ARGUMENT="x"
 DEBUG_OUTPUT_DEV="null"
-NON_INTERACTIVE=""
 DISPENSABLE_OUTPUT_DEV="null"
+SECRET_OUTPUT_DEV="null"
+EXPOSE_SECRETS=""
+NON_INTERACTIVE=""
 KEEP_BUILD_DIR=""
 KERNEL_VERSION=""
 RECOVERY_MODE=""
@@ -142,7 +144,7 @@ WORKFLOW=""
 
 # Parse options
 help_note_text="Use '$PROGRAM --help' or 'man $PROGRAM' for more information."
-if ! OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVr:n" -l "help,version,non-interactive,debugscripts:" -- "$@" )" ; then
+if ! OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVr:ne" -l "help,version,non-interactive,debugscripts:,expose-secrets" -- "$@" )" ; then
     echo "$help_note_text"
     exit 1
 fi
@@ -162,6 +164,9 @@ while true ; do
             ;;
         (-n|--non-interactive)
             NON_INTERACTIVE=1
+            ;;
+        (-e|--expose-secrets)
+            EXPOSE_SECRETS=1
             ;;
         (-c)
             if [[ "$2" == -* ]] ; then
@@ -284,6 +289,18 @@ if test "$DEBUG" ; then
     verbose="--verbose"
 fi
 
+# By default SECRET_OUTPUT_DEV="null"
+# but if '--expose-secrets' is set we set SECRET_OUTPUT_DEV="stderr"
+# in particular to get commands with secret arguments of the form
+#   { COMMAND $SECRET_ARGUMENT ; } 2>>/dev/$SECRET_OUTPUT_DEV
+# in the log file via 'set -x' when DEBUGSCRIPTS is set
+# but also in non-debugscript mode '--expose-secrets'
+# could show secrets where /dev/stderr points to
+# which is STDOUT_STDERR_FILE in normal modes
+# and RUNTIME_LOGFILE in debug modes
+# cf. https://github.com/rear/rear/issues/2967#issuecomment-1562732484
+test "$EXPOSE_SECRETS" && SECRET_OUTPUT_DEV="stderr"
+
 # Mark variables that are not meant to be changed later as constants (i.e. readonly).
 # Exceptions here:
 # CONFIG_DIR because "rear recover" sets it in /etc/rear/rescue.conf in the recovery system
@@ -292,6 +309,7 @@ fi
 readonly ARGS
 readonly CONFIG_APPEND_FILES
 readonly DEBUG DEBUGSCRIPTS DEBUGSCRIPTS_ARGUMENT DEBUG_OUTPUT_DEV DISPENSABLE_OUTPUT_DEV
+readonly EXPOSE_SECRETS SECRET_OUTPUT_DEV
 readonly SIMULATE STEPBYSTEP VERBOSE
 
 # The udev workflow is a special case because it is only a wrapper workflow

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -289,16 +289,16 @@ if test "$DEBUG" ; then
     verbose="--verbose"
 fi
 
-# By default SECRET_OUTPUT_DEV="null"
-# but if '--expose-secrets' is set we set SECRET_OUTPUT_DEV="stderr"
+# By default SECRET_OUTPUT_DEV="null".
+# But if '--expose-secrets' is set we set SECRET_OUTPUT_DEV="stderr"
 # in particular to get commands with secret arguments of the form
 #   { COMMAND $SECRET_ARGUMENT ; } 2>>/dev/$SECRET_OUTPUT_DEV
-# in the log file via 'set -x' when DEBUGSCRIPTS is set
-# but also in non-debugscript mode '--expose-secrets'
+# in the log file via 'set -x' when DEBUGSCRIPTS is set.
+# But also in non-debugscript modes '--expose-secrets'
 # could show secrets where /dev/stderr points to
 # which is STDOUT_STDERR_FILE in normal modes
-# and RUNTIME_LOGFILE in debug modes
-# cf. https://github.com/rear/rear/issues/2967#issuecomment-1562732484
+# and RUNTIME_LOGFILE in debug modes.
+# Cf. https://github.com/rear/rear/issues/2967#issuecomment-1562732484
 test "$EXPOSE_SECRETS" && SECRET_OUTPUT_DEV="stderr"
 
 # Mark variables that are not meant to be changed later as constants (i.e. readonly).

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -458,6 +458,30 @@ function Log () {
     echo "$log_message" >>"$RUNTIME_LOGFILE" || true
 }
 
+# For messages that should only appear in the log file if EXPOSE_SECRETS is set.
+# Usage example:
+#   if { COMMAND $SECRET_ARGUMENT ; } 2>>/dev/$SECRET_OUTPUT_DEV ; then
+#       Log "COMMAND succeeded"
+#   else
+#       { LogSecret "'COMMAND $SECRET_ARGUMENT' failed with exit code $?" ; } 2>>/dev/$SECRET_OUTPUT_DEV
+#       Error "COMMAND failed"
+#   fi
+# The LogSecret command itself must be within '{ ... ; } 2>>/dev/$SECRET_OUTPUT_DEV'
+# because otherwise $SECRET_ARGUMENT in the LogSecret function call
+# would leak into the log file in debuscript mode via 'set -x'.
+# The
+#   Log "COMMAND succeeded"
+# is needed to have something in the log about COMMAND because the command call itself
+# gets not logged (also not in debugscript mode) unless EXPOSE_SECRETS is set,
+# cf. https://github.com/rear/rear/issues/2967
+# The command's failure exit code '$?' is only available when
+#   if COMMAND ; then ... ; else Log "COMMAND failed with exit code $?" ; fi
+# is used because when 'if ! COMMAND' is used the '!' results $?=0
+# cf. https://github.com/rear/rear/pull/2985#issuecomment-1545455356
+function LogSecret () {
+    test "$EXPOSE_SECRETS" && Log "$@" || true
+}
+
 # For messages that should only appear in the log file when the user launched 'rear -d' in debug mode:
 function Debug () {
     test "$DEBUG" && Log "$@" || true


### PR DESCRIPTION
* Type: **Critical Fix** / **Enhancement**

* Impact: **Critical**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2967

* How was this pull request tested?

* Brief description of the changes in this pull request:

In sbin/rear added --expose-secrets option
and SECRET_OUTPUT_DEV
