### PR TITLE
Set GRUB2_IMAGE_FORMAT correctly in prep/Linux-i386/330_set_efi_arch.sh

### DIFF
--- a/usr/share/rear/prep/Linux-i386/330_set_efi_arch.sh
+++ b/usr/share/rear/prep/Linux-i386/330_set_efi_arch.sh
@@ -2,21 +2,27 @@
 # Set EFI architecture, used as suffix for various files in the ESP
 # See https://github.com/rhboot/shim/blob/main/Make.defaults
 
-# Se the variables even if USING_UEFI_BOOTLOADER empty or no explicit 'true' value
+# Set the variables even if USING_UEFI_BOOTLOADER empty or no explicit 'true' value
+# which sets GRUB2_IMAGE_FORMAT (used as argument for 'grub-mkstandalone -O ...')
+# to a value for EFI systems ('x86_64-efi' or 'i386-efi') also on BIOS systems
+# but that does not matter for now because currently GRUB2_IMAGE_FORMAT
+# is only used in case of EFI in the scripts lib/uefi-functions.sh
+# and output/RAWDISK/Linux-i386/270_create_grub2_efi_bootloader.sh
+# see https://github.com/rear/rear/pull/3157
+# and https://github.com/rear/rear/issues/3191
 
 case "$REAL_MACHINE" in
-    # cf. the seting of REAL_MACHINE and MACHINE in default.conf
+    # cf. the seting of REAL_MACHINE ('uname -m') and MACHINE in default.conf
     (i686|i586|i386)
         # all these behave exactly like i386.
         # ia32 is another name for i386, used by EFI
         # (but ia64 is not x86_64 aka amd64, it is the architecture of Itanium)
         EFI_ARCH=ia32
-        # argument for grub2-mkstandalone -O ...
-        GRUB2_IMAGE_FORMAT=x86_64-efi
+        GRUB2_IMAGE_FORMAT=i386-efi
         ;;
     (x86_64)
         EFI_ARCH=x64
-        GRUB2_IMAGE_FORMAT=i386-efi
+        GRUB2_IMAGE_FORMAT=x86_64-efi
         ;;
     (*)
         BugError "Unknown architecture $REAL_MACHINE"


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3191

* How was this pull request tested?
https://github.com/rear/rear/issues/3191#issue-2223294278

* Description of the changes in this pull request:

In prep/Linux-i386/330_set_efi_arch.sh
set GRUB2_IMAGE_FORMAT=i386-efi
in case of i686|i586|i386
and
set GRUB2_IMAGE_FORMAT=x86_64-efi
in case of x86_64

Additionally describe current GRUB2_IMAGE_FORMAT usage
only in case of EFI so that currently it does not matter
when GRUB2_IMAGE_FORMAT is set to a value for EFI systems
also on BIOS systems, cf.
https://github.com/rear/rear/issues/3191#issuecomment-2036618057