### PR TITLE
Set TMPDIR to ReaR's TMP_DIR=$BUILD_DIR/tmp for programs that are called by ReaR

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -553,7 +553,7 @@ if test "$WORKFLOW" != "help" ; then
     export TMPDIR="$( readlink -e "${TMPDIR-}" || true )"
     if ! test -d "$TMPDIR" ; then
         # Don't use Error() unless "QuietAddExitTask cleanup_build_area_and_end_program" was done:
-        echo -e "ERROR: TMPDIR '$TMPDIR' is no directory" >&2
+        echo "ERROR: TMPDIR '$TMPDIR' is no directory" >&2
         exit 1
     fi
     # We rely on sufficiently safe 'mktemp -d' behaviour
@@ -564,7 +564,7 @@ if test "$WORKFLOW" != "help" ; then
     # Create ReaR's working area BUILD_DIR:
     if ! BUILD_DIR="$( mktemp -d -t rear.XXXXXXXXXXXXXXX )" ; then
         # Don't use Error() unless "QuietAddExitTask cleanup_build_area_and_end_program" was done:
-        echo -e "ERROR: Could not create build area '$BUILD_DIR'" >&2
+        echo "ERROR: Could not create build area '$BUILD_DIR'" >&2
         exit 1
     fi
     # Prepend working area (BUILD_DIR) removal exit task

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -700,6 +700,7 @@ if test "$WORKFLOW" != "help" ; then
     DebugPrint "Command line options: $0 ${CMD_OPTS[*]}"
     LogPrint "Using log file: $RUNTIME_LOGFILE"
     DebugPrint "Using build area: $BUILD_DIR"
+    DebugPrint "$tmpdir_debug_info"
 fi
 
 # In DEBUG mode keep by default the build area but that can be overridden in user config files

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -590,8 +590,8 @@ if test "$WORKFLOW" != "help" ; then
     # We create TMPDIR inside ROOTFS_DIR i.e. we create $ROOTFS_DIR$TMPDIR which is
     # usually /var/tmp/rear.XXXXXXXXXXXXXXX/rootfs/var/tmp/rear.XXXXXXXXXXXXXXX/tmp
     # (with same 'XXXXXXXXXXXXXXX' characters for both parts)
-    # or when TMPDIR was set via export TMPDIR="/path/to/tmpdir" before ReaR was launched
-    # then $ROOTFS_DIR$TMPDIR is /var/tmp/rear.XXXXXXXXXXXXXXX/rootfs/path/to/tmpdir
+    # or when TMPDIR was set via "export TMPDIR=/path/to/tmpdir" before ReaR was launched
+    # then $ROOTFS_DIR$TMPDIR is /path/to/tmpdir/rear.XXXXXXXXXXXXXXX/rootfs/path/to/tmpdir
     # so that "chroot $ROOTFS_DIR COMMAND" will not fail when COMMAND uses TMPDIR.
     # For example build/default/490_fix_broken_links.sh
     # and build/default/990_verify_rootfs.sh run "chroot $ROOTFS_DIR COMMAND".

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -524,8 +524,18 @@ fi
 # "exec 7>&-"
 # "exec 6<&-"
 
+# Set RECOVERY_MODE only if we are running inside the rescue/recovery system.
+# RECOVERY_MODE is a boolean variable (cf. conf/default.conf) because we need it below
+# to set TMPDIR to ReaR's TMP_DIR only when we are not running inside the recovery system
+# but we do not yet have lib/global-functions.sh (which contains is_false) sourced here.
+# In the recovery system /etc/rear-release is unique (it does not exist otherwise)
+# see build/default/970_add_rear_release.sh that adds it to identify the rescue environment:
+test -e "/etc/rear-release" && RECOVERY_MODE='y' || RECOVERY_MODE=''
+readonly RECOVERY_MODE
+
 # Create a sufficiently safe temporary working area BUILD_DIR for ReaR and
-# set TMPDIR to TMP_DIR within BUILD_DIR for programs that are called by ReaR:
+# additionally set TMPDIR to TMP_DIR within BUILD_DIR for programs that are called by ReaR
+# (the latter only when ReaR runs on the original system i.e. when we are not in RECOVERY_MODE):
 if test "$WORKFLOW" != "help" ; then
     # Prepend temporary working area (BUILD_DIR) removal exit task
     # so it gets executed directly before the above listed exit tasks.
@@ -555,7 +565,13 @@ if test "$WORKFLOW" != "help" ; then
     # via 'mktemp -d' where BUILD_DIR and implicitly TMP_DIR=$BUILD_DIR/tmp
     # has permissions only for root but none for the group or others,
     # see https://github.com/rear/rear/issues/3167
