### PR TITLE
#3067 use exit code of nc to check BACULA directory availability

### DIFF
--- a/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
+++ b/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
@@ -12,7 +12,8 @@ fi
 # See if we can ping the director
 #
 # is the director server present? Fetch from $BACULA_CONF_DIR/bconsole.conf file
-BACULA_DIRECTOR=$(grep -i address $BACULA_CONF_DIR/bconsole.conf | awk '{ print $3 }')
+# For issue #3082 collect the BACULA_DIRECTOR in a more error proof way
+BACULA_DIRECTOR=$(grep -i '[[:space:]]address[[:space:]]=' $BACULA_CONF_DIR/bconsole.conf | sed -e 's/[ ]*#.*//' -e 's/[ \t]address[ \t]=[ \t]//')
 [ "${BACULA_DIRECTOR}" ] || Error "Director not defined in $BACULA_CONF_DIR/bconsole.conf"
 
 # check if the director is responding?
@@ -27,7 +28,9 @@ fi
 # and that the director can connect to the file daemon on this system.
 # "Connecting to Director 'director_name-fd:9101'"
 # "Connecting to Client 'bacula_client_name-fd at FQDN:9102"
-BACULA_CLIENT=$(grep $(hostname -s) $BACULA_CONF_DIR/bacula-fd.conf | grep "\-fd" | awk '{print $3}' | sed -e "s/-fd//g")
+# For issue #3082 collect the BACULA_CLIENT in a more error proof way
+BACULA_CLIENT=$(grep -i 'Name[[:space:]]' $BACULA_CONF_DIR/bacula-fd.conf | sed -e 's/[ ]*#.*//' -e 's/[ \t]Name[ \t]=[ \t]//' | cut -d'-' -f1)
+
 [ "${BACULA_CLIENT}" ] || Error "Client $(hostname -s) not defined in $BACULA_CONF_DIR/bacula-fd.conf"
 
 BACULA_RESULT=( $(echo -e " status client=${BACULA_CLIENT}-fd" | bconsole | grep Connect) )

--- a/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
+++ b/usr/share/rear/prep/BACULA/default/500_check_BACULA_bconsole_results.sh
@@ -17,8 +17,8 @@ BACULA_DIRECTOR=$(grep -i address $BACULA_CONF_DIR/bconsole.conf | awk '{ print 
 
 # check if the director is responding?
 if has_binary nc; then
-   DIRECTOR_RESULT=$(nc -vz "${BACULA_DIRECTOR}" 9101 2>&1 | grep -i connected | wc -l)
-   [[ $DIRECTOR_RESULT -eq 0 ]] && Error "Bacula director ${BACULA_DIRECTOR} is not responding."
+   DIRECTOR_RESULT=$(nc -vz "${BACULA_DIRECTOR}" 9101 2>&1 ; echo $?)
+   [[ $DIRECTOR_RESULT -ne 0 ]] && Error "Bacula director ${BACULA_DIRECTOR} is not responding."
 fi
 
 # does the director allow connections from this client? bconsole knows!


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
#3067 
#3082

* How was this pull request tested? Not yet - requested it via issue #3067 

* Description of the changes in this pull request:
`ERROR: Bacula director debian11-DR6 is not responding` - purpose is to have a simple test to verify to Bacula connector is responsive or not.
