### PR TITLE
Fixed 800_enforce_usb_output.sh

### DIFF
--- a/usr/share/rear/build/USB/default/800_enforce_usb_output.sh
+++ b/usr/share/rear/build/USB/default/800_enforce_usb_output.sh
@@ -1,11 +1,16 @@
 # Verify there is the correct OUTPUT=USB in $ROOTFS_DIR/etc/rear/local.conf
 
-# The reason for this verification is unknown,
+# This script was added in 2011 as build/USB/default/80_enforce_usb_output.sh via
+# https://github.com/rear/rear/commit/4ec9ed4aa58787f42ad2946d68358d1de3417a60
+# with only this git commit comment
+# "Make sure OUTPUT=USB is enforced in udev workflow during recover"
+# but the reason for this verification script is unknown,
 # see the description below and
-# see https://github.com/rear/rear/pull/3103
+# see https://github.com/rear/rear/pull/3110
+# and https://github.com/rear/rear/pull/3110#issuecomment-1862366094
+# and https://github.com/rear/rear/pull/3103
 # and https://github.com/rear/rear/issues/1571#issuecomment-343461088
 # and https://github.com/rear/rear/issues/1571#issuecomment-343516020
-# and https://github.com/rear/rear/pull/3110#issuecomment-1862366094
 
 local_conf_output=$( source $ROOTFS_DIR/etc/rear/local.conf ; echo $OUTPUT )
 test "USB" = "$local_conf_output" && return
@@ -19,9 +24,10 @@ test "USB" = "$local_conf_output" && return
 # so somehow OUTPUT got modified in $ROOTFS_DIR/etc/rear/local.conf 
 # after etc/rear/local.conf was copied via build/GNU/Linux/100_copy_as_is.sh
 # i.e. between build/GNU/Linux/100_copy_as_is.sh and build/USB/default/800_enforce_usb_output.sh
-# but nothing was found in those build stage scripts which modifies $ROOTFS_DIR/etc/rear/local.conf
+# but as of this writing (19. Dec. 2023) nothing could be found in those build stage scripts
+# which modifies $ROOTFS_DIR/etc/rear/local.conf (at least nothing obvious was found)
 # cf. https://github.com/rear/rear/pull/3110#issuecomment-1862366094
-# nevertheless it would be a bu g in ReaR if OUTPUT got modified in $ROOTFS_DIR/etc/rear/local.conf
+# nevertheless it would be a bug in ReaR if OUTPUT got modified in $ROOTFS_DIR/etc/rear/local.conf
 LogPrintError "OUTPUT=USB is used but that is missing in $ROOTFS_DIR/etc/rear/local.conf"
 LogPrintError "See https://github.com/rear/rear/pull/3110 and follow the links therein"
 BugError "'rear $WORKFLOW' uses OUTPUT=USB which will not be used for 'rear recover'"

--- a/usr/share/rear/build/USB/default/800_enforce_usb_output.sh
+++ b/usr/share/rear/build/USB/default/800_enforce_usb_output.sh
@@ -1,22 +1,27 @@
 # Verify there is the correct OUTPUT=USB in $ROOTFS_DIR/etc/rear/local.conf
 
 # The reason for this verification is unknown,
+# see the description below and
 # see https://github.com/rear/rear/pull/3103
 # and https://github.com/rear/rear/issues/1571#issuecomment-343461088
 # and https://github.com/rear/rear/issues/1571#issuecomment-343516020
+# and https://github.com/rear/rear/pull/3110#issuecomment-1862366094
 
 local_conf_output=$( source $ROOTFS_DIR/etc/rear/local.conf ; echo $OUTPUT )
 test "USB" = "$local_conf_output" && return
 
 # At this point we run this script build/USB/default/800_enforce_usb_output.sh
 # which means there is OUTPUT=USB in etc/rear/local.conf
-# (ortherwise this script would not have been picked up by the SourceStage function)
+# (ortherwise this script is not picked up by the SourceStage function)
 # cf. https://github.com/rear/rear/pull/3103#issuecomment-1860001618
 # and https://github.com/rear/rear/pull/3103#issuecomment-1860169199
 # but in $ROOTFS_DIR/etc/rear/local.conf there is not OUTPUT=USB
-# so OUTPUT got somehow modified in $ROOTFS_DIR/etc/rear/local.conf 
-# after etc/rear/local.conf got copied via build/GNU/Linux/100_copy_as_is.sh
-# which is a bug in ReaR:
+# so somehow OUTPUT got modified in $ROOTFS_DIR/etc/rear/local.conf 
+# after etc/rear/local.conf was copied via build/GNU/Linux/100_copy_as_is.sh
+# i.e. between build/GNU/Linux/100_copy_as_is.sh and build/USB/default/800_enforce_usb_output.sh
+# but nothing was found in those build stage scripts which modifies $ROOTFS_DIR/etc/rear/local.conf
+# cf. https://github.com/rear/rear/pull/3110#issuecomment-1862366094
+# nevertheless it would be a bu g in ReaR if OUTPUT got modified in $ROOTFS_DIR/etc/rear/local.conf
 LogPrintError "OUTPUT=USB is used but that is missing in $ROOTFS_DIR/etc/rear/local.conf"
 LogPrintError "See https://github.com/rear/rear/pull/3110 and follow the links therein"