-    export TMPDIR="$TMP_DIR"
+    # We export TMPDIR to ReaR's TMP_DIR only when we are not in RECOVERY_MODE
+    # because TMP_DIR does not exist in the recreated/restored system
+    # i.e. there is no /mnt/local/var/tmp/rear.XXXXXXXXXXXXXXX/tmp so that
+    #   chroot /mnt/local COMMAND
+    # fails when COMMAND uses TMPDIR - in particular "chroot /mnt/local dracut" fails
+    # see https://github.com/rear/rear/pull/3168#issuecomment-1983377528
+    test "$RECOVERY_MODE" || export TMPDIR="$TMP_DIR"
     # Since the above BUILD_DIR="$( mktemp ... )" does not always return a path under /tmp
     # the build directory must be excluded from the backup to be on the safe side:
     BACKUP_PROG_EXCLUDE+=( "$BUILD_DIR" )
@@ -638,10 +654,6 @@ fi
 # In DEBUG mode keep by default the build area but that can be overridden in user config files
 # therefore no readonly KEEP_BUILD_DIR (it is also set to 1 in build/default/990_verify_rootfs.sh):
 test "$DEBUG" && KEEP_BUILD_DIR=1 || true
-
-# Check if we are in recovery mode:
-test -e "/etc/rear-release" && RECOVERY_MODE="y" || true
-readonly RECOVERY_MODE
 
 test "$SIMULATE" && LogPrint "Simulation mode activated, Relax-and-Recover base directory: $SHARE_DIR" || true
 

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -363,6 +363,15 @@ hash -r
 # Make sure that we use only English:
 export LC_CTYPE=C LC_ALL=C LANG=C
 
+# Remember if TMPDIR was unset when ReaR was launched
+# before TMPDIR may be set to /var/tmp in default.conf
+# because testing if TMPDIR is '/var/tmp' is insufficient
+# to determine if TMPDIR was unset when the user called 'rear'
+# because the user may have specified TMPDIR to be '/var/tmp'
+# cf. https://github.com/rear/rear/pull/3168#issuecomment-1997057144
+test -v TMPDIR && TMPDIR_WAS_UNSET='' || TMPDIR_WAS_UNSET='y'
+readonly TMPDIR_WAS_UNSET
+
 # Include default config before the RUNTIME_LOGFILE value is set because
 # setting the right RUNTIME_LOGFILE value requires values from default.conf
 # in particular the default LOGFILE value and the values of the
@@ -535,7 +544,8 @@ readonly RECOVERY_MODE
 
 # Create a sufficiently safe temporary working area BUILD_DIR for ReaR and
 # additionally set TMPDIR to TMP_DIR within BUILD_DIR for programs that are called by ReaR
-# (the latter only when ReaR runs on the original system i.e. when we are not in RECOVERY_MODE):
+# (the latter only when ReaR runs on the original system i.e. when we are not in RECOVERY_MODE
+#  and when TMPDIR was not set before ReaR was launched by the user via export TMPDIR="..."):
 if test "$WORKFLOW" != "help" ; then
     # Prepend temporary working area (BUILD_DIR) removal exit task
     # so it gets executed directly before the above listed exit tasks.
@@ -553,36 +563,41 @@ if test "$WORKFLOW" != "help" ; then
     TMP_DIR=$BUILD_DIR/tmp
     mkdir -p $ROOTFS_DIR || Error "Could not create $ROOTFS_DIR"
     mkdir -p $TMP_DIR || Error "Could not create $TMP_DIR"
-    # For programs that are called by ReaR set TMPDIR to ReaR's TMP_DIR
-    # regardless what TMPDIR was or what it currently is, for example when
-    # TMPDIR was initially unset so it is now ReaR's default /var/tmp
-    # or when TMPDIR is exported by the user like TMPDIR=/somewhere
-    # to ensure in any case that also for programs that are called by ReaR
-    # ReaR will clean up all temporary stuff carefully and completely
-    # via the function cleanup_build_area_and_end_program()
-    # and that temporary files from programs that are called by ReaR
+    # Normally set TMPDIR to ReaR's TMP_DIR which is /var/tmp/rear.XXXXXXXXXXXXXXX/tmp
+    # to ensure that temporary files from programs that are called by ReaR
     # are sufficiently safe against unwanted access by non-root users
-    # via 'mktemp -d' where BUILD_DIR and implicitly TMP_DIR=$BUILD_DIR/tmp
-    # has permissions only for root but none for the group or others,
+    # (only 'root' has permissions to access ReaR's working area)
+    # and that those temporary files will get cleaned up "by the way"
+    # via the cleanup_build_area_and_end_program() function,
     # see https://github.com/rear/rear/issues/3167
     if ! test "$RECOVERY_MODE" ; then
