### PR TITLE
Show BugError message arguments without single quotes

### DIFF
--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -818,7 +818,7 @@ function BugError () {
     Error "
 ====================
 BUG in $caller_source:
-'$*'
+$*
 --------------------
 Please report it at $BUG_REPORT_SITE
 and include all related parts from $RUNTIME_LOGFILE


### PR DESCRIPTION
* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):
Triggered by the BugError output in
https://github.com/rear/rear/pull/3110#issuecomment-1862408735

* How was this pull request tested?
See below at
"With the change here that output gets simpler and easier to read"

* Description of the changes in this pull request:

In the BugError function in lib/_input-output-functions.sh
do no longer show the BugError function message arguments '$*'
within single quotes as
```
    Error "
...
'$*'
... "
```
because the message arguments are shown
on a separated line where the additional single quotes
do not make the output easier to read or understand.

For an example see
https://github.com/rear/rear/pull/3110#issuecomment-1862408735
where
```
BugError "'rear $WORKFLOW' uses OUTPUT=USB which will not be used for 'rear recover'"
```
results this output
```
ERROR: 
====================
BUG in /root/rear.github.master/usr/share/rear/build/USB/default/800_enforce_usb_output.sh line 34:
''rear mkrescue' uses OUTPUT=USB which will not be used for 'rear recover''
--------------------
Please report it at https://github.com/rear/rear/issues
and include all related parts from /root/rear.github.master/var/log/rear/rear-linux-h9wr.log
preferably the whole debug information via 'rear -D mkrescue'
====================
```
with rather strange looking double single quotes.

With the change here that output gets simpler and easier to read:
```
ERROR: 
====================
BUG in /root/rear.github.master/usr/share/rear/build/USB/default/800_enforce_usb_output.sh line 34:
'rear mkrescue' uses OUTPUT=USB which will not be used for 'rear recover'
--------------------
Please report it at https://github.com/rear/rear/issues
and include all related parts from /root/rear.github.master/var/log/rear/rear-linux-h9wr.log
preferably the whole debug information via 'rear -D mkrescue'
====================
```
