### PR TITLE
Do not touch $BUILD_DIR/outputfs (the backup location) during restore

### DIFF
--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -21,8 +21,6 @@ local backup_restore_log_suffix="restore.log"
 test "$CONFIG_APPEND_FILES" && backup_restore_log_prefix=$backup_restore_log_prefix.$( echo -n $CONFIG_APPEND_FILES | tr -d -c '[:alnum:]/[:space:]' | tr -s '/[:space:]' ':_' )
 local restore_input_basename=""
 
-mkdir -p $BUILD_DIR/outputfs/$NETFS_PREFIX
-
 # The RESTORE_ARCHIVES array contains the restore input files.
 # If it is not set, RESTORE_ARCHIVES is only one element which is the backup archive:
 test "$RESTORE_ARCHIVES" || RESTORE_ARCHIVES=( "$backuparchive" )


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested?

with original code, `OUTPUT=ISO` and
`POST_RECOVERY_COMMANDS=( 'cp $STDOUT_STDERR_FILE /mnt/local/root' )`,
`/root/rear.recover.stdout_stderr` contains:
```
Including restore/NETFS/default/400_restore_backup.sh
mkdir: cannot create directory '/var/tmp/rear.pUTNJoLWHyPL5wP/outputfs/kvm-03-guest18': Read-only file system
```
In ReaR 2.6, when stdout and stderr of commands used to appear in the recover log, this was printed to the recover log.

With the changed code, this does not appear.

* Description of the changes in this pull request:

Remove a forgotten
`mkdir -p $BUILD_DIR/outputfs/$NETFS_PREFIX`
command in restore/NETFS/default/400_restore_backup.sh.
Should have been deleted in 7dda23d708854db2d09db1308c159aea667763c0
with other code that touched the backup location.
For the YUM method, the same change was already done
in 6b9d8d8508183144f56eec92b828ae037c03a6f7