### PR TITLE
 Make OS detection from `/etc/os-release` more robust

### DIFF
--- a/usr/share/rear/lib/config-functions.sh
+++ b/usr/share/rear/lib/config-functions.sh
@@ -20,7 +20,7 @@ function SetOSVendorAndVersion () {
         # Try to find all the required information from that file
         if [[ -f /etc/os-release ]] ; then
             grep -q -i 'fedora' /etc/os-release && OS_VENDOR=Fedora
-            grep -q -i -E '(centos|redhat|scientific|oracle)' /etc/os-release && OS_VENDOR=RedHatEnterpriseServer
+            grep -q -i -E '(centos|rhel|scientific|oracle)' /etc/os-release && OS_VENDOR=RedHatEnterpriseServer
             grep -q -i 'suse' /etc/os-release && OS_VENDOR=SUSE_LINUX
             grep -q -i 'debian' /etc/os-release && OS_VENDOR=Debian
             grep -q -i -E '(ubuntu|linuxmint)' /etc/os-release && OS_VENDOR=Ubuntu

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -104,6 +104,9 @@ function SourceStage () {
     # that match the specified backup method and output method
     # and that match the used operating system and architecture and Linux distribution.
     # The pipe sorts the listed scripts by their 3-digit number independent of the directory of the script.
+    # We want to make sure that there are no duplicates in the listed scripts
+    # so that each script gets executed at most once.
+    # cf. https://github.com/rear/rear/issues/3149#issuecomment-1935586311
     # First sed inserts a ! before and after the script number
     # e.g. default/123_some_script.sh becomes default/!123!_some_script.sh
     # which makes the script number field nr. 2 when dividing lines into fields by !
@@ -122,7 +125,7 @@ function SourceStage () {
               "$BACKUP"/{default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
               "$OUTPUT"/{default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
     "$OUTPUT"/"$BACKUP"/{default,"$ARCH","$OS","$OS_MASTER_VENDOR","$OS_MASTER_VENDOR_ARCH","$OS_MASTER_VENDOR_VERSION","$OS_VENDOR","$OS_VENDOR_ARCH","$OS_VENDOR_VERSION"}/*.sh \
-                 | sed -e 's#/\([0-9][0-9][0-9]\)_#/!\1!_#g' | sort -t \! -k 2 | tr -d \! ) )
+                 | sed -e 's#/\([0-9][0-9][0-9]\)_#/!\1!_#g' | sort -t \! -k 2 -u | tr -d \! ) )
     # If no script is found, then the scripts array contains only one element '.'
     if test "$scripts" = '.' ; then
         Log "Finished running empty '$stage' stage"


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):  https://github.com/rear/rear/issues/3149

* How was this pull request tested? `rear dump` and then rescue on x86_64 Fedora Rawhide and RHEL 9.4

* Description of the changes in this pull request - Notable changes:

  1. Search for `rhel` when detecting RHEL\
\
The `redhat` substring is present only in auxiliary variables and URLs in `/etc/os-release` both on Fedora and RHEL.  Therefore, the `grep` worked only by accident on RHEL and was broken on Fedora because it wrongly classified Fedora as RHEL because its `BUG_REPORT_URL` refers to Red Hat's Bugzilla.\
\
On the other hand, `rhel` is the actual `ID` of RHEL and this string is
not present in Fedora's `/etc/os-release` at all.\
\
Resolves: https://github.com/rear/rear/issues/3149#issuecomment-1964290116

   1. Always source a script in `SourceStage` at most once\
\
`sort -u` makes sure that each relevant script is listed and sourced
only and that duplicates get discarded.
\
Otherwise, some scripts could have been executed repeatedly (see the last
linked comment).  Especially, when `OS_VENDOR` and `OS_MASTER_VENDOR` have the
same value which is the case at least on Fedora.
\
Related: https://github.com/rear/rear/pull/3171#pullrequestreview-2053278291
Resolves: https://github.com/rear/rear/issues/3149#issuecomment-1935586311
