### PR TITLE
Replace the `OUTPUT=IPL` with equivalent `OUTPUT=RAMDISK`

### DIFF
--- a/usr/share/rear/output/IPL/Linux-s390/800_create_ipl.sh
+++ b/usr/share/rear/output/IPL/Linux-s390/800_create_ipl.sh
@@ -1,5 +1,0 @@
-# Create the 'initial program' to boot/load the ReaR recovery system
-# on IBM Z via IPL (initial program load)
-LogPrint "Creating initial program for IPL on IBM Z"
-RESULT_FILES+=( $KERNEL_FILE $TMP_DIR/$REAR_INITRD_FILENAME )
-

--- a/usr/share/rear/prep/Linux-s390/034_check_config.sh
+++ b/usr/share/rear/prep/Linux-s390/034_check_config.sh
@@ -1,0 +1,8 @@
+if [ "$OUTPUT" = "IPL" ]; then
+    LogPrintError "Warning: OUTPUT=IPL is deprecated. Use OUTPUT=RAMDISK instead."
+    OUTPUT=RAMDISK
+fi
+
+if [ "$OUTPUT" != "RAMDISK" ] ; then
+   Error "Currently, only OUTPUT=RAMDISK is supported on s390/s390x"
+fi


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement** / **Clean-up**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/3149#issuecomment-1941620475

* How was this pull request tested? I was able to successfully boot the generated kernel and initrd on s390x Fedora Rawhide machine with both `OUTPUT=IPL` and `OUTPUT=RAMDISK` options.

* Description of the changes in this pull request:

The initial PR with s390 support in ReaR introduced an s390-only `OUTPUT=IPL` undocumented option.  However, the `OUTPUT=IPL` option is completely redundant because it does the exact same thing as the already existing and documented OUTPUT=RAMDISK option.

This commit removes the whole `IPL` directory sub-tree and introduces a fallback that replaces `OUTPUT=IPL` with `OUTPUT=RAMDISK` during the `prep` phase with a deprecation warning to still be backwards compatible with existing `local.conf` files.
