### PR TITLE
Remove the lvmdevices file at the end of recovery

### DIFF
--- a/usr/share/rear/finalize/GNU/Linux/230_remove_lvmdevices.sh
+++ b/usr/share/rear/finalize/GNU/Linux/230_remove_lvmdevices.sh
@@ -1,0 +1,25 @@
+# Adapted from 260_rename_diskbyid.sh
+
+# Remove /etc/lvm/devices/system.devices
+# The file restricts LVM to disks with given (hardware) IDs (serial
+# numbers, WWNs). See lvmdevices(8).
+# Unfortunately, when restoring to different disks than in the original 
+# system, it will mean that LVM is broken in the recovered system (it
+# won't find any disks).  Therefore it is safer to remove the file to
+# force the old behavior where LVM scans all disks. This used to be the
+# LVM default (use_devicesfile=0).
+
+# There may be other files under /etc/lvm/devices, but they are not used
+# by default
+
+local file=/etc/lvm/devices/system.devices
+local realfile
+
+realfile="$TARGET_FS_ROOT/$file"
+# OK if file not found
+test -f "$realfile" || return 0
+mv $v "$realfile" "$realfile.rearbak"
+LogPrint "Renamed LVM devices file $realfile to $realfile.rearbak
+to prevent LVM problems in the recovered system, verify that the file
+is correct after booting the recovered system and move it back, or
+regenerate it using vgimportdevices."


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):  closes #2917, closes #3042 

* How was this pull request tested?
Full backup and recovery on a KVM virtual machine (x86_64) with virtio disk (vda) and a PowerVM LPAR (ppc64le) withs SCSI disk (sda), both with RHEL 9 (where the LVM default is `use_devicesfile=1`).
Before backup and recovery:

```
# cat /etc/lvm/devices/system.devices
# LVM uses devices listed in this file.
# Created by LVM command lvmdevices pid 3645 at Thu Aug 24 11:52:38 2023
VERSION=1.1.4
IDTYPE=sys_serial IDNAME=00fac60100004c000000017bead7ca41.10 DEVNAME=/dev/sda3 PVID=3NFhwAW1RAQzJz8uOsZqkcqasKhlZt9b PART=3
# lvmdevices 
  Device /dev/sda3 IDTYPE=sys_serial IDNAME=00fac60100004c000000017bead7ca41.10 DEVNAME=/dev/sda3 PVID=3NFhwAW1RAQzJz8uOsZqkcqasKhlZt9b PART=3
```
After recovery:
```
# lvmdevices 
  Devices file does not exist.
# cat /etc/lvm/devices/system.devices.rearbak 
# LVM uses devices listed in this file.
# Created by LVM command lvmdevices pid 3645 at Thu Aug 24 11:52:38 2023
VERSION=1.1.4
IDTYPE=sys_serial IDNAME=00fac60100004c000000017bead7ca41.10 DEVNAME=/dev/sda3 PVID=3NFhwAW1RAQzJz8uOsZqkcqasKhlZt9b PART=3
```

* Brief description of the changes in this pull request:

The file `/etc/lvm/devices/system.devices` restricts LVM to disks with given (hardware) IDs (serial numbers, WWNs). See lvmdevices(8).

Unfortunately, when restoring to different disks than in the original system, it will mean that LVM is broken in the recovered system (it won't find any disks).  Therefore it is safer to remove the file to force the old behavior where LVM scans all disks. This used to be the LVM default (`use_devicesfile=0`).

I don't think one can delete the devices file and do /usr/sbin/vgimportdevices -a to reimport the VGs automatically at the end of recovery. The problem is, imagine you have several volume groups. One for the system (rootvg) and one for data (datavg), on different disks. Now you system is broken and you want to recover it, but the data are unaffected and you want them to survive the recovery procedure. For this, it is advisable to disconnect the data disks during the recovery procedure to avoid accidentally reformatting them. But, as they are not connected, /usr/sbin/vgimportdevices -a will not find datavg, therefore it will not add them to the devices file and when you reboot after recovery with the disks attached again, they will not be found by LVM and datavg will not be activated.
I was thinking about some automated procedure to update only the obsolete entries in lvmdevices and keep all others, but I have not found anything simple. I therefore believe the only reliable solution is to remove the devices file at the end of recovery, since running without it is preferable to a broken system due to some fragile attempt at an "ideal" solution.