### PR TITLE
Improve the description of AUTOEXCLUDE_PATH

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3264,17 +3264,21 @@ AUTOEXCLUDE_AUTOFS=
 # This is different from EXCLUDE_MOUNTPOINTS, which accepts only mountpoints.
 # Filesystems with mountpoints in the AUTOEXCLUDE_PATH array are not excluded.
 # For details see the layout/save/default/320_autoexclude.sh script.
-# For example a separated filesystem with mountpoint /tmp is not excluded
-# but the files in the /tmp directory are excluded from the backup
-# when an internal backup method is used by default
-# via the above BACKUP_PROG_EXCLUDE=( '/tmp/*' ... )
-# so that this filesystem will be recreated as an empty filesystem
-# cf. https://github.com/rear/rear/pull/2261
+# For example a separate filesystem with mountpoint /mnt is not excluded
+# if AUTOEXCLUDE_PATH contains /mnt, but a separate filesystem /mnt/test is.
 # The AUTOEXCLUDE_PATH default /media /run[/media] /mnt and /tmp
 # intends to exclude temporarily mounted things (e.g. USB devices)
 # because mountpoints for temporarily mounted things are usually
 # sub-directories below /media /run[/media] /mnt and /tmp
 # see https://github.com/rear/rear/issues/2239
+# Even if /tmp is a separate filesystem, the /tmp entry in AUTOEXCLUDE_PATH
+# does not cause files in the /tmp directory to be excluded from the backup
+# (except for files in filesystems mounted on directories below /tmp, if any).
+# Excluding files in the /tmp directory when an internal backup method is used
+# is achieved via a different default setting:
+# BACKUP_PROG_EXCLUDE=( '/tmp/*' ... ) above
+# so that /tmp filesystem will be recreated as an empty filesystem
+# cf. https://github.com/rear/rear/pull/2261
 AUTOEXCLUDE_PATH=( /media /run /mnt /tmp )
 #
 ## New Style include/excludes


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): #2261

* How was this pull request tested?
```sh
pvcreate /dev/vdb
vgcreate testvg /dev/vdc
vgcreate testvg /dev/vdb
lvcreate -L 1G testvg -n testlv 
mkfs.xfs /dev/testvg/testlv
lvcreate -L 1G testvg -n testlv2
mkfs.xfs /dev/testvg/testlv2
mount /dev/testvg/testlv /mnt
mkdir /mnt/test
mount  /dev/testvg/testlv2 /mnt/test
```
now `rear savelayout` creates disklayout.conf with this:
```
fs /dev/mapper/testvg-testlv /mnt xfs uuid=9f9a9874-0325-43e0-9979-6849109c44a9 label=  options=rw,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota
#fs /dev/mapper/testvg-testlv2 /mnt/test xfs uuid=b6dd2e35-2e7a-495a-a219-4e38b41a3530 label=  options=rw,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota
```

* Description of the changes in this pull request:

Separate the example of AUTOEXCLUDE_PATH handling from the treatment of /tmp. /tmp is a bad example, because it is handled specially by the default setting of another config variable (BACKUP_PROG_EXCLUDE). Use /mnt as an example for AUTOEXCLUDE_PATH instead and make clear that AUTOEXCLUDE_PATH=( /tmp ) does not exclude files under /tmp from the backup and an independent setting is used for that purpose.