### PR TITLE
Fix swapped image formats in 330_set_efi_arch.sh

### DIFF
--- a/usr/share/rear/prep/Linux-i386/330_set_efi_arch.sh
+++ b/usr/share/rear/prep/Linux-i386/330_set_efi_arch.sh
@@ -12,11 +12,11 @@ case "$REAL_MACHINE" in
         # (but ia64 is not x86_64 aka amd64, it is the architecture of Itanium)
         EFI_ARCH=ia32
         # argument for grub2-mkstandalone -O ...
-        GRUB2_IMAGE_FORMAT=x86_64-efi
+        GRUB2_IMAGE_FORMAT=i386-efi
         ;;
     (x86_64)
         EFI_ARCH=x64
-        GRUB2_IMAGE_FORMAT=i386-efi
+        GRUB2_IMAGE_FORMAT=x86_64-efi
         ;;
     (*)
         BugError "Unknown architecture $REAL_MACHINE"


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): #3195 

* How was this pull request tested? I tested it locally.  It fixed the error I was receiving in #3195.

* Description of the changes in this pull request: It looks like the programmer just mixed up the two grub2 image types.  This commit swaps them.

