### PR TITLE
New unique_unsorted() function

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -45,7 +45,7 @@ fi
 Log "Backup include list (backup-include.txt contents without subsequent duplicates):"
 while read -r backup_include_item ; do
     test "$backup_include_item" && Log "  $backup_include_item"
-done < <( without_subsequent_duplicates $TMP_DIR/backup-include.txt )
+done < <( unique_unsorted $TMP_DIR/backup-include.txt )
 Log "Backup exclude list (backup-exclude.txt contents):"
 while read -r backup_exclude_item ; do
     test "$backup_exclude_item" && Log "  $backup_exclude_item"
@@ -127,7 +127,7 @@ case "$(basename ${BACKUP_PROG})" in
                 $BACKUP_PROG_CREATE_NEWER_OPTIONS \
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
-                $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
+                $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
         else
             Log $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
                 --no-wildcards-match-slash --one-file-system \
@@ -135,7 +135,7 @@ case "$(basename ${BACKUP_PROG})" in
                 $BACKUP_PROG_CREATE_NEWER_OPTIONS \
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
-                $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $SPLIT_COMMAND
+                $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $SPLIT_COMMAND
         fi
 
         if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
@@ -151,7 +151,7 @@ case "$(basename ${BACKUP_PROG})" in
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                                      \
                 "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                               \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f -                                        \
-                $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |    \
+                $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |                  \
             { $BACKUP_PROG_CRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV | \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
@@ -160,14 +160,14 @@ case "$(basename ${BACKUP_PROG})" in
                 "$(basename $(echo "$BACKUP_PROG" | awk '{ print $1 }'))"
                 "$(basename $(echo "$SPLIT_COMMAND" | awk '{ print $1 }'))"
             )
-            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose                \
-                --no-wildcards-match-slash --one-file-system                                    \
-                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                                \
-                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                               \
-                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                                   \
-                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                            \
-                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                                     \
-                $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE | \
+            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose  \
+                --no-wildcards-match-slash --one-file-system                      \
+                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                  \
+                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                 \
+                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                     \
+                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                              \
+                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                       \
+                $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE | \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
         fi
@@ -213,21 +213,21 @@ case "$(basename ${BACKUP_PROG})" in
         mkdir -p $v "$backuparchive" >&2
         Log $BACKUP_PROG --verbose "${BACKUP_RSYNC_OPTIONS[@]}" --one-file-system --delete \
             --exclude-from=$TMP_DIR/backup-exclude.txt --delete-excluded \
-            $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) "$backuparchive"
+            $(unique_unsorted $TMP_DIR/backup-include.txt) "$backuparchive"
         $BACKUP_PROG --verbose "${BACKUP_RSYNC_OPTIONS[@]}" --one-file-system --delete \
             --exclude-from=$TMP_DIR/backup-exclude.txt --delete-excluded \
-            $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) "$backuparchive" >&2
+            $(unique_unsorted $TMP_DIR/backup-include.txt) "$backuparchive" >&2
     ;;
     (*)
         Log "Using unsupported backup program '$BACKUP_PROG'"
         Log $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
             $BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
             "${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
-            $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
+            $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
         $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
             $BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
             "${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
-            $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
+            $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
     ;;
 esac 2> "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log"
 # For the rsync and default case the backup prog is the last in the case entry

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -42,10 +42,10 @@ fi
 
 # Log what is included in the backup and what is excluded from the backup
 # cf. backup/NETFS/default/400_create_include_exclude_files.sh
-Log "Backup include list (backup-include.txt contents):"
+Log "Backup include list (backup-include.txt contents without subsequent duplicates):"
 while read -r backup_include_item ; do
     test "$backup_include_item" && Log "  $backup_include_item"
-done < $TMP_DIR/backup-include.txt
+done < <( without_subsequent_duplicates $TMP_DIR/backup-include.txt )
 Log "Backup exclude list (backup-exclude.txt contents):"
 while read -r backup_exclude_item ; do
     test "$backup_exclude_item" && Log "  $backup_exclude_item"
@@ -127,7 +127,7 @@ case "$(basename ${BACKUP_PROG})" in
                 $BACKUP_PROG_CREATE_NEWER_OPTIONS \
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
-                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
+                $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
         else
             Log $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
                 --no-wildcards-match-slash --one-file-system \
@@ -135,7 +135,7 @@ case "$(basename ${BACKUP_PROG})" in
                 $BACKUP_PROG_CREATE_NEWER_OPTIONS \
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
-                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $SPLIT_COMMAND
+                $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $SPLIT_COMMAND
         fi
 
         if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
@@ -151,7 +151,7 @@ case "$(basename ${BACKUP_PROG})" in
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                                      \
                 "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                               \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f -                                        \
-                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |                              \
+                $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |    \
             { $BACKUP_PROG_CRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV | \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
@@ -160,14 +160,14 @@ case "$(basename ${BACKUP_PROG})" in
                 "$(basename $(echo "$BACKUP_PROG" | awk '{ print $1 }'))"
                 "$(basename $(echo "$SPLIT_COMMAND" | awk '{ print $1 }'))"
             )
-            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
-                --no-wildcards-match-slash --one-file-system                     \
-                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                 \
-                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                \
-                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                    \
-                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                             \
-                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                      \
-                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |            \
+            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose                \
+                --no-wildcards-match-slash --one-file-system                                    \
+                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                                \
+                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                               \
+                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                                   \
+                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                            \
+                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                                     \
+                $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE | \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
         fi