-BugError "rear $WORKFLOW uses OUTPUT=USB which will not be used for rear recover"
+BugError "'rear $WORKFLOW' uses OUTPUT=USB which will not be used for 'rear recover'"

--- a/usr/share/rear/build/USB/default/800_enforce_usb_output.sh
+++ b/usr/share/rear/build/USB/default/800_enforce_usb_output.sh
@@ -1,13 +1,20 @@
-# Make sure we use the correct OUTPUT in local.conf
+# Verify there is the correct OUTPUT=USB in $ROOTFS_DIR/etc/rear/local.conf
 
-real_output=$(source $ROOTFS_DIR/etc/rear/local.conf; echo $OUTPUT)
+# The reason for this verification is unknown,
+# see https://github.com/rear/rear/pull/3103
+# and https://github.com/rear/rear/issues/1571#issuecomment-343461088
+# and https://github.com/rear/rear/issues/1571#issuecomment-343516020
 
-if [[ "$real_output" == "USB" ]]; then
-    return
-fi
+real_output=$( source $ROOTFS_DIR/etc/rear/local.conf; echo $OUTPUT )
+test "USB" = "$real_output" && return
 
-cat <<EOF >>$ROOTFS_DIR/etc/rear/local.conf
-
-# Added by udev workflow
-OUTPUT=USB
-EOF
+# At this point we run this script build/USB/default/800_enforce_usb_output.sh
+# which means there is OUTPUT=USB in etc/rear/local.conf
+# (ortherwise this script would not have been picked up by the SourceStage function)
+# cf. https://github.com/rear/rear/pull/3103#issuecomment-1860001618
+# and https://github.com/rear/rear/pull/3103#issuecomment-1860169199
+# but in $ROOTFS_DIR/etc/rear/local.conf there is not OUTPUT=USB
+# so OUTPUT got somehow modified in $ROOTFS_DIR/etc/rear/local.conf 
+# after etc/rear/local.conf got copied via build/GNU/Linux/100_copy_as_is.sh
+# which is a bug in ReaR:
+BugError "OUTPUT=USB is used but that is missing in $ROOTFS_DIR/etc/rear/local.conf"

--- a/usr/share/rear/build/USB/default/800_enforce_usb_output.sh
+++ b/usr/share/rear/build/USB/default/800_enforce_usb_output.sh
@@ -5,8 +5,8 @@
 # and https://github.com/rear/rear/issues/1571#issuecomment-343461088
 # and https://github.com/rear/rear/issues/1571#issuecomment-343516020
 
-real_output=$( source $ROOTFS_DIR/etc/rear/local.conf; echo $OUTPUT )
-test "USB" = "$real_output" && return
+local_conf_output=$( source $ROOTFS_DIR/etc/rear/local.conf ; echo $OUTPUT )
+test "USB" = "$local_conf_output" && return
 
 # At this point we run this script build/USB/default/800_enforce_usb_output.sh
 # which means there is OUTPUT=USB in etc/rear/local.conf
@@ -17,4 +17,6 @@ test "USB" = "$real_output" && return
 # so OUTPUT got somehow modified in $ROOTFS_DIR/etc/rear/local.conf 
 # after etc/rear/local.conf got copied via build/GNU/Linux/100_copy_as_is.sh
 # which is a bug in ReaR:
-BugError "OUTPUT=USB is used but that is missing in $ROOTFS_DIR/etc/rear/local.conf"
+LogPrintError "OUTPUT=USB is used but that is missing in $ROOTFS_DIR/etc/rear/local.conf"
+LogPrintError "See https://github.com/rear/rear/pull/3110 and follow the links therein"
+BugError "rear $WORKFLOW uses OUTPUT=USB which will not be used for rear recover"


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):

https://github.com/rear/rear/pull/3103
and
https://github.com/rear/rear/issues/1571#issuecomment-343461088
and
https://github.com/rear/rear/issues/1571#issuecomment-343516020

* How was this pull request tested?

see https://github.com/rear/rear/pull/3110#issuecomment-1860611433

* Description of the changes in this pull request:

Overhauled build/USB/default/800_enforce_usb_output.sh
Now BugError when OUTPUT=USB got somehow modified
in $ROOTFS_DIR/etc/rear/local.conf
plus explanatory comments.
Triggered by https://github.com/rear/rear/pull/3103
and replacing it by this new pull request.