### PR TITLE
Support saving and restoring hybrid BIOS/UEFI bootloader setup and clean up bootloader detection

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/630_install_grub.sh
+++ b/usr/share/rear/finalize/Linux-i386/630_install_grub.sh
@@ -37,14 +37,12 @@ test "GRUB" = "$BOOTLOADER" || return 0
 #    as grub-install also exist in legacy grub
 # so that it seems there are cases where actually GRUB 2 is used
 # but wrongly detected as "GRUB" so that another test is needed
-# to detected if actually GRUB 2 is used and that test is to
-# check if grub-probe or grub2-probe is installed because
-# grub-probe or grub2-probe is only installed in case of GRUB 2
-# and when GRUB 2 is installed we assume GRUB 2 is used as boot loader
+# to detect if actually GRUB 2 is used.
+# When GRUB 2 is installed we assume GRUB 2 is used as boot loader
 # so that then we skip this script (which is only for GRUB Legacy)
 # because finalize/Linux-i386/660_install_grub2.sh is for installing GRUB 2:
-if type -p grub-probe >&2 || type -p grub2-probe >&2 ; then
-    LogPrint "Skip installing GRUB Legacy boot loader because GRUB 2 is installed (grub-probe or grub2-probe exist)."
+if is_grub2_installed ; then
+    LogPrint "Skip installing GRUB Legacy boot loader because GRUB 2 is installed."
     return
 fi
 

--- a/usr/share/rear/finalize/Linux-i386/630_install_grub.sh
+++ b/usr/share/rear/finalize/Linux-i386/630_install_grub.sh
@@ -77,8 +77,8 @@ if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]] ; then
 
     for disk in $disks ; do
         # Installing grub on an LVM PV will wipe the metadata so we skip those
-        # function is_disk_a_pv returns with 1 if disk is a PV
-        is_disk_a_pv "$disk"  ||  continue
+        # function is_disk_a_pv returns true if disk is a PV
+        is_disk_a_pv "$disk"  &&  continue
         # Use first boot partition by default
         part=$( echo $bootparts | cut -d' ' -f1 )
 

--- a/usr/share/rear/finalize/Linux-i386/630_install_grub.sh
+++ b/usr/share/rear/finalize/Linux-i386/630_install_grub.sh
@@ -1,15 +1,9 @@
 # This script is an improvement over the default grub-install '(hd0)'
 #
-# However the following issues still exist:
+# However the following issue still exists:
 #
 #  * We don't know what the first disk will be, so we cannot be sure the MBR
-#    is written to the correct disk(s). That's why we make all disks bootable.
-#
-#  * There is no guarantee that GRUB was the boot loader used originally.
-#    One possible attempt would be to save and restore the MBR for each disk,
-#    but this does not guarantee a correct boot order,
-#    or even a working boot loader config
-#    (eg. GRUB stage2 might not be at the exact same location).
+#    is written to the correct disk(s). That's why we make all suitable disks bootable.
 
 # Skip if another boot loader is already installed
 # (then $NOBOOTLOADER is not a true value cf. finalize/default/010_prepare_checks.sh):

--- a/usr/share/rear/finalize/Linux-i386/630_install_grub.sh
+++ b/usr/share/rear/finalize/Linux-i386/630_install_grub.sh
@@ -81,6 +81,8 @@ if [[ -r "$LAYOUT_FILE" && -r "$LAYOUT_DEPS" ]] ; then
         # Installing grub on an LVM PV will wipe the metadata so we skip those
         # function is_disk_a_pv returns true if disk is a PV
         is_disk_a_pv "$disk"  &&  continue
+        # Is the disk suitable for GRUB installation at all?
+        is_disk_grub_candidate "$disk" || continue
         # Use first boot partition by default
         part=$( echo $bootparts | cut -d' ' -f1 )
 

--- a/usr/share/rear/finalize/Linux-i386/630_install_grub.sh
+++ b/usr/share/rear/finalize/Linux-i386/630_install_grub.sh
@@ -15,8 +15,10 @@
 # (then $NOBOOTLOADER is not a true value cf. finalize/default/010_prepare_checks.sh):
 is_true $NOBOOTLOADER || return 0
 
