### PR TITLE
Set 'dmesg -n 5' in etc/scripts/boot

### DIFF
--- a/usr/share/rear/skel/default/etc/scripts/boot
+++ b/usr/share/rear/skel/default/etc/scripts/boot
@@ -1,7 +1,17 @@
 #!/bin/bash
 # Relax-and-Recover
-# disable console logging for kernel messages
-dmesg -n1
+
+# Limit console logging for 'dmesg' messages to level 5
+# (i.e. what kernel messages appear intermixed with ReaR messages on the console)
+# where level 5 means to show only the following kernel messages (cf. 'dmesg -h')
+#   emerg - system is unusable
+#   alert - action must be taken immediately
+#    crit - critical conditions
+#     err - error conditions
+#    warn - warning conditions
+# We need also kernel warning messages because some errors are reported as warning
+# cf. https://github.com/rear/rear/issues/3107#issuecomment-1855560152
+dmesg -n 5
 
 # basic mounts
 mountpoint /proc || mount -t proc -n none /proc


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3107

* How was this pull request tested?
 
I tested various 'dmesg -n [1-7]' during "rear recover"
and up to 'dmesg -n 5' i.e. up to warning messages
there are almost no kernel messages so that level 5
does not "pollute" the usual ReaR messages.
In contrast level 6 (notice messages) shows some more
kernel messages which could be considered as disturbing
and with level 7 (info messages) it really gets too much.

* Description of the changes in this pull request:

In [skel/default]/etc/scripts/boot set
```
dmesg -n 5
```
to limit console logging for 'dmesg' messages to level 5
so that kernel error and warning messages appear
(intermixed with ReaR messages) on the console
so that the user can notice when things go wrong
in kernel area which helps to understand problems.
