### PR TITLE
Use '2>>/dev/$SECRET_OUTPUT_DEV'

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -35,8 +35,8 @@ if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
     # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode
     # cf. the comment of the UserInput function in lib/_input-output-functions.sh
     # how to keep things confidential when usr/sbin/rear is run in debugscript mode
-    # ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
-    { test "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive encryption"
+    # ('2>>/dev/$SECRET_OUTPUT_DEV' should be sufficient here because 'test' does not output on stdout):
+    { test "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive encryption"
     LogPrint "Encrypting backup archive with key defined in BACKUP_PROG_CRYPT_KEY"
 fi
 
@@ -144,15 +144,15 @@ case "$(basename ${BACKUP_PROG})" in
                 "$(basename $(echo "$BACKUP_PROG_CRYPT_OPTIONS" | awk '{ print $1 }'))"
                 "$(basename $(echo "$SPLIT_COMMAND" | awk '{ print $1 }'))"
             )
-            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose    \
-                --no-wildcards-match-slash --one-file-system                        \
-                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                    \
-                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                   \
-                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                       \
-                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                \
-                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                         \
-                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |               \
-            { $BACKUP_PROG_CRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null | \
+            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose                   \
+                --no-wildcards-match-slash --one-file-system                                       \
+                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                                   \
+                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                                  \
+                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                                      \
+                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                               \
+                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                                        \
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |                              \
+            { $BACKUP_PROG_CRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV | \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
         else
@@ -160,14 +160,14 @@ case "$(basename ${BACKUP_PROG})" in
                 "$(basename $(echo "$BACKUP_PROG" | awk '{ print $1 }'))"
                 "$(basename $(echo "$SPLIT_COMMAND" | awk '{ print $1 }'))"
             )
-            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose    \
-                --no-wildcards-match-slash --one-file-system                        \
-                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                    \
-                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                   \
-                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                       \
-                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                \
-                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                         \
-                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |               \
+            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
+                --no-wildcards-match-slash --one-file-system                     \
+                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                 \
+                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                \
+                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                    \
+                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                             \
+                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                      \
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |            \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
         fi

--- a/usr/share/rear/build/default/500_ssh_setup.sh
+++ b/usr/share/rear/build/default/500_ssh_setup.sh
@@ -14,7 +14,7 @@ local sshd_config_file="$ROOTFS_DIR/etc/ssh/sshd_config"
 if [[ -f "$sshd_config_file" ]]; then
     # Enable root login with a password only if SSH_ROOT_PASSWORD is set
     local password_authentication_value=no
-    { test "$SSH_ROOT_PASSWORD" ; } 2>/dev/null && password_authentication_value=yes
+    { test "$SSH_ROOT_PASSWORD" ; } 2>>/dev/$SECRET_OUTPUT_DEV && password_authentication_value=yes
 
     # List of setting overrides required for the rescue system's sshd - see sshd_config(5)
     # Each list element must be a string of the form 'keyword [value]' or a comment '#...'.

--- a/usr/share/rear/build/default/503_store_tty_root_password.sh
+++ b/usr/share/rear/build/default/503_store_tty_root_password.sh
@@ -1,4 +1,4 @@
 # Store TTY_ROOT_PASSWORD for terminal logins
 
 # stderr is redirected here to avoid exposing the password hash in the log file when ReaR runs in debugscript mode.
-{ [[ -n "$TTY_ROOT_PASSWORD" ]] && echo "$TTY_ROOT_PASSWORD" > "$ROOTFS_DIR/.TTY_ROOT_PASSWORD"; } 2>/dev/null
+{ test "$TTY_ROOT_PASSWORD" && echo "$TTY_ROOT_PASSWORD" > "$ROOTFS_DIR/.TTY_ROOT_PASSWORD" ; } 2>>/dev/$SECRET_OUTPUT_DEV

--- a/usr/share/rear/build/default/960_remove_encryption_keys.sh
+++ b/usr/share/rear/build/default/960_remove_encryption_keys.sh
@@ -10,8 +10,8 @@
 # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode
 # cf. the comment of the UserInput function in lib/_input-output-functions.sh
 # how to keep things confidential when usr/sbin/rear is run in debugscript mode
-# ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
-{ test "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null || return 0
+# ('2>>/dev/$SECRET_OUTPUT_DEV' should be sufficient here because 'test' does not output on stdout):
+{ test "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV || return 0
 
 # BACKUP_PROG_CRYPT_KEY must be removed regardless if BACKUP_PROG_CRYPT_ENABLED is true or false
 # because when the user has in his etc/rear/local.conf BACKUP_PROG_CRYPT_KEY=my_secret_key
@@ -24,21 +24,21 @@ for configfile in $( find ${ROOTFS_DIR}/etc/rear ${ROOTFS_DIR}/usr/share/rear/co
     # therein the 'sedeasy' function that escapes both keyword and replacement
     # where here only the keyword part (i.e. the regexp part) is used.
     # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode as described above:
-    { escaped_regexp="$( echo "$BACKUP_PROG_CRYPT_KEY" | sed -e 's/\([[\/.*]\|\]\)/\\&/g' )" ; } 2>/dev/null
+    { escaped_regexp="$( echo "$BACKUP_PROG_CRYPT_KEY" | sed -e 's/\([[\/.*]\|\]\)/\\&/g' )" ; } 2>>/dev/$SECRET_OUTPUT_DEV
     # Avoid running 'sed' needlessly on files that do not contain 'BACKUP_PROG_CRYPT_KEY=' with its actual value
     # which is the case for default.conf that contains the example BACKUP_PROG_CRYPT_KEY="my_secret_passphrase".
     # Avoid that the escaped BACKUP_PROG_CRYPT_KEY value in escaped_regexp is shown in debugscript mode as described above.
     # Without '-q' grep would output the escaped BACKUP_PROG_CRYPT_KEY value in escaped_regexp on stdout which is redirected to the log:
-    { grep -q "BACKUP_PROG_CRYPT_KEY=.*$escaped_regexp" $configfile ; } 2>/dev/null || continue
+    { grep -q "BACKUP_PROG_CRYPT_KEY=.*$escaped_regexp" $configfile ; } 2>>/dev/$SECRET_OUTPUT_DEV || continue
     # It must work for simple unquoted assignment as in
     #   BACKUP_PROG_CRYPT_KEY=my_secret_passphrase
     # but also for more advanced things like
-    #   { BACKUP_PROG_CRYPT_KEY='my;secret;passphrase'; } 2>/dev/null
+    #   { BACKUP_PROG_CRYPT_KEY='my;secret;passphrase' ; } 2>>/dev/$SECRET_OUTPUT_DEV
     # cf. the example in doc/user-guide/04-scenarios.adoc
     # To avoid arbitrary syntax matching via complicated regular expressions
     # we simply remove all BACKUP_PROG_CRYPT_KEY values in lines that contain 'BACKUP_PROG_CRYPT_KEY='.
     # Avoid that the escaped BACKUP_PROG_CRYPT_KEY value in escaped_regexp is shown in debugscript mode as described above:
-    if { sed -i -e "/BACKUP_PROG_CRYPT_KEY=/s/$escaped_regexp//g" $configfile ; } 2>/dev/null ; then
+    if { sed -i -e "/BACKUP_PROG_CRYPT_KEY=/s/$escaped_regexp//g" $configfile ; } 2>>/dev/$SECRET_OUTPUT_DEV ; then
         DebugPrint "Removed BACKUP_PROG_CRYPT_KEY value from $configfile"
     else
         LogPrintError "Failed to remove BACKUP_PROG_CRYPT_KEY value from $configfile"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -12,9 +12,9 @@
 #
 # Some variables are for secret values (like passwords or encryption keys)
 # which are set to a default value in a confidential way via
-#   { VAR='secret_value' ; } 2>/dev/null
+#   { VAR='secret_value' ; } 2>>/dev/$SECRET_OUTPUT_DEV
 # The STDERR output must be discarded via a compound group command
-#   { confidential_command ; } 2>/dev/null
+#   { confidential_command ; } 2>>/dev/$SECRET_OUTPUT_DEV
 # even for a single command to discard STDERR also for 'set -x'.
 # Otherwise the confidential command and its arguments would be shown
 # in the ReaR log file when usr/sbin/rear is run in debugscript mode.
@@ -43,7 +43,7 @@
 #    cf. https://en.wikipedia.org/wiki/MD5#Security
 # 2. Copy the entire openssl output line between single quotes
 #    in a confidential variable assignment command like
-#      { PASSWORD='$6$96u44a5mgLn9fNBy$pyNnCvw...' ; } 2>/dev/null
+#      { PASSWORD='$6$96u44a5mgLn9fNBy$pyNnCvw...' ; } 2>>/dev/$SECRET_OUTPUT_DEV
 #
 # Several variables are set to a default value via
 #   VAR="${VAR:-default value}"
@@ -748,7 +748,7 @@ OPAL_PBA_UNLOCK_MODE="transient"
 # PBA debug password as a salted hash (empty for not using the debug shell facility).
 # If the debug password is entered when the PBA asks for a password to unlock disks,
 # an interactive emergency shell will be started, which can be used to debug the PBA system.
-{ OPAL_PBA_DEBUG_PASSWORD='' ; } 2>/dev/null
+{ OPAL_PBA_DEBUG_PASSWORD='' ; } 2>>/dev/$SECRET_OUTPUT_DEV
 #
 # When not empty, OPAL_PBA_DEBUG_DEVICE_COUNT overrides the number of TCG Opal 2-compliant self-encrypting disks
 # installed. To test the PBA system on a machine without any Opal 2-compliant disk, set OPAL_PBA_DEBUG_DEVICE_COUNT=1.
@@ -783,7 +783,7 @@ OPAL_PBA_TKNOFFSET=0
 #      https://www.freedesktop.org/software/systemd/man/systemd-stub.html
 #      https://www.freedesktop.org/software/systemd/man/systemd-creds.html
 #      https://www.freedesktop.org/software/systemd/man/systemd-cryptenroll.html
-{ OPAL_PBA_TKNKEY='tpm:opalauthtoken:7' ; } 2>/dev/null
+{ OPAL_PBA_TKNKEY='tpm:opalauthtoken:7' ; } 2>>/dev/$SECRET_OUTPUT_DEV
 #
 # Poor man's alternative for AT <-> PBA binding, additionaly encrypts Opal password using PBA image hash as a key
 # Optional, may be used independently of TKNKEY type
@@ -871,7 +871,7 @@ OUTPUT_PREFIX_PXE=""
 # Example: OUTPUT_LFTP_OPTIONS=("set ftp:ssl-force true" "set ftp:ssl-protect-data true")
 OUTPUT_LFTP_OPTIONS=()
 OUTPUT_LFTP_USERNAME=${OUTPUT_LFTP_USERNAME:-}
-{ OUTPUT_LFTP_PASSWORD=${OUTPUT_LFTP_PASSWORD:-} ; } 2>/dev/null
+{ OUTPUT_LFTP_PASSWORD=${OUTPUT_LFTP_PASSWORD:-} ; } 2>>/dev/$SECRET_OUTPUT_DEV
 
 ####
 # OUTPUT=RAMDISK
@@ -1441,8 +1441,8 @@ BACKUP_PROG_CRYPT_ENABLED="false"
 # cf. the reasoning about SSH_UNPROTECTED_PRIVATE_KEYS below
 # and see https://github.com/rear/rear/issues/2155
 # Therefore BACKUP_PROG_CRYPT_KEY must be manually set before running "rear recover".
-# In local.conf set it confidentially via { BACKUP_PROG_CRYPT_KEY='secret_key' ; } 2>/dev/null
-{ BACKUP_PROG_CRYPT_KEY="${BACKUP_PROG_CRYPT_KEY:-}" ; } 2>/dev/null
+# In local.conf set it confidentially via { BACKUP_PROG_CRYPT_KEY='secret_key' ; } 2>>/dev/$SECRET_OUTPUT_DEV
+{ BACKUP_PROG_CRYPT_KEY="${BACKUP_PROG_CRYPT_KEY:-}" ; } 2>>/dev/$SECRET_OUTPUT_DEV
 # The command for backup encryption during "rear mkbackup" will be basically
 #    tar ... | BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY
 # for details see the backup/NETFS/default/500_make_backup.sh script:
@@ -1921,7 +1921,7 @@ CLONE_ALL_USERS_GROUPS="true"
 # A terminal login password as a salted hash.
 # If empty, a root login into the ReaR recovery system via the system console or a serial terminal
 # is possible without being asked for a password.
-{ TTY_ROOT_PASSWORD='' ; } 2>/dev/null
+{ TTY_ROOT_PASSWORD='' ; } 2>>/dev/$SECRET_OUTPUT_DEV
 
 ####
 # SSH_FILES
@@ -1991,7 +1991,7 @@ SSH_FILES='avoid_sensitive_files'
 # To avoid a plain text password in the etc/rear/local.conf config file
 # generate a MD5 hashed password with the openssl command.
 # SSH_ROOT_PASSWORD is ignored when SSH_FILES is set to a 'false' value.
-{ SSH_ROOT_PASSWORD='' ; } 2>/dev/null
+{ SSH_ROOT_PASSWORD='' ; } 2>>/dev/$SECRET_OUTPUT_DEV
 #
 # SSH_UNPROTECTED_PRIVATE_KEYS="yes" makes ReaR also include SSH keys without a passphrase
 # in the ReaR rescue/recovery system at the price of having the rescue system/medium
@@ -2269,7 +2269,7 @@ GALAXY11_Q_ARGUMENTFILE=
 # CommVault login credentials for restore
 # Remember to adequately protect the rescue media if you include credentials in it
 GALAXY11_USER=${GALAXY11_USER:-}
-{ GALAXY11_PASSWORD=${GALAXY11_PASSWORD:-} ; } 2>/dev/null
+{ GALAXY11_PASSWORD=${GALAXY11_PASSWORD:-} ; } 2>>/dev/$SECRET_OUTPUT_DEV
 
 ##
 # BACKUP=TSM stuff
@@ -2954,7 +2954,7 @@ PROGS_ZYPPER=()
 # As fallback "rear recover" sets 'root' as root password in the target system.
 # If SSH_ROOT_PASSWORD is specified it is used as root password in the target system
 # unless ZYPPER_ROOT_PASSWORD is specified which is used with highest priority:
-{ ZYPPER_ROOT_PASSWORD='root' ; } 2>/dev/null
+{ ZYPPER_ROOT_PASSWORD='root' ; } 2>>/dev/$SECRET_OUTPUT_DEV
 # ZYPPER_NETWORK_SETUP_COMMANDS specifies the initial network setup in the target system for BACKUP=ZYPPER:
 # This initial network setup is only meant to make the target system
 # accessible from remote in a very basic way (e.g. for 'ssh').
@@ -2988,7 +2988,7 @@ COPY_AS_IS_YUM=( '/etc/yum*' '/etc/logrotate.d/yum*' '/usr/bin/python*' '/bin/py
 COPY_AS_IS_EXCLUDE_YUM=()
 REQUIRED_PROGS_YUM=( yum rpm rpm2cpio rpmdb rpmquery rpmverify chpasswd )
 PROGS_YUM=()
-{ YUM_ROOT_PASSWORD='root' ; } 2>/dev/null
+{ YUM_ROOT_PASSWORD='root' ; } 2>>/dev/$SECRET_OUTPUT_DEV
 YUM_NETWORK_SETUP_COMMANDS=()
 YUM_EXCLUDE_PKGS=("")
 ##

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -1036,11 +1036,17 @@ function cleanup_build_area_and_end_program () {
 #       If confidential user input is needed also in debugscript mode the caller of the UserInput function
 #       must call it in an appropriate (temporary) environment e.g. with STDERR redirected to /dev/null like
 #           { password="$( UserInput -I PASSWORD -C -r -s -p 'Enter the pasword' )" ; } 2>/dev/null
-#       The redirection must be done via a compound group command { confidential_command ; } 2>/dev/null
+#       or since https://github.com/rear/rear/pull/3006 probably better as
+#           { password="$( UserInput -I PASSWORD -C -r -s -p 'Enter the pasword' )" ; } 2>>/dev/$SECRET_OUTPUT_DEV
+#       to still make debugging possible for the user by calling rear with the --expose-secrets option.
+#       The redirection must be done via a compound group command like
+#           { confidential_command ; } 2>/dev/null
 #       even for a single confidential command to ensure STDERR is redirected to /dev/null also for 'set -x'
 #       otherwise the confidential command and its arguments would be shown in the log file, for example
 #           { openssl des3 -salt -k secret_passphrase ; } 2>/dev/null
-#       where the secret passphrase must not appear in the log, cf. https://github.com/rear/rear/issues/2155
+#       where the secret passphrase must not appear in the log,
+#       cf. https://github.com/rear/rear/issues/2155
+#       and https://github.com/rear/rear/issues/2967
 # Result:
 #   Any actual user input or an automated user input or the default response is output via STDOUT.
 # Return code:

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -146,7 +146,7 @@ case "$scheme" in
     	lftp_cmds_heredoc=$(IFS=$'\n'; echo "${lftp_cmds[*]}")
 
         if contains_visible_char "$OUTPUT_LFTP_USERNAME" ; then
-            { lftp_user_opts="-u $OUTPUT_LFTP_USERNAME,$OUTPUT_LFTP_PASSWORD" ; } 2>/dev/null
+            { lftp_user_opts="-u $OUTPUT_LFTP_USERNAME,$OUTPUT_LFTP_PASSWORD" ; } 2>>/dev/$SECRET_OUTPUT_DEV
             Log "lftp -u $OUTPUT_LFTP_USERNAME,******* $OUTPUT_URL"
         else
             Log "lftp $lftp_user_opts $OUTPUT_URL"

--- a/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
+++ b/usr/share/rear/prep/OPALPBA/Linux-i386/001_configure_workflow.sh
@@ -36,7 +36,7 @@ if (( ${#OPAL_PBA_PROGS[@]} == 0 && ${#OPAL_PBA_COPY_AS_IS[@]} == 0)) && has_bin
     LogPrintError "     interface for the PBA by setting OPAL_PBA_{PROGS,COPY_AS_IS,LIBS} to include Plymouth components."
 fi
 PROGS+=( "${OPAL_PBA_PROGS[@]}" clear )
-{ test "$OPAL_PBA_DEBUG_PASSWORD" ; } 2>/dev/null && REQUIRED_PROGS+=( openssl )
+{ test "$OPAL_PBA_DEBUG_PASSWORD" ; } 2>>/dev/$SECRET_OUTPUT_DEV && REQUIRED_PROGS+=( openssl )
 COPY_AS_IS+=( "${OPAL_PBA_COPY_AS_IS[@]}" )
 LIBS+=( "${OPAL_PBA_LIBS[@]}" )
 

--- a/usr/share/rear/prep/default/340_include_password_tools.sh
+++ b/usr/share/rear/prep/default/340_include_password_tools.sh
@@ -1,4 +1,4 @@
 # Include tools to check TTY_ROOT_PASSWORD for terminal logins
 
 # stderr is redirected here to avoid exposing the password hash in the log file when ReaR runs in debugscript mode.
-{ [[ -n "$TTY_ROOT_PASSWORD" ]] && REQUIRED_PROGS+=( openssl ); } 2>/dev/null
+{ test "$TTY_ROOT_PASSWORD" && REQUIRED_PROGS+=( openssl ) ; } 2>>/dev/$SECRET_OUTPUT_DEV

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -9,7 +9,7 @@ has_binary ssh || has_binary sshd || return 0
 # Do nothing when not any SSH file should be copied into the recovery system:
 if is_false "$SSH_FILES" ; then
     # Print an info if SSH_ROOT_PASSWORD is set but that cannot work when SSH_FILES is set to a 'false' value:
-    { test "$SSH_ROOT_PASSWORD" ; } 2>/dev/null && LogPrintError "SSH_ROOT_PASSWORD cannot work when SSH_FILES is set to a 'false' value"
+    { test "$SSH_ROOT_PASSWORD" ; } 2>>/dev/$SECRET_OUTPUT_DEV && LogPrintError "SSH_ROOT_PASSWORD cannot work when SSH_FILES is set to a 'false' value"
     return 0
 fi
 
@@ -88,7 +88,7 @@ echo "ssh:23:respawn:/etc/scripts/run-sshd" >>$ROOTFS_DIR/etc/inittab
 { if ! test -f "$ROOT_HOME_DIR/.ssh/authorized_keys" -o "$SSH_ROOT_PASSWORD" ; then
     LogPrintError "To log into the recovery system via ssh set up $ROOT_HOME_DIR/.ssh/authorized_keys or specify SSH_ROOT_PASSWORD"
   fi
-} 2>/dev/null
+} 2>>/dev/$SECRET_OUTPUT_DEV
 
 # Set the SSH root password; if pw is encrypted just copy it otherwise use openssl (for backward compatibility)
 # Encryption syntax is detected as a '$D$' or '$Dx$' prefix in the password, where D is a single digit and x is one lowercase character.
@@ -104,4 +104,4 @@ echo "ssh:23:respawn:/etc/scripts/run-sshd" >>$ROOTFS_DIR/etc/inittab
             ;;
     esac
   fi
-} 2>/dev/null
+} 2>>/dev/$SECRET_OUTPUT_DEV

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -135,7 +135,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
     # therefore 'Log ... BACKUP_PROG_CRYPT_KEY ...' is used (and not '$BACKUP_PROG_CRYPT_KEY')
     # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
     # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
-    # so that stderr of the confidential command is redirected to /dev/null
+    # so that stderr of the confidential command is redirected to SECRET_OUTPUT_DEV (normally /dev/null)
     # cf. the comment of the UserInput function in lib/_input-output-functions.sh
     # how to keep things confidential when rear is run in debugscript mode
     # because it is more important to not leak out user secrets into a log file
@@ -150,7 +150,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                 # cf. https://github.com/rear/rear/issues/2369 and https://github.com/rear/rear/issues/2458
                 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then 
                     Log "dd if=$restore_input bs=1M | $BACKUP_PROG_DECRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY | $BACKUP_PROG --block-number --totals --verbose ${BACKUP_PROG_OPTIONS[@]} ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C $TARGET_FS_ROOT/ -x -f -"
-                    dd if=$restore_input bs=1M | { $BACKUP_PROG_DECRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null | $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
+                    dd if=$restore_input bs=1M | { $BACKUP_PROG_DECRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV | $BACKUP_PROG --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $TARGET_FS_ROOT/ -x -f -
 
                 else
                     Log "dd if=$restore_input bs=1M | $BACKUP_PROG --block-number --totals --verbose ${BACKUP_PROG_OPTIONS[@]} ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C $TARGET_FS_ROOT/ -x -f -"

--- a/usr/share/rear/restore/YUM/default/405_recreate_users_and_groups.sh
+++ b/usr/share/rear/restore/YUM/default/405_recreate_users_and_groups.sh
@@ -27,7 +27,7 @@ fi
 # therefore 'Log ... BACKUP_PROG_CRYPT_KEY ...' is used (and not '$BACKUP_PROG_CRYPT_KEY')
 # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
 # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
-# so that stderr of the confidential command is redirected to /dev/null
+# so that stderr of the confidential command is redirected to SECRET_OUTPUT_DEV (normally /dev/null)
 # cf. the comment of the UserInput function in lib/_input-output-functions.sh
 # how to keep things confidential when rear is run in debugscript mode
 # because it is more important to not leak out user secrets into a log file
@@ -37,7 +37,7 @@ fi
 # cf. https://github.com/rear/rear/issues/2369 and https://github.com/rear/rear/issues/2458
 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
     dd if=$backuparchive bs=1M | \
-        { $BACKUP_PROG_DECRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null | \
+        { $BACKUP_PROG_DECRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV | \
         $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C $tmp_dir -x -f - $passwd_group_shadow_files
 else
     dd if=$backuparchive bs=1M | \

--- a/usr/share/rear/restore/YUM/default/410_restore_backup.sh
+++ b/usr/share/rear/restore/YUM/default/410_restore_backup.sh
@@ -136,7 +136,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                 # cf. https://github.com/rear/rear/issues/2369 and https://github.com/rear/rear/issues/2458
                 if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
                     Log "dd if=$restore_input bs=1M | $BACKUP_PROG_DECRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose ${BACKUP_PROG_OPTIONS[@]} ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C / -x -f -"
-                    dd if=$restore_input bs=1M | { $BACKUP_PROG_DECRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -
+                    dd if=$restore_input bs=1M | { $BACKUP_PROG_DECRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -
                 else
                     Log "dd if=$restore_input bs=1M | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose ${BACKUP_PROG_OPTIONS[@]} ${BACKUP_PROG_COMPRESS_OPTIONS[@]} -C / -x -f -"
                     dd if=$restore_input bs=1M | chroot $TARGET_FS_ROOT/ $BACKUP_PROG --acls --preserve-permissions --same-owner --block-number --totals --verbose "${BACKUP_PROG_OPTIONS[@]}" "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" -C / -x -f -

--- a/usr/share/rear/restore/YUM/default/970_set_root_password.sh
+++ b/usr/share/rear/restore/YUM/default/970_set_root_password.sh
@@ -25,7 +25,7 @@ set -e -u -o pipefail
   test "$SSH_ROOT_PASSWORD" && root_password="$SSH_ROOT_PASSWORD"
   # If YUM_ROOT_PASSWORD is specified used that as root password in the target system:
   test "$YUM_ROOT_PASSWORD" && root_password="$YUM_ROOT_PASSWORD"
-} 2>/dev/null
+} 2>>/dev/$SECRET_OUTPUT_DEV
 
 # Set the root password in the target system.
 # Use a login shell in between so that one has in the chrooted environment
@@ -33,7 +33,7 @@ set -e -u -o pipefail
 # the commands inside 'chroot' as one would type them in a normal working shell.
 # In particular one can call programs (like 'passwd') by their basename without path
 # cf. https://github.com/rear/rear/issues/862#issuecomment-274068914
-{ chroot $TARGET_FS_ROOT /bin/bash --login -c "echo -e '$root_password\n$root_password' | passwd root" ; } 2>/dev/null
+{ chroot $TARGET_FS_ROOT /bin/bash --login -c "echo -e '$root_password\n$root_password' | passwd root" ; } 2>>/dev/$SECRET_OUTPUT_DEV
 
 # Restore the ReaR default bash flags and options (see usr/sbin/rear):
 apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"

--- a/usr/share/rear/restore/ZYPPER/default/970_set_root_password.sh
+++ b/usr/share/rear/restore/ZYPPER/default/970_set_root_password.sh
@@ -24,7 +24,7 @@ set -e -u -o pipefail
   test "$SSH_ROOT_PASSWORD" && root_password="$SSH_ROOT_PASSWORD"
   # If ZYPPER_ROOT_PASSWORD is specified used that as root password in the target system:
   test "$ZYPPER_ROOT_PASSWORD" && root_password="$ZYPPER_ROOT_PASSWORD"
-} 2>/dev/null
+} 2>>/dev/$SECRET_OUTPUT_DEV
 
 # Set the root password in the target system.
 # Use a login shell in between so that one has in the chrooted environment
@@ -32,7 +32,7 @@ set -e -u -o pipefail
 # the commands inside 'chroot' as one would type them in a normal working shell.
 # In particular one can call programs (like 'passwd') by their basename without path
 # cf. https://github.com/rear/rear/issues/862#issuecomment-274068914
-{ chroot $TARGET_FS_ROOT /bin/bash --login -c "echo -e '$root_password\n$root_password' | passwd root" ; } 2>/dev/null
+{ chroot $TARGET_FS_ROOT /bin/bash --login -c "echo -e '$root_password\n$root_password' | passwd root" ; } 2>>/dev/$SECRET_OUTPUT_DEV
 
 # Restore the ReaR default bash flags and options (see usr/sbin/rear):
 apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"

--- a/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
+++ b/usr/share/rear/verify/GALAXY11/default/420_login_to_galaxy_and_setup_environment.sh
@@ -10,11 +10,11 @@ let qlist_ret=$?
 if test $qlist_ret -eq 0; then
 	Log "CommVault client logged in automatically"
 elif test $qlist_ret -eq 2; then
-	if test "$GALAXY11_USER" && { test "$GALAXY11_PASSWORD" ; } 2>/dev/null ; then
+	if test "$GALAXY11_USER" && { test "$GALAXY11_PASSWORD" ; } 2>>/dev/$SECRET_OUTPUT_DEV ; then
 		# try to login with Credentials from env
         # Using "if COMMAND ; then ... ; else echo COMMAND failed with $? ; fi" is mandatory
         # because "if ! COMMAND ; then echo COMMAND failed with $? ..." shows wrong $? because '!' results $?=0
-		if { qlogin -u "$GALAXY11_USER" -clp "$GALAXY11_PASSWORD" ; } 2>/dev/null ; then
+		if { qlogin -u "$GALAXY11_USER" -clp "$GALAXY11_PASSWORD" ; } 2>>/dev/$SECRET_OUTPUT_DEV ; then
             LogPrint "CommVault client logged in with credentials from GALAXY11_USER '$GALAXY11_USER' and GALAXY11_PASSWORD"
         else
             Error "CommVault 'qlogin -u $GALAXY11_USER -clp GALAXY11_PASSWORD' failed with exit code $? (retry on command line to see error messages)"

--- a/usr/share/rear/verify/NETFS/default/600_check_encryption_key.sh
+++ b/usr/share/rear/verify/NETFS/default/600_check_encryption_key.sh
@@ -11,7 +11,7 @@ is_true "$BACKUP_PROG_CRYPT_ENABLED" || return 0
 # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode
 # cf. the comment of the UserInput function in lib/_input-output-functions.sh
 # how to keep things confidential when usr/sbin/rear is run in debugscript mode
-# ('2>/dev/null' should be sufficient here because 'test' does not output on stdout):
-{ test "$BACKUP_PROG_CRYPT_KEY" ; } 2>/dev/null || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive decryption"
+# ('2>>/dev/$SECRET_OUTPUT_DEV' should be sufficient here because 'test' does not output on stdout):
+{ test "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive decryption"
 LogPrint "Decrypting backup archive with key defined in BACKUP_PROG_CRYPT_KEY"
 


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):

See
https://github.com/rear/rear/issues/2967
and
https://github.com/rear/rear/pull/3006
therein in particular
https://github.com/rear/rear/pull/3006#issuecomment-1590775360

* How was this pull request tested?

See
https://github.com/rear/rear/pull/3006#issuecomment-1578565338

* Brief description of the changes in this pull request:

Use
```
{ SECRET COMMAND ; } 2>>/dev/$SECRET_OUTPUT_DEV
```
instead of
```
{ SECRET COMMAND ; } 2>/dev/null
```

Reasoning:
See
https://github.com/rear/rear/issues/2967#issuecomment-1562732484
that reads (excerpt):
```
the

{ ... ; } 2>>/dev/$SECRET_OUTPUT_DEV

syntax makes it clear which redirections are
explicitly meant to hide secrets to distinguish them
from usual unwanted output discard via '2>/dev/null'
```