-# For UEFI systems with grub legacy with should use efibootmgr instead:
-is_true $USING_UEFI_BOOTLOADER && return
+# For UEFI systems with grub legacy with should use efibootmgr instead,
+# but if BOOTLOADER is explicitly set to GRUB, we are on a hybrid (BIOS/UEFI)
+# boot system and we need to install GRUB to MBR as well.
+# Therefore, we don't test $USING_UEFI_BOOTLOADER.
 
 # If the BOOTLOADER variable (read by finalize/default/010_prepare_checks.sh)
 # is not "GRUB" (which means GRUB Legacy) skip this script (which is only for GRUB Legacy)

--- a/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
@@ -171,6 +171,8 @@ for disk in $disks ; do
 
     # Install GRUB2 on the boot disk if one was found:
     if test "$bootdisk" ; then
+        # Is the disk suitable for GRUB installation at all?
+        is_disk_grub_candidate "$bootdisk" || continue
         # Continue with the next possible boot disk when GRUB2 was already installed on the current one.
         # When there are more disks like /dev/sda and /dev/sdb it can happen that
         # for /dev/sda bootdisk=/dev/sda and GRUB2 gets installed on /dev/sda and

--- a/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
@@ -57,7 +57,7 @@ is_true $USING_UEFI_BOOTLOADER && return
 # Only for GRUB2 - GRUB Legacy will be handled by its own script.
 # GRUB2 is detected by testing for grub-probe or grub2-probe which does not exist in GRUB Legacy.
 # If neither grub-probe nor grub2-probe is there assume GRUB2 is not there:
-type -p grub-probe || type -p grub2-probe || return 0
+is_grub2_installed || return 0
 
 LogPrint "Installing GRUB2 boot loader..."
 

--- a/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
@@ -151,8 +151,8 @@ fi
 grub2_installed_disks=()
 for disk in $disks ; do
     # Installing GRUB2 on an LVM PV will wipe the metadata so we skip those:
-    # function is_disk_a_pv returns with 1 if disk is a PV
-    is_disk_a_pv "$disk" || continue
+    # function is_disk_a_pv returns true if disk is a PV
+    is_disk_a_pv "$disk" && continue
 
     # Use first boot partition by default:
     part=$( echo $bootparts | cut -d' ' -f1 )

--- a/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
@@ -36,7 +36,9 @@
 #   This script does not check BOOTLOADER because it is also used as fallback
 #   to install the nowadays most often used bootloader GRUB2
 #   unless the BOOTLOADER variable tells to install another bootloader
-#   (other bootloader install scripts check the BOOTLOADER variable).
+#   (other bootloader install scripts check the BOOTLOADER variable)
+#   and unless we are using UEFI (BOOTLOADER then indicates the BIOS bootloader
+#   in a a hybrid boot setup).
 #
 # This script does not error out because at this late state of "rear recover"
 # (i.e. after the backup was restored) I <jsmeix@suse.de> consider it too hard
@@ -52,7 +54,11 @@ is_true $NOBOOTLOADER || return 0
 
 # For UEFI systems with grub2 we should use efibootmgr instead,
 # cf. finalize/Linux-i386/670_run_efibootmgr.sh
-is_true $USING_UEFI_BOOTLOADER && return
+# but if BOOTLOADER is explicitly set to GRUB2, we are on a hybrid (BIOS/UEFI)
+# boot system and we need to install GRUB to MBR as well
+if is_true $USING_UEFI_BOOTLOADER && [ "GRUB2" != "$BOOTLOADER" ] ; then
+   return 0
+fi
 
 # Only for GRUB2 - GRUB Legacy will be handled by its own script.
 # GRUB2 is detected by testing for grub-probe or grub2-probe which does not exist in GRUB Legacy.

--- a/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-i386/660_install_grub2.sh
@@ -47,6 +47,13 @@
 # so that after "rear recover" finished he can manually install the bootloader
 # as appropriate for his particular system.
 
