### PR TITLE
Update 200_check_usb_layout.sh

### DIFF
--- a/usr/share/rear/format/USB/default/200_check_usb_layout.sh
+++ b/usr/share/rear/format/USB/default/200_check_usb_layout.sh
@@ -33,7 +33,14 @@ test -b "$RAW_USB_DEVICE" || Error "Raw device $RAW_USB_DEVICE of $REAL_USB_DEVI
 # USB_FORMAT_ANSWER is also used in format/USB/default/300_format_usb_disk.sh
 USB_FORMAT_ANSWER=""
 
-test "ext3" = "$USB_DEVICE_FILESYSTEM" -o "ext4" = "$USB_DEVICE_FILESYSTEM" || USB_DEVICE_FILESYSTEM="ext3"
+case "$USB_DEVICE_FILESYSTEM" in
+    ("")
+        USB_DEVICE_FILESYSTEM="ext3";;
+    (ext3|ext4)
+        :;;
+    (*)
+        Error "Invalid USB_DEVICE_FILESYSTEM value '$USB_DEVICE_FILESYSTEM'. Must be 'ext3' or 'ext4'.";;
+esac
 
 local file_output=$( file -sbL "$REAL_USB_DEVICE" )
 # ID_FS_TYPE is also used in format/USB/default/350_label_usb_disk.sh


### PR DESCRIPTION
Issue an error message and exit if USB_DEVICE_FILESYSTEM is invalid, instead of setting it to "ext3". It's safer to fail due to configuation errors than to ignore/fix them silently.

Fixes: issue #3029

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): https://github.com/rear/rear/issues/3029

* How was this pull request tested?

    Ran `rear mkbackup` with a configuration containing

    ~~~
    BACKUP=NETFS
    BACKUP_PROG_COMPRESS_OPTIONS=( )
    BACKUP_PROG_COMPRESS_SUFFIX=
    BACKUP_URL=usb:///dev/disk/by-label/REAR-000
    MODULES=()
    OUTPUT=USB
    USB_BOOTLOADER=grub
    USB_DEVICE_FILESYSTEM=xfs
    USB_DEVICE_PARTED_LABEL=gpt
    USB_UEFI_PART_SIZE=2048
    SECURE_BOOT_BOOTLOADER=/boot/efi/EFI/redhat/shimx64.efi
    ~~~

* Brief description of the changes in this pull request:

Issue an error message and exit if USB_DEVICE_FILESYSTEM is invalid.