### PR TITLE
Better describe OUTPUT_PREFIX and NETFS_PREFIX

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -877,6 +877,8 @@ OUTPUT_URL_FILES_PATTERNS=()
 OUTPUT_OPTIONS=
 OUTPUT_MOUNTCMD=
 OUTPUT_UMOUNTCMD=
+# The directory that is created at the output location to store the RESULT_FILES therein.
+# For example OUTPUT_PREFIX specifies the prefix directory of a rescue/recovery system ISO image:
 OUTPUT_PREFIX="$HOSTNAME"
 ####
 
@@ -2883,8 +2885,11 @@ BACKUP_DUPLICITY_NAME="rear-backup"
 # cf. https://github.com/rear/rear/issues/1532#issuecomment-336810460
 # so that it is an error to use BACKUP=NETFS without a BACKUP_URL.
 #
-# Prefix directory to create under the network filesystem share:
-NETFS_PREFIX="$HOSTNAME"
+# Prefix directory to create under the network filesystem share to store the NETFS backup.
+# By default NETFS_PREFIX is same as OUTPUT_PREFIX to store for example with BACKUP_PROG=tar the backup.tar.gz
+# at the same place where for example with OUTPUT=ISO the rescue/recovery system ISO image gets stored
+# in particular when OUTPUT_URL is not specified so OUTPUT_URL inherits the BACKUP_URL value:
+NETFS_PREFIX="$OUTPUT_PREFIX"
 #
 # Keep an older copy of the backup (mv $NETFS_PREFIX $NETFS_PREFIX.old before we copy the new version)
 # empty means only keep current backup:


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **None**

No default should change.

* Reference to related issue (URL):

No GitHub issue.

A colleague asked me how to get backup.tar.gz
and the ISO and all other RESULT_FILES
in the same directory that is not $HOSTNAME.

I had to somewhat reverse engineer things to find out how
because this is basically not described in default.conf.

* How was this pull request tested?

I did not yet test that this pull request
does not change anything.

I had only tested that with
```
OUTPUT=ISO
OUTPUT_PREFIX="my_prefix"
NETFS_PREFIX="$OUTPUT_PREFIX"
BACKUP=NETFS
BACKUP_URL=file:///other/
```
backup.tar.gz and the ISO and all other RESULT_FILES
get stored in the same "my_prefix" directory.

* Description of the changes in this pull request:

In default.conf better descriptions
for OUTPUT_PREFIX and NETFS_PREFIX
(OUTPUT_PREFIX was not at all described)
plus explanation how OUTPUT_PREFIX and NETFS_PREFIX
belong to each other for the usual case
OUTPUT=ISO and BACKUP=NETFS
and made it explicit that by default
```
NETFS_PREFIX="$OUTPUT_PREFIX"
```
to get backup.tar.gz and ISO image stored at the same place.
