### PR TITLE
OUTPUT=USB: add a check that OUTPUT_URL is mounted

### DIFF
--- a/usr/share/rear/output/USB/Linux-i386/105_check_mounted_usb.sh
+++ b/usr/share/rear/output/USB/Linux-i386/105_check_mounted_usb.sh
@@ -1,0 +1,49 @@
+# To be executed after output/default/100_mount_output_path.sh
+# Check whether the the USB directory is a moutpoint.
+# We need it to be a mountpoint, with a block device mounted there,
+# because later tasks (like installing bootloader) depend on it.
+# output/default/100_mount_output_path.sh should have mounted it.
+
+# Usually one would use a usb:// URL for OUTPUT=USB. Otherwise
+# one would have to use a URL that causes the output disk to be mounted
+# at $BUILD_DIR/outputfs. file:// does not satisfy this requirement
+# (see below).
+
+local usbdev
+local scheme
+
+scheme="$( url_scheme $OUTPUT_URL )"
+
+if ! mountpoint $BUILD_DIR/outputfs ; then
+    # It should be possible to support OUTPUT_URL=file://...,
+    # the user whould have to mount the USB manually.
+    # For this to work, one would need to eliminate all the hardcoded
+    # $BUILD_DIR/outputfs in the OUTPUT=USB code, incl. the one above
+    # (replace by url_path $OUTPUT_URL).
+    # USB_DEVICE would need to be properly set as well.
+    if [ "$scheme" == file ] ; then
+        LogPrintError "file:// OUTPUT_URL is currently unsupported for OUTPUT=USB, use usb://"
+    fi
+    Error "OUTPUT_URL '$OUTPUT_URL' is not mounted at $BUILD_DIR/outputfs"
+fi
+
+if usbdev="$(findmnt -funo SOURCE --target $BUILD_DIR/outputfs)" ; then
+    if [ -z "$usbdev" ] ; then
+        LogPrintError "'findmnt -funo SOURCE --target $BUILD_DIR/outputfs' returned an empty string"
+        Error "Could not check that OUTPUT_URL '$OUTPUT_URL' refers to a block device mounted at $BUILD_DIR/outputfs"
+    fi
+    # It needs to be a disk-based filesystem (not e.g. NFS)
+    # as OUTPUT=USB basically means "disk" (not necessarily USB).
+    if ! [ -b "$usbdev" ] ; then
+        LogPrintError "OUTPUT=USB needs OUTPUT_URL to refer to a block device."
+        if [ "$scheme" != usb ] ; then
+            LogPrintError "Use the usb:// scheme for OUTPUT_URL"
+        fi
+        Error "OUTPUT_URL '$OUTPUT_URL' refers to mounted '$usbdev' which is not a block device"
+    fi
+else
+    # needs to be in the "else" branch. "! usbdev=$(findmnt ...)" would clobber
+    # the exit status of "findmnt" and $? would become useless.
+    LogPrintError "'findmnt -funo SOURCE --target $BUILD_DIR/outputfs' failed with exit code $?"
+    Error "Failed to check that OUTPUT_URL '$OUTPUT_URL' refers to a block device mounted at $BUILD_DIR/outputfs"
+fi


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): closes #3098

* How was this pull request tested?
  * full backup and recovery with OUTPUT=USB on RHEL 8
  * `rear mkrescue` with
```
OUTPUT=USB
BACKUP=NETFS
BACKUP_URL=usb:///dev/disk/by-label/REAR-000
OUTPUT_URL=file:///srv
```
   fails with
```
file:// OUTPUT_URL is currently unsupported for OUTPUT=USB, use usb://
ERROR: OUTPUT_URL 'file:///srv' is not mounted at /var/tmp/rear.9WxhsNfKKQjmgsP/outputfs
Some latest log messages since the last called script 105_check_mounted_usb.sh:
  2023-12-08 13:31:11.869249473 file:// OUTPUT_URL is currently unsupported for OUTPUT=USB, use usb://
Some messages from /var/tmp/rear.9WxhsNfKKQjmgsP/tmp/rear.mkrescue.stdout_stderr since the last called script 105_check_mounted_usb.sh:
  mountpoint: /var/tmp/rear.9WxhsNfKKQjmgsP/outputfs: No such file or directory
```

- * `rear mkrescue` with

```
OUTPUT=USB
BACKUP=NETFS
BACKUP_URL=usb:///dev/disk/by-label/REAR-000
OUTPUT_URL=nfs://example.com/mnt/qa
OUTPUT_OPTIONS=ro,noatime
```
   fails with
```
OUTPUT=USB needs OUTPUT_URL to refer to a block device.
Use the usb:// scheme for OUTPUT_URL
ERROR: OUTPUT_URL 'nfs://example.com/mnt/qa' refers to mounted 'example.com:/mnt/qa' which is not a block device
Some latest log messages since the last called script 105_check_mounted_usb.sh:
  2023-12-10 10:54:53.662592565 OUTPUT=USB needs OUTPUT_URL to refer to a block device.
  2023-12-10 10:54:53.665507523 Use the usb:// scheme for OUTPUT_URL
Some messages from /var/tmp/rear.LtDKhi18fRteQRF/tmp/rear.mkrescue.stdout_stderr since the last called script 105_check_mounted_usb.sh:
  /var/tmp/rear.LtDKhi18fRteQRF/outputfs is a mountpoint
```
* Description of the changes in this pull request:
 
If OUTPUT_URL uses the `file://` scheme, ReaR aborts with a weird error message "BUG: Filesystem where the booting related files are on ... could not be found" in `output/USB/Linux-i386/850_make_USB_bootable.sh`.

Check if OUTPUT_URL got actually mounted at the right place ($BUILD_DIR/outputfs) by `output/default/100_mount_output_path.sh` and abort earlier with a meaningful error message if not.