### PR TITLE
Remove unnecessary curly braces in var expansion

### DIFF
--- a/usr/share/rear/finalize/GNU/Linux/260_rename_diskbyid.sh
+++ b/usr/share/rear/finalize/GNU/Linux/260_rename_diskbyid.sh
@@ -21,7 +21,7 @@
 
 FILES="/etc/fstab /boot/grub/menu.lst /boot/grub2/grub.cfg /boot/grub/device.map /boot/efi/*/*/grub.cfg /etc/lvm/lvm.conf /etc/lilo.conf /etc/yaboot.conf /etc/default/grub_installdevice"
 
-OLD_ID_FILE="${VAR_DIR}/recovery/diskbyid_mappings"
+OLD_ID_FILE="$VAR_DIR/recovery/diskbyid_mappings"
 NEW_ID_FILE="$TMP_DIR/diskbyid_mappings"
 
 [ ! -s "$OLD_ID_FILE" ] && return 0
@@ -109,7 +109,7 @@ for file in $FILES; do
         fi
     fi
     # keep backup
-    cp $v "$realfile" "${realfile}.rearbak"
+    cp $v "$realfile" "$realfile.rearbak"
     # we should consider creating a sed script within a string
     # and then call sed once (as done other times)
     while read ID DEV_NAME ID_NEW; do


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested?
Backup and recovery on RHEL 9: the log contains
```
2023-09-07 09:16:51.683209039 Including finalize/GNU/Linux/260_rename_diskbyid.sh
2023-09-07 09:16:51.751526112 Migrating disk-by-id mappings in certain restored files in /mnt/local to current disk-by-id mappings ...
```
and the recovered system has backup files:
```
# find /etc -name \*.rearbak
/etc/lvm/devices/system.devices.rearbak
/etc/lvm/lvm.conf.rearbak
/etc/fstab.rearbak
```
showing that the creation of backups still works.

* Brief description of the changes in this pull request:
Respect coding style in finalize/GNU/Linux/260_rename_diskbyid.sh: https://github.com/rear/rear/wiki/Coding-Style#variables

Inspired by discussion of PR #3043 : https://github.com/rear/rear/pull/3043#discussion_r1314863175