### PR TITLE
Add REBOOT_COMMANDS (issue 3068)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3883,18 +3883,18 @@ POST_BACKUP_SCRIPT=
 #     eval "$command"
 #   done
 # For details see the [skel/default]/etc/scripts/system-setup script.
-# Normally a single command 'reboot' is called to 'reboot' the recreated system:
+# Normally a single command 'reboot' is called to reboot the recreated system:
 REBOOT_COMMANDS=( 'reboot' )
-# But in 'unattended' mode an automated 'reboot' call could lead to an endless loop
+# But in unattended mode an automated 'reboot' call could lead to an endless loop
 # when the ReaR recovery system is booted by default by the BIOS
-# so that "rear recover" and 'reboot' would be run automatically in an endless loop.
+# so that "rear recover" and 'reboot' would run automatically in an endless loop.
 # In this case REBOOT_COMMANDS=( 'poweroff' ) could be the right way
-# to get an as much as possible automated recovery via the 'unattended' mode
+# to get an as much as possible automated recovery via the unattended mode
 # with 'poweroff' after successful "rear recover" to be able to remove
 # the ReaR recovery system medium before booting the recreated system
 # so no login into the ReaR recovery system is needed.
 # For special cases more than a single command can be called,
-# in particular when additional commands are neded to prepare a 'reboot'
+# in particular when additional commands are neded to prepare the reboot
 # for example on machines with more sophisticated firmware one may need
 # some complicated dance with firmware settings before rebooting,
 # cf. https://github.com/rear/rear/pull/3070#issuecomment-1802901263

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -169,7 +169,7 @@ COPY_KERNEL_PARAMETERS=( 'net.ifnames' 'biosdevname' )
 # Normally 'reboot' is called to 'reboot' the recreated system:
 RECOVERY_REBOOT_COMMAND="reboot"
 # But in 'unattended' mode an automated 'reboot' call could lead to an endless loop
-# when the ReaR recovery system is booted by default by the firmware (BIOS or UEFI)
+# when the ReaR recovery system is booted by default by the BIOS
 # so that "rear recover" and 'reboot' would be run automatically in an endless loop.
 # In this case RECOVERY_REBOOT_COMMAND="poweroff" could be the right way
 # to get an as much as possible automated recovery via the 'unattended' mode

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3873,8 +3873,10 @@ POST_BACKUP_SCRIPT=
 
 ####
 # REBOOT_COMMANDS
+# REBOOT_COMMANDS_LABEL
 #
-# The commands that are called after "rear recover" succeeded to recreate the system
+# The REBOOT_COMMANDS array specifies the commands
+# that are called after "rear recover" succeeded to recreate the system
 # when "rear recover" is run in 'auto_recover'/'automatic' or 'unattended' mode
 # which evaluate like this:
 #   for command in "${REBOOT_COMMANDS[@]}" ; do
@@ -3896,6 +3898,11 @@ REBOOT_COMMANDS=( 'reboot' )
 # for example on machines with more sophisticated firmware one may need
 # some complicated dance with firmware settings before rebooting,
 # cf. https://github.com/rear/rear/pull/3070#issuecomment-1802901263
+#
+# The REBOOT_COMMANDS_LABEL string (normally a single meaningful word) specifies
+# what is shown to the user when the REBOOT_COMMANDS will be run
+# which is by default to reboot the recreated system:
+REBOOT_COMMANDS_LABEL="Reboot"
 ####
 
 # Some external backup software request user input

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -164,6 +164,21 @@ COPY_KERNEL_PARAMETERS=( 'net.ifnames' 'biosdevname' )
 ####
 
 ####
+# The command that is called after "rear recover" succeeded to recreate the system
+# when "rear recover" is run in 'auto_recover'/'automatic' or 'unattended' mode.
+# Normally 'reboot' is called to 'reboot' the recreated system:
+RECOVERY_REBOOT_COMMAND="reboot"
+# But in 'unattended' mode an automated 'reboot' call could lead to an endless loop
+# when the ReaR recovery system is booted by default by the firmware (BIOS or UEFI)
+# so that "rear recover" and 'reboot' would be run automatically in an endless loop.
+# In this case RECOVERY_REBOOT_COMMAND="poweroff" could be the right way
+# to get an as much as possible automated recovery via the 'unattended' mode
+# with 'poweroff' after successful "rear recover" to be able to remove
+# the ReaR recovery system medium before booting the recreated system
+# so no login into the ReaR recovery system is needed.
+####
+
+####
 # These variables are used to include arch/os/version specific stuff:
 # machine architecture, OS independent
 REAL_MACHINE="$( uname -m )"

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3886,6 +3886,31 @@ PRE_BACKUP_SCRIPT=
 POST_BACKUP_SCRIPT=
 ####
 
