### PR TITLE
Include GRUB tools unconditionally and don't create $VAR_DIR/recovery/bootdisk in prep

### DIFF
--- a/usr/share/rear/prep/GNU/Linux/300_include_grub_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/300_include_grub_tools.sh
@@ -1,8 +1,6 @@
 #
 # GRUB2 has much more commands than the legacy grub command, including modules
 
-test -d $VAR_DIR/recovery || mkdir -p $VAR_DIR/recovery
-
 # cf. https://github.com/rear/rear/issues/2137
 # s390 zlinux does not use grub 
 # *********************************************************************************
@@ -19,9 +17,9 @@ test -d "$grubdir" || grubdir='/boot/grub'
 
 # Check if we're using grub or grub2 before doing something.
 if has_binary grub-probe ; then
-    grub-probe -t device $grubdir >$VAR_DIR/recovery/bootdisk 2>/dev/null || return 0
+    grub-probe -t device $grubdir >/dev/null 2>&1 || return 0
 elif has_binary grub2-probe ; then
-    grub2-probe -t device $grubdir >$VAR_DIR/recovery/bootdisk 2>/dev/null || return 0
+    grub2-probe -t device $grubdir >/dev/null 2>&1 || return 0
 fi
 
 # Missing programs in the PROGS array are ignored:

--- a/usr/share/rear/prep/GNU/Linux/300_include_grub_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/300_include_grub_tools.sh
@@ -9,19 +9,8 @@
 # *********************************************************************************
 [ "$ARCH" == "Linux-s390"  ] && return 0
 
-# Because usr/sbin/rear sets 'shopt -s nullglob' the 'echo -n' command
-# outputs nothing if nothing matches the bash globbing pattern '/boot/grub*'
-local grubdir="$( echo -n /boot/grub* )"
-# Use '/boot/grub' as fallback if nothing matches '/boot/grub*'
-test -d "$grubdir" || grubdir='/boot/grub'
-
-# Check if we're using grub or grub2 before doing something.
-if has_binary grub-probe ; then
-    grub-probe -t device $grubdir >/dev/null 2>&1 || return 0
-elif has_binary grub2-probe ; then
-    grub2-probe -t device $grubdir >/dev/null 2>&1 || return 0
-fi
-
+# It is safe to assume that we are using GRUB and try to add these files to the rescue image
+# even if the assumption is wrong.
 # Missing programs in the PROGS array are ignored:
 PROGS+=( grub-bios-setup      grub2-bios-setup
          grub-install         grub2-install

--- a/usr/share/rear/prep/Linux-s390/305_include_s390_tools.sh
+++ b/usr/share/rear/prep/Linux-s390/305_include_s390_tools.sh
@@ -1,8 +1,6 @@
 #
 #  s390 zIPL boot loader and grubby for configuring boot loader`
 
-test -d $VAR_DIR/recovery || mkdir -p $VAR_DIR/recovery
-
 # See the code in prep/GNU/Linux/300_include_grub_tools.sh
 # that sets grubdir via
 #   local grubdir="$( echo -n /boot/grub* )"
@@ -21,7 +19,7 @@ local bootdir="/boot/"
 #   findmnt returns --> /dev/dasda3[/@/.snapshots/1/snapshot]
 #   use 300_include_grub_tools.sh instead of this file (grub2-probe)
 if has_binary findmnt ; then
-    findmnt -no SOURCE --target $bootdir >$VAR_DIR/recovery/bootdisk || return 0
+    findmnt -no SOURCE --target $bootdir > /dev/null || return 0
 fi
 
 # Missing programs in the PROGS array are ignored:

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -87,7 +87,3 @@ fi
 DebugPrint "Found EFI system partition ${esp_proc_mounts_line[0]} on ${esp_proc_mounts_line[1]} type ${esp_proc_mounts_line[2]}"
 USING_UEFI_BOOTLOADER=1
 LogPrint "Using UEFI Boot Loader for Linux (USING_UEFI_BOOTLOADER=1)"
-
-# Remember the ESP device node in VAR_DIR/recovery/bootdisk:
-echo "${esp_proc_mounts_line[0]}" >$VAR_DIR/recovery/bootdisk
-


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): see discussion in commit ccae513d8362078c5d4bcffe9b1167835e6449b8

* How was this pull request tested?
  * `touch /boot/grub2FAIL` full backup and recovery. Original code fails to recover: "Installing GRUB Legacy boot loader: 
ERROR: Cannot install GRUB Legacy boot loader because there is no 'grub' program." New code works.
  * `touch /boot/grub2FAIL && shopt -s nullglob && rear -d mkrescue && find /*/tmp/rear.*/rootfs /tmp/rear.*/rootfs -name grub\*-\* -executable`
original code: nothing
new code:
```
/usr/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-mkimage
/usr/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-mkpasswd-pbkdf2
/usr/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-mkrelpath
/usr/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-bios-setup
/usr/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-install
/usr/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-mkconfig
/usr/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-probe
/usr/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-reboot
/usr/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-set-default
/var/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-mkimage
/var/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-mkpasswd-pbkdf2
/var/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-mkrelpath
/var/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-bios-setup
/var/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-install
/var/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-mkconfig
/var/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-probe
/var/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-reboot
/var/tmp/rear.noYr1PET9AefVbz/rootfs/bin/grub2-set-default
```
* Description of the changes in this pull request:
  * Do not detect GRUB before including GRUB tools. When there was a file matching `grub*` in `/boot` (e.g. `/boot/grub2FAIL`), the code got confused by the glob pattern intended to match `/boot/grub` or `/boot/grub2` and subsequently the rest of the script was skipped, as `grubdir` got assigned something like `"/boot/grub2 /boot/grub2FAIL"`, which does not exist, so `grubdir` was set to `/boot/grub`, which does not exist either, and `grub-probe` fails.
As a result, the GRUB tools were not included in the recovery image.
The code have been proceeding anyway when neither `grub-probe` nor grub2-probe was found, so the tests have not been very useful.
Fix and simplify by not checking for the existence of GRUB and just trying to include the GRUB tools always.
  * Don't create `$VAR_DIR/recovery/bootdisk` in `prep`. This file is unused and creating it in prep stage is against the guideline in prep/README:
```
You should not put scripts into this 'prep' stage that modify things
in ROOTFS_DIR or in VAR_DIR/recovery and VAR_DIR/layout because
scripts for ROOTFS_DIR belong to the 'rescue' stage and scripts
for VAR_DIR/recovery and VAR_DIR/layout belong to the 'layout' stages.
```