### PR TITLE
Make initrd accessible only by root

### DIFF
--- a/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
+++ b/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
@@ -126,7 +126,7 @@ case "$REAR_INITRD_COMPRESSION" in
         ;;
 esac
 
-# Only root should allowed to access the initrd
+# Only root should be allowed to access the initrd
 # because the ReaR recovery system can contain secrets
 # cf. https://github.com/rear/rear/issues/3122
 test -s "$TMP_DIR/$REAR_INITRD_FILENAME" && chmod 0600 "$TMP_DIR/$REAR_INITRD_FILENAME"

--- a/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
+++ b/usr/share/rear/pack/GNU/Linux/900_create_initramfs.sh
@@ -125,4 +125,10 @@ case "$REAR_INITRD_COMPRESSION" in
         fi
         ;;
 esac
+
+# Only root should allowed to access the initrd
+# because the ReaR recovery system can contain secrets
+# cf. https://github.com/rear/rear/issues/3122
+test -s "$TMP_DIR/$REAR_INITRD_FILENAME" && chmod 0600 "$TMP_DIR/$REAR_INITRD_FILENAME"
+
 popd >/dev/null


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal** / **Critical**

Normally (i.e. by default) the ReaR recovery system
does not contain secrets but when it contains secrets
and when e.g. GRUB_RESCUE=Y is used then it is critical
that only root is allowed to access the initrd.

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3122

* How was this pull request tested?
Not yet tested.

* Description of the changes in this pull request:

In pack/GNU/Linux/900_create_initramfs.sh call
chmod 0600 "$TMP_DIR/$REAR_INITRD_FILENAME"
to let only root access the initrd because
the ReaR recovery system can contain secrets