+####
+# The commands that are called after "rear recover" succeeded to recreate the system
+# when "rear recover" is run in 'auto_recover'/'automatic' or 'unattended' mode
+# which evaluate like this:
+#   for command in "${REBOOT_COMMANDS[@]}" ; do
+#     eval "$command"
+#   done
+# For details see the [skel/default]/etc/scripts/system-setup script.
+# Normally a single command 'reboot' is called to 'reboot' the recreated system:
+REBOOT_COMMANDS=( 'reboot' )
+# But in 'unattended' mode an automated 'reboot' call could lead to an endless loop
+# when the ReaR recovery system is booted by default by the BIOS
+# so that "rear recover" and 'reboot' would be run automatically in an endless loop.
+# In this case REBOOT_COMMANDS=( 'poweroff' ) could be the right way
+# to get an as much as possible automated recovery via the 'unattended' mode
+# with 'poweroff' after successful "rear recover" to be able to remove
+# the ReaR recovery system medium before booting the recreated system
+# so no login into the ReaR recovery system is needed.
+# For special cases more than a single command can be called,
+# in particular when additional commands are neded to prepare a 'reboot'
+# for example on machines with more sophisticated firmware one may need
+# some complicated dance with firmware settings before rebooting,
+# cf. https://github.com/rear/rear/pull/3070#issuecomment-1802901263
+####
+
 # Some external backup software request user input
 # (e.g. to enter paths to exclude or date and time values for point in time restore).
 # We use here the same default timeout as USER_INPUT_TIMEOUT was set above

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -164,21 +164,6 @@ COPY_KERNEL_PARAMETERS=( 'net.ifnames' 'biosdevname' )
 ####
 
 ####
-# The command that is called after "rear recover" succeeded to recreate the system
-# when "rear recover" is run in 'auto_recover'/'automatic' or 'unattended' mode.
-# Normally 'reboot' is called to 'reboot' the recreated system:
-RECOVERY_REBOOT_COMMAND="reboot"
-# But in 'unattended' mode an automated 'reboot' call could lead to an endless loop
-# when the ReaR recovery system is booted by default by the BIOS
-# so that "rear recover" and 'reboot' would be run automatically in an endless loop.
-# In this case RECOVERY_REBOOT_COMMAND="poweroff" could be the right way
-# to get an as much as possible automated recovery via the 'unattended' mode
-# with 'poweroff' after successful "rear recover" to be able to remove
-# the ReaR recovery system medium before booting the recreated system
-# so no login into the ReaR recovery system is needed.
-####
-
-####
 # These variables are used to include arch/os/version specific stuff:
 # machine architecture, OS independent
 REAL_MACHINE="$( uname -m )"
@@ -3887,6 +3872,8 @@ POST_BACKUP_SCRIPT=
 ####
 
 ####
+# REBOOT_COMMANDS
+#
 # The commands that are called after "rear recover" succeeded to recreate the system
 # when "rear recover" is run in 'auto_recover'/'automatic' or 'unattended' mode
 # which evaluate like this:

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -72,7 +72,17 @@ fi
 # we abort when there is no default.conf (or when it is empty),
 # cf. https://github.com/rear/rear/pull/3070#discussion_r1389361339
 if ! test -s /usr/share/rear/conf/default.conf ; then
-    echo -e "\nERROR: ReaR recovery cannot work without /usr/share/rear/conf/default.conf - exiting\n"
+    echo -e "\nERROR: ReaR recovery cannot work without /usr/share/rear/conf/default.conf\n"
+    # Wait hardcoded 10 seconds in any case so that the user can notice the
+    # 'ERROR: ReaR recovery cannot work without /usr/share/rear/conf/default.conf'
+    # on his screen before the screen gets cleared and replaced by the login screen
+    # also in unattended mode regardless if someone is actually watching:
+    sleep 10
+    # Replace the usual /etc/motd message
+    # 'Welcome to Relax-and-Recover. Run "rear recover" to restore your system !'
+    # because it does not make sense to run "rear recover" without default.conf:
+    echo -e "\nRelax-and-Recover cannot work without /usr/share/rear/conf/default.conf\n" >/etc/motd
+    # exiting this script proceeds directly to the login screen:
     exit 1
 fi
 
