### PR TITLE
Error() instead of BugError() in 850_make_USB_bootable.sh

### DIFF
--- a/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
+++ b/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
@@ -63,8 +63,8 @@ case "$usb_filesystem" in
         Error "An ext2/3/4 or vfat filesystem must be mounted for the booting related files on $RAW_USB_DEVICE"
         ;;
     (*)
-        LogPrintError "Filesystem $usb_filesystem is mounted at $BUILD_DIR/outputfs"
-        Error "Only ext2/3/4 and vfat are supported for the booting related files on $RAW_USB_DEVICE"
+        LogPrintError "Only ext2/3/4 and vfat are supported for the booting related files on $RAW_USB_DEVICE"
+        Error "Unsupported filesystem $usb_filesystem is mounted at $BUILD_DIR/outputfs"
         ;;
 esac
 

--- a/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
+++ b/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
@@ -59,11 +59,12 @@ case "$usb_filesystem" in
         fi
         ;;
     ("")
-        LogPrintError "Could not find a filesystem for $BUILD_DIR/outputfs in /proc/mounts"
+        LogPrintError "Could not find a filesystem in /proc/mounts for $BUILD_DIR/outputfs"
         Error "An ext2/3/4 or vfat filesystem must be mounted for the booting related files on $RAW_USB_DEVICE"
         ;;
     (*)
-        Error "Unsupported filesystem $usb_filesystem for the booting related files on $RAW_USB_DEVICE"
+        LogPrintError "Filesystem $usb_filesystem is mounted at $BUILD_DIR/outputfs"
+        Error "Only ext2/3/4 and vfat are supported for the booting related files on $RAW_USB_DEVICE"
         ;;
 esac
 

--- a/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
+++ b/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
@@ -59,10 +59,11 @@ case "$usb_filesystem" in
         fi
         ;;
     ("")
-        BugError "Filesystem where the booting related files are on $RAW_USB_DEVICE could not be found"
+        LogPrintError "Could not find a filesystem for $BUILD_DIR/outputfs in /proc/mounts"
+        Error "An ext2/3/4 or vfat filesystem must be mounted for the booting related files on $RAW_USB_DEVICE"
         ;;
     (*)
-        Error "Filesystem $usb_filesystem for the booting related files is not supported"
+        Error "Unsupported filesystem $usb_filesystem for the booting related files on $RAW_USB_DEVICE"
         ;;
 esac
 


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/1571
and
https://github.com/rear/rear/issues/3098
i.e. false BUG Error in
output/USB/Linux-i386/850_make_USB_bootable.sh
because of unsupported OUTPUT_URL for OUTPUT=USB

* How was this pull request tested?
Not tested.
Those code changes should not cause any issue.

* Description of the changes in this pull request:

In output/USB/Linux-i386/850_make_USB_bootable.sh replaced the
```
BugError "Filesystem where the booting related files are on $RAW_USB_DEVICE could not be found"
```
with more explanatory LogPrintError plus Error what the actual reason is,
similar as in the related
https://github.com/rear/rear/pull/3102
because in most cases it is not a bug in ReaR
but an error (e.g. a user configuration error for OUTPUT=USB).
