### PR TITLE
In DoExitTasks() skip 'sleep 3' when all went well

### DIFF
--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -303,8 +303,9 @@ function DoExitTasks () {
     # terminate_descendants_from_children_to_grandchildren that sleeps two times one second
     # so that we wait here three seconds to be on the safe side that a possibly running
     # terminate_descendants_from_children_to_grandchildren has done its job and finished
-    # to avoid that two functions run in parallel that terminate descendant processes:
-    sleep 3
+    # to avoid that two functions run in parallel that terminate descendant processes.
+    # Skip sleeping when all went well and DoExitTasks is called at normal exit:
+    (( EXIT_FAIL_MESSAGE )) && sleep 3
     # Show descendant processes PIDs with their commands in the log
     # so that the plain PIDs in the log get more comprehensible
     # when terminate_descendants_from_grandchildren_to_children is called afterwards:


### PR DESCRIPTION

* Type: **Enhancement**

* Impact: **Low**

* How was this pull request tested?

Before:
```
# time usr/sbin/rear help
...
Use 'rear -v help' for more advanced commands.
[here nothing happens for 3 seconds]

real    0m3.690s
user    0m0.629s
sys     0m0.254s
```

With the change of this pull request:
```
# time usr/sbin/rear help
...
Use 'rear -v help' for more advanced commands.

real    0m0.686s
user    0m0.644s
sys     0m0.234s
```

* Brief description of the changes in this pull request:

In the DoExitTasks function skip 'sleep 3'
when all went well and DoExitTasks is called at normal exit
to avoid needless 3 seconds delay of normal end of program.