@@ -104,17 +114,18 @@ done
 # during "rear mkrescue/mkbackup" by the build/default/995_md5sums_rootfs.sh script:
 if test -s "/md5sums.txt" ; then
     echo -e "\nVerifying md5sums of the files in the Relax-and-Recover rescue system\n"
-    # /etc/issue is always excluded to avoid that verifying its md5sum fails with "./etc/issue: FAILED"
+    # /etc/motd is excluded because it was changed above when default.conf is missing.
+    # /etc/issue is excluded to avoid that verifying its md5sum fails with "./etc/issue: FAILED"
     # when there is no rsa SSH host key /etc/ssh/ssh_host_rsa_key in the recovery system
     # because then /etc/scripts/run-sshd creates one and adds its SSH fingerprint to /etc/issue
     # and /etc/scripts/run-sshd is run by SysVinit or systemd
     # (via /etc/inittab and /etc/init/start-sshd.conf or /usr/lib/systemd/system/sshd.service)
     # so that /etc/issue may get modified before its md5sum is verified here.
     # run-sshd also modifies /etc/ssh/sshd_config, so this is excluded as well.
-    # Also /etc/udev/rules.d/70-persistent-net.rules is always excluded to avoid false alarm
+    # Also /etc/udev/rules.d/70-persistent-net.rules is excluded to avoid false alarm
     # because it seems it can be modified even before this md5sum verification here runs,
     # see https://github.com/rear/rear/issues/1883#issuecomment-409875733
-    egrep_pattern="/etc/issue|/etc/ssh/sshd_config|/etc/udev/rules.d/70-persistent-net.rules"
+    egrep_pattern="/etc/motd|/etc/issue|/etc/ssh/sshd_config|/etc/udev/rules.d/70-persistent-net.rules"
     test "$EXCLUDE_MD5SUM_VERIFICATION" && egrep_pattern+="|$EXCLUDE_MD5SUM_VERIFICATION"
     # Regardless of '--quiet' md5sum shows "FAILED" messages nevertheless (cf. 'man md5sum'):
     if grep -E -v "$egrep_pattern" md5sums.txt | md5sum --quiet --check ; then

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -66,20 +66,28 @@ if rear_debug ; then
     esac
 fi
 
+# Because "rear recover" won't work without default.conf
+# we abort when there is no default.conf (or when it is empty),
+# cf. https://github.com/rear/rear/pull/3070#discussion_r1389361339
+if ! test -s /usr/share/rear/conf/default.conf ; then
+    echo -e "\nERROR: ReaR recovery cannot work without /usr/share/rear/conf/default.conf - exiting\n"
+    exit 1
+fi
+
 # Set SECRET_OUTPUT_DEV because secret default values are set via
 #   { VARIABLE='secret value' ; } 2>>/dev/$SECRET_OUTPUT_DEV
 # cf. https://github.com/rear/rear/pull/3034#issuecomment-1691609782
 SECRET_OUTPUT_DEV="null"
 # Sourcing of the conf/default.conf file as we may use some defined variables or arrays
 # E.g. UDEV_NET_MAC_RULE_FILES is used by script 55-migrate-network-devices.sh
-if test -f /usr/share/rear/conf/default.conf ; then
-    source /usr/share/rear/conf/default.conf
-fi
+source /usr/share/rear/conf/default.conf || echo -e "\n'source /usr/share/rear/conf/default.conf' failed with exit code $?\n"
 # Sourcing user and rescue configuration as we need some variables
 # (EXCLUDE_MD5SUM_VERIFICATION right now and other variables in the system setup scripts):
 # The order of sourcing should be 'site' then 'local' and as last 'rescue'
 for conf in site local rescue ; do
-    test -f /etc/rear/$conf.conf && source /etc/rear/$conf.conf
+    if test -s /etc/rear/$conf.conf ; then
+        source /etc/rear/$conf.conf || echo -e "\n'source /etc/rear/$conf.conf' failed with exit code $?\n"
+    fi
 done
 
 # Verifying md5sums must happen first of all during recovery system startup