+local grub_name
+local grub2_install_failed grub2_install_device
+local source_disk target_disk junk
+local grub2_installed_disks
+local part bootparts
+local disk disks bootdisk
+
 # Skip if another bootloader was already installed:
 # In this case NOBOOTLOADER is not true,
 # cf. finalize/default/050_prepare_checks.sh

--- a/usr/share/rear/finalize/default/050_prepare_checks.sh
+++ b/usr/share/rear/finalize/default/050_prepare_checks.sh
@@ -10,10 +10,18 @@
 NOBOOTLOADER=1
 
 # Try to read the BOOTLOADER value if /var/lib/rear/recovery/bootloader is not empty.
-# Currently (June 2016) the used BOOTLOADER values (grep for '$BOOTLOADER') are:
+# Currently (February 2024) the used BOOTLOADER values (grep for '$BOOTLOADER') are:
 #   GRUB  for GRUB Legacy
 #   GRUB2 for GRUB 2
 #   ELILO for elilo
+#   LILO  for lilo
+#   GRUB2-EFI for GRUB 2, EFI version
+#   EFI   for any EFI bootloader, dummy value
+#   ARM   for ARM devices, dummy value
+#   ARM-ALLWINNER for Allwinner devices
+#   ZIPL  for zIPL, on IBM Z (s390x)
+#   PPC   for any bootloader in the PReP boot partition (can be LILO, YABOOT, GRUB2)
+
 local bootloader_file="$VAR_DIR/recovery/bootloader"
 # The output is stored in an artificial bash array so that $BOOTLOADER is the first word:
 test -s $bootloader_file && BOOTLOADER=( $( grep -v '^[[:space:]]*#' $bootloader_file ) )