-        # We export TMPDIR to ReaR's TMP_DIR only when we are not in RECOVERY_MODE
+        # We set TMPDIR to ReaR's TMP_DIR only when we are not in RECOVERY_MODE
         # because TMP_DIR does not exist in the recreated/restored system
         # i.e. there is no /mnt/local/var/tmp/rear.XXXXXXXXXXXXXXX/tmp so that
         #   chroot /mnt/local COMMAND
         # fails when COMMAND uses TMPDIR - in particular "chroot /mnt/local dracut" fails
         # see https://github.com/rear/rear/pull/3168#issuecomment-1983377528
-        export TMPDIR="$TMP_DIR"
-        # We create TMPDIR inside ROOTFS_DIR i.e. we create $ROOTFS_DIR$TMP_DIR which is
-        # /var/tmp/rear.XXXXXXXXXXXXXXX/rootfs/var/tmp/rear.XXXXXXXXXXXXXXX/tmp
-        # (with same 'XXXXXXXXXXXXXXX' characters for both parts) so that
-        #   chroot $ROOTFS_DIR COMMAND
-        # will not fail when COMMAND uses TMPDIR - e.g. build/default/490_fix_broken_links.sh
-        # and build/default/990_verify_rootfs.sh run "chroot $ROOTFS_DIR COMMAND"
-        # see https://github.com/rear/rear/pull/3168#issuecomment-1991356186
-        # We create with default mode because all in BUILD_DIR is sufficiently safe:
-        mkdir -p $ROOTFS_DIR$TMP_DIR || Error "Could not create $ROOTFS_DIR$TMP_DIR"
+        if test "$TMPDIR_WAS_UNSET" ; then
+            # We set TMPDIR to ReaR's TMP_DIR only when TMPDIR was not set
+            # before ReaR was launched by the user via export TMPDIR="..."
+            # to provide final power to the user so that a specific TMPDIR can be specified
+            # e.g. for certain third-party backup tools that may need a specific TMPDIR
+            # cf. https://github.com/rear/rear/pull/3168#issuecomment-1997014841
+            # and https://github.com/rear/rear/pull/3168#issuecomment-1997057144
+            export TMPDIR="$TMP_DIR"
+        fi
     fi
+    # We create TMPDIR inside ROOTFS_DIR i.e. we create $ROOTFS_DIR$TMPDIR which is
+    # usually /var/tmp/rear.XXXXXXXXXXXXXXX/rootfs/var/tmp/rear.XXXXXXXXXXXXXXX/tmp
+    # (with same 'XXXXXXXXXXXXXXX' characters for both parts)
+    # or when TMPDIR was set via export TMPDIR="/path/to/tmpdir" before ReaR was launched
+    # then $ROOTFS_DIR$TMPDIR is /var/tmp/rear.XXXXXXXXXXXXXXX/rootfs/path/to/tmpdir
+    # so that "chroot $ROOTFS_DIR COMMAND" will not fail when COMMAND uses TMPDIR.
+    # For example build/default/490_fix_broken_links.sh
+    # and build/default/990_verify_rootfs.sh run "chroot $ROOTFS_DIR COMMAND".
+    # See https://github.com/rear/rear/pull/3168#issuecomment-1991356186
+    # We create with default mode because all in BUILD_DIR is sufficiently safe:
+    mkdir -p $ROOTFS_DIR$TMPDIR || Error "Could not create $ROOTFS_DIR$TMPDIR"
     # Since the above BUILD_DIR="$( mktemp ... )" does not always return a path under /tmp
     # the build directory must be excluded from the backup to be on the safe side:
     BACKUP_PROG_EXCLUDE+=( "$BUILD_DIR" )

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -550,10 +550,13 @@ if test "$WORKFLOW" != "help" ; then
     # so we set TMPDIR to its resolved absolute path.
     # Ignore when 'readlink -e' fails (e.g. it won't fail when TMPDIR is a regular file)
     # and verify afterwards that the 'readlink -e' result is a directory:
-    export TMPDIR="$( readlink -e "${TMPDIR-}" || true )"
+    export TMPDIR="$( readlink -e "$TMPDIR" || true )"
+    # TMPDIR must be a directory to make 'mktemp' work below.
+    # When TMPDIR was unset by the user it is set to '/var/tmp' in default.conf
+    # but it is an error when TMPDIR is set by the user to an empty or blank value:
     if ! test -d "$TMPDIR" ; then
         # Don't use Error() unless "QuietAddExitTask cleanup_build_area_and_end_program" was done:
-        echo "ERROR: TMPDIR '$TMPDIR' is no directory" >&2
+        echo "ERROR: TMPDIR '$TMPDIR' is not a directory" >&2
         exit 1
     fi
     # We rely on sufficiently safe 'mktemp -d' behaviour
@@ -564,7 +567,7 @@ if test "$WORKFLOW" != "help" ; then
     # Create ReaR's working area BUILD_DIR:
     if ! BUILD_DIR="$( mktemp -d -t rear.XXXXXXXXXXXXXXX )" ; then
         # Don't use Error() unless "QuietAddExitTask cleanup_build_area_and_end_program" was done:
