### PR TITLE
Take AUTOEXCLUDE_PATH into account in layout doc

### DIFF
--- a/doc/user-guide/06-layout-configuration.adoc
+++ b/doc/user-guide/06-layout-configuration.adoc
@@ -84,7 +84,7 @@ component that's part of it. The reason is that no mounted filesystem
 uses these two disks. After all, you don't want to recreate your
 backup disk when you're recovering your system.
 
-If we mount the filesystem on +/dev/mapper/backup-backup+ on +/media/backup+,
+If we mount the filesystem on +/dev/mapper/backup-backup+ on +/backup+,
 Relax-and-Recover will think that it's necessary to recreate the filesystem:
 ----------------------------------
 disk /dev/sda 160041885696 msdos
@@ -116,7 +116,7 @@ fs /dev/mapper/system-var /var ext4 uuid=a12bb95f-99f2-42c6-854f-1cb3f144d662 la
 fs /dev/mapper/system-vmxfs /vmware xfs uuid=7457d2ab-8252-4f41-bab6-607316259975 label=  options=rw,noatime
 fs /dev/mapper/system-kvm /kvm ext4 uuid=173ab1f7-8450-4176-8cf7-c09b47f5e3cc label= blocksize=4096 reserved_blocks=256000 max_mounts=21 check_interval=180d options=rw,noatime,commit=0
 fs /dev/sda1 /boot ext3 uuid=f6b08566-ea5e-46f9-8f73-5e8ffdaa7be6 label= blocksize=1024 reserved_blocks=10238 max_mounts=35 check_interval=180d options=rw,commit=0
-fs /dev/mapper/backup-backup /media/backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
+fs /dev/mapper/backup-backup /backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
 swap /dev/mapper/system-swap uuid=9f347fc7-1605-4788-98fd-fca828beedf1 label=
 crypt /dev/mapper/disk /dev/sda2 cipher=aes-xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
 ----------------------------------
@@ -130,6 +130,18 @@ variable in +default.conf+ prevents Relax-and-Recover from overwriting
 multipath disks. Typically, they are part of the SAN disaster recovery
 strategy. However, there can be cases where you want to recover them. The
 information is retained in +disklayout.conf+.
+
+Some filesystems are excluded from the layout file by default if their
+mountpoints are located under certain directories. This behavior is
+controlled by the +AUTOEXCLUDE_PATH+ variable. It is an array of
+paths. If a mountpoint of a filesystem is under one of the paths, the
+filesystem is excluded. The default value includes +/media+, +/mnt+
+and +/tmp+. See +default.conf+ for the full list. Note that if one of
+the paths is itself a mountpoint, the filesystem is not excluded. So,
+if +/media+ is a mounted filesystem, it will not be excluded, but if
+we mount the +/dev/mapper/backup-backup+ filesystem on
++/media/backup+, it will get excluded, as the mountpoint is under
++/media+.
 
 === Manual excludes
 It seems prudent to prevent the external drives from ever being backed-up or overwritten. The default configuration contains these lines:
@@ -149,7 +161,7 @@ EXCLUDE_RESTORE=()
 
 To prevent an inadvertently mounted backup filesystem being added to the restore list, the easiest way is to add the filesystem to the +EXCLUDE_RECREATE+ array.
 ----------------------------------
-EXCLUDE_RECREATE+=( "fs:/media/backup" )
+EXCLUDE_RECREATE+=( "fs:/backup" )
 ----------------------------------
 
 The layout file is as expected:
@@ -183,7 +195,7 @@ fs /dev/mapper/system-var /var ext4 uuid=a12bb95f-99f2-42c6-854f-1cb3f144d662 la
 fs /dev/mapper/system-vmxfs /vmware xfs uuid=7457d2ab-8252-4f41-bab6-607316259975 label=  options=rw,noatime
 fs /dev/mapper/system-kvm /kvm ext4 uuid=173ab1f7-8450-4176-8cf7-c09b47f5e3cc label= blocksize=4096 reserved_blocks=256000 max_mounts=21 check_interval=180d options=rw,noatime,commit=0
 fs /dev/sda1 /boot ext3 uuid=f6b08566-ea5e-46f9-8f73-5e8ffdaa7be6 label= blocksize=1024 reserved_blocks=10238 max_mounts=35 check_interval=180d options=rw,commit=0
-# fs /dev/mapper/backup-backup /media/backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
+# fs /dev/mapper/backup-backup /backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
 swap /dev/mapper/system-swap uuid=9f347fc7-1605-4788-98fd-fca828beedf1 label=
 crypt /dev/mapper/disk /dev/sda2 cipher=aes-xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
 ----------------------------------
