### PR TITLE
ErrorIfDeprecated when GRUB Legacy is used

### DIFF
--- a/usr/share/rear/layout/save/default/450_check_bootloader_files.sh
+++ b/usr/share/rear/layout/save/default/450_check_bootloader_files.sh
@@ -13,10 +13,17 @@ used_bootloader=( $( cat $VAR_DIR/recovery/bootloader ) )
 # so nonexistent files are not appended to CHECK_CONFIG_FILES
 # cf. https://github.com/rear/rear/pull/2796#issuecomment-1117171070
 case $used_bootloader in
+    (GRUB)
+        # GRUB Legacy support should be dropped
+        # so if users still use it we like to get reports via BugError
+        # and when there are no valid use cases its code can be removed
+        # see https://github.com/rear/rear/issues/3127
+        BugError "GRUB Legacy is no longer supported" 
+        ;;
     (EFI|GRUB2-EFI)
         CHECK_CONFIG_FILES+=( /boot/efi/EFI/*/grub*.cfg )
         ;;
-    (GRUB|GRUB2)
+    (GRUB2)
         CHECK_CONFIG_FILES+=( /[e]tc/grub*.cfg /[b]oot/*/grub*.cfg )
         ;;
     (LILO)


### PR DESCRIPTION
* Type: **Cleanup**

* Impact: **Low**
Hopefully even no impact because I hope
nobody uses current ReaR on a system
that uses GRUB Legacy as bootloader

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3127

* How was this pull request tested?
 
"rear mkrescue" still works for me on openSUSE Leap 15.5
I get
```
Using sysconfig bootloader 'grub2' for 'rear recover'
```
so I have GRUB2 in var/lib/rear/recovery/bootloader

* Description of the changes in this pull request:

In layout/save/default/450_check_bootloader_files.sh
BugError when GRUB Legacy is used as bootloader
so we get user reports when GRUB Legacy is still used