-        echo "ERROR: Could not create build area '$BUILD_DIR'" >&2
+        echo "ERROR: Could not create working area ('mktemp -d -t rear.XXXXXXXXXXXXXXX' failed)" >&2
         exit 1
     fi
     # Prepend working area (BUILD_DIR) removal exit task
@@ -632,7 +635,7 @@ fi
 # After the 'mktemp' above, changing TMPDIR does not have the intended effect.
 # Save the current value to detect TMPDIR changes regardless if 'mktemp' above was called
 # so even the help workflow would report that error, see https://github.com/rear/rear/pull/3163
-saved_tmpdir="${TMPDIR-}"
+saved_tmpdir="$TMPDIR"
 
 # Keep old log file:
 test -r "$RUNTIME_LOGFILE" && mv -f "$RUNTIME_LOGFILE" "$RUNTIME_LOGFILE".old 2>/dev/null
@@ -794,7 +797,7 @@ if test "$CONFIG_APPEND_FILES" ; then
     done
 fi
 
-if [ "$saved_tmpdir" != "${TMPDIR-}" ] ; then
+if [ "$saved_tmpdir" != "$TMPDIR" ] ; then
     Error "Setting TMPDIR in a configuration file is not supported. To specify a working area directory prefix, export TMPDIR before executing '$PROGRAM'"
 fi
 

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -363,14 +363,13 @@ hash -r
 # Make sure that we use only English:
 export LC_CTYPE=C LC_ALL=C LANG=C
 
-# Remember if TMPDIR was unset when ReaR was launched
-# before TMPDIR may be set to /var/tmp in default.conf
-# because testing if TMPDIR is '/var/tmp' is insufficient
-# to determine if TMPDIR was unset when the user called 'rear'
+# Remember what TMPDIR was originally set when ReaR was launched
+# before TMPDIR may be set (if unset) to /var/tmp in default.conf
+# because testing if TMPDIR is '/var/tmp' would be insufficient
+# to determine if TMPDIR was set or unset when the user called 'rear'
 # because the user may have specified TMPDIR to be '/var/tmp'
 # cf. https://github.com/rear/rear/pull/3168#issuecomment-1997057144
-test -v TMPDIR && TMPDIR_WAS_UNSET='' || TMPDIR_WAS_UNSET='y'
-readonly TMPDIR_WAS_UNSET
+readonly TMPDIR_ORIG="${TMPDIR-}"
 
 # Include default config before the RUNTIME_LOGFILE value is set because
 # setting the right RUNTIME_LOGFILE value requires values from default.conf
@@ -519,15 +518,15 @@ fi
 # Source usr/share/rear/lib/_input-output-functions.sh because therein
 # the original STDIN STDOUT and STDERR file descriptors are saved as fd6 fd7 and fd8
 # so that ReaR functions for actually intended user messages can use fd7 and fd8
-# to show messages to the user regardless where to STDOUT and STDERR are redirected
-# and fd6 to get input from the user regardless where to STDIN is redirected:
+# to show messages to the user regardless where STDOUT and STDERR are redirected
+# and fd6 to get input from the user regardless where STDIN is redirected:
 if ! source $SHARE_DIR/lib/_input-output-functions.sh ; then
     echo -e "ERROR: BUG in $PRODUCT\nFailed to source $SHARE_DIR/lib/_input-output-functions.sh\nPlease report it at $BUG_REPORT_SITE" >&2
     exit 1
 fi
 
 # Via source usr/share/rear/lib/_input-output-functions.sh
-# those exit tasks are now set to be executed (via bash EXIT trap) in the following order:
+# those final exit tasks are now set to be executed (via bash EXIT trap) in the following order:
 # "(( EXIT_FAIL_MESSAGE )) && echo '${MESSAGE_PREFIX}$PROGRAM $WORKFLOW failed, check $RUNTIME_LOGFILE for details' 1>&8"
 # "exec 8>&-"
 # "exec 7>&-"
@@ -544,24 +543,46 @@ readonly RECOVERY_MODE
 
 # Create a sufficiently safe temporary working area BUILD_DIR for ReaR and
 # additionally set TMPDIR to TMP_DIR within BUILD_DIR for programs that are called by ReaR
-# (the latter only when ReaR runs on the original system i.e. when we are not in RECOVERY_MODE
-#  and when TMPDIR was not set before ReaR was launched by the user via export TMPDIR="..."):
+# (the latter only when ReaR runs on the original system i.e. when we are not in RECOVERY_MODE):
 if test "$WORKFLOW" != "help" ; then
