### PR TITLE
issue: #3018: remove $SESAM_WORK_DIR from excludes

### DIFF
--- a/usr/share/rear/prep/SESAM/default/400_prep_sesam.sh
+++ b/usr/share/rear/prep/SESAM/default/400_prep_sesam.sh
@@ -25,7 +25,6 @@ if [ -e /etc/sesam2000.ini ]; then
         # files are included
         COPY_AS_IS_EXCLUDE+=(
             "${COPY_AS_IS_EXCLUDE_SESAM[@]}" 
-            $SESAM_WORK_DIR 
             $SESAM_TMP_DIR 
             $SESAM_LIS_DIR 
             $SESAM_LGC_DIR 


### PR DESCRIPTION
Follow up fix for issue #3018 

After the excludes have been fixed tests with more recent sesam client verisons have shown that the service fails to startup during recovery image boot due to missing semaphore files. Removing the sesam work directory where those information is stored from the excludes solves this problem.
