### PR TITLE
Add USER_INPUT_UNATTENDED_TIMEOUT config variable

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -312,7 +312,7 @@ PROGRESS_WAIT_SECONDS="1"
 # his particular input when the default is not the right one.
 USER_INPUT_TIMEOUT="${USER_INPUT_TIMEOUT:-300}"
 #
-# USER_INPUT_INTERRUPT_TIMEOUT specifies the default timeout in seconds
+# USER_INPUT_INTERRUPT_TIMEOUT specifies the timeout in seconds
 # for how long UserInput() waits for the user to interrupt an automated input
 # when a predefined input value is specified for a particular UserInput() call
 # via a matching USER_INPUT_user_input_ID variable (see below).
@@ -323,6 +323,12 @@ USER_INPUT_TIMEOUT="${USER_INPUT_TIMEOUT:-300}"
 # the automated action is actually the right one and
 # if not a bit more time to hit a key to interrupt.
 USER_INPUT_INTERRUPT_TIMEOUT="${USER_INPUT_INTERRUPT_TIMEOUT:-30}"
+#
+# USER_INPUT_UNATTENDED_TIMEOUT specifies the timeout in seconds
+# for how long UserInput() waits for user input
+# when ReaR is run in 'unattended' or 'non-interactive' mode
+# i.e. when there is (usually) no user who would or could input something.
+USER_INPUT_UNATTENDED_TIMEOUT="${USER_INPUT_UNATTENDED_TIMEOUT:-3}"
 #
 # USER_INPUT_PROMPT specifies the default prompt text that is shown
 # if no prompt was specified for a particular UserInput() call.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -296,9 +296,17 @@ PROGRESS_WAIT_SECONDS="1"
 #
 # USER_INPUT_TIMEOUT
 # USER_INPUT_INTERRUPT_TIMEOUT
+# USER_INPUT_UNATTENDED_TIMEOUT
 # USER_INPUT_PROMPT
 # USER_INPUT_MAX_CHARS
 # USER_INPUT_user_input_ID
+#
+# All timeout values must be at least '1' (i.e. one second timeout).
+# The reason is that 'read -t 0' returns immediately without trying to read any data
+# so when 'read' should time out the minimum timeout value is '1'.
+# That the 'read' timeout can be a fractional number requires bash 4.x
+# see https://github.com/rear/rear/issues/2866#issuecomment-1254908270
+# but in general ReaR should still work with bash 3.x so we use '-t 1'.
 #
 # USER_INPUT_TIMEOUT specifies the default timeout in seconds
 # after that UserInput() automatically proceeds with a default value.
@@ -316,7 +324,6 @@ USER_INPUT_TIMEOUT="${USER_INPUT_TIMEOUT:-300}"
 # for how long UserInput() waits for the user to interrupt an automated input
 # when a predefined input value is specified for a particular UserInput() call
 # via a matching USER_INPUT_user_input_ID variable (see below).
-# The minimum waiting time to interrupt an automated input is one second.
 # The default interrupt timeout must be sufficiently long for the user
 # to read and understand the possibly unexpected UserInput() message
 # and then some more time to make a decision whether or not


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
 
While testing
https://github.com/rear/rear/pull/3070
I noticed that UserInput() timeout is 3 seconds
but I had no idea where that came from
(default UserInput() timeout is 300 or 30 seconds)
until I found out that in unattended recovery mode
skel/default/etc/scripts/system-setup
calls `rear --non-interactive recover`
and in non-interactive mode UserInput() does
```
# set timeouts to low but acceptable 3 seconds for non-interactive mode:
timeout=3
automated_input_interrupt_timeout=3
```
with a hardcoded '3' that I could not find easily
in the whole ReaR code (without knowing where to look for).
I think having it hardcoded is wrong because for example
why should UserInput() wait at all when there is no user
who could see any input request or ever respond to it
so it should be possible to set it to 1 if needed
(e.g. for 'unattended' recovery).
A timeout of 0 would get complicated to be implemented because
'read -t 0' returns immediately without trying to read any data
so it seems when 'read' should time out the minimum is '1',
cf. the "Drain stdin" comment in the UserInput function:
```
# That the 'read' timeout can be a fractional number requires bash 4.x
# see https://github.com/rear/rear/issues/2866#issuecomment-1254908270
# but in general ReaR should still work with bash 3.x so we use '-t 1'
```
and I think a 'read' timeout fractional number is not a sufficient
reason to require bash 4.x mandatorily for the UserInput function.

* How was this pull request tested?

Works well for me so far...

* Description of the changes in this pull request:

Added USER_INPUT_UNATTENDED_TIMEOUT
to specify the timeout in seconds (by default 3)
for how long UserInput() waits for user input
when ReaR is run in 'unattended' or 'non-interactive' mode.