@@ -116,10 +124,11 @@ if test -s "/md5sums.txt" ; then
             # In debug mode let the user confirm to proceed:
             read -p "Press ENTER to proceed 'bona fide' nevertheless "
         else
-            # In non-debug mode wait 10 seconds so that the user can read the md5sum output
-            # unless in unattended_recovery mode where there is no user who reads something:
+            # In non-debug mode wait USER_INPUT_INTERRUPT_TIMEOUT (by default 30 seconds)
+            # so that the user can read and understand the md5sum output (could be several lines)
+            # unless in unattended_recovery mode where there is normally no user who reads something:
             echo -e "Proceeding 'bona fide' nevertheless...\n"
-            unattended_recovery || sleep 10
+            unattended_recovery && sleep $USER_INPUT_UNATTENDED_TIMEOUT || sleep $USER_INPUT_INTERRUPT_TIMEOUT
         fi
     fi
 fi
@@ -129,19 +138,20 @@ for system_setup_script in /etc/scripts/system-setup.d/*.sh ; do
     if rear_debug ; then
         read -p "Press ENTER to run $( basename $system_setup_script ) "
         set -x
-        source $system_setup_script
+        source $system_setup_script || echo -e "\n'source $system_setup_script' exited with $?\n"
         # The only known way how to do 'set +x' after 'set -x' without a '+ set +x' output:
         { set +x ; } 2>/dev/null
         echo
     else
         echo "Running $( basename $system_setup_script )..."
-        source $system_setup_script
+        source $system_setup_script || echo -e "\n'source $system_setup_script' exited with $?\n"
     fi
 done
 echo -e "\nRelax-and-Recover rescue system is ready\n"
-# Wait two seconds so that the user can read the 'Relax-and-Recover rescue system is ready' message
+# Wait USER_INPUT_UNATTENDED_TIMEOUT (by default 3 seconds)
+# so that the user can read the 'Relax-and-Recover rescue system is ready' message
 # on his screen before the screen gets cleared and replaced by the login screen:
-sleep 2
+sleep $USER_INPUT_UNATTENDED_TIMEOUT
 
 # In debug mode run the automated 'rear recover' also with debug options.
 # Because the kernel command line option 'debug' means 'set -x' for the system setup scripts
@@ -152,8 +162,6 @@ else
     rear_debug_options=''
 fi
 
-reboot_command="${RECOVERY_REBOOT_COMMAND:-reboot}"
-
 # Launch "rear recover" automatically:
 if automatic_recovery ; then
     choices=( "View Relax-and-Recover log file(s)"
@@ -162,7 +170,7 @@ if automatic_recovery ; then
     echo -e "\nLaunching 'rear recover' automatically\n"
     if rear $rear_debug_options recover ; then
         echo -e "\n'rear recover' finished successfully\n"
-        choices+=( "$reboot_command" )
+        choices+=( "Reboot" )
     else
         echo -e "\n'rear recover' failed, check the Relax-and-Recover log file(s)\n"
     fi
@@ -180,7 +188,10 @@ if automatic_recovery ; then
                 break
                 ;;
             (3)
-                $reboot_command
+                for command in "${REBOOT_COMMANDS[@]}" ; do
+                    echo "Running REBOOT_COMMANDS '$command'"
+                    eval "$command" || echo -e "\n'eval $command' exited with $?\n"
+                done
                 ;;
         esac
         for (( i=1 ; i <= ${#choices[@]} ; i++ )) ; do
@@ -192,7 +203,6 @@ fi
 # In unattended mode launch "rear --non-interactive recover" automatically 
 # i.e. with automated "reboot" (reboot_command) after successful recovery:
 if unattended_recovery ; then
-    timeout="${USER_INPUT_INTERRUPT_TIMEOUT:-30}"
     choices=( "View Relax-and-Recover log file(s)"
               "Go to Relax-and-Recover shell"
             )
@@ -200,8 +210,11 @@ if unattended_recovery ; then
     if rear $rear_debug_options --non-interactive recover ; then
         echo -e "\n'rear recover' finished successfully\n"
         echo -e "\n'$reboot_command' in $timeout seconds (Ctrl-C to interrupt)\n"
-        sleep $timeout
-        $reboot_command
+        sleep $USER_INPUT_INTERRUPT_TIMEOUT
+        for command in "${REBOOT_COMMANDS[@]}" ; do
+            echo "Running REBOOT_COMMANDS '$command'"
+            eval "$command" || echo -e "\n'eval $command' exited with $?\n"
+        done
     else
         echo -e "\n'rear recover' failed, check the Relax-and-Recover log file(s)\n"
         PS3="Select what to do "

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -116,9 +116,10 @@ if test -s "/md5sums.txt" ; then
             # In debug mode let the user confirm to proceed:
             read -p "Press ENTER to proceed 'bona fide' nevertheless "
         else
-            # In non-debug mode wait 10 seconds so that the user can read the md5sum output:
+            # In non-debug mode wait 10 seconds so that the user can read the md5sum output
+            # unless in unattended_recovery mode where there is no user who reads something:
             echo -e "Proceeding 'bona fide' nevertheless...\n"
-            sleep 10
+            unattended_recovery || sleep 10
         fi
     fi
 fi
@@ -151,7 +152,9 @@ else
     rear_debug_options=''
 fi
 
-# Launch rear recover automatically:
+reboot_command="${RECOVERY_REBOOT_COMMAND:-reboot}"
+
+# Launch "rear recover" automatically:
 if automatic_recovery ; then
     choices=( "View Relax-and-Recover log file(s)"
               "Go to Relax-and-Recover shell"
@@ -159,7 +162,7 @@ if automatic_recovery ; then
     echo -e "\nLaunching 'rear recover' automatically\n"
     if rear $rear_debug_options recover ; then
         echo -e "\n'rear recover' finished successfully\n"
-        choices+=( "$RECOVERY_REBOOT_COMMAND" )
+        choices+=( "$reboot_command" )
     else
         echo -e "\n'rear recover' failed, check the Relax-and-Recover log file(s)\n"
     fi
@@ -177,7 +180,7 @@ if automatic_recovery ; then
                 break
                 ;;
             (3)
-                $RECOVERY_REBOOT_COMMAND
+                $reboot_command
                 ;;
         esac
         for (( i=1 ; i <= ${#choices[@]} ; i++ )) ; do
@@ -186,18 +189,19 @@ if automatic_recovery ; then
     done 2>&1
 fi
 
-# Launch rear recover automatically in unattended mode
-# i.e. with automated reboot after successful 'rear recover':
+# In unattended mode launch "rear --non-interactive recover" automatically 
+# i.e. with automated "reboot" (reboot_command) after successful recovery:
 if unattended_recovery ; then
+    timeout="${USER_INPUT_INTERRUPT_TIMEOUT:-30}"
     choices=( "View Relax-and-Recover log file(s)"
               "Go to Relax-and-Recover shell"
             )
-    echo -e "\nLaunching 'rear recover' automatically in unattended mode\n"
+    echo -e "\nLaunching 'rear recover' automatically in unattended (non-interactive) mode\n"
     if rear $rear_debug_options --non-interactive recover ; then
         echo -e "\n'rear recover' finished successfully\n"
-        echo -e "\n'$RECOVERY_REBOOT_COMMAND' in 30 seconds (Ctrl-C to interrupt)\n"
-        sleep 30
-        $RECOVERY_REBOOT_COMMAND
+        echo -e "\n'$reboot_command' in $timeout seconds (Ctrl-C to interrupt)\n"
+        sleep $timeout
+        $reboot_command
     else
         echo -e "\n'rear recover' failed, check the Relax-and-Recover log file(s)\n"
         PS3="Select what to do "

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -66,13 +66,13 @@ if rear_debug ; then
     esac
 fi
 
+# Set SECRET_OUTPUT_DEV because secret default values are set via
+#   { VARIABLE='secret value' ; } 2>>/dev/$SECRET_OUTPUT_DEV
+# cf. https://github.com/rear/rear/pull/3034#issuecomment-1691609782
+SECRET_OUTPUT_DEV="null"
 # Sourcing of the conf/default.conf file as we may use some defined variables or arrays
 # E.g. UDEV_NET_MAC_RULE_FILES is used by script 55-migrate-network-devices.sh
 if test -f /usr/share/rear/conf/default.conf ; then
-    # Set SECRET_OUTPUT_DEV because secret default values are set via
-    #   { VARIABLE='secret value' ; } 2>>/dev/$SECRET_OUTPUT_DEV
-    # cf. https://github.com/rear/rear/pull/3034#issuecomment-1691609782
-    SECRET_OUTPUT_DEV="null"
     source /usr/share/rear/conf/default.conf
 fi
 # Sourcing user and rescue configuration as we need some variables
@@ -159,7 +159,7 @@ if automatic_recovery ; then
     echo -e "\nLaunching 'rear recover' automatically\n"
     if rear $rear_debug_options recover ; then
         echo -e "\n'rear recover' finished successfully\n"
-        choices+=( "Reboot" )
+        choices+=( "$RECOVERY_REBOOT_COMMAND" )
     else
         echo -e "\n'rear recover' failed, check the Relax-and-Recover log file(s)\n"
     fi
@@ -177,7 +177,7 @@ if automatic_recovery ; then
                 break
                 ;;
             (3)
-                reboot
+                $RECOVERY_REBOOT_COMMAND
                 ;;
         esac
         for (( i=1 ; i <= ${#choices[@]} ; i++ )) ; do
@@ -195,9 +195,9 @@ if unattended_recovery ; then
     echo -e "\nLaunching 'rear recover' automatically in unattended mode\n"
     if rear $rear_debug_options --non-interactive recover ; then
         echo -e "\n'rear recover' finished successfully\n"
-        echo -e "\nRebooting in 30 seconds (Ctrl-C to interrupt)\n"
+        echo -e "\n'$RECOVERY_REBOOT_COMMAND' in 30 seconds (Ctrl-C to interrupt)\n"
         sleep 30
-        reboot
+        $RECOVERY_REBOOT_COMMAND
     else
         echo -e "\n'rear recover' failed, check the Relax-and-Recover log file(s)\n"
         PS3="Select what to do "

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -40,11 +40,13 @@ function automatic_recovery() {
     return 1
 }
 
-# The 'sleep 1' is used as workaround to avoid whatever inexplicable actual reason
+# The hardcoded 'sleep 1' is used as workaround to avoid whatever inexplicable actual reason
 # that at least on SLES12 some initial output lines of this script would get lost
-# (perhaps somewhere in systemd's nowhere land) which results that in particular
-# in Relax-and-Recover debug mode the user sits in front of an empty screen wondering
-# why nothing happens because in particular the read prompt "Press ENTER ..." was lost,
+# (perhaps somewhere in systemd's nowhere land) and even in unattended_recovery mode
+# all output should always appear regardless if someone is actually watching.
+# In particular in Relax-and-Recover debug mode missing initial output lines results
+# that the user sits in front of an empty screen wondering why nothing happens
+# because in particular the read prompt "Press ENTER ..." was lost,
 # cf. the 'if rear_debug' part below:
 sleep 1
 
@@ -128,7 +130,7 @@ if test -s "/md5sums.txt" ; then
             # so that the user can read and understand the md5sum output (could be several lines)
             # unless in unattended_recovery mode where there is normally no user who reads something:
             echo -e "Proceeding 'bona fide' nevertheless...\n"
-            unattended_recovery && sleep $USER_INPUT_UNATTENDED_TIMEOUT || sleep $USER_INPUT_INTERRUPT_TIMEOUT
+            unattended_recovery || sleep $USER_INPUT_INTERRUPT_TIMEOUT
         fi
     fi
 fi
@@ -138,20 +140,29 @@ for system_setup_script in /etc/scripts/system-setup.d/*.sh ; do
     if rear_debug ; then
         read -p "Press ENTER to run $( basename $system_setup_script ) "
         set -x
-        source $system_setup_script || echo -e "\n'source $system_setup_script' exited with $?\n"
+        source $system_setup_script || echo -e "\n'source $system_setup_script' results exit code $?\n"
         # The only known way how to do 'set +x' after 'set -x' without a '+ set +x' output:
         { set +x ; } 2>/dev/null
         echo
     else
         echo "Running $( basename $system_setup_script )..."
-        source $system_setup_script || echo -e "\n'source $system_setup_script' exited with $?\n"
+        # In non-debug mode when a system setup script results non-zero exit code
+        # do not show an 'exit code' message (like the above) to avoid false alarm
+        # cf. https://github.com/rear/rear/pull/3070#discussion_r1393738863
+        # but just wait USER_INPUT_UNATTENDED_TIMEOUT (by default 3 seconds)
+        # so that the user could at least notice potential error messages from the script
+        # unless in unattended_recovery mode where there is normally no watching user:
+        if ! source $system_setup_script ; then
+            unattended_recovery || sleep $USER_INPUT_UNATTENDED_TIMEOUT
+        fi
     fi
 done
 echo -e "\nRelax-and-Recover rescue system is ready\n"
 # Wait USER_INPUT_UNATTENDED_TIMEOUT (by default 3 seconds)
-# so that the user can read the 'Relax-and-Recover rescue system is ready' message
-# on his screen before the screen gets cleared and replaced by the login screen:
-sleep $USER_INPUT_UNATTENDED_TIMEOUT
+# so that the user can notice the 'Relax-and-Recover rescue system is ready' message
+# on his screen before the screen gets cleared and replaced by the login screen
+# unless in unattended_recovery mode where there is normally no watching user:
+unattended_recovery || sleep $USER_INPUT_UNATTENDED_TIMEOUT
 
 # In debug mode run the automated 'rear recover' also with debug options.
 # Because the kernel command line option 'debug' means 'set -x' for the system setup scripts
@@ -190,7 +201,7 @@ if automatic_recovery ; then
             (3)
                 for command in "${REBOOT_COMMANDS[@]}" ; do
                     echo "Running REBOOT_COMMANDS '$command'"
-                    eval "$command" || echo -e "\n'eval $command' exited with $?\n"
+                    eval "$command" || echo -e "\n'eval $command' results exit code $?\n"
                 done
                 ;;
         esac
@@ -213,7 +224,7 @@ if unattended_recovery ; then
         sleep $USER_INPUT_INTERRUPT_TIMEOUT
         for command in "${REBOOT_COMMANDS[@]}" ; do
             echo "Running REBOOT_COMMANDS '$command'"
-            eval "$command" || echo -e "\n'eval $command' exited with $?\n"
+            eval "$command" || echo -e "\n'eval $command' results exit code $?\n"
         done
     else
         echo -e "\n'rear recover' failed, check the Relax-and-Recover log file(s)\n"

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -170,7 +170,7 @@ if automatic_recovery ; then
     echo -e "\nLaunching 'rear recover' automatically\n"
     if rear $rear_debug_options recover ; then
         echo -e "\n'rear recover' finished successfully\n"
-        choices+=( "Reboot" )
+        choices+=( "$REBOOT_COMMANDS_LABEL" )
     else
         echo -e "\n'rear recover' failed, check the Relax-and-Recover log file(s)\n"
     fi
@@ -209,7 +209,7 @@ if unattended_recovery ; then
     echo -e "\nLaunching 'rear recover' automatically in unattended (non-interactive) mode\n"
     if rear $rear_debug_options --non-interactive recover ; then
         echo -e "\n'rear recover' finished successfully\n"
-        echo -e "\n'$reboot_command' in $timeout seconds (Ctrl-C to interrupt)\n"
+        echo -e "\n'$REBOOT_COMMANDS_LABEL' in $USER_INPUT_INTERRUPT_TIMEOUT seconds (Ctrl-C to interrupt)\n"
         sleep $USER_INPUT_INTERRUPT_TIMEOUT
         for command in "${REBOOT_COMMANDS[@]}" ; do
             echo "Running REBOOT_COMMANDS '$command'"


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3068

* How was this pull request tested?
See https://github.com/rear/rear/pull/3070#issuecomment-1801948014

* Description of the changes in this pull request:

In skel/default/etc/scripts/system-setup
replaced the hardcoded 'reboot'
by using a `REBOOT_COMMANDS` array
(plus REBOOT_COMMANDS_LABEL string)
so the user could specify a alternative command
like 'shutdown' or 'poweroff'
(see https://github.com/rear/rear/issues/3068)
or a sequence of commands if needed
(plus a label that is shown to the user).

Use USER_INPUT_INTERRUPT_TIMEOUT
and USER_INPUT_UNATTENDED_TIMEOUT
instead of hardcoded 'sleep' timeout values
to speed up things in unattended_recovery mode.

Show non-zero exit codes to the user
when sourcing config files failed.

Abort when /usr/share/rear/conf/default.conf
does not exist (or is empty).

Set `SECRET_OUTPUT_DEV="null"` in any case
(not only when sourcing default.conf)
because also in other config files (e.g. local.conf)
secret default values could be set via
```
{ VARIABLE='secret value' ; } 2>>/dev/$SECRET_OUTPUT_DEV
```
cf. https://github.com/rear/rear/commit/9629b29dbbb73efb6229c4bfc509d1fcb70b29e3