@@ -323,7 +335,7 @@ fs /dev/mapper/system-var /var ext4 uuid=a12bb95f-99f2-42c6-854f-1cb3f144d662 la
 fs /dev/mapper/system-vmxfs /vmware xfs uuid=7457d2ab-8252-4f41-bab6-607316259975 label=  options=rw,noatime
 fs /dev/mapper/system-kvm /kvm ext4 uuid=173ab1f7-8450-4176-8cf7-c09b47f5e3cc label= blocksize=4096 reserved_blocks=256000 max_mounts=21 check_interval=180d options=rw,noatime,commit=0
 fs /dev/sdb1 /boot ext3 uuid=f6b08566-ea5e-46f9-8f73-5e8ffdaa7be6 label= blocksize=1024 reserved_blocks=10238 max_mounts=35 check_interval=180d options=rw,commit=0
-# fs /dev/mapper/backup-backup /media/backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
+# fs /dev/mapper/backup-backup /backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
 swap /dev/mapper/system-swap uuid=9f347fc7-1605-4788-98fd-fca828beedf1 label=
 crypt /dev/mapper/disk /dev/sdb2 cipher=aes-xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
 
@@ -372,7 +384,7 @@ fs /dev/mapper/system-var /var ext4 uuid=a12bb95f-99f2-42c6-854f-1cb3f144d662 la
 #fs /dev/mapper/system-vmxfs /vmware xfs uuid=7457d2ab-8252-4f41-bab6-607316259975 label=  options=rw,noatime
 #fs /dev/mapper/system-kvm /kvm ext4 uuid=173ab1f7-8450-4176-8cf7-c09b47f5e3cc label= blocksize=4096 reserved_blocks=256000 max_mounts=21 check_interval=180d options=rw,noatime,commit=0
 fs /dev/sdb1 /boot ext3 uuid=f6b08566-ea5e-46f9-8f73-5e8ffdaa7be6 label= blocksize=1024 reserved_blocks=10238 max_mounts=35 check_interval=180d options=rw,commit=0
-# fs /dev/mapper/backup-backup /media/backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
+# fs /dev/mapper/backup-backup /backup ext4 uuid=da20354a-dc4c-4bef-817c-1c92894bb002 label= blocksize=4096 reserved_blocks=655360 max_mounts=24 check_interval=180d options=rw
 swap /dev/mapper/system-swap uuid=9f347fc7-1605-4788-98fd-fca828beedf1 label=
 crypt /dev/mapper/disk /dev/sdb2 cipher=aes-xts-plain hash=sha1 uuid=beafe67c-d9a4-4992-80f1-e87791a543bb
 ----------------------------------


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
Triggred by PR #2261. Found while working on #2997.

* How was this pull request tested?
```
pvcreate /dev/vdc
vgcreate testvg /dev/vdc
lvcreate -L 1G testvg -n testlv 
mkfs.xfs /dev/testvg/testlv
lvcreate -L 1G testvg -n testlv2
mkfs.xfs /dev/testvg/testlv2
mkdir /media/testfs
mkdir /media/testfs/testfs2
mount /dev/testvg/testlv /media/testfs
mount /dev/testvg/testlv2 /media/testfs/testfs2
```
Observe that everything related to the storage created above is commented out in disklayout.conf:
```
# Disk /dev/vdc
# Format: disk <devname> <size(bytes)> <partition label type>
#disk /dev/vdc 10737418240 unknown
# Partitions on /dev/vdc
# Format: part <device> <partition size(bytes)> <partition start(bytes)> <partition type|name> <flags> /dev/<partition>
# Format for LVM PVs
# lvmdev <volume_group> <device> [<uuid>] [<size(bytes)>]
#lvmdev /dev/testvg /dev/vdc noCtfr-i5N5-y03V-lw4W-0axd-TAk0-KqWlG4 10733223936
# Format for LVM VGs
# lvmgrp <volume_group> <extentsize> [<size(extents)>] [<size(bytes)>]
#lvmgrp /dev/testvg 4096 2559 10481664
# Format for LVM LVs
# lvmvol <volume_group> <name> <size(bytes)> <layout> [key:value ...]
#lvmvol /dev/testvg testlv 1073741824b linear 
#lvmvol /dev/testvg testlv2 1073741824b linear 
# Filesystems (only ext2,ext3,ext4,vfat,xfs,reiserfs,btrfs are supported).
# Format: fs <device> <mountpoint> <fstype> [uuid=<uuid>] [label=<label>] [<attributes>]
#fs /dev/mapper/testvg-testlv /media/testfs xfs uuid=7809e5c6-8012-43e2-a1c6-3cdc3d4cfc0e label=  options=rw,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota
#fs /dev/mapper/testvg-testlv2 /media/testfs/testfs2 xfs uuid=2bf30849-24f8-4438-bd20-61b53ccd738d label=  options=rw,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota
```
* Description of the changes in this pull request:

Since PR #2261, /media is included in the default AUTOEXCLUDE_PATH. This means that a filesystem mounted on a directory like /media/backup will not be included in the layout. This makes the example invalid, as it describes how a filesystem mounted under /media/backup will be included in the layout and what manual steps are needed to exclude it.

To preserve the validity of the example, change all paths in the example from /media/backup to /backup.

Take this opportunity to also describe the AUTOEXCLUDE_PATH variable among other autoexclusions.