@@ -213,21 +213,21 @@ case "$(basename ${BACKUP_PROG})" in
         mkdir -p $v "$backuparchive" >&2
         Log $BACKUP_PROG --verbose "${BACKUP_RSYNC_OPTIONS[@]}" --one-file-system --delete \
             --exclude-from=$TMP_DIR/backup-exclude.txt --delete-excluded \
-            $(cat $TMP_DIR/backup-include.txt) "$backuparchive"
+            $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) "$backuparchive"
         $BACKUP_PROG --verbose "${BACKUP_RSYNC_OPTIONS[@]}" --one-file-system --delete \
             --exclude-from=$TMP_DIR/backup-exclude.txt --delete-excluded \
-            $(cat $TMP_DIR/backup-include.txt) "$backuparchive" >&2
+            $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) "$backuparchive" >&2
     ;;
     (*)
         Log "Using unsupported backup program '$BACKUP_PROG'"
         Log $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
             $BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
             "${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
-            $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
+            $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
         $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
             $BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
             "${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
-            $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
+            $(without_subsequent_duplicates $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
     ;;
 esac 2> "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log"
 # For the rsync and default case the backup prog is the last in the case entry

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -39,10 +39,7 @@ function unique_unsorted () {
     if test "$filename" ; then
         test -r "$filename" && awk '!seen[$0]++' "$filename" || return 1
     else
-        # Timeout after 5 seconds when there is nothing at STDIN or when STDIN does not get closed
-        # to avoid that 'awk' waits endlessly for (further) input which makes ReaR behave as if it hung up
-        # cf. https://github.com/rear/rear/wiki/Coding-Style#beware-of-the-emptiness
-        timeout 5 awk '!seen[$0]++'
+        awk '!seen[$0]++'
     fi
 }
 

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -14,6 +14,35 @@ function read_and_strip_file () {
     sed -e '/^[[:space:]]/d;/^$/d;/^#/d' "$filename"
 }
 
+# Output lines in STDIN or in a file without subsequent duplicate lines
+# i.e. for each line that was seen (and output) do not output subsequent duplicates of that line.
+# This keeps the ordering of the lines so the input
+#   one
+#   two
+#   one
+#   three
+#   two
+#   one
+# gets output as
+#   one
+#   two
+#   three
+# To remove duplicate lines and keep the ordering one could use ... | cat -n | sort -uk2 | sort -nk1 | cut -f2-
+# cf. https://stackoverflow.com/questions/11532157/remove-duplicate-lines-without-sorting/11532197#11532197
+# that also explains an awk command that prints each line provided the line was not seen before.
+# The awk variable $0 holds an entire line and square brackets is associative array access in awk.
+# For each line the node of the associative array 'seen' is incremented and the line is printed
+# if the content of that node was not '!' previously set (i.e. if the line was not previously seen)
+# cf. https://www.thegeekstuff.com/2010/03/awk-arrays-explained-with-5-practical-examples/
+function without_subsequent_duplicates () {
+    local filename="$1"
+    if test "$filename" ; then
+        test -r "$filename" && awk '!seen[$0]++' "$filename" || return 1
+    else
+        awk '!seen[$0]++'
+    fi
+}
+
 # Three functions to test
 #   if the argument is an integer
 #   if the argument is a positive integer (i.e. test for '> 0')

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -34,7 +34,7 @@ function read_and_strip_file () {
 # For each line the node of the associative array 'seen' is incremented and the line is printed
 # if the content of that node was not '!' previously set (i.e. if the line was not previously seen)
 # cf. https://www.thegeekstuff.com/2010/03/awk-arrays-explained-with-5-practical-examples/
-function without_subsequent_duplicates () {
+function unique_unsorted () {
     local filename="$1"
     if test "$filename" ; then
         test -r "$filename" && awk '!seen[$0]++' "$filename" || return 1

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -37,7 +37,7 @@ function read_and_strip_file () {
 function unique_unsorted () {
     local filename="$1"
     if test "$filename" ; then
-        test -r "$filename" && awk '!seen[$0]++' "$filename" || return 1
+        test -r "$filename" && awk '!seen[$0]++' "$filename"
     else
         awk '!seen[$0]++'
     fi

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -39,7 +39,10 @@ function unique_unsorted () {
     if test "$filename" ; then
         test -r "$filename" && awk '!seen[$0]++' "$filename" || return 1
     else
-        awk '!seen[$0]++'
+        # Timeout after 5 seconds when there is nothing at STDIN or when STDIN does not get closed
+        # to avoid that 'awk' waits endlessly for (further) input which makes ReaR behave as if it hung up
+        # cf. https://github.com/rear/rear/wiki/Coding-Style#beware-of-the-emptiness
+        timeout 5 awk '!seen[$0]++'
     fi
 }
 


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **High**
High impact where needed.
No impact esewhere.

* Reference to related issue (URL):

Triggred by my experiments in
https://github.com/rear/rear/pull/3175
how 'tar' behaves when exact same files or directories
are provided as 'tar' arguments to be archived.

* How was this pull request tested?

See
https://github.com/rear/rear/pull/3175#issuecomment-1985907542
But I did not yet test "rear recover".

* Description of the changes in this pull request:

In lib/global-functions.sh added a
new unique_unsorted() function
that outputs lines in STDIN or in a file
without subsequent duplicate lines
which keeps the ordering of the lines.
