### PR TITLE
Resolve libs for executable links in COPY_AS_IS

### DIFF
--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -139,6 +139,8 @@ while read -r copy_as_is_file ; do
     # but do not skip symbolic links. Their targets will be copied later by build/default/490_fix_broken_links.sh.
     # We thus need library dependencies for symlinked executables just like for normal executables
     # and build/default/490_fix_broken_links.sh does not perform library dependency scan.
+    # See GitHub PR https://github.com/rear/rear/pull/3073
+    # and issue https://github.com/rear/rear/issues/3064 for details.
     test -f "$copy_as_is_file" || continue
     # Remember actual regular files that are executable:
     test -x "$copy_as_is_file" && copy_as_is_executables+=( "$copy_as_is_file" )

--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -135,10 +135,11 @@ local copy_as_is_file=""
 # cf. https://github.com/rear/rear/pull/2378
 # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_input-output-functions.sh):
 while read -r copy_as_is_file ; do
-    # Skip non-regular files like directories, device files, and 'tar' error messages (e.g. in case of non-existent files, see above):
+    # Skip non-regular files like directories, device files, and 'tar' error messages (e.g. in case of non-existent files, see above)
+    # but do not skip symbolic links. Their targets will be copied later by build/default/490_fix_broken_links.sh.
+    # We thus need library dependencies for symlinked executables just like for normal executables
+    # and build/default/490_fix_broken_links.sh does not perform library dependency scan.
     test -f "$copy_as_is_file" || continue
-    # Skip symbolic links (only care about symbolic link targets):
-    test -L "$copy_as_is_file" && continue
     # Remember actual regular files that are executable:
     test -x "$copy_as_is_file" && copy_as_is_executables+=( "$copy_as_is_file" )
 done < <( sort -u $copy_as_is_filelist_file ) 2>>/dev/$DISPENSABLE_OUTPUT_DEV


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): fixes #3064

* How was this pull request tested?
`yum erase rsync` and `yum install chkconfig` followed by `rear mkrescue` on RHEL 9

* Description of the changes in this pull request:
Do not skip symbolic links when adding libraries required by executables in COPY_AS_IS. The symlink targets will be copied later by build/default/490_fix_broken_links.sh.  We thus need library dependencies for symlinked executables just like for normal executables and build/default/490_fix_broken_links.sh does not perform library dependency scan, so we need to do it at the same place as for normal executables (in build/GNU/Linux/100_copy_as_is.sh). Otherwise it can happen that we add a (broken) symlink via COPY_AS_IS, the actual executable is then added by build/default/490_fix_broken_links.sh, but without its libraries, and "rear mkrescue" then fails because required libraries are missing. Happens for example with /usr/lib/systemd/systemd-sysv-install, which is a symlink to /bin/chkconfig and gets added to COPY_AS_IS in prep/GNU/Linux/280_include_systemd.sh.

Gets rid of one exception for symlinks, which looks good in any case (shorter and simpler code).