-    # Prepend temporary working area (BUILD_DIR) removal exit task
-    # so it gets executed directly before the above listed exit tasks.
-    # This must be done before the first possible call of the 'Error' function
-    # otherwise we may error out but leave the build area behind:
-    QuietAddExitTask cleanup_build_area_and_end_program
+    # ReaR fails when TMPDIR is a relative directory, see
+    # https://github.com/rear/rear/pull/3168#issuecomment-1999996162
+    # so we set TMPDIR to its resolved absolute path.
+    # Ignore when 'readlink -e' fails (e.g. it won't fail when TMPDIR is a regular file)
+    # and verify afterwards that the 'readlink -e' result is a directory:
+    export TMPDIR="$( readlink -e "${TMPDIR-}" || true )"
+    if ! test -d "$TMPDIR" ; then
+        # Don't use Error() unless "QuietAddExitTask cleanup_build_area_and_end_program" was done:
+        echo -e "ERROR: TMPDIR '$TMPDIR' is no directory" >&2
+        exit 1
+    fi
     # We rely on sufficiently safe 'mktemp -d' behaviour
     # that the BUILD_DIR directory will have read, write, and search permissions
     # for the current user (i.e. for root), but no permissions for the group or others
     # (i.e. BUILD_DIR is "drwx------ root root /var/tmp/rear.XXXXXXXXXXXXXXX"), cf.
     # https://www.gnu.org/software/coreutils/manual/html_node/mktemp-invocation.html#mktemp-invocation
-    # as of this writing in Feb. 2024, see also https://github.com/rear/rear/issues/3167
-    BUILD_DIR="$( mktemp -d -t rear.XXXXXXXXXXXXXXX || Error "Could not create build area '$BUILD_DIR'" )"
+    # Create ReaR's working area BUILD_DIR:
+    if ! BUILD_DIR="$( mktemp -d -t rear.XXXXXXXXXXXXXXX )" ; then
+        # Don't use Error() unless "QuietAddExitTask cleanup_build_area_and_end_program" was done:
+        echo -e "ERROR: Could not create build area '$BUILD_DIR'" >&2
+        exit 1
+    fi
+    # Prepend working area (BUILD_DIR) removal exit task
+    # so it gets executed last directly before the above listed final exit tasks.
+    # On the one hand this must be done after the build area was successfully created,
+    # otherwise cleanup_build_area_and_end_program would try to remove a nonexistent build area
+    # by calling plain 'rm -Rf --one-file-system' where nothing is specified to be removed
+    # where (fortunately) 'rm' does not remove anything when nothing is specified to be removed,
+    # see https://github.com/rear/rear/issues/3180
+    # On the other hand this must be done before the first possible call of the 'Error' function,
+    # otherwise we may error out but leave the build area behind,
+    # see https://github.com/rear/rear/pull/2633
+    QuietAddExitTask cleanup_build_area_and_end_program
+    # Create ROOTFS_DIR in ReaR's working area:
     ROOTFS_DIR=$BUILD_DIR/rootfs
-    TMP_DIR=$BUILD_DIR/tmp
     mkdir -p $ROOTFS_DIR || Error "Could not create $ROOTFS_DIR"
+    # Create TMP_DIR in ReaR's working area:
+    TMP_DIR=$BUILD_DIR/tmp
     mkdir -p $TMP_DIR || Error "Could not create $TMP_DIR"
     # Normally set TMPDIR to ReaR's TMP_DIR which is /var/tmp/rear.XXXXXXXXXXXXXXX/tmp
     # to ensure that temporary files from programs that are called by ReaR
@@ -577,14 +598,18 @@ if test "$WORKFLOW" != "help" ; then
         #   chroot /mnt/local COMMAND
         # fails when COMMAND uses TMPDIR - in particular "chroot /mnt/local dracut" fails
         # see https://github.com/rear/rear/pull/3168#issuecomment-1983377528
-        if test "$TMPDIR_WAS_UNSET" ; then
-            # We set TMPDIR to ReaR's TMP_DIR only when TMPDIR was not set
-            # before ReaR was launched by the user via export TMPDIR="..."
-            # to provide final power to the user so that a specific TMPDIR can be specified
-            # e.g. for certain third-party backup tools that may need a specific TMPDIR
-            # cf. https://github.com/rear/rear/pull/3168#issuecomment-1997014841
-            # and https://github.com/rear/rear/pull/3168#issuecomment-1997057144
-            export TMPDIR="$TMP_DIR"
+        if test "$TMPDIR_ORIG" ; then
+            tmpdir_debug_info="Changing TMPDIR to '$TMP_DIR' (was '$TMPDIR_ORIG' when ReaR was launched)"
+        else
+            tmpdir_debug_info="Setting TMPDIR to '$TMP_DIR' (was unset when ReaR was launched)"
+        fi
+        export TMPDIR="$TMP_DIR"
+    else
+        # Also in RECOVERY_MODE provide debug info what TMPDIR is:
+        if test "$TMPDIR_ORIG" ; then
+            tmpdir_debug_info="Using TMPDIR '$TMPDIR' (was '$TMPDIR_ORIG' when ReaR was launched)"
+        else
+            tmpdir_debug_info="Setting TMPDIR to '$TMPDIR' (was unset when ReaR was launched)"
         fi
     fi
     # We create TMPDIR inside ROOTFS_DIR i.e. we create $ROOTFS_DIR$TMPDIR which is

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -524,7 +524,7 @@ fi
 # "exec 7>&-"
 # "exec 6<&-"
 
