### PR TITLE
Fail safe USB_DEVICE_BOOT_LABEL setting and fallback

### DIFF
--- a/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_grub.sh
@@ -78,7 +78,11 @@ DebugPrint "Creating GRUB2 config for legacy BIOS boot as USB bootloader"
 # In default.conf there is USB_BOOT_PART_SIZE="0" i.e. no (optional) boot partition
 # and USB_DEVICE_BOOT_LABEL="REARBOOT" which conflicts with "no boot partition"
 # so we need to use the ReaR data partition label as fallback
-# when "lsblk" shows nothing with a USB_DEVICE_BOOT_LABEL.
+# when 'lsblk' shows nothing with a USB_DEVICE_BOOT_LABEL.
+# Very old Linux distributions that do not contain lsblk (e.g. SLES10)
+# are not supported by ReaR and the code below will error out there.
+# "lsblk -no LABEL /dev/..." works e.g. on SLES11 SP3 (which is also not supported)
+# so the code should work on all Linux distributions that are supported by ReaR.
 # USB_DEVICE_BOOT_LABEL must not be empty (otherwise grep "" falsely succeeds):
 contains_visible_char "$USB_DEVICE_BOOT_LABEL" || USB_DEVICE_BOOT_LABEL="REARBOOT"
 if lsblk -no LABEL $RAW_USB_DEVICE | grep "$USB_DEVICE_BOOT_LABEL" ; then


### PR DESCRIPTION
* Type: **Bug Fix** / **Enhancement**
 
* Impact: **Normal**

* Reference to related issue (URL):
Found by chance while testing
https://github.com/rear/rear/pull/2961#issuecomment-1754987492
with
```
OUTPUT=USB
USB_BOOTLOADER="grub"
USB_DEVICE_PARTED_LABEL=gpt
BACKUP=NETFS
BACKUP_URL=usb:///dev/disk/by-label/REAR-000
```

* How was this pull request tested?
See below how "rear mkrescue" looks now.
I tested that GRUB in the recovery system boots now without error message.
Before it had also booted but via some GRUB fallback with an error message.

* Description of the changes in this pull request:

In output/USB/Linux-i386/300_create_grub.sh
check with "lsblk -no LABEL" if something with USB_DEVICE_BOOT_LABEL exists
and if not try to use USB_DEVICE_FILESYSTEM_LABEL if something with it exists
and error out otherwise.
