### PR TITLE
Make sure rescue contains all COPY_AS_IS files

### DIFF
--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -110,12 +110,12 @@ done >$copy_as_is_exclude_file
 # COPY_AS_IS+=( /path/to/directory/* )
 # which are used in our scripts and by users in their etc/rear/local.conf
 # cf. https://github.com/rear/rear/pull/2405#issuecomment-633512932
+# Using '-i' when extracting is necessary to avoid a false regular exit of 'tar'
+# in particular when padding zeroes get added when a file being read shrinks
+# because for 'tar' (without '-i') two consecutive 512-blocks of zeroes mean EOF,
+# cf. https://github.com/rear/rear/pull/3027
 # FIXME: The following code fails if file names contain characters from IFS (e.g. blanks),
 # cf. https://github.com/rear/rear/issues/1372
-#
-# Note the usage of '-i' when extracting the archive, this is necessary to
-# avoid tar from exiting due to padding zeros getting added when a file being
-# read shrinks, cf. https://github.com/rear/rear/pull/3027
 if ! tar -v -X $copy_as_is_exclude_file -P -C / -c ${COPY_AS_IS[*]} 2>$copy_as_is_filelist_file | tar $v -C $ROOTFS_DIR/ -x -i 1>/dev/null ; then
     Error "Failed to copy files and directories in COPY_AS_IS minus COPY_AS_IS_EXCLUDE"
 fi

--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -112,7 +112,11 @@ done >$copy_as_is_exclude_file
 # cf. https://github.com/rear/rear/pull/2405#issuecomment-633512932
 # FIXME: The following code fails if file names contain characters from IFS (e.g. blanks),
 # cf. https://github.com/rear/rear/issues/1372
-if ! tar -v -X $copy_as_is_exclude_file -P -C / -c ${COPY_AS_IS[*]} 2>$copy_as_is_filelist_file | tar $v -C $ROOTFS_DIR/ -x 1>/dev/null ; then
+#
+# Note the usage of '-i' when extracting the archive, this is necessary to
+# avoid tar from exiting due to padding zeros getting added when a file being
+# read shrinks, cf. https://github.com/rear/rear/pull/3027
+if ! tar -v -X $copy_as_is_exclude_file -P -C / -c ${COPY_AS_IS[*]} 2>$copy_as_is_filelist_file | tar $v -C $ROOTFS_DIR/ -x -i 1>/dev/null ; then
     Error "Failed to copy files and directories in COPY_AS_IS minus COPY_AS_IS_EXCLUDE"
 fi
 Log "Finished copying files and directories in COPY_AS_IS minus COPY_AS_IS_EXCLUDE"


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**
* Impact: **Normal**

* Reference to related issue (URL): N/A

* How was this pull request tested?

Using an automated reproducer implemented using *systemtap*

1. Create a file in `/dev` which will be embedded in the rescue environment

   ~~~
   # dd if=/dev/urandom of=/dev/shrinking bs=10K count=3
   3+0 records in
   3+0 records out
   30720 bytes (31 kB, 30 KiB) copied, 0.000689566 s, 44.5 MB/s
   ~~~

2. Execute the systemtap script in charge of shrinking the file while being copied

   ~~~
   # stap -v -g ./shrinking.stp
   [...]
   Pass 5: starting run.
   ~~~

3. Execute `rear mkrescue` from another terminal

* Brief description of the changes in this pull request:

The files copied as-is in the rescue are copied using a `tar -c | tar -x` command.
It may happen that inodes are shrinking during the copy (e.g. `/dev/mqueue/nnsc` (HPE device)), which can cause the `tar -x` command to stop extracting the next files, due to the padding zeros inserted in the shrank inode.
This leads to an error when checking the integrity of the rescue environment.

The solution is to add `-i` option when extracting, to continue the processing.