-# Set RECOVERY_MODE only if we are running inside the rescue/recovery system.
+# Set RECOVERY_MODE when we are running inside the rescue/recovery system.
 # RECOVERY_MODE is a boolean variable (cf. conf/default.conf) because we need it below
 # to set TMPDIR to ReaR's TMP_DIR only when we are not running inside the recovery system
 # but we do not yet have lib/global-functions.sh (which contains is_false) sourced here.
@@ -565,13 +565,24 @@ if test "$WORKFLOW" != "help" ; then
     # via 'mktemp -d' where BUILD_DIR and implicitly TMP_DIR=$BUILD_DIR/tmp
     # has permissions only for root but none for the group or others,
     # see https://github.com/rear/rear/issues/3167
-    # We export TMPDIR to ReaR's TMP_DIR only when we are not in RECOVERY_MODE
-    # because TMP_DIR does not exist in the recreated/restored system
-    # i.e. there is no /mnt/local/var/tmp/rear.XXXXXXXXXXXXXXX/tmp so that
-    #   chroot /mnt/local COMMAND
-    # fails when COMMAND uses TMPDIR - in particular "chroot /mnt/local dracut" fails
-    # see https://github.com/rear/rear/pull/3168#issuecomment-1983377528
-    test "$RECOVERY_MODE" || export TMPDIR="$TMP_DIR"
+    if ! test "$RECOVERY_MODE" ; then
+        # We export TMPDIR to ReaR's TMP_DIR only when we are not in RECOVERY_MODE
+        # because TMP_DIR does not exist in the recreated/restored system
+        # i.e. there is no /mnt/local/var/tmp/rear.XXXXXXXXXXXXXXX/tmp so that
+        #   chroot /mnt/local COMMAND
+        # fails when COMMAND uses TMPDIR - in particular "chroot /mnt/local dracut" fails
+        # see https://github.com/rear/rear/pull/3168#issuecomment-1983377528
+        export TMPDIR="$TMP_DIR"
+        # We create TMPDIR inside ROOTFS_DIR i.e. we create $ROOTFS_DIR$TMP_DIR which is
+        # /var/tmp/rear.XXXXXXXXXXXXXXX/rootfs/var/tmp/rear.XXXXXXXXXXXXXXX/tmp
+        # (with same 'XXXXXXXXXXXXXXX' characters for both parts) so that
+        #   chroot $ROOTFS_DIR COMMAND
+        # will not fail when COMMAND uses TMPDIR - e.g. build/default/490_fix_broken_links.sh
+        # and build/default/990_verify_rootfs.sh run "chroot $ROOTFS_DIR COMMAND"
+        # see https://github.com/rear/rear/pull/3168#issuecomment-1991356186
+        # We create with default mode because all in BUILD_DIR is sufficiently safe:
+        mkdir -p $ROOTFS_DIR$TMP_DIR || Error "Could not create $ROOTFS_DIR$TMP_DIR"
+    fi
     # Since the above BUILD_DIR="$( mktemp ... )" does not always return a path under /tmp
     # the build directory must be excluded from the backup to be on the safe side:
     BACKUP_PROG_EXCLUDE+=( "$BUILD_DIR" )

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -524,26 +524,48 @@ fi
 # "exec 7>&-"
 # "exec 6<&-"
 
-# Used to determine whether TMPDIR has been changed in user config.
-# After the `mktemp` below, changing TMPDIR does not have the intended effect.
-# Save the current value to detect changes.
-saved_tmpdir="${TMPDIR-}"
+# Create a sufficiently safe temporary working area BUILD_DIR for ReaR and
+# set TMPDIR to TMP_DIR within BUILD_DIR for programs that are called by ReaR:
 if test "$WORKFLOW" != "help" ; then
     # Prepend temporary working area (BUILD_DIR) removal exit task
     # so it gets executed directly before the above listed exit tasks.
     # This must be done before the first possible call of the 'Error' function
     # otherwise we may error out but leave the build area behind:
     QuietAddExitTask cleanup_build_area_and_end_program
