### PR TITLE
Update 998_dump_variables.sh

### DIFF
--- a/usr/share/rear/init/default/998_dump_variables.sh
+++ b/usr/share/rear/init/default/998_dump_variables.sh
@@ -1,16 +1,16 @@
 
-# Output all variable values into the log file
-# which may also output possibly confidential values 
-# so do this only in debugscript mode where the 'set -x' output
-# in general already reveals possibly confidential information:
-test "$DEBUGSCRIPTS" || return 0
+# This file is part of Relax-and-Recover, licensed under the GNU General
+# Public License. Refer to the included COPYING for full text of license.
 
-# For now disable this script until https://github.com/rear/rear/issues/2967 is solved.
-# Users who need this script can disable the next two lines:
-DebugPrint "Skipped init/default/998_dump_variables.sh for legal liability worries, see https://github.com/rear/rear/issues/2967"
-return 1
-
-# Suppress output that contains 'pass' or 'key' or 'crypt' (ignore case) to skip output
-# e.g. for BACKUP_PROG_CRYPT_KEY or SSH_ROOT_PASSWORD or LUKS_CRYPTSETUP_OPTIONS
-# cf. https://github.com/rear/rear/issues/2967
-Debug "Runtime Configuration (except what contains 'pass' or 'key' or 'crypt'):$LF$( declare -p | egrep -vi 'pass|key|crypt' )"
+# To help with debugging dump all currently existing variable values into the log file.
+#
+# Because this will also output possibly confidential values into the log file
+# (like passwords, encryption keys, authentication tokens, ...)
+# this happens only if rear is run by the user with the 'expose-secrets' option
+# see https://github.com/rear/rear/issues/2967
+if LogSecret "Runtime Configuration:$LF$( declare -p )" ; then
+    # Show the log file name here in any case because sbin/rear shows "Using log file ..." only in verbose mode:
+    LogUserOutput "Dumped all variable values (including possibly confidential values) into $RUNTIME_LOGFILE"
+else
+    Debug "Skipped dumping all variable values into the log file (use 'expose-secrets' for that)"
+fi

--- a/usr/share/rear/init/default/998_dump_variables.sh
+++ b/usr/share/rear/init/default/998_dump_variables.sh
@@ -8,7 +8,10 @@
 # (like passwords, encryption keys, authentication tokens, ...)
 # this happens only if rear is run by the user with the 'expose-secrets' option
 # see https://github.com/rear/rear/issues/2967
-if LogSecret "Runtime Configuration:$LF$( declare -p )" ; then
+
+# 'declare -p' is a secret command so '$( declare -p )' is also a secret command
+# because 'set -x' prints the result of $( declare -p ) as part of the LogSecret argument:
+if { LogSecret "Runtime Configuration:$LF$( declare -p )" ; } 2>>/dev/$SECRET_OUTPUT_DEV ; then
     # Show the log file name here in any case because sbin/rear shows "Using log file ..." only in verbose mode:
     LogUserOutput "Dumped all variable values (including possibly confidential values) into $RUNTIME_LOGFILE"
 else

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -466,9 +466,13 @@ function Log () {
 #       { LogSecret "'COMMAND $SECRET_ARGUMENT' failed with exit code $?" ; } 2>>/dev/$SECRET_OUTPUT_DEV
 #       Error "COMMAND failed"
 #   fi
-# The LogSecret function call must be within '{ ... ; } 2>>/dev/$SECRET_OUTPUT_DEV'
+# Every LogSecret function call must be within '{ ... ; } 2>>/dev/$SECRET_OUTPUT_DEV'
 # because otherwise $SECRET_ARGUMENT in the LogSecret function call
-# would leak into the log file in debuscript mode via 'set -x'.
+# would leak into the log file in debuscript mode via 'set -x'
+# in particular also when there is no directly visible secret argument
+# but command substitution may result confidential information like
+#   { LogSecret "The value is: $( COMMAND )" ; } 2>>/dev/$SECRET_OUTPUT_DEV
+# because 'set -x' prints the result of COMMAND as part of the LogSecret argument.
 # The "COMMAND ... succeeded" log messages are needed
 # to have something in the log about COMMAND because the command call itself
 # gets not logged (also not in debugscript mode) unless EXPOSE_SECRETS is set,


### PR DESCRIPTION

* Type: **Bug Fix**

* Impact: **Critical**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2967

* How was this pull request tested?
see below

* Brief description of the changes in this pull request:

Overhauled init/default/998_dump_variables.sh
so that its intended functionality happens
only when explicitly requested by the user
to avoid that possibly confidential values
are output into the log file by accident, see
https://github.com/rear/rear/issues/2967
