### PR TITLE
Remove hardcoded architecture-dependend strings from EFI code

### DIFF
--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -36,7 +36,7 @@ function trim {
     echo -n "$var"
 }
 
-function build_bootx86_efi {
+function build_boot_efi {
     local outfile="$1"
     local embedded_config=""
     local gmkstandalone=""
@@ -62,8 +62,8 @@ function build_bootx86_efi {
         # At least SUSE systems use 'grub2' prefixed names for GRUB2 programs:
         gmkstandalone=grub2-mkstandalone
     else
-        # This build_bootx86_efi function is only called in output/ISO/Linux-i386/250_populate_efibootimg.sh
-        # and output/USB/Linux-i386/100_create_efiboot.sh and output/default/940_grub2_rescue.sh
+        # This build_boot_efi function is only called in 250_populate_efibootimg.sh
+        # and 100_create_efiboot.sh and 940_grub2_rescue.sh
         # only if UEFI is used so that we simply error out here if we cannot make a bootable EFI image of GRUB2
         # (normally a function should not exit but return to its caller with a non-zero return code):
         Error "Cannot make bootable EFI image of GRUB2 (neither grub-mkstandalone nor grub2-mkstandalone found)"

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -15,7 +15,7 @@ mkdir $v -p $efi_boot_tmp_dir/locale || Error "Could not create $efi_boot_tmp_di
 
 # Copy the grub*.efi or shim.efi executable to EFI/BOOT/BOOTX64.efi
 # Intentionally an empty UEFI_BOOTLOADER results an invalid "cp -v /tmp/.../mnt/EFI/BOOT/BOOTX64.efi" command that fails:
-cp $v "$UEFI_BOOTLOADER" $efi_boot_tmp_dir/BOOTX64.efi || Error "Could not find UEFI_BOOTLOADER '$UEFI_BOOTLOADER'"
+cp $v "$UEFI_BOOTLOADER" $efi_boot_tmp_dir/BOOT$EFI_ARCH_UPPER.efi || Error "Could not find UEFI_BOOTLOADER '$UEFI_BOOTLOADER'"
 local uefi_bootloader_dirname="$( dirname $UEFI_BOOTLOADER )"
 if test -f "$SECURE_BOOT_BOOTLOADER" ; then
     # For a technical description of Shim see https://mjg59.dreamwidth.org/19448.html
@@ -28,7 +28,7 @@ if test -f "$SECURE_BOOT_BOOTLOADER" ; then
     # (cf. rescue/default/850_save_sysfs_uefi_vars.sh)
     # then Shim (usually shim.efi) was copied above as efi_boot_tmp_dir/BOOTX64.efi
     # and Shim's second stage bootloader must be also copied where Shim already is.
-    DebugPrint "Using Shim '$SECURE_BOOT_BOOTLOADER' as first stage UEFI bootloader BOOTX64.efi"
+    DebugPrint "Using Shim '$SECURE_BOOT_BOOTLOADER' as first stage UEFI bootloader BOOT${EFI_ARCH_UPPER}.efi"
     # When Shim is used, its second stage bootloader can be actually anything
     # named grub*.efi (second stage bootloader is Shim compile time option), see
     # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim
@@ -68,7 +68,7 @@ if test "ebiso" = "$( basename $ISO_MKISOFS_BIN )" ; then
 fi
 
 if [[ -n "$(type -p grub)" ]]; then
-    cat > $efi_boot_tmp_dir/BOOTX64.conf << EOF
+    cat > $efi_boot_tmp_dir/BOOT$EFI_ARCH_UPPER.conf << EOF
 default=0
 timeout 5
 splashimage=/EFI/BOOT/splash.xpm.gz
@@ -98,7 +98,7 @@ fi
 # See issue #1374
 # build_bootx86_efi () can be safely used for other scenarios.
 if ! test -f "$SECURE_BOOT_BOOTLOADER" ; then
-    build_bootx86_efi $TMP_DIR/mnt/EFI/BOOT/BOOTX64.efi $efi_boot_tmp_dir/grub.cfg "$boot_dir" "$UEFI_BOOTLOADER"
+    build_bootx86_efi $TMP_DIR/mnt/EFI/BOOT/BOOT$EFI_ARCH_UPPER.efi $efi_boot_tmp_dir/grub.cfg "$boot_dir" "$UEFI_BOOTLOADER"
 fi
 
 # We will be using grub-efi or grub2 (with efi capabilities) to boot from ISO.
@@ -137,7 +137,7 @@ cp $v -r $TMP_DIR/mnt/EFI $TMP_DIR/isofs/ || Error "Could not create the isofs/E
 # Make /boot/grub/grub.cfg available on isofs/
 mkdir $v -p -m 755 $TMP_DIR/isofs/boot/grub
 if test "$( type -p grub )" ; then
-    cp $v $TMP_DIR/isofs/EFI/BOOT/BOOTX64.conf $TMP_DIR/isofs/boot/grub/ || Error "Could not copy EFI/BOOT/BOOTX64.conf to isofs/boot/grub"
+    cp $v $TMP_DIR/isofs/EFI/BOOT/BOOT$EFI_ARCH_UPPER.conf $TMP_DIR/isofs/boot/grub/ || Error "Could not copy EFI/BOOT/BOOT${EFI_ARCH_UPPER}.conf to isofs/boot/grub"
 else
     cp $v $TMP_DIR/isofs/EFI/BOOT/grub.cfg $TMP_DIR/isofs/boot/grub/ || Error "Could not copy EFI/BOOT/grub.cfg to isofs/boot/grub"
 fi

--- a/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/250_populate_efibootimg.sh
@@ -96,9 +96,9 @@ fi
 # We are not able to create signed boot loader
 # so we need to reuse existing one.
 # See issue #1374
-# build_bootx86_efi () can be safely used for other scenarios.
+# build_boot_efi () can be safely used for other scenarios.
 if ! test -f "$SECURE_BOOT_BOOTLOADER" ; then
-    build_bootx86_efi $TMP_DIR/mnt/EFI/BOOT/BOOT$EFI_ARCH_UPPER.efi $efi_boot_tmp_dir/grub.cfg "$boot_dir" "$UEFI_BOOTLOADER"
+    build_boot_efi $TMP_DIR/mnt/EFI/BOOT/BOOT$EFI_ARCH_UPPER.efi $efi_boot_tmp_dir/grub.cfg "$boot_dir" "$UEFI_BOOTLOADER"
 fi
 
 # We will be using grub-efi or grub2 (with efi capabilities) to boot from ISO.

--- a/usr/share/rear/output/ISO/Linux-i386/260_EFISTUB_populate.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/260_EFISTUB_populate.sh
@@ -33,7 +33,7 @@ else
     Error "EFI_STUB: EFI executable $OUTPUT_EFISTUB_SYSTEMD_BOOTLOADER not found"
 fi
 
-cp $v "$OUTPUT_EFISTUB_SYSTEMD_BOOTLOADER" $efi_boot_tmp_dir/BOOTX64.efi
+cp $v "$OUTPUT_EFISTUB_SYSTEMD_BOOTLOADER" $efi_boot_tmp_dir/BOOT${EFI_ARCH_UPPER}.efi
 
 
 # Create boot menu entries for systemd-bootx64.efi.

--- a/usr/share/rear/output/RAWDISK/Linux-i386/260_create_syslinux_efi_bootloader.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/260_create_syslinux_efi_bootloader.sh
@@ -35,7 +35,7 @@ local efi_boot_directory="$RAWDISK_BOOT_EFI_STAGING_ROOT/BOOT"
 
 mkdir $v -p "$efi_boot_directory" || Error "Could not create $efi_boot_directory"
 
-cp $v "$syslinux_efi" "$efi_boot_directory/BOOTX64.EFI" >&2
+cp $v "$syslinux_efi" "$efi_boot_directory/BOOT${EFI_ARCH_UPPER}.EFI" >&2
 cp $v "$ldlinux_e64" "$efi_boot_directory" >&2
 
 

--- a/usr/share/rear/output/RAWDISK/Linux-i386/270_create_grub2_efi_bootloader.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/270_create_grub2_efi_bootloader.sh
@@ -21,7 +21,7 @@ fi
 # cf. https://github.com/rear/rear/issues/2338#issuecomment-594432946
 local efi_modules_directory
 local dir
-for dir in /usr/lib/grub/x86_64-efi /usr/lib/grub2/x86_64-efi /usr/share/grub2/x86_64-efi; do
+for dir in "/usr/lib/grub/$GRUB2_IMAGE_FORMAT" "/usr/lib/grub2/$GRUB2_IMAGE_FORMAT" "/usr/share/grub2/$GRUB2_IMAGE_FORMAT"; do
     if [[ -d "$dir" ]]; then
         efi_modules_directory="$dir"
         break
@@ -71,7 +71,7 @@ if [[ -n "$SECURE_BOOT_BOOTLOADER" ]]; then
     # If /boot/$grub2_name exists, it contains additional Grub modules, which are not compiled into the grub core image.
     # Pick required ones from there, too.
     local additional_grub_directory="/boot/$grub2_name"
-    local grub_modules_directory="x86_64-efi"
+    local grub_modules_directory="$GRUB2_IMAGE_FORMAT"
     local additional_grub_modules=( all_video.mod )
     if [[ -d "$additional_grub_directory/$grub_modules_directory" ]]; then
         local grub_target_directory="$(dirname "$(find "$RAWDISK_BOOT_EFI_STAGING_ROOT" -iname grubx64.efi -print)")"
@@ -105,6 +105,6 @@ else
     local boot_loader="$efi_boot_directory/BOOTX64.EFI"
     local grub_modules=( part_gpt fat normal configfile linux video all_video )
     [[ -f "$efi_modules_directory/linuxefi.mod" ]] && grub_modules+=("$efi_modules_directory/linuxefi.mod")
-    $grub2_name-mkimage -O x86_64-efi -o "$boot_loader" -p "/EFI/BOOT" "${grub_modules[@]}"
+    $grub2_name-mkimage -O "$GRUB2_IMAGE_FORMAT" -o "$boot_loader" -p "/EFI/BOOT" "${grub_modules[@]}"
     StopIfError "Error occurred during $grub2_name-mkimage of $boot_loader"
 fi

--- a/usr/share/rear/output/RAWDISK/Linux-i386/270_create_grub2_efi_bootloader.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/270_create_grub2_efi_bootloader.sh
@@ -74,7 +74,7 @@ if [[ -n "$SECURE_BOOT_BOOTLOADER" ]]; then
     local grub_modules_directory="$GRUB2_IMAGE_FORMAT"
     local additional_grub_modules=( all_video.mod )
     if [[ -d "$additional_grub_directory/$grub_modules_directory" ]]; then
-        local grub_target_directory="$(dirname "$(find "$RAWDISK_BOOT_EFI_STAGING_ROOT" -iname grubx64.efi -print)")"
+        local grub_target_directory="$(dirname "$(find "$RAWDISK_BOOT_EFI_STAGING_ROOT" -iname grub${EFI_ARCH}.efi -print)")"
         [[ "$grub_target_directory" == "." ]] && Error "Could not find Grub executable"  # dirname "" returns "."
 
         mkdir "$grub_target_directory/$grub_modules_directory" || Error "Could not create Grub modules directory"
@@ -102,7 +102,7 @@ else
 
     # Create a Grub 2 EFI core image and install it as boot loader. (NOTE: This version will not be signed.)
     # Use the UEFI default boot loader name, so that firmware will find it without an existing boot entry.
-    local boot_loader="$efi_boot_directory/BOOTX64.EFI"
+    local boot_loader="$efi_boot_directory/BOOT${EFI_ARCH_UPPER}.EFI"
     local grub_modules=( part_gpt fat normal configfile linux video all_video )
     [[ -f "$efi_modules_directory/linuxefi.mod" ]] && grub_modules+=("$efi_modules_directory/linuxefi.mod")
     $grub2_name-mkimage -O "$GRUB2_IMAGE_FORMAT" -o "$boot_loader" -p "/EFI/BOOT" "${grub_modules[@]}"

--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -141,9 +141,9 @@ EOF
             # We are not able to create signed boot loader
             # so we need to reuse existing one.
             # See issue #1374
-            # build_bootx86_efi () can be safely used for other scenarios.
+            # build_boot_efi () can be safely used for other scenarios.
             if ! test -f "$SECURE_BOOT_BOOTLOADER" ; then
-                build_bootx86_efi $efi_dst/BOOT$EFI_ARCH_UPPER.efi $efi_dst/grub.cfg "/boot" "$UEFI_BOOTLOADER"
+                build_boot_efi $efi_dst/BOOT$EFI_ARCH_UPPER.efi $efi_dst/grub.cfg "/boot" "$UEFI_BOOTLOADER"
             fi
         ;;
         (*)

--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -73,8 +73,8 @@ if test -f "$SECURE_BOOT_BOOTLOADER" ; then
     # (cf. rescue/default/850_save_sysfs_uefi_vars.sh)
     # then Shim (usually shim.efi) must be copied as EFI/BOOT/BOOTX64.efi
     # and Shim's second stage bootloader must be also copied where Shim already is.
-    DebugPrint "Using '$SECURE_BOOT_BOOTLOADER' as first stage Secure Boot bootloader BOOTX64.efi"
-    cp -L $v "$SECURE_BOOT_BOOTLOADER" "$efi_dst/BOOTX64.efi" || Error "Failed to copy SECURE_BOOT_BOOTLOADER '$SECURE_BOOT_BOOTLOADER' to $efi_dst/BOOTX64.efi"
+    DebugPrint "Using '$SECURE_BOOT_BOOTLOADER' as first stage Secure Boot bootloader BOOT${EFI_ARCH_UPPER}.efi"
+    cp -L $v "$SECURE_BOOT_BOOTLOADER" "$efi_dst/BOOT${EFI_ARCH_UPPER}.efi" || Error "Failed to copy SECURE_BOOT_BOOTLOADER '$SECURE_BOOT_BOOTLOADER' to $efi_dst/BOOT${EFI_ARCH_UPPER}.efi"
     # When Shim is used, its second stage bootloader can be actually anything
     # named grub*.efi (second stage bootloader is Shim compile time option), see
     # http://www.rodsbooks.com/efi-bootloaders/secureboot.html#initial_shim
@@ -87,7 +87,7 @@ if test -f "$SECURE_BOOT_BOOTLOADER" ; then
     DebugPrint "Using second stage Secure Boot bootloader files: $second_stage_UEFI_bootloader_files"
     cp -L $v $second_stage_UEFI_bootloader_files $efi_dst/ || Error "Failed to copy second stage Secure Boot bootloader files"
 else
-    cp -L $v "$UEFI_BOOTLOADER" "$efi_dst/BOOTX64.efi" || Error "Failed to copy UEFI_BOOTLOADER '$UEFI_BOOTLOADER' to $efi_dst/BOOTX64.efi"
+    cp -L $v "$UEFI_BOOTLOADER" "$efi_dst/BOOT${EFI_ARCH_UPPER}.efi" || Error "Failed to copy UEFI_BOOTLOADER '$UEFI_BOOTLOADER' to $efi_dst/BOOT${EFI_ARCH_UPPER}.efi"
 fi
 # Copy kernel:
 cp -L $v "$KERNEL_FILE" "$efi_dst/kernel" || Error "Failed to copy KERNEL_FILE '$KERNEL_FILE' to $efi_dst/kernel"
@@ -120,7 +120,7 @@ else
     case $grub_version in
         (0)
             DebugPrint "Configuring legacy GRUB for EFI boot"
-            cat > $efi_dst/BOOTX64.conf << EOF
+            cat > $efi_dst/BOOT${EFI_ARCH_UPPER}.conf << EOF
 default=0
 timeout=5
 title Relax-and-Recover (no Secure Boot)
@@ -143,7 +143,7 @@ EOF
             # See issue #1374
             # build_bootx86_efi () can be safely used for other scenarios.
             if ! test -f "$SECURE_BOOT_BOOTLOADER" ; then
-                build_bootx86_efi $efi_dst/BOOTX64.efi $efi_dst/grub.cfg "/boot" "$UEFI_BOOTLOADER"
+                build_bootx86_efi $efi_dst/BOOT$EFI_ARCH_UPPER.efi $efi_dst/grub.cfg "/boot" "$UEFI_BOOTLOADER"
             fi
         ;;
         (*)

--- a/usr/share/rear/output/default/940_grub2_rescue.sh
+++ b/usr/share/rear/output/default/940_grub2_rescue.sh
@@ -176,8 +176,8 @@ if is_true $USING_UEFI_BOOTLOADER ; then
     ) > $grub_config_dir/rear.cfg
 
     # Create rear.efi at UEFI default boot directory location.
-    # The build_bootx86_efi errors out if it cannot make a bootable EFI image of GRUB2:
-    build_bootx86_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear.cfg "$boot_dir" "$UEFI_BOOTLOADER"
+    # The build_boot_efi errors out if it cannot make a bootable EFI image of GRUB2:
+    build_boot_efi $boot_dir/efi/EFI/BOOT/rear.efi $grub_config_dir/rear.cfg "$boot_dir" "$UEFI_BOOTLOADER"
 
     # If UEFI boot entry for 'Relax-and-Recover' does not exist, create it.
     # This will also add 'Relax-and-Recover' to boot order because if UEFI entry is not listed in BootOrder,

--- a/usr/share/rear/prep/Linux-arm/330_set_efi_arch.sh
+++ b/usr/share/rear/prep/Linux-arm/330_set_efi_arch.sh
@@ -7,9 +7,11 @@
 case "$REAL_MACHINE" in
     (arm64|aarch64)
         EFI_ARCH=aa64
+        GRUB2_IMAGE_FORMAT=arm64-efi
         ;;
     (arm*)
         EFI_ARCH=arm
+        GRUB2_IMAGE_FORMAT=arm-efi
         ;;
     (*)
         BugError "Unknown architecture $REAL_MACHINE"

--- a/usr/share/rear/prep/Linux-arm/330_set_efi_arch.sh
+++ b/usr/share/rear/prep/Linux-arm/330_set_efi_arch.sh
@@ -1,0 +1,18 @@
+
+# Set EFI architecture, used as suffix for various files in the ESP
+# See https://github.com/rhboot/shim/blob/main/Make.defaults
+
+# Se the variables even if USING_UEFI_BOOTLOADER empty or no explicit 'true' value
+
+case "$REAL_MACHINE" in
+    (arm64|aarch64)
+        EFI_ARCH=aa64
+        ;;
+    (arm*)
+        EFI_ARCH=arm
+        ;;
+    (*)
+        BugError "Unknown architecture $REAL_MACHINE"
+esac
+
+EFI_ARCH_UPPER="${EFI_ARCH^^}"

--- a/usr/share/rear/prep/Linux-i386/330_set_efi_arch.sh
+++ b/usr/share/rear/prep/Linux-i386/330_set_efi_arch.sh
@@ -8,9 +8,12 @@ case "$REAL_MACHINE" in
     (i686|i586|i386)
         # all these behave exactly like i386.
         EFI_ARCH=ia32
+        # argument for grub2-mkstandalone -O ...
+        GRUB2_IMAGE_FORMAT=x86_64-efi
         ;;
     (x86_64)
         EFI_ARCH=x64
+        GRUB2_IMAGE_FORMAT=i386-efi
         ;;
     (*)
         BugError "Unknown architecture $REAL_MACHINE"

--- a/usr/share/rear/prep/Linux-i386/330_set_efi_arch.sh
+++ b/usr/share/rear/prep/Linux-i386/330_set_efi_arch.sh
@@ -1,0 +1,19 @@
+
+# Set EFI architecture, used as suffix for various files in the ESP
+# See https://github.com/rhboot/shim/blob/main/Make.defaults
+
+# Se the variables even if USING_UEFI_BOOTLOADER empty or no explicit 'true' value
+
+case "$REAL_MACHINE" in
+    (i686|i586|i386)
+        # all these behave exactly like i386.
+        EFI_ARCH=ia32
+        ;;
+    (x86_64)
+        EFI_ARCH=x64
+        ;;
+    (*)
+        BugError "Unknown architecture $REAL_MACHINE"
+esac
+
+EFI_ARCH_UPPER="${EFI_ARCH^^}"

--- a/usr/share/rear/prep/Linux-i386/330_set_efi_arch.sh
+++ b/usr/share/rear/prep/Linux-i386/330_set_efi_arch.sh
@@ -5,8 +5,11 @@
 # Se the variables even if USING_UEFI_BOOTLOADER empty or no explicit 'true' value
 
 case "$REAL_MACHINE" in
+    # cf. the seting of REAL_MACHINE and MACHINE in default.conf
     (i686|i586|i386)
         # all these behave exactly like i386.
+        # ia32 is another name for i386, used by EFI
+        # (but ia64 is not x86_64 aka amd64, it is the architecture of Itanium)
         EFI_ARCH=ia32
         # argument for grub2-mkstandalone -O ...
         GRUB2_IMAGE_FORMAT=x86_64-efi

--- a/usr/share/rear/prep/Linux-ia64/330_set_efi_arch.sh
+++ b/usr/share/rear/prep/Linux-ia64/330_set_efi_arch.sh
@@ -1,0 +1,11 @@
+
+# Set EFI architecture, used as suffix for various files in the ESP
+# See https://github.com/rhboot/shim/blob/main/Make.defaults
+
+# Se the variables even if USING_UEFI_BOOTLOADER empty or no explicit 'true' value
+
+EFI_ARCH=ia64
+# argument for grub2-mkstandalone -O ...
+GRUB2_IMAGE_FORMAT=ia64-efi
+
+EFI_ARCH_UPPER="${EFI_ARCH^^}"

--- a/usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
+++ b/usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
@@ -55,11 +55,11 @@ for dummy in "once" ; do
     UEFI_BOOTLOADER=$( find /boot/efi -name 'elilo.efi' | tail -1 )
     test -f "$UEFI_BOOTLOADER" && continue
     # In case we have a 64-bit systemd bootloader we might be lucky with next statement:
-    UEFI_BOOTLOADER=$( find /boot/EFI -name 'BOOTX64.EFI' | tail -1 )
+    UEFI_BOOTLOADER=$( find /boot/EFI -name "BOOT${EFI_ARCH_UPPER}.EFI" | tail -1 )
     test -f "$UEFI_BOOTLOADER" && continue
     # Try more generic finds in whole /boot with case insensitive filename matching.
     # On older systems where 'find' does not support '-iname' this does not make it really worse because there 'find' just fails.
-    for find_name_pattern in 'grub*.efi' 'elilo.efi' 'BOOTX64.EFI' ; do
+    for find_name_pattern in 'grub*.efi' 'elilo.efi' "BOOT${EFI_ARCH_UPPER}.EFI" ; do
         # No need to test if find_name_pattern is empty because 'find' does not find anything with empty '-iname':
         UEFI_BOOTLOADER=$( find /boot -iname "$find_name_pattern" | tail -1 )
         # Continue with the code after the outer 'for' loop:
@@ -120,7 +120,7 @@ for dummy in "once" ; do
             LogPrint "EFI variables directory $SYSFS_DIR_EFI_VARS is neither /sys/firmware/efi/vars nor /sys/firmware/efi/efivars (ReaR supports only those)"
             LogPrint "This is expected if you try to make a UEFI boot media on a BIOS system"
             # try some path guessing now
-            UEFI_BOOTLOADER=$( find /usr/lib/grub -iname "grubx64.efi" | tail -1 )
+            UEFI_BOOTLOADER=$( find /usr/lib/grub -iname "grub${EFI_ARCH}.efi" | tail -1 )
             # Continue with the code after the outer 'for' loop:
             test -f "$UEFI_BOOTLOADER" && continue 2
             ;;


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested?

* Description of the changes in this pull request:

Introduce variables EFI_ARCH{_UPPER} and GRUB2_IMAGE_FORMAT. Use them for various EFI bootloader suffixes, parameters and paths instead of hardcoding strings like BOOTX64.EFI. EFI_ARCH is "x64" and EFI_ARCH_UPPER is "X64" and GRUB2_IMAGE_FORMAT is "x86_64-efi" on x86_64 architecture.

Should make it easier to port the code to e.g. Arm.

See e.g.
https://github.com/rhboot/shim/blob/main/Make.defaults
for possible values.