-    # Create temporary working area:
+    # We rely on sufficiently safe 'mktemp -d' behaviour
+    # that the BUILD_DIR directory will have read, write, and search permissions
+    # for the current user (i.e. for root), but no permissions for the group or others
+    # (i.e. BUILD_DIR is "drwx------ root root /var/tmp/rear.XXXXXXXXXXXXXXX"), cf.
+    # https://www.gnu.org/software/coreutils/manual/html_node/mktemp-invocation.html#mktemp-invocation
+    # as of this writing in Feb. 2024, see also https://github.com/rear/rear/issues/3167
     BUILD_DIR="$( mktemp -d -t rear.XXXXXXXXXXXXXXX || Error "Could not create build area '$BUILD_DIR'" )"
     ROOTFS_DIR=$BUILD_DIR/rootfs
     TMP_DIR=$BUILD_DIR/tmp
     mkdir -p $ROOTFS_DIR || Error "Could not create $ROOTFS_DIR"
     mkdir -p $TMP_DIR || Error "Could not create $TMP_DIR"
+    # For programs that are called by ReaR set TMPDIR to ReaR's TMP_DIR
+    # regardless what TMPDIR was or what it currently is, for example when
+    # TMPDIR was initially unset so it is now ReaR's default /var/tmp
+    # or when TMPDIR is exported by the user like TMPDIR=/somewhere
+    # to ensure in any case that also for programs that are called by ReaR
+    # ReaR will clean up all temporary stuff carefully and completely
+    # via the function cleanup_build_area_and_end_program()
+    # and that temporary files from programs that are called by ReaR
+    # are sufficiently safe against unwanted access by non-root users
+    # via 'mktemp -d' where BUILD_DIR and implicitly TMP_DIR=$BUILD_DIR/tmp
+    # has permissions only for root but none for the group or others,
+    # see https://github.com/rear/rear/issues/3167
+    export TMPDIR="$TMP_DIR"
     # Since the above BUILD_DIR="$( mktemp ... )" does not always return a path under /tmp
     # the build directory must be excluded from the backup to be on the safe side:
     BACKUP_PROG_EXCLUDE+=( "$BUILD_DIR" )
 fi
+
+# Used to determine below whether TMPDIR has been changed in user config.
+# After the 'mktemp' above, changing TMPDIR does not have the intended effect.
+# Save the current value to detect TMPDIR changes regardless if 'mktemp' above was called
+# so even the help workflow would report that error, see https://github.com/rear/rear/pull/3163
+saved_tmpdir="${TMPDIR-}"
 
 # Keep old log file:
 test -r "$RUNTIME_LOGFILE" && mv -f "$RUNTIME_LOGFILE" "$RUNTIME_LOGFILE".old 2>/dev/null

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -93,7 +93,7 @@
 # The directory name of the working area is created in /usr/sbin/rear by calling
 #   mktemp -d -t rear.XXXXXXXXXXXXXXX
 # which results $TMPDIR/rear.XXXXXXXXXXXXXXX for ReaR's working area.
-# To have a specific working area directory prefix for Relax-and-Recover specify
+# To have a specific working area directory prefix for Relax-and-Recover call
 #   export TMPDIR="/prefix/for/rear/working/directory"
 # before calling 'rear' (/prefix/for/rear/working/directory must already exist).
 # This is useful for example when there is not sufficient free space

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -108,6 +108,14 @@
 # because /tmp is not intended for such large amounts of data that ReaR usually
 # produces when creating the image (see file-hierarchy(7)). In particular,
 # /tmp can be a tmpfs, and thus restricted by the available RAM/swap.
+# When TMPDIR is not set (e.g. via export TMPDIR="...") before ReaR is launched
+# then ReaR will set TMPDIR to ReaR's TMP_DIR which is /var/tmp/rear.XXXXXXXXXXXXXXX/tmp
+# when ReaR runs on the original system (e.g. for "rear mkbackup" but not for "rear recover")
+# to ensure that temporary files from programs that are called by ReaR
+# are sufficiently safe against unwanted access by non-root users
+# (only 'root' has permissions to access ReaR's working area)
+# and that those temporary files will get cleaned up "by the way"
+# when ReaR removes its working area at the end.
 export TMPDIR="${TMPDIR-/var/tmp}"
 ####
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -92,30 +92,28 @@
 # the rescue/recovery system ISO image (and perhaps even stores the backup archive).
 # The directory name of the working area is created in /usr/sbin/rear by calling
 #   mktemp -d -t rear.XXXXXXXXXXXXXXX
-# which usually results /tmp/rear.XXXXXXXXXXXXXXX or $TMPDIR/rear.XXXXXXXXXXXXXXX
-# the latter when the canonical Linux/Unix environment variable TMPDIR
-# is set in the environment where /usr/sbin/rear is called.
-# To have a specific working area directory prefix for Relax-and-Recover call
+# which results $TMPDIR/rear.XXXXXXXXXXXXXXX for ReaR's working area.
+# To have a specific working area directory prefix for Relax-and-Recover specify
 #   export TMPDIR="/prefix/for/rear/working/directory"
 # before calling 'rear' (/prefix/for/rear/working/directory must already exist).
 # This is useful for example when there is not sufficient free space
