### PR TITLE
BACKUP=NSR set NSRSERVER properly in 650_check_iso_recoverable.sh

### DIFF
--- a/usr/share/rear/layout/save/NSR/default/650_check_iso_recoverable.sh
+++ b/usr/share/rear/layout/save/NSR/default/650_check_iso_recoverable.sh
@@ -4,8 +4,20 @@
 if is_true "$NSR_CLIENT_MODE"; then
     return
 fi
-    
+
 CLIENTNAME=$(hostname)
+
+# read NSR server name from /nsr/res/servers file of /var/lib/rear/recovery/nsr_server
+# code snippet taken from verify/NSR/default/400_verify_nsr.sh
+# see https://github.com/rear/rear/issues/2162#issuecomment-541343374
+# and https://github.com/rear/rear/issues/3069
+if [[ ! -z "$NSRSERVER" ]]; then
+    Log "NSRSERVER ($NSRSERVER) was defined in $CONFIG_DIR/local.conf"
+elif [[ -f $VAR_DIR/recovery/nsr_server ]]; then
+    NSRSERVER=$( cat $VAR_DIR/recovery/nsr_server )
+else
+    Error "Could not retrieve the EMC NetWorker Server name. Define NSRSERVER in $CONFIG_DIR/local.conf file"
+fi
 
 OBJECTS=$( nsrinfo -s ${NSRSERVER} -N ${ISO_DIR}/${ISO_PREFIX}.iso ${CLIENTNAME} | \
            awk '/objects found/ { print $1; }' )


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3069

* How was this pull request tested?
I cannot test it because I do not use BACKUP=NSR

* Description of the changes in this pull request:

In layout/save/NSR/default/650_check_iso_recoverable.sh
also read NSR server name from var/lib/rear/recovery/nsr_server
by using the same code snippet as in verify/NSR/default/400_verify_nsr.sh
see https://github.com/rear/rear/issues/2162#issuecomment-541343374
and https://github.com/rear/rear/issues/3069
