### PR TITLE
Don't mount /sys and other directories if already mounted

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,10 +18,7 @@ jobs:
   trigger: pull_request
   metadata:
   targets:
-# see issue #3017 with f39 and later
-#  - fedora-all
-  - fedora-37-x86_64
-  - fedora-38-x86_64
+  - fedora-all
   - centos-stream-8-x86_64
   - centos-stream-9-x86_64
 specfile_path: packaging/rpm/rear.spec

--- a/usr/share/rear/skel/default/etc/scripts/boot
+++ b/usr/share/rear/skel/default/etc/scripts/boot
@@ -4,8 +4,8 @@
 dmesg -n1
 
 # basic mounts
-mount -t proc -n none /proc
-mount -t sysfs none /sys
+mountpoint /proc || mount -t proc -n none /proc
+mountpoint /sys || mount -t sysfs none /sys
 
 if type udevd &>/dev/null && ! type udevinfo &>/dev/null; then
     ### we use udevinfo to filter out old udev versions (<106) that don't
@@ -13,7 +13,7 @@ if type udevd &>/dev/null && ! type udevinfo &>/dev/null; then
     udev_version=$(udevd --version)
     if [[ "$udev_version" -gt 175 ]]; then
         ### udev > 175 needs devtmpfs
-        mount -t devtmpfs none /dev
+        mountpoint /dev || mount -t devtmpfs none /dev
     fi
 fi
 
@@ -26,7 +26,7 @@ if [[ ! -L /dev/fd ]] ; then
     ln -s /proc/self/fd /dev/fd
 fi
 
-mount -t devpts -o gid=5,mode=620 none /dev/pts
+mountpoint /dev/pts || mount -t devpts -o gid=5,mode=620 none /dev/pts
 
 cat /proc/mounts >/etc/mtab 2>/dev/null
 


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL): fixes #3017 

* How was this pull request tested?
CI tested it - I enabled tests on Fedora 39 and Fedora Rawhide

* Description of the changes in this pull request:
 Newer versions of systemd (starting with Fedora 39) seem to mount /sys themselves. Mounting it again leads to errors on the recovery system startup (startup scripts failing with status=219/CGROUP ), see https://github.com/rear/rear/issues/3017.

Check if /sys is already mounted using the `mountpoint` tool and mount it only if it is not.

Do the same for the other system mountpoints like /proc, /dev, /dev/pts. Not sure if they suffer from the same problem, but they probably could.
    
N.B. the `mountpoint` command is already among REQUIRED_PROGS.