### PR TITLE
ErrorIfDeprecated when 'gpt_sync_mbr' is used

### DIFF
--- a/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
+++ b/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
@@ -70,7 +70,11 @@ while read keyword disk_dev disk_size parted_mklabel junk ; do
     Log "Verifying that the 'part' entries for $disk_dev in $DISKLAYOUT_FILE specify consecutive partitions"
     # The SUSE specific gpt_sync_mbr partitioning scheme is actually a GPT partitioning (plus some compatibility stuff in MBR)
     # see create_partitions() in prepare/GNU/Linux/100_include_partition_code.sh
-    test "gpt_sync_mbr" = "$parted_mklabel" && parted_mklabel="gpt"
+    if test "gpt_sync_mbr" = "$parted_mklabel" ; then
+        ErrorIfDeprecated gpt_sync_mbr "The 'gpt_sync_mbr' partitioning is no longer supported by SUSE since 2016
+                                        see https://github.com/rear/rear/issues/3148"
+        parted_mklabel="gpt"
+    fi
     # Using the parted_mklabel fallback behaviour in create_partitions() in prepare/GNU/Linux/100_include_partition_code.sh
     # only when there is no parted_mklabel value, but when there is a parted_mklabel value use it as is:
     test "$parted_mklabel" || parted_mklabel="gpt"


### PR DESCRIPTION
* Type: **Cleanup**

* Impact: **Unknown**
It is unknown how many user will file issues
because 'gpt_sync_mbr' is indispensable for them
(i.e. they have no alternative to it).

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3148

* How was this pull request tested?
Not yet tested.

* Description of the changes in this pull request:

In layout/save/default/950_verify_disklayout_file.sh
ErrorIfDeprecated when 'gpt_sync_mbr' is used.

I used layout/save/default/950_verify_disklayout_file.sh
and not layout/save/GNU/Linux/200_partition_layout.sh
because in 950_verify_disklayout_file.sh
there is only one place with 'gpt_sync_mbr'
while in 200_partition_layout.sh it appears more than once
and 950_verify_disklayout_file.sh runs after disklayout.conf
was created so we check the actual final result there.