--- a/usr/share/rear/layout/save/default/445_guess_bootloader.sh
+++ b/usr/share/rear/layout/save/default/445_guess_bootloader.sh
@@ -65,37 +65,10 @@ for block_device in /sys/block/* ; do
         # Continue guessing the used bootloader by inspecting the first bytes on the next disk:
         continue
     fi
-    # 'Hah!IdontNeedEFI' is the ASCII representation of the official GUID number
-    # for a GPT BIOS boot partition which is 21686148-6449-6E6F-744E-656564454649
-    # see https://en.wikipedia.org/wiki/BIOS_boot_partition (issue #1752).
-    # Use single quotes for 'Hah!IdontNeedEFI' to be on the safe side
-    # because with double quotes the ! would cause history expansion if that is enabled
-    # (non-interactive shells do not perform history expansion by default but better safe than sorry):
-    if grep -q 'Hah!IdontNeedEFI' $bootloader_area_strings_file ; then
-        # Because 'Hah!IdontNeedEFI' contains the known bootloader 'EFI'
-        # the default code below would falsely guess that 'EFI' is used
-        # but actually another non-EFI bootloader is used here
-        # cf. https://github.com/rear/rear/issues/1752#issue-303856221
-        # so that in the 'Hah!IdontNeedEFI' case only non-EFI bootloaders are tested.
-        # IBM Z (s390) uses zipl boot loader for RHEL and Ubuntu
-        # cf. https://github.com/rear/rear/issues/2137
-        for known_bootloader in GRUB2 GRUB ELILO LILO ZIPL ; do
-            if grep -q -i "$known_bootloader" $bootloader_area_strings_file ; then
-                LogPrint "Using guessed bootloader '$known_bootloader' for 'rear recover' (found in first bytes on $disk_device with GPT BIOS boot partition)"
-                echo "$known_bootloader" >$bootloader_file
-                return
-            fi
-        done
-        # When in the 'Hah!IdontNeedEFI' case no known non-EFI bootloader is found
-        # continue guessing the used bootloader by inspecting the first bytes on the next disk
-        # because otherwise the default code below would falsely guess that 'EFI' is used
-        # cf. https://github.com/rear/rear/pull/1754#issuecomment-383531597
-        continue
-    fi
     # Check the default cases of known bootloaders.
     # IBM Z (s390) uses zipl boot loader for RHEL and Ubuntu
     # cf. https://github.com/rear/rear/issues/2137
-    for known_bootloader in GRUB2-EFI EFI GRUB2 GRUB ELILO LILO ZIPL ; do
+    for known_bootloader in GRUB2 GRUB LILO ZIPL ; do
         if grep -q -i "$known_bootloader" $bootloader_area_strings_file ; then
             # If we find "GRUB" (which means GRUB Legacy)
             # do not unconditionally trust that because https://github.com/rear/rear/pull/589
@@ -130,6 +103,26 @@ for block_device in /sys/block/* ; do
     Log "End of strings in the first bytes on $disk_device"
 done
 
+# No bootloader detected, but we are using UEFI - there is probably an EFI bootloader
+if is_true $USING_UEFI_BOOTLOADER ; then
+    if is_grub2_installed ; then
+        echo "GRUB2-EFI" >$bootloader_file
+    elif test -f /sbin/elilo ; then
+        echo "ELILO" >$bootloader_file
+    else
+        # There is an EFI bootloader, we don't know which one exactly.
+        # The value "EFI" is a bit redundant with USING_UEFI_BOOTLOADER=1,
+        # which already indicates that there is an EFI bootloader. We use it as a placeholder
+        # to not leave $bootloader_file empty.
+        # Note that it is legal to have USING_UEFI_BOOTLOADER=1 and e.g. known_bootloader=GRUB2
+        # (i.e. a non=EFI bootloader). This will happen in BIOS/UEFI hybrid boot scenarios.
+        # known_bootloader=GRUB2 indicates that there is a BIOS bootloader and USING_UEFI_BOOTLOADER=1
+        # indicates that there is also an EFI bootloader. Only the EFI one is being used at this
+        # time, but both will need to be restored.
+        echo "EFI" >$bootloader_file
+    fi
+    return 0
+fi
 
 # Error out when no bootloader was specified or could be autodetected:
 Error "Cannot autodetect what is used as bootloader, see default.conf about 'BOOTLOADER'"

--- a/usr/share/rear/layout/save/default/445_guess_bootloader.sh
+++ b/usr/share/rear/layout/save/default/445_guess_bootloader.sh
@@ -13,6 +13,14 @@ local known_bootloader
 
 # When BOOTLOADER is specified use that:
 if test "$BOOTLOADER" ; then
+    # case-insensitive match, as later we conver all to uppercase
+    if [[ "$BOOTLOADER" == [Gg][Rr][Uu][Bb] ]] ; then
+        if is_grub2_installed ; then
+            LogPrintError "BOOTLOADER=GRUB used to mean GRUB 2 if GRUB 2 is installed and GRUB Legacy if not"
+            Error "BOOTLOADER set to '$BOOTLOADER', set it to 'GRUB2' explicitly to avoid the ambiguity"
+        fi
+        # we should add an ErrorIfDeprecated call here or later for GRUB Legacy deprecation
+    fi
     LogPrint "Using specified bootloader '$BOOTLOADER' for 'rear recover'"
     echo "$BOOTLOADER" | tr '[a-z]' '[A-Z]' >$bootloader_file
     return

--- a/usr/share/rear/layout/save/default/445_guess_bootloader.sh
+++ b/usr/share/rear/layout/save/default/445_guess_bootloader.sh
@@ -1,7 +1,15 @@
 
 # Determine or guess the used bootloader if not specified by the user
 # and save this information into /var/lib/rear/recovery/bootloader
-bootloader_file="$VAR_DIR/recovery/bootloader"
+local bootloader_file="$VAR_DIR/recovery/bootloader"
+
+local sysconfig_bootloader
+local block_device
+local blockd
+local disk_device
+local bootloader_area_strings_file
+local block_size
+local known_bootloader
 
 # When BOOTLOADER is specified use that:
 if test "$BOOTLOADER" ; then

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -543,6 +543,39 @@ function is_grub2_installed () {
     fi
 }
 
+# Determine whether a disk is worth detecting or installing GRUB on
+function is_disk_grub_candidate () {
+    local disk="$1"
+    local disk_partitions part
+    local label flags
+
+    # ToDo : validate $disk (does it even exist? Isn't it write-protected?)
+
+    # Installing grub on an LVM PV will wipe the metadata so we skip those
+    is_disk_a_pv "$disk" && return 1
+
+    label="$( get_disklabel_type "$disk" )" || return 1
+    # We don't care about the SUSE-specific 'gpt_sync_mbr' partition scheme
+    # anymore: https://github.com/rear/rear/pull/3145#discussion_r1481388431
+    if [ "$label" == gpt ] ; then
+        # GPT needs a special BIOS boot partition to store GRUB (BIOS version).
+        # Let's try to find it. It can be recognized as having the bios_grub flag.
+        disk_partitions=( $( get_child_components "$disk" "part" ) )
+        for part in "${disk_partitions[@]}" ; do
+            flags=( $( get_partition_flags "$part" ) )
+            IsInArray bios_grub "${flags[@]}" && return 0 # found!
+        done
+        # If a given GPT-partitioned disk does not contain a BIOS boot partition,
+        # GRUB for BIOS booting can not be installed into its MBR (grub-install errors out).
+        return 1
+    else
+        # Other disklabel types don't need anything special to install GRUB.
+        # The test for the PReP boot partition (finalize/Linux-ppc64le/660_install_grub2.sh)
+        # is a bit similar, but operates on the partition itself, not on the uderlying disk.
+        return 0
+    fi
+}
+
 # Output GRUB2 configuration on stdout:
 # $1 is the kernel file with appropriate path for GRUB2 to load the kernel from within GRUB2's root filesystem
 # $2 is the initrd file with appropriate path for GRUB2 to load the initrd from within GRUB2's root filesystem

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -529,6 +529,20 @@ function get_root_disk_UUID {
     ( set -o pipefail ; mount | grep ' on / ' | awk '{print $1}' | xargs blkid -s UUID -o value || Error "Failed to get root disk UUID" )
 }
 
+# Detect whether actually GRUB 2 is installed and that test is to
+# check if grub-probe or grub2-probe is installed because
+# grub-probe or grub2-probe is only installed in case of GRUB 2.
+# Needed because one can't tell the GRUB version by looking at the MBR
+# (both GRUB 2 and GRUB Legacy have the string "GRUB" in their MBR).
+function is_grub2_installed () {
+    if type -p grub-probe >&2 || type -p grub2-probe >&2 ; then
+        Log "GRUB 2 is installed (grub-probe or grub2-probe exist)."
+        return 0
+    else
+        return 1
+    fi
+}
+
 # Output GRUB2 configuration on stdout:
 # $1 is the kernel file with appropriate path for GRUB2 to load the kernel from within GRUB2's root filesystem
 # $2 is the initrd file with appropriate path for GRUB2 to load the initrd from within GRUB2's root filesystem

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -532,6 +532,33 @@ get_component_type() {
     grep -E "^[^ ]+ $1 " $LAYOUT_TODO | cut -d " " -f 3
 }
 
+# Get the disklabel (partition table) type of the disk $1 from the layout file
+# (NOT from the actual disk, so layout file must exist before calling this,
+# and it is useful during recovery even before the disk layout has been recreated)
+function get_disklabel_type () {
+    # from create_disk() in layout/prepare/GNU/Linux/100_include_partition_code.sh
+    local component disk size label junk
+
+    disk=''
+
+    read component disk size label junk < <(grep "^disk $1 " "$LAYOUT_FILE")
+    test $disk || return 1
+
+    echo $label
+}
+
+# Get partition flags from layout (space-separated) of partition given as $1
+function get_partition_flags () {
+    local part disk size pstart name flags partition junk
+
+    while read part disk size pstart name flags partition junk; do
+        if [ "$partition" == "$1" ] ; then
+            echo "$flags" | tr ',' ' '
+            return 0
+        fi
+    done < <(grep "^part " $LAYOUT_FILE)
+}
+
 # Function returns 0 when v1 is greater or equal than v2
 version_newer() {
   local v1list=( ${1//[-.]/ } )

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -806,17 +806,17 @@ blkid_label_of_device() {
     echo "$label"
 }
 
-# Returns 1 if the device is an LVM physical volume
-# Returns 0 otherwise or if the device doesn't exists
+# Returns true if the device is an LVM physical volume
+# Returns false otherwise or if the device doesn't exist
 is_disk_a_pv() {
     disk=$1
 
     # Using awk, select the 'lvmdev' line for which $disk is the device (column 3),
     # cf. https://github.com/rear/rear/pull/1897
     # If exit == 1, then there is such line (so $disk is a PV),
-    # otherwise exit with default value '0', which falls through to 'return 0' below.
-    awk "\$1 == \"lvmdev\" && \$3 == \"${disk}\" { exit 1 }" "$LAYOUT_FILE" >/dev/null || return 1
-    return 0
+    # otherwise exit with default value '0', which falls through to 'return 1' below.
+    awk "\$1 == \"lvmdev\" && \$3 == \"${disk}\" { exit 1 }" "$LAYOUT_FILE" >/dev/null || return 0
+    return 1
 }
 
 # Check whether disk is suitable for being added to layout

--- a/usr/share/rear/lib/savelayout-workflow.sh
+++ b/usr/share/rear/lib/savelayout-workflow.sh
@@ -10,6 +10,10 @@ if [[ "$VERBOSE" ]]; then
 fi
 WORKFLOWS+=( savelayout )
 WORKFLOW_savelayout () {
+    # layout code needs to know whether we are using UEFI (USING_UEFI_BOOTLOADER)
+    # as it also detects the bootloader in use ( layout/save/default/445_guess_bootloader.sh )
+    Source $SHARE_DIR/prep/default/320_include_uefi_env.sh
+
     #DISKLAYOUT_FILE=$VAR_DIR/layout/disklayout.conf # defined in default.conf now (issue #678)
     SourceStage "layout/save"
 }


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix** / **Enhancement**

* Impact: **High**

* Reference to related issue (URL): also helps with the problem in #3128

* How was this pull request tested?
Full backup and recovery on a hybrid UEFI/BIOS bootloader setup, with UEFI firmware.

* Description of the changes in this pull request:
  * Fixes a bug where a system with hybrid BIOS/UEFI boot was restored without the BIOS bootloader (`GRUB2`) and on subsequent `mkrescue` it will abort because it can't detect the bootloader - the BIOS bootloader was not found in the boot sector and the presence of the BIOS boot partition confused the EFI bootloader detection. In detail:
  * Support BOOTLOADER=GRUB/GRUB2 with UEFI. This will happen with hybrid boot: BOOTLOADER=GRUB2 indicates that there is the BIOS version of GRUB2 installed and at the same time, USING_UEFI_BOOTLOADER=1 indicates theat there is also an EFI bootloader. Note that it is now perfectly legal to have USING_UEFI_BOOTLOADER=1 and BOOTLOADER neither EFI nor GRUB2-EFI nor ELILO. This will happen with hybrid BIOS/UEFI booting: BOOTLOADER will be detected as GRUB2, but USING_UEFI_BOOTLOADER=1.
  * Detect GRUB2 earlier - when saving layout. We used to distinguish between GRUB and GRUB2 when reinstalling the bootloader. This meant that the saved bootloader was wrong: GRUB for GRUB2. Detect GRUB2 earlier, already at the moment when we guess the bootloader, and save the correct value. This should help with the problem reported in PR #3128 (misdetection of GRUB2 as GRUB on any non-SUSE distro).
  * Don't look for EFI bootloader in the start of disk. EFI bootloader is not installed to the start of the disk, but to the EFI System partition as a regular file. It is this futile to search for EFI bootloaders in the first sectors of disks. If we find "EFI", it is only because there is a GPT, and "EFI PART" is the GPT signature (this does not tell anything about the presence of an EFI bootloader). See https://github.com/rear/rear/commit/67ac463446a5b140ea1eb1d9268e86422f869ebf#r138332329 .
  * Delete the code that checked for 'Hah!IdontNeedEFI' as a special case - it is not needed now. The code effectively skipped the check for EFI when there was a B[IOS boot partition](https://wiki.archlinux.org/title/BIOS_boot_partition). Its presence does not indicate the absence of an EFI bootloader, though. We could be on an UEFI machine with the disk partitioned in hybrid (BIOS/UEFI compatible) mode. In this case ReaR can error out if legacy GRUB is not installed, because it does not find any bootloader (the EFI check is skipped).