-# in /var/tmp or $TMPDIR for the ISO image or even the backup archive.
-# TMPDIR cannot be set to a default value here unconditionally but only
-# if it is not set before calling the program, otherwise /usr/sbin/rear
+# in /var/tmp or $TMPDIR for the ReaR recovery system ISO image or even the backup archive.
+# TMPDIR cannot be set to a default value here unconditionally
+# but only if it is not set before calling 'rear', otherwise ReaR (/usr/sbin/rear)
 # would not work in compliance with the Linux/Unix standards regarding TMPDIR
 # see https://github.com/rear/rear/issues/968
-# The default is /var/tmp instead of the more usual /tmp (the system default),
+# When TMPDIR is unset ReaR uses by default /var/tmp instead of /tmp (the system default),
 # because /tmp is not intended for such large amounts of data that ReaR usually
-# produces when creating the image (see file-hierarchy(7)). In particular,
-# /tmp can be a tmpfs, and thus restricted by the available RAM/swap.
-# When TMPDIR is not set (e.g. via export TMPDIR="...") before ReaR is launched
-# then ReaR will set TMPDIR to ReaR's TMP_DIR which is /var/tmp/rear.XXXXXXXXXXXXXXX/tmp
+# produces when creating the ReaR recovery system ISO image, see file-hierarchy(7).
+# In particular, /tmp can be a tmpfs, and thus restricted by the available RAM/swap.
+# ReaR will set TMPDIR to ReaR's TMP_DIR which is $TMPDIR/rear.XXXXXXXXXXXXXXX/tmp
 # when ReaR runs on the original system (e.g. for "rear mkbackup" but not for "rear recover")
 # to ensure that temporary files from programs that are called by ReaR
 # are sufficiently safe against unwanted access by non-root users
 # (only 'root' has permissions to access ReaR's working area)
 # and that those temporary files will get cleaned up "by the way"
-# when ReaR removes its working area at the end.
+# when ReaR removes its working area at the end
+# see https://github.com/rear/rear/issues/3167
 export TMPDIR="${TMPDIR-/var/tmp}"
 ####
 

--- a/usr/share/rear/prep/default/990_verify_empty_rootfs.sh
+++ b/usr/share/rear/prep/default/990_verify_empty_rootfs.sh
@@ -27,5 +27,5 @@
 # cf. https://github.com/rear/rear/commit/9b4efb2469b8cf3585206dbb10700960b480008e#r139765325
 test "$( find $ROOTFS_DIR -type f )" || return 0
 DebugPrint "Modified ReaR recovery system area after 'prep' stage ($ROOTFS_DIR contains regular files)"
-Debug "$( find $ROOTFS_DIR )"
+Debug "$( find $ROOTFS_DIR -ls )"
 return 1

--- a/usr/share/rear/prep/default/990_verify_empty_rootfs.sh
+++ b/usr/share/rear/prep/default/990_verify_empty_rootfs.sh
@@ -22,7 +22,10 @@
 # some 'prep' scripts modify things in ROOTFS_DIR,
 # see https://github.com/rear/rear/issues/2951
 
-test "$( ls -A $ROOTFS_DIR )" || return 0
-DebugPrint "Modified ReaR recovery system area after 'prep' stage ($ROOTFS_DIR not empty)"
+# Only check for regular files in ROOTFS_DIR
+# so in particular empty directories like ROOTFS_DIR/TMP_DIR are OK
+# cf. https://github.com/rear/rear/commit/9b4efb2469b8cf3585206dbb10700960b480008e#r139765325
+test "$( find $ROOTFS_DIR -type f )" || return 0
+DebugPrint "Modified ReaR recovery system area after 'prep' stage ($ROOTFS_DIR contains regular files)"
 Debug "$( find $ROOTFS_DIR )"
 return 1


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **High**
Hopefully a high positive impact
because of improved default confidentiality and
because of improved careful and complete cleanup of temporary leftovers

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3167

* How was this pull request tested?
A simple "rear mkbackup"
and "rear recover" work for me.

* Description of the changes in this pull request:

In usr/sbin/rear set TMPDIR to TMP_DIR (within BUILD_DIR)
to ensure
that also for programs that are called by ReaR
ReaR will clean up all temporary stuff carefully and completely
via the function cleanup_build_area_and_end_program()
AND
that temporary files from programs that are called by ReaR
are sufficiently safe against unwanted access by non-root users
via  'mktemp -d' where BUILD_DIR and implicitly TMP_DIR=$BUILD_DIR/tmp
has permissions only for root but none for the group or others
