### PR TITLE
Automatically include mounted btrfs subvolumes in NETFS backups 

### DIFF
--- a/usr/share/rear/layout/prepare/default/610_exclude_from_restore.sh
+++ b/usr/share/rear/layout/prepare/default/610_exclude_from_restore.sh
@@ -21,10 +21,9 @@ for component in "${EXCLUDE_RESTORE[@]}" ; do
             echo "${child#/}" >> "$RESTORE_EXCLUDE_FILE"
             echo "${child#/}/*" >> "$RESTORE_EXCLUDE_FILE"
         done
-    else
-        # if there are no fs deps, assume it is a wildcard path
-        component=${component#fs:}
-        echo "${component#/}" >> "$RESTORE_EXCLUDE_FILE"
-        echo "${component#/}/*" >> "$RESTORE_EXCLUDE_FILE"
-    fi
+
+    # exclude the component itself
+    component=${component#fs:}
+    echo "${component#/}" >> "$RESTORE_EXCLUDE_FILE"
+    echo "${component#/}/*" >> "$RESTORE_EXCLUDE_FILE"
 done

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -434,6 +434,7 @@ fi
                     # Output header only once:
                     btrfsmountedsubvol_entry_exists="yes"
                     echo "# All mounted btrfs subvolumes (including mounted btrfs default subvolumes and mounted btrfs snapshot subvolumes)."
+                    echo "# Mounted btrfs snapshot subvolumes are autoexcluded."
                     if test "$findmnt_FSROOT_works" ; then
                         echo "# Determined by the findmnt command that shows the mounted btrfs_subvolume_path."
                         echo "# Format: btrfsmountedsubvol <device> <subvolume_mountpoint> <mount_options> <btrfs_subvolume_path>"
@@ -469,7 +470,10 @@ fi
                 # Finally, test whether the btrfs subvolume listed as mounted actually exists. A running docker
                 # daemon apparently can convince the system to list a non-existing btrfs volume as mounted.
                 # See https://github.com/rear/rear/issues/1496
-                if btrfs_subvolume_exists "$subvolume_mountpoint" "$btrfs_subvolume_path"; then
+                if btrfs_snapshot_subvolume_exists "$subvolume_mountpoint" "$btrfs_subvolume_path"; then
+                    # Exclude mounted snapshot subvolumes
+                    echo "#btrfsmountedsubvol $device $subvolume_mountpoint $mount_options $btrfs_subvolume_path"
+                elif btrfs_subvolume_exists "$subvolume_mountpoint" "$btrfs_subvolume_path"; then
                     echo "btrfsmountedsubvol $device $subvolume_mountpoint $mount_options $btrfs_subvolume_path"
                 else
                     LogPrintError "Ignoring non-existing btrfs subvolume listed as mounted: $subvolume_mountpoint"

--- a/usr/share/rear/layout/save/default/340_generate_mountpoint_device.sh
+++ b/usr/share/rear/layout/save/default/340_generate_mountpoint_device.sh
@@ -7,15 +7,15 @@
 # EXCLUDE_RECREATE is handled automatically (commented out in LAYOUT_FILE)
 excluded_mountpoints=()
 while read fs device mountpoint junk ; do
-    if IsInArray "fs:$mountpoint" "${EXCLUDE_BACKUP[@]}" ; then
+    if IsInArray "$fs:$mountpoint" "${EXCLUDE_BACKUP[@]}" ; then
         excluded_mountpoints+=( $mountpoint )
     fi
-    for component in $(get_parent_components "fs:$mountpoint" | sort -u) ; do
+    for component in $(get_parent_components "$fs:$mountpoint" | sort -u) ; do
         if IsInArray "$component" "${EXCLUDE_BACKUP[@]}" ; then
             excluded_mountpoints+=( $mountpoint )
         fi
     done
-done < <(grep ^fs $LAYOUT_FILE)
+done < <(grep -E '^(fs|btrfsmountedsubvol)' $LAYOUT_FILE)
 
 # Generate the list of mountpoints and devices to include in the backup
 # via backup/NETFS/default/400_create_include_exclude_files.sh
@@ -25,4 +25,4 @@ while read fs device mountpoint junk ; do
         continue
     fi
     echo "$mountpoint $device"
-done < <(grep '^fs' $LAYOUT_FILE) > $VAR_DIR/recovery/mountpoint_device
+done < <(grep -E '^(fs|btrfsmountedsubvol)' $LAYOUT_FILE) | unique_unsorted > $VAR_DIR/recovery/mountpoint_device

--- a/usr/share/rear/lib/filesystems-functions.sh
+++ b/usr/share/rear/lib/filesystems-functions.sh
@@ -3,16 +3,27 @@
 #
 # File system support functions
 
+function btrfs_snapshot_subvolume_exists() {
+    # returns true if the btrfs snapshot subvolume ($2) exists in the Btrfs
+    # file system at the mount point ($1).
+
+    # Use -s so that btrfs subvolume list considers snapshots only
+    btrfs_subvolume_exists "$1" "$2" "-s"
+}
+
 function btrfs_subvolume_exists() {
     # returns true if the btrfs subvolume ($2) exists in the Btrfs file system at the mount point ($1).
     local subvolume_mountpoint="$1" btrfs_subvolume_path="$2"
+
+    # extra options for the btrfs subvolume list command ($3)
+    local btrfs_extra_opts="$3"
 
     # A root subvolume can be assumed to always exist
     [ "$btrfs_subvolume_path" == "/" ] && return 0
 
     # A non-root subvolume exists if the btrfs subvolume list contains its complete path at the end of one line.
     # This code deliberately uses a plain string comparison rather than a regexp.
-    btrfs subvolume list -a "$subvolume_mountpoint" | sed -e 's; path <FS_TREE>/; path ;' |
+    btrfs subvolume list -a $btrfs_extra_opts "$subvolume_mountpoint" | sed -e 's; path <FS_TREE>/; path ;' |
     awk -v path="$btrfs_subvolume_path" '
         BEGIN {
             match_string = " path " path;


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **High**

* Reference to related issue (URL): https://github.com/rear/rear/issues/2928

* How was this pull request tested? `rear savelayout` and manual inspection of generated files and backup/restore of a Fedora Rawhide machine

* Description of the changes in this pull request:
  * automatically include mounted btrfs subvolumes in NETFS backups
  * improve generation of `$RESTORE_EXCLUDE_FILE`
