### PR TITLE
Save LVM pool metadata volume size in disk layout

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -307,11 +307,16 @@ local lvs_exit_code
         # With the above example poolmetadatasize=""
         poolmetadatasize="$( echo "$line" | awk -F ':' '{ print $11 }' )"
 
-        # TODO: Explain what that code is meant to do.
-        # In particular a more explanatory variable name than 'kval' might help.
-        # In 110_include_lvm_code.sh there is a comment what 'kval' means there
-        #   # kval: "key:value" pairs, separated by spaces
-        # so probably 'kval' means the same here, but what is 'infokval'?
+        # kval is a string of space-separated key:value pairs. Key names are chosen to represent
+        # long options to lvcreate, and value will be the parameter for each long option.
+        # e.g. "chunksize:${chunksize}b" will eventually become a --chunksize=${chunksize}b
+        # argument to lvcreate.
+        # This way 110_include_lvm_code.sh which constructs the arguments to lvcreate
+        # can be kept generic and does not need to be updated every time an argument is added,
+        # as long as the argument can follow this generic scheme.
+        # infokval are key:value pairs that are not used when restoring the layout
+        # and are kept in disklayout.conf only as comments for information
+        # (because the setting is not easy or desirable to preserve).
         kval=""
         infokval=""
         [ -z "$thinpool" ] || kval="${kval:+$kval }thinpool:$thinpool"

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -130,7 +130,7 @@ local lvs_exit_code
             echo "# Skipping PV $pdev that is not part of a valid VG (VG '$vgrp' empty or more than one word):"
             contains_visible_char "$vgrp" || vgrp='<missing_VG>'
             echo "# lvmdev /dev/$vgrp $pdev $uuid $size"
-            # Continue with the next line in the output of "lvm pvdisplay -c"
+            # Continue with the next line in the output of "lvm pvdisplay -C"
             continue
         fi
         # With the above example the output is:
@@ -138,10 +138,10 @@ local lvs_exit_code
         echo "lvmdev /dev/$vgrp $pdev $uuid $size"
 
     done
-    # Check the exit code of "lvm pvdisplay -c"
-    # in the "lvm pvdisplay -c | while read line ; do ... done" pipe:
+    # Check the exit code of "lvm pvdisplay -C"
+    # in the "lvm pvdisplay -C ... | while read line ; do ... done" pipe:
     pvdisplay_exit_code=${PIPESTATUS[0]}
-    test $pvdisplay_exit_code -eq 0 || Error "LVM command 'lvm pvdisplay -c' failed with exit code $pvdisplay_exit_code"
+    test $pvdisplay_exit_code -eq 0 || Error "LVM command 'lvm pvdisplay -C ... -o pv_name,vg_name,pv_size,pv_uuid' failed with exit code $pvdisplay_exit_code"
 
     # Get the volume group configuration:
     # Format: lvmgrp <volume_group> <extentsize> [<size(extents)>] [<size(bytes)>]


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested?
  * Installed RHEL 9 system to a thin pool
  * Extended the thin pool to another disk, while artificially keeping its metadata volume size unchanged, and using 100% of the VG (no free space in the VG left).
  * Backed up and recovered

With ReaR version before this change, recovery fails with:
```
+++ lvm lvcreate -y -L 1073741824b -n swap rhel_kvm-08-guest06
  Volume group "rhel_kvm-08-guest06" has insufficient free space (250 extents): 256 required.
```
swap is not part of the thin pool and is created after the thin pool. Without the change, the thin pool consumes too much space in the VG due to the metadata volume being too large, and there is not enough space for the swap volume, leading to the error above. With this change the recovery is successful.

* Description of the changes in this pull request:

Instead of letting LVM use the default pool metadata volume size when restoring a layout with thin pools, use the size  from the original system. The pool metadata size will be saved in disklayout.conf as the new key "poolmetadatasize" on the thin pool LV.

This makes the layout of the recovered system closer to the original system.

Prevents some cases of recovery failures during layout restoration: if the original system used a non-default (in particular, smaller) metadata volume size, and the space in the VG was fully used, there would not be enough space in the VG for recovery of all LVs (as layout restoration would create a larger pool metadata size than before and if restoring to disks of the same size, the space will be missing elsewhere).