### PR TITLE
Skip invalid disk drives (zero sized, no media) when saving layout

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -422,12 +422,7 @@ Log "Saving disks and their partitions"
                     continue
                 fi
                 disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")
-                # We do not error out when there is no partition label type value because
-                # "rear recover" works in a special case without partition label type value when there is
-                # only a 'disk' entry but nothing else for this disk exists in disklayout.conf
-                # which can happen when /dev/sdX is an empty SD card slot without medium,
-                # see https://github.com/rear/rear/issues/2810
-                test $disktype || LogPrintError "No partition label type for 'disk $devname' (may cause 'rear recover' failure)"
+                test $disktype || Error "Invalid 'disk $devname' entry (no partition table type for '$devname')"
                 if [ "$disktype" != "dasd" ]; then
                     echo "# Disk $devname"
                     echo "# Format: disk <devname> <size(bytes)> <partition label type>"

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -413,11 +413,11 @@ Log "Saving disks and their partitions"
             elif [[ ! ($blockd = *rpmb || $blockd = *[0-9]boot[0-9]) ]]; then # Silently skip Replay Protected Memory Blocks and others  
                 devname=$(get_device_name $disk)
                 devsize=$(get_disk_size ${disk#/sys/block/})
-                disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")
                 # Ensure syntactically correct 'disk' entries:
                 # Each value must exist and each value must be a single non-blank word so we 'test' without quoting the value:
                 test $devname || Error "Invalid 'disk' entry (no disk device name for '$disk')"
                 test $devsize || Error "Invalid 'disk $devname' entry (no device size for '$devname')"
+                disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")
                 # We do not error out when there is no partition label type value because
                 # "rear recover" works in a special case without partition label type value when there is
                 # only a 'disk' entry but nothing else for this disk exists in disklayout.conf

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -417,6 +417,11 @@ Log "Saving disks and their partitions"
                 # Each value must exist and each value must be a single non-blank word so we 'test' without quoting the value:
                 test $devname || Error "Invalid 'disk' entry (no disk device name for '$disk')"
                 test $devsize || Error "Invalid 'disk $devname' entry (no device size for '$devname')"
+                # Validation error can happen when /dev/sdX is an empty SD card slot without medium,
+                # see https://github.com/rear/rear/issues/2810 https://github.com/rear/rear/issues/2958
+                # this is normal, but such device must be skipped and not be added to the layout
+                # - it does not contain any data anyway.
+                # See https://github.com/rear/rear/pull/3047
                 if ! validation_error=$(is_disk_valid $devname) ; then
                     LogPrintError "Ignoring $blockd: $validation_error"
                     continue

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -417,6 +417,10 @@ Log "Saving disks and their partitions"
                 # Each value must exist and each value must be a single non-blank word so we 'test' without quoting the value:
                 test $devname || Error "Invalid 'disk' entry (no disk device name for '$disk')"
                 test $devsize || Error "Invalid 'disk $devname' entry (no device size for '$devname')"
+                if ! validation_error=$(is_disk_valid $devname) ; then
+                    LogPrintError "Ignoring $blockd: $validation_error"
+                    continue
+                fi
                 disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")
                 # We do not error out when there is no partition label type value because
                 # "rear recover" works in a special case without partition label type value when there is


### PR DESCRIPTION
##### Pull Request Details:

* Type:  **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): fixes #2958

* How was this pull request tested?
  * `rear savelayout` on Fedora 36 with empty USB SD card reader
     I show the relevant log excerpt and the corresponding part of `disklayout.conf`, if any.
    * original code:
      ```
      No partition label type for 'disk /dev/sdb' (may cause 'rear recover' failure)
      ```
      ```
      # Disk /dev/sdb
      # Format: disk <devname> <size(bytes)> <partition label type>
      #disk /dev/sdb 0 
      ```
    * new code:
      ```
      Ignoring sdb: blockdev: cannot open /dev/sdb: No medium found
      ```
      No sdb in disklayout
    * new code without reverting 0a1d634ed15500bb21f37ac1bbb11c8a4bb11545
      same result
    * original code only with 0a1d634ed15500bb21f37ac1bbb11c8a4bb11545 reverted
      This reproduces https://github.com/rear/rear/issues/2810
      ```
      ERROR: Invalid 'disk /dev/sdb' entry (no partition table type for '/dev/sdb')
      Some latest log messages since the last called script 200_partition_layout.sh:
        2023-06-20 19:23:08.249840221 Saving disks and their partitions
      Some messages from /var/tmp/rear.ZC1Unp4TNvGyfNj/tmp/rear.savelayout.stdout_stderr since the last called script 200_partition_layout.sh:
        blockdev: cannot open /dev/sdb: No medium found
        Error: Error opening /dev/sdb: No medium found
      Use debug mode '-d' for some debug messages or debugscript mode '-D' for full debug messages with 'set -x' output
      Aborting due to an error, check /home/pcahyna/rear/rear/var/log/rear/rear-pacaziste.log for details
      Terminated
      ```
  * `rear savelayout` on Fedora 36 with empty USB SD card reader and `AUTOEXCLUDE_DISKS=n`
    * original code:
      ```
      No partition label type for 'disk /dev/sdb' (may cause 'rear recover' failure)
      /dev/sdb size 0 is not a positive integer
      ERROR: 
      ====================
      BUG in /home/pcahyna/rear/rear/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh line 257:
      'Entries in /home/pcahyna/rear/rear/var/lib/rear/layout/disklayout.conf are broken ('rear recover' would fail)'
      --------------------
      Please report it at https://github.com/rear/rear/issues
      and include all related parts from /home/pcahyna/rear/rear/var/log/rear/rear-pacaziste.log
      preferably the whole debug information via 'rear -D savelayout'
      ====================
      Some latest log messages since the last called script 950_verify_disklayout_file.sh:
        2023-06-20 19:16:28.417175129 Verifying that the entries in /home/pcahyna/rear/rear/var/lib/rear/layout/disklayout.conf are correct
        2023-06-20 19:16:28.424548585 Verifying that the 'disk' entries in /home/pcahyna/rear/rear/var/lib/rear/layout/disklayout.conf are correct
        2023-06-20 19:16:28.436529921 Verifying that the 'part' entries for /dev/sda in /home/pcahyna/rear/rear/var/lib/rear/layout/disklayout.conf are correct
        2023-06-20 19:16:28.446834398 Verifying that the 'part' entries for /dev/sda in /home/pcahyna/rear/rear/var/lib/rear/layout/disklayout.conf specify consecutive partitions
        2023-06-20 19:16:28.458051434 Verifying that the 'part' entries for /dev/sdb in /home/pcahyna/rear/rear/var/lib/rear/layout/disklayout.conf are correct
        2023-06-20 19:16:28.468396791 Verifying that the 'part' entries for /dev/sdb in /home/pcahyna/rear/rear/var/lib/rear/layout/disklayout.conf specify consecutive partitions
        2023-06-20 19:16:28.473731880 Verifying that the 'lvm...' entries in /home/pcahyna/rear/rear/var/lib/rear/layout/disklayout.conf are correct
        2023-06-20 19:16:28.506275876 /dev/sdb size 0 is not a positive integer
      Some messages from /var/tmp/rear.dSRYZZLoczSVake/tmp/rear.savelayout.stdout_stderr since the last called script 950_verify_disklayout_file.sh:
        256060514304
        1073741824
        1048576
        254985371648
        1074790400
        0
      Use debug mode '-d' for some debug messages or debugscript mode '-D' for full debug messages with 'set -x' output
      Aborting due to an error, check /home/pcahyna/rear/rear/var/log/rear/rear-pacaziste.log for details
      Terminated
      ```
      ```
      # Disk /dev/sdb
      # Format: disk <devname> <size(bytes)> <partition label type>
      disk /dev/sdb 0 
      # Partitions on /dev/sdb
      ```
      This reproduces #2958
    * new code:
      ```
      Ignoring sdb: blockdev: cannot open /dev/sdb: No medium found
      ```
      No sdb in disklayout
    * new code without reverting 0a1d634ed15500bb21f37ac1bbb11c8a4bb11545
      same result
  * full backup and recovery on RHEL 8 with empty USB SD card reader
     ```
     Running 'layout/save' stage ======================
     Creating disk layout
     Ignoring sde: blockdev: cannot open /dev/sde: No medium found
     Automatically excluding disk /dev/sdb (not used by any mounted filesystem)
     Marking component '/dev/sdb' as done in /var/lib/rear/layout/disktodo.conf
     Automatically excluding disk /dev/sdc (not used by any mounted filesystem)
     Marking component '/dev/sdc' as done in /var/lib/rear/layout/disktodo.conf
     Automatically excluding disk /dev/sdd (not used by any mounted filesystem)
     Marking component '/dev/sdd' as done in /var/lib/rear/layout/disktodo.conf
     Disabling excluded components in /var/lib/rear/layout/disklayout.conf
     Disabling component 'disk /dev/sdb' in /var/lib/rear/layout/disklayout.conf
     Disabling component 'disk /dev/sdc' in /var/lib/rear/layout/disklayout.conf
     Disabling component 'disk /dev/sdd' in /var/lib/rear/layout/disklayout.conf
     ```
  * full backup and recovery on RHEL 8 with empty USB SD card reader and `AUTOEXCLUDE_DISKS=n`
     ```
     Running 'layout/save' stage ======================
     Creating disk layout
     Ignoring sde: blockdev: cannot open /dev/sde: No medium found
     Disabling excluded components in /var/lib/rear/layout/disklayout.conf
     ```
* Brief description of the changes in this pull request:
    * Introduce function is_disk_valid, which performs checks for disk usability beyond validating the device name, and use it when saving the disk layout. In some cases the device name may be valid, but there are no data, typically because it is a drive with removable media and there is no medium in the tray. Happens typically with card (e.g. SD card) readers with empty slot.
       This is a normal occurrence, so do not Error out, only display a message and skip the device.
    * Revert commit 0a1d634ed15500bb21f37ac1bbb11c8a4bb11545 . We now skip disks with no data (like when there is no medium), so incomplete disk entries (without partition type) should not occur anymore. Restore the code that aborted when such disks were encountered.
       Incomplete entries should not be allowed to occur, as they could confuse the layout restoration code. Moreover, the layout restoration wipes all disks in the layout, so if during layout restoration there happens to be a medium in the drive that was empty during layout save, the data on the medium would get overwritten and lost. And if there is not medium, the layout recreation script would fail.
      See the discussion at https://github.com/rear/rear/issues/2958#issuecomment-1479588829
