### PR TITLE
Portable recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ else
 RUNASUSER :=
 endif
 
-tarparams = --exclude-from=.gitignore --exclude=.gitignore --exclude=".??*" $(DIST_CONTENT)
+# .gitignore is optional, avoid tar errors if it does not exist, e.g. in a dist archive
+tarparams = $(shell test -f .gitignore && echo --exclude-from=.gitignore --exclude=.gitignore) --exclude=".??*" $(DIST_CONTENT)
 
 DIST_FILES := $(shell tar -cv -f /dev/null $(tarparams))
 
@@ -165,10 +166,10 @@ install-config:
 install-bin:
 	@echo -e "\033[1m== Installing binary ==\033[0;0m"
 	install -Dp -m0755 $(rearbin) $(DESTDIR)$(sbindir)/rear
-	sed -i -e 's,^CONFIG_DIR=.*,CONFIG_DIR="$(sysconfdir)/rear",' \
-		-e 's,^SHARE_DIR=.*,SHARE_DIR="$(datadir)/rear",' \
-		-e 's,^VAR_DIR=.*,VAR_DIR="$(localstatedir)/lib/rear",' \
-		-e 's,^LOG_DIR=.*,LOG_DIR="$(localstatedir)/log/rear",' \
+	sed -i -e 's,^CONFIG_DIR=.*,CONFIG_DIR="$$REAR_DIR_PREFIX$(sysconfdir)/rear",' \
+		-e 's,^SHARE_DIR=.*,SHARE_DIR="$$REAR_DIR_PREFIX$(datadir)/rear",' \
+		-e 's,^VAR_DIR=.*,VAR_DIR="$$REAR_DIR_PREFIX$(localstatedir)/lib/rear",' \
+		-e 's,^LOG_DIR=.*,LOG_DIR="$$REAR_DIR_PREFIX$(localstatedir)/log/rear",' \
 		$(DESTDIR)$(sbindir)/rear
 
 install-data:

--- a/README.adoc
+++ b/README.adoc
@@ -217,24 +217,27 @@ To use Relax-and-Recover you always call the main script '/usr/sbin/rear':
 ----
 # rear help
 
-Usage: rear [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-C CONFIG] [-r KERNEL] [-n|--non-interactive] [--] COMMAND [ARGS...]
+Usage: rear [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-C CONFIG] [-r KERNEL] [-n|--non-interactive] [-e|--expose-secrets] [-p|--portable] [--] COMMAND [ARGS...]
 
 Relax-and-Recover comes with ABSOLUTELY NO WARRANTY; for details see
 the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 Available options:
- -h --help              usage information
- -c DIR                 alternative config directory; instead of /etc/rear
- -C CONFIG              additional config file; absolute path or relative to config directory
- -d                     debug mode; log debug messages
- -D                     debugscript mode; log every function call (via 'set -x')
+ -h --help              usage information (this text)
+ -c DIR                 alternative config directory; instead of /src/rear/etc/rear
+ -C CONFIG              additional config files; absolute path or relative to config directory
+ -d                     debug mode; run many commands verbosely with debug messages in log file (also sets -v)
+ -D                     debugscript mode; log executed commands via 'set -x' (also sets -v and -d)
  --debugscripts SET     same as -d -v -D but debugscript mode with 'set -SET'
- -r KERNEL              kernel version to use; current: '3.12.49-3-default'
- -s                     simulation mode; show what scripts rear would include
+ -r KERNEL              kernel version to use; currently '5.15.0-204.147.6.3.el9uek.x86_64'
+ -s                     simulation mode; show what scripts are run (without executing them)
  -S                     step-by-step mode; acknowledge each script individually
- -v                     verbose mode; show more output
- -V --version           version information
+ -v                     verbose mode; show messages what Relax-and-Recover is doing on the terminal or show verbose help
  -n --non-interactive   non-interactive mode; aborts when any user input is required (experimental)
+ -e --expose-secrets    do not suppress output of confidential values (passwords, encryption keys) in particular in the log file
+ -p --portable          allow running any ReaR workflow, especially recover, from a git checkout or rear source archive
+ -V --version           version information
+
 
 List of commands:
  checklayout     check if the disk layout has changed
@@ -249,7 +252,6 @@ List of commands:
  recover         recover the system
  restoreonly     only restore the backup
  validate        submit validation information
-
 Use 'rear -v help' for more advanced commands.
 ----
 

--- a/doc/rear.8
+++ b/doc/rear.8
@@ -1,195 +1,217 @@
 '\" t
 .\"     Title: rear
-.\"    Author: [see the "AUTHORS" section]
-.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 09 June 2022
+.\"    Author: [see the "AUTHOR(S)" section]
+.\" Generator: Asciidoctor 2.0.16
+.\"      Date: 2024-04-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "REAR" "8" "09 June 2022" "\ \&" "\ \&"
-.\" -----------------------------------------------------------------
-.\" * Define some portability stuff
-.\" -----------------------------------------------------------------
-.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.\" http://bugs.debian.org/507673
-.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
-.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.TH "REAR" "8" "2024-04-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
-.\" -----------------------------------------------------------------
-.\" * set default formatting
-.\" -----------------------------------------------------------------
-.\" disable hyphenation
+.ss \n[.ss] 0
 .nh
-.\" disable justification (adjust text to left margin only)
 .ad l
-.\" -----------------------------------------------------------------
-.\" * MAIN CONTENT STARTS HERE *
-.\" -----------------------------------------------------------------
+.de URL
+\fI\\$2\fP <\\$1>\\$3
+..
+.als MTO URL
+.if \n[.g] \{\
+.  mso www.tmac
+.  am URL
+.    ad l
+.  .
+.  am MTO
+.    ad l
+.  .
+.  LINKSTYLE blue R < >
+.\}
 .SH "NAME"
 rear \- bare metal disaster recovery and system migration tool
 .SH "SYNOPSIS"
 .sp
-\fBrear\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-dsSv\fR] [\fB\-D\fR|\fB\-\-debugscripts\fR \fISET\fR] [\fB\-c\fR \fIDIR\fR] [\fB\-C\fR \fICONFIG\fR] [\fB\-r\fR \fIKERNEL\fR] [\fB\-n\fR|\fB\-\-non\-interactive\fR] [\fB\-e\fR|\fB\-\-expose\-secrets\fR] [\-\-] \fICOMMAND\fR [\fIARGS\fR\&...]
+\fBrear\fP [\fB\-h\fP|\fB\-\-help\fP] [\fB\-V\fP|\fB\-\-version\fP] [\fB\-dsSv\fP] [\fB\-D\fP|\fB\-\-debugscripts\fP \fISET\fP] [\fB\-c\fP \fIDIR\fP] [\fB\-C\fP \fICONFIG\fP] [\fB\-r\fP \fIKERNEL\fP] [\fB\-n\fP|\fB\-\-non\-interactive\fP] [\fB\-e\fP|\fB\-\-expose\-secrets\fP] [\-\-] \fICOMMAND\fP [\fIARGS\fP...]
 .SH "DESCRIPTION"
 .sp
-Relax\-and\-Recover (abbreviated ReaR) is the leading Open Source disaster recovery solution\&. It is a modular framework with many ready\-to\-go workflows for common situations\&.
+Relax\-and\-Recover (abbreviated ReaR) is the leading Open Source disaster recovery solution.
+It is a modular framework with many ready\-to\-go workflows for common situations.
 .sp
-Relax\-and\-Recover produces a bootable image\&. This image can repartition the system\&. Once that is done it initiates a restore from backup\&. Restores to different hardware are possible\&. Relax\-and\-Recover can therefore be used as a migration tool as well\&.
+Relax\-and\-Recover produces a bootable image. This image can repartition the
+system. Once that is done it initiates a restore from backup. Restores to
+different hardware are possible. Relax\-and\-Recover can therefore be used as a
+migration tool as well.
 .sp
-Currently Relax\-and\-Recover supports various boot media (incl\&. ISO, PXE, OBDR tape, USB or eSATA storage), a variety of network protocols (incl\&. sftp, ftp, http, nfs, cifs) for storage and backup as well as a multitude of backup strategies (incl\&. IBM Tivoli Storage Manager, MircoFocus Data Protector, Symantec NetBackup, EMC NetWorker, EMC Avamar, FDR/Upstream, NovaStor DC, Rubrik Cloud Data Management (CDM), Bareos, Bacula, rsync, rbme, Borg)\&. This results in a bootable image that is capable of booting via PXE, DVD/CD, bootable tape or virtual provisioning\&.
+Currently Relax\-and\-Recover supports various boot media (incl. ISO, PXE,
+OBDR tape, USB or eSATA storage), a variety of network protocols (incl.
+sftp, ftp, http, nfs, cifs) for storage and backup as well as a multitude
+of backup strategies (incl.  IBM Tivoli Storage Manager, MircoFocus Data Protector,
+Symantec NetBackup, EMC NetWorker, EMC Avamar, FDR/Upstream, NovaStor DC, Rubrik Cloud Data Management (CDM),
+Bareos, Bacula, rsync, rbme, Borg). This results in a bootable image that is capable of
+booting via PXE, DVD/CD, bootable tape or virtual provisioning.
 .sp
-Relax\-and\-Recover was designed to be easy to set up, requires no maintenance and is there to assist when disaster strikes\&. Its setup\-and\-forget nature removes any excuses for not having a disaster recovery solution implemented\&.
+Relax\-and\-Recover was designed to be easy to set up, requires no maintenance
+and is there to assist when disaster strikes. Its setup\-and\-forget nature
+removes any excuses for not having a disaster recovery solution implemented.
 .sp
-Recovering from disaster is made very straight\-forward by a 2\-step recovery process so that it can be executed by operational teams when required\&. When used interactively (e\&.g\&. when used for migrating systems), menus help make decisions to restore to a new (hardware) environment\&.
+Recovering from disaster is made very straight\-forward by a 2\-step recovery
+process so that it can be executed by operational teams when required.
+When used interactively (e.g. when used for migrating systems), menus help
+make decisions to restore to a new (hardware) environment.
 .sp
-Extending Relax\-and\-Recover is made possible by its modular framework\&. Consistent logging and optionally extended output help understand the concepts behind Relax\-and\-Recover and help debug during development\&.
+Extending Relax\-and\-Recover is made possible by its modular framework.
+Consistent logging and optionally extended output help understand the concepts
+behind Relax\-and\-Recover and help debug during development.
 .sp
-Relax\-and\-Recover comes with ABSOLUTELY NO WARRANTY; for details see the GNU General Public License at: \m[blue]\fBhttp://www\&.gnu\&.org/licenses/gpl\&.html\fR\m[]
+Relax\-and\-Recover comes with ABSOLUTELY NO WARRANTY; for details see
+the GNU General Public License at: \c
+.URL "http://www.gnu.org/licenses/gpl.html" "" ""
 .SH "OPTIONS"
 .SS "GLOBAL OPTIONS"
-.PP
+.sp
 \-h \-\-help
 .RS 4
 usage information
 .RE
-.PP
+.sp
 \-c DIR
 .RS 4
 alternative config directory instead of /etc/rear
 .RE
-.PP
+.sp
 \-C CONFIG
 .RS 4
 additional config files (absolute path or relative to config directory)
 .RE
-.PP
+.sp
 \-d
 .RS 4
-\fBdebug mode\fR: run many commands verbosely with debug messages in the log file (also sets \-v)
+\fBdebug mode\fP: run many commands verbosely with debug messages in the log file (also sets \-v)
 .RE
-.PP
+.sp
 \-D
 .RS 4
-\fBdebugscript mode\fR: log executed commands via
-\fIset \-x\fR
-(also sets \-v and \-d)
+\fBdebugscript mode\fP: log executed commands via \*(Aqset \-x\*(Aq (also sets \-v and \-d)
 .RE
-.PP
+.sp
 \-\-debugscripts SET
 .RS 4
-same as \-D but
-\fBdebugscript mode\fR
-with
-\fIset \-SET\fR
+same as \-D but \fBdebugscript mode\fP with \*(Aqset \-SET\*(Aq
 .RE
-.PP
+.sp
 \-r KERNEL
 .RS 4
 kernel version to use (by default the version of the running kernel)
 .RE
-.PP
+.sp
 \-s
 .RS 4
-\fBsimulation mode\fR: show what scripts are run without executing them
+\fBsimulation mode\fP: show what scripts are run without executing them
 .RE
-.PP
+.sp
 \-S
 .RS 4
-\fBstep\-by\-step mode\fR: acknowledge each script individually
+\fBstep\-by\-step mode\fP: acknowledge each script individually
 .RE
-.PP
+.sp
 \-v
 .RS 4
-\fBverbose mode\fR: show messages what ReaR is doing on the terminal
+\fBverbose mode\fP: show messages what ReaR is doing on the terminal
 .RE
-.PP
+.sp
 \-n \-\-non\-interactive
 .RS 4
-\fBnon\-interactive mode\fR: abort in UserInput() if default input does not make ReaR proceed (experimental)
+\fBnon\-interactive mode\fP: abort in UserInput() if default input does not make ReaR proceed (experimental)
 .RE
-.PP
+.sp
 \-e \-\-expose\-secrets
 .RS 4
 do not suppress output of confidential values (passwords, encryption keys) in particular in the log file
 .RE
-.PP
+.sp
+\-p \-\-portable
+.RS 4
+allow running any ReaR workflow, especially recover, from a git checkout or rear source archive
+.RE
+.sp
 \-V \-\-version
 .RS 4
 version information
 .RE
 .SS "COMMANDS"
-.PP
-\fBchecklayout\fR
+.sp
+\fBchecklayout\fP
 .RS 4
-check if the disk layout has changed since the last run of mkbackup/mkrescue
+check if the disk layout has changed since the last run of
+mkbackup/mkrescue
 .RE
-.PP
-\fBdump\fR
+.sp
+\fBdump\fP
 .RS 4
-dump configuration and system information; run this to verify your setup
+dump configuration and system information; run this to verify
+your setup
 .RE
-.PP
-\fBformat\fR
+.sp
+\fBformat\fP
 .RS 4
-format and label USB or tape media to be used with rear; first argument is the USB or tape device to use, eg\&.
-\fI/dev/sdX\fR
-or
-\fI/dev/stX\fR
+format and label USB or tape media to be used with rear;
+first argument is the USB or tape device to use, eg. \fI/dev/sdX\fP or
+\fI/dev/stX\fP
 .RE
-.PP
-\fBhelp\fR
+.sp
+\fBhelp\fP
 .RS 4
 print full list of commands and options
 .RE
-.PP
-\fBmkbackup\fR
+.sp
+\fBmkbackup\fP
 .RS 4
-create rescue media and backup the system (only for internal backup methods)
+create rescue media and backup the system (only for internal backup
+methods)
 .RE
-.PP
-\fBmkbackuponly\fR
+.sp
+\fBmkbackuponly\fP
 .RS 4
-backup the system (only for internal backup methods) without creating rescue media
+backup the system (only for internal backup methods) without creating
+rescue media
 .RE
-.PP
-\fBmkrescue\fR
+.sp
+\fBmkrescue\fP
 .RS 4
 create rescue media only
 .RE
-.PP
-\fBmountonly\fR
+.sp
+\fBmountonly\fP
 .RS 4
 use ReaR as live media to mount and repair the system
 .RE
-.PP
-\fBrecover\fR
+.sp
+\fBrecover\fP
 .RS 4
 recover the system; can be used only when running from the rescue media
 .RE
-.PP
-\fBrestoreonly\fR
+.sp
+\fBrestoreonly\fP
 .RS 4
 only restore the backup; can be used only when running from the rescue media
 .RE
-.PP
-\fBmkopalpba\fR
+.sp
+\fBmkopalpba\fP
 .RS 4
 create a pre\-boot authentication (PBA) image to boot from TCG Opal 2\-compliant self\-encrypting disks
 .RE
-.PP
-\fBopaladmin\fR
+.sp
+\fBopaladmin\fP
 .RS 4
 administrate TCG Opal 2\-compliant self\-encrypting disks
 .RE
-.PP
-\fBvalidate\fR
+.sp
+\fBvalidate\fP
 .RS 4
 submit validation information
 .RE
 .sp
-Use \fIrear \-v help\fR for more advanced commands\&.
+Use \*(Aqrear \-v help\*(Aq for more advanced commands.
 .SH "BACKGROUND INFORMATION"
 .sp
 The process of bare metal disaster recovery consists of two parts:
@@ -199,8 +221,8 @@ The process of bare metal disaster recovery consists of two parts:
 \h'-04'\(bu\h'+03'\c
 .\}
 .el \{\
-.sp -1
-.IP \(bu 2.3
+.  sp -1
+.  IP \(bu 2.3
 .\}
 Recreate the system layout
 .RE
@@ -210,60 +232,71 @@ Recreate the system layout
 \h'-04'\(bu\h'+03'\c
 .\}
 .el \{\
-.sp -1
-.IP \(bu 2.3
+.  sp -1
+.  IP \(bu 2.3
 .\}
 Restore the data to the system
 .RE
 .sp
-Most backup software solutions are very good at restoring data but do not support recreating the system layout\&. Relax\-and\-Recover is very good at recreating the system layout but works best when used together with supported backup software\&.
+Most backup software solutions are very good at restoring data but do not
+support recreating the system layout. Relax\-and\-Recover is very good at
+recreating the system layout but works best when used together with
+supported backup software.
 .sp
-In this combination Relax\-and\-Recover recreates the system layout and calls the backup software to restore the actual data\&. Thus there is no unnecessary duplicate data storage and the Relax\-and\-Recover rescue media can be very small\&.
+In this combination Relax\-and\-Recover recreates the system layout and calls
+the backup software to restore the actual data. Thus there is no unnecessary
+duplicate data storage and the Relax\-and\-Recover rescue media can be very small.
 .sp
-For demonstration and special use purposes Relax\-and\-Recover also includes an internal backup method, NETFS, which can be used to create a simple tar\&.gz archive of the system\&. For all permanent setups we recommend using something more professional for backup, either a traditional backup software (open source or commercial) or rsync with hardlink based solutions, e\&.g\&. RSYNC BACKUP MADE EASY\&.
+For demonstration and special use purposes Relax\-and\-Recover also includes
+an internal backup method, NETFS, which can be used to create a simple tar.gz
+archive of the system. For all permanent setups we recommend using something
+more professional for backup, either a traditional backup software (open
+source or commercial) or rsync with hardlink based solutions, e.g. RSYNC
+BACKUP MADE EASY.
 .SH "RESCUE IMAGE CONFIGURATION"
 .sp
-The OUTPUT variable defines from where our bootable rescue image will be booted and the OUTPUT_URL variable defines where the rescue image should be send to\&. Possible OUTPUT settings are:
-.PP
-OUTPUT=\fBRAMDISK\fR
+The OUTPUT variable defines from where our bootable rescue image will be
+booted and the OUTPUT_URL variable defines where the rescue image should be
+send to. Possible OUTPUT settings are:
+.sp
+OUTPUT=\fBRAMDISK\fP
 .RS 4
-Create only the Relax\-and\-Recover initramfs\&.
+Create only the Relax\-and\-Recover initramfs.
 .RE
-.PP
-OUTPUT=\fBISO\fR
+.sp
+OUTPUT=\fBISO\fP
 .RS 4
-\fB(Default)\fR
-Create a bootable ISO9660 image on disk as
-\fIrear\-$(hostname)\&.iso\fR
+\fB(Default)\fP Create a bootable ISO9660 image on disk as \fIrear\-$(hostname).iso\fP
 .RE
-.PP
-OUTPUT=\fBPXE\fR
+.sp
+OUTPUT=\fBPXE\fP
 .RS 4
-Create on a remote PXE/NFS server the required files (such as configuration file, kernel and initrd image)
+Create on a remote PXE/NFS server the required files (such as
+configuration file, kernel and initrd image)
 .RE
-.PP
-OUTPUT=\fBOBDR\fR
+.sp
+OUTPUT=\fBOBDR\fP
 .RS 4
-Create a bootable OBDR tape (optionally including the backup archive)\&. Specify the OBDR tape device by using
-TAPE_DEVICE\&.
+Create a bootable OBDR tape (optionally including the backup archive).
+Specify the OBDR tape device by using TAPE_DEVICE.
 .RE
-.PP
-OUTPUT=\fBUSB\fR
+.sp
+OUTPUT=\fBUSB\fP
 .RS 4
-Create a bootable USB disk\&.
+Create a bootable USB disk.
 .RE
-.PP
-OUTPUT=\fBRAWDISK\fR
+.sp
+OUTPUT=\fBRAWDISK\fP
 .RS 4
-Create a bootable image file named "rear\-$(hostname)\&.raw\&.gz", which
+Create a bootable image file named "rear\-$(hostname).raw.gz", which
 .sp
 .RS 4
 .ie n \{\
 \h'-04'\(bu\h'+03'\c
 .\}
 .el \{\
-.sp -1
-.IP \(bu 2.3
+.  sp -1
+.  IP \(bu 2.3
 .\}
 supports UEFI boot if syslinux/EFI or Grub 2/EFI is installed,
 .RE
@@ -273,8 +306,8 @@ supports UEFI boot if syslinux/EFI or Grub 2/EFI is installed,
 \h'-04'\(bu\h'+03'\c
 .\}
 .el \{\
-.sp -1
-.IP \(bu 2.3
+.  sp -1
+.  IP \(bu 2.3
 .\}
 supports Legacy BIOS boot if syslinux is installed,
 .RE
@@ -284,423 +317,407 @@ supports Legacy BIOS boot if syslinux is installed,
 \h'-04'\(bu\h'+03'\c
 .\}
 .el \{\
-.sp -1
-.IP \(bu 2.3
+.  sp -1
+.  IP \(bu 2.3
 .\}
-supports UEFI/Legacy BIOS dual boot if syslinux
-\fBand\fR
-one of the supported EFI bootloaders are installed\&.
+supports UEFI/Legacy BIOS dual boot if syslinux \fBand\fP one of the supported EFI
+bootloaders are installed.
 .RE
 .RE
 .sp
-When using OUTPUT=ISO, RAMDISK, OBDR, USB, or RAWDISK you should provide the backup target location through the OUTPUT_URL variable\&. Possible OUTPUT_URL settings are:
-.PP
-OUTPUT_URL=\fBfile://\fR
+OUTPUT=\fBPORTABLE\fP
 .RS 4
-Write the image to disk\&. The default is in
-\fI/var/lib/rear/output/\fR\&.
-.RE
-.PP
-OUTPUT_URL=\fBnfs://\fR
-.RS 4
-Write the image by mounting the target filesystem via NFS\&.
-.RE
-.PP
-OUTPUT_URL=\fBcifs://\fR
-.RS 4
-Write the image by mounting the target filesystem via CIFS\&.
-.RE
-.PP
-OUTPUT_URL=\fBfish://\fR
-.RS 4
-Write the image using
-lftp
-and the FISH protocol\&.
-.RE
-.PP
-OUTPUT_URL=\fBftp://\fR
-.RS 4
-Write the image using
-lftp
-and the FTP protocol\&.
-.RE
-.PP
-OUTPUT_URL=\fBftps://\fR
-.RS 4
-Write the image using
-lftp
-and the FTPS protocol\&.
-.RE
-.PP
-OUTPUT_URL=\fBhftp://\fR
-.RS 4
-Write the image using
-lftp
-and the HFTP protocol\&.
-.RE
-.PP
-OUTPUT_URL=\fBhttp://\fR
-.RS 4
-Write the image using
-lftp
-and the HTTP (PUT) procotol\&.
-.RE
-.PP
-OUTPUT_URL=\fBhttps://\fR
-.RS 4
-Write the image using
-lftp
-and the HTTPS (PUT) protocol\&.
-.RE
-.PP
-OUTPUT_URL=\fBsftp://\fR
-.RS 4
-Write the image using
-lftp
-and the secure FTP (SFTP) protocol\&.
-.RE
-.PP
-OUTPUT_URL=\fBrsync://\fR
-.RS 4
-Write the image using
-rsync
-and the RSYNC protocol\&.
-.RE
-.PP
-OUTPUT_URL=\fBsshfs://\fR
-.RS 4
-Write the image using sshfs and the SSH protocol\&.
-.RE
-.PP
-OUTPUT_URL=\fBnull\fR
-.RS 4
-Do not copy the rescue image from
-\fI/var/lib/rear/output/\fR
-to a remote output location\&.
-OUTPUT_URL=null
-is useful when another program (e\&.g\&. an
-\fIexternal\fR
-backup program) is used to save the rescue image from the local system to a remote place, or with
-BACKUP_URL=iso:///backup
-when the backup is included in the rescue image to avoid a (big) copy of the rescue image at a remote output location\&. In the latter case the rescue image must be manually saved from the local system to a remote place\&.
-OUTPUT_URL=null
-is only supported together with
-BACKUP=NETFS\&.
+Create a portable ReaR archive that can be used on any rescue system to run
+any ReaR workflow, especially recover. Assumes that all required software is
+installed and usable there. This is experimental, please report any issues.
 .RE
 .sp
-If you do not specify OUTPUT_URL variable then by default it will be aligned to what was defined by variable BACKUP_URL\&. And, the rescue image will then be copied to the same location as your backup of the system disk(s)\&.
+When using OUTPUT=ISO, RAMDISK, OBDR, USB, PORTABLE or RAWDISK you should
+provide the backup target location through the OUTPUT_URL variable. Possible
+OUTPUT_URL settings are:
 .sp
-The ISO_DEFAULT variable defines what default boot option is used on the rescue image\&. Possible values are manual, boothd or automatic\&. Manual will make you boot into the shell directly by default, boothd will boot to the first disk (default) or automatic will automatically start in recovery mode\&.
+OUTPUT_URL=\fBfile://\fP
+.RS 4
+Write the image to disk. The default is in \fI/var/lib/rear/output/\fP.
+.RE
+.sp
+OUTPUT_URL=\fBnfs://\fP
+.RS 4
+Write the image by mounting the target filesystem via NFS.
+.RE
+.sp
+OUTPUT_URL=\fBcifs://\fP
+.RS 4
+Write the image by mounting the target filesystem via CIFS.
+.RE
+.sp
+OUTPUT_URL=\fBfish://\fP
+.RS 4
+Write the image using lftp and the FISH protocol.
+.RE
+.sp
+OUTPUT_URL=\fBftp://\fP
+.RS 4
+Write the image using lftp and the FTP protocol.
+.RE
+.sp
+OUTPUT_URL=\fBftps://\fP
+.RS 4
+Write the image using lftp and the FTPS protocol.
+.RE
+.sp
+OUTPUT_URL=\fBhftp://\fP
+.RS 4
+Write the image using lftp and the HFTP protocol.
+.RE
+.sp
+OUTPUT_URL=\fBhttp://\fP
+.RS 4
+Write the image using lftp and the HTTP (PUT) procotol.
+.RE
+.sp
+OUTPUT_URL=\fBhttps://\fP
+.RS 4
+Write the image using lftp and the HTTPS (PUT) protocol.
+.RE
+.sp
+OUTPUT_URL=\fBsftp://\fP
+.RS 4
+Write the image using lftp and the secure FTP (SFTP) protocol.
+.RE
+.sp
+OUTPUT_URL=\fBrsync://\fP
+.RS 4
+Write the image using rsync and the RSYNC protocol.
+.RE
+.sp
+OUTPUT_URL=\fBsshfs://\fP
+.RS 4
+Write the image using sshfs and the SSH protocol.
+.RE
+.sp
+OUTPUT_URL=\fBnull\fP
+.RS 4
+Do not copy the rescue image from \fI/var/lib/rear/output/\fP to a remote output location.
+OUTPUT_URL=null is useful when another program (e.g. an \fIexternal\fP backup program)
+is used to save the rescue image from the local system to a remote place,
+or with BACKUP_URL=iso:///backup when the backup is included in the rescue image
+to avoid a (big) copy of the rescue image at a remote output location.
+In the latter case the rescue image must be manually saved from the local system to a remote place.
+OUTPUT_URL=null is only supported together with BACKUP=NETFS.
+.RE
+.sp
+If you do not specify OUTPUT_URL variable then by default it will be aligned to what
+was defined by variable BACKUP_URL. And, the rescue image will then be copied to the same
+location as your backup of the system disk(s).
+.sp
+The ISO_DEFAULT variable defines what default boot option is used on the rescue image.
+Possible values are \f(CRmanual\fP, \f(CRboothd\fP or \f(CRautomatic\fP. Manual will make you boot into
+the shell directly by default, boothd will boot to the first disk (default) or automatic
+will automatically start in recovery mode.
 .SH "RESCUE IMAGE KERNEL COMMAND LINE OPTIONS"
 .sp
-When booting the rescue image you can edit the kernel command line\&. There are some Relax\-and\-Recover specific kernel command line options:
-.PP
-\fBdebug\fR
+When booting the rescue image you can edit the kernel command line.
+There are some Relax\-and\-Recover specific kernel command line options:
+.sp
+\fBdebug\fP
 .RS 4
-The rescue system start up scripts in /etc/scripts/system\-setup\&.d/ are run one by one each one after pressing
-\fIEnter\fR
-and the scripts are run with
-\fIset \-x\fR
-which prints commands and their arguments as they are executed\&.
-.RE
-.PP
-\fBauto_recover\fR or \fBautomatic\fR
-.RS 4
-Launch
-\fIrear recover\fR
-automatically (without automated reboot)\&. Together with
-\fIdebug\fR
-it runs
-\fIrear recover\fR
-in debugscript mode\&.
-.RE
-.PP
-\fBunattended\fR
-.RS 4
-Launch
-\fIrear recover\fR
-automatically as with
-\fIauto_recover\fR
-plus automated reboot after successful
-\fIrear recover\fR\&.
-.RE
-.PP
-\fBip= nm= netdev= gw=\fR
-.RS 4
-When IP address plus optionally netmask (default 255\&.255\&.255\&.0), network device (default eth0), and default gateway are specified, then only that single network device is set up\&. Example:
+The rescue system start up scripts in /etc/scripts/system\-setup.d/
+are run one by one each one after pressing \*(AqEnter\*(Aq and
+the scripts are run with \*(Aqset \-x\*(Aq which prints commands
+and their arguments as they are executed.
 .RE
 .sp
-.if n \{\
+\fBauto_recover\fP or \fBautomatic\fP
 .RS 4
-.\}
-.nf
-ip=192\&.168\&.100\&.2 nm=255\&.255\&.255\&.0 netdev=eth0 gw=192\&.168\&.100\&.1
-.fi
-.if n \{\
+Launch \*(Aqrear recover\*(Aq automatically (without automated reboot).
+Together with \*(Aqdebug\*(Aq it runs \*(Aqrear recover\*(Aq in debugscript mode.
 .RE
-.\}
-.PP
-\fBnoip\fR
+.sp
+\fBunattended\fP
 .RS 4
-Skip network devices setup by the rescue system start up scripts (overrides ip= nm= netdev= gw=)\&.
+Launch \*(Aqrear recover\*(Aq automatically as with \*(Aqauto_recover\*(Aq
+plus automated reboot after successful \*(Aqrear recover\*(Aq.
+.RE
+.sp
+\fBip= nm= netdev= gw=\fP
+.RS 4
+When IP address plus optionally netmask (default 255.255.255.0),
+network device (default eth0), and default gateway are specified,
+then only that single network device is set up. Example:
+.RE
+.sp
+.if n .RS 4
+.nf
+.fam C
+ip=192.168.100.2 nm=255.255.255.0 netdev=eth0 gw=192.168.100.1
+.fam
+.fi
+.if n .RE
+.sp
+\fBnoip\fP
+.RS 4
+Skip network devices setup by the rescue system start up scripts (overrides ip= nm= netdev= gw=).
 .RE
 .SH "BACKUP SOFTWARE INTEGRATION"
 .sp
-Currently Relax\-and\-Recover supports the following backup methods\&. There is a distinction between Relax\-and\-Recover support for 3rd party backup software and Relax\-and\-Recover internal backup methods\&. The latter also creates a backup of your data while the former will only integrate Relax\-and\-Recover with the backup software to restore the data with the help of the backup software without actually creating backups\&. This means that for all non\-internal backup software you \fBmust\fR take care of creating backups yourself (unless otherwise noted)\&.
+Currently Relax\-and\-Recover supports the below listed backup methods.
 .sp
-Especially the rear mkbackup command can be confusing as it is only useful for the internal backup methods and has usually no function at all with the other (external) backup methods\&.
+There is a distinction between Relax\-and\-Recover support for 3rd party
+backup software and Relax\-and\-Recover internal backup methods. The latter
+also creates a backup of your data while the former will only integrate
+Relax\-and\-Recover with the backup software to restore the data with the
+help of the backup software without actually creating backups. This means
+that for all non\-internal backup software you \fBmust\fP take care of creating
+backups yourself (unless otherwise noted).
 .sp
-The following backup methods need to be set in Relax\-and\-Recover with the BACKUP option\&. As mentioned we have two types of BACKUP methods \- \fIinternal\fR and \fIexternal\fR\&.
+Especially the rear mkbackup command can be confusing as it is only
+useful for the internal backup methods and has usually no function at all with
+the other (external) backup methods where the rear mkrescue command applies.
 .sp
-The following BACKUP methods are \fIexternal\fR of Relax\-and\-Recover meaning that usually you are responsible of backups being made:
-.PP
-BACKUP=\fBREQUESTRESTORE\fR
+The following backup methods need to
+be set in Relax\-and\-Recover with the BACKUP option. As mentioned we have
+two types of BACKUP methods \- \fIinternal\fP and \fIexternal\fP.
+.sp
+The following BACKUP methods are \fIexternal\fP of Relax\-and\-Recover meaning
+that usually you are responsible of backups being made:
+.sp
+BACKUP=\fBREQUESTRESTORE\fP
 .RS 4
-\fB(default)\fR
-Not really a backup method at all, Relax\-and\-Recover simply halts the recovery and requests that somebody will restore the data to the appropriate location (e\&.g\&. via SSH)\&. This method works especially well with an rsync based backup that is pushed back to the backup client\&.
-.RE
-.PP
-BACKUP=\fBEXTERNAL\fR
-.RS 4
-Internal backup method that uses an arbitrary external command to create a backup and restore the data\&.
-.RE
-.PP
-BACKUP=\fBDP\fR
-.RS 4
-Use Micro Focus Data Protector to restore the data\&.
-.RE
-.PP
-BACKUP=\fBFDRUPSTREAM\fR
-.RS 4
-Use FDR/Upstream to restore the data\&.
-.RE
-.PP
-BACKUP=\fBGALAXY\fR
-.RS 4
-Use CommVault Galaxy 5 to restore the data\&.
-.RE
-.PP
-BACKUP=\fBGALAXY7\fR
-.RS 4
-Use CommVault Galaxy 7 to restore the data\&.
-.RE
-.PP
-BACKUP=\fBGALAXY10\fR
-.RS 4
-Use CommVault Galaxy 10 (or Simpana 10) to restore the data\&.
-.RE
-.PP
-BACKUP=\fBGALAXY11\fR
-.RS 4
-Use CommVault Galaxy 11 (or Simpana 11) to restore the data\&.
-.RE
-.PP
-BACKUP=\fBNBU\fR
-.RS 4
-Use Symantec NetBackup to restore the data\&.
-.RE
-.PP
-BACKUP=\fBTSM\fR
-.RS 4
-Use IBM Tivoli Storage Manager to restore the data\&. The Relax\-and\-Recover result files (e\&.g\&. ISO image) are also saved into TSM\&. There is a (currently experimental) first draft implementation that a TSM backup is created by calling
-\fIdsmc incremental\fR
-during
-\fIrear mkbackup\fR\&.
-.RE
-.PP
-BACKUP=\fBNSR\fR
-.RS 4
-Using EMC NetWorker (Legato) to restore the data\&.
-.RE
-.PP
-BACKUP=\fBPPDM\fR
-.RS 4
-Using Dell PowerProtect Data Manager to restore the data\&.
-.RE
-.PP
-BACKUP=\fBAVA\fR
-.RS 4
-Using EMC Avamar to restore the data\&.
-.RE
-.PP
-BACKUP=\fBSESAM\fR
-.RS 4
-Using SEP Sesam to restore the data\&.
-.RE
-.PP
-BACKUP=\fBNBKDC\fR
-.RS 4
-Using NovaStor DC to restore the data\&.
-.RE
-.PP
-BACKUP=\fBCDM\fR
-.RS 4
-Using Rubrik Cloud Data Management (CDM) to restore the data\&.
-.RE
-.PP
-BACKUP=\fBRBME\fR
-.RS 4
-Use Rsync Backup Made Easy (rbme) to restore the data\&.
-.RE
-.PP
-BACKUP=\fBBAREOS\fR
-.RS 4
-Use Open Source backup solution BAREOS (a fork a BACULA) to restore the data\&.
-.RE
-.PP
-BACKUP=\fBBACULA\fR
-.RS 4
-Use Open Source backup solution BACULA to restore the data\&.
-.RE
-.PP
-BACKUP=\fBDUPLICITY\fR
-.RS 4
-Use encrypted bandwidth\-efficient backup solution using the rsync algorithm to restore the data\&.
-.RE
-.PP
-BACKUP=\fBBORG\fR
-.RS 4
-Use BorgBackup (short Borg) a deduplicating backup program to restore the data\&. Executing
-\fIrear mkbackup\fR
-will create a Borg backup, see the section
-\fIReaR with Borg back end\fR
-in the ReaR user\-guide
-\fIScenarios\fR
-documentation\&.
-.RE
-.PP
-BACKUP=\fBNFS4SERVER\fR
-.RS 4
-This is a restore only method\&. ReaR starts a NFSv4 server in the restore stage and provides the to be restored filesystems as NFSv4 share\&. Another server (with a special backup sotware) can mount this share and can push the backup data into it\&.
+\fB(default)\fP Not really a backup method at all, Relax\-and\-Recover simply
+halts the recovery and requests that somebody will restore the data
+to the appropriate location (e.g. via SSH). This method works especially
+well with an rsync based backup that is pushed back to the backup
+client.
 .RE
 .sp
-The following BACKUP methods are \fIinternal\fR of Relax\-and\-Recover:
-.PP
-BACKUP=\fBNETFS\fR
+BACKUP=\fBEXTERNAL\fP
 .RS 4
-Internal backup method which can be used to create a simple backup (tar archive)\&.
-.RE
-.PP
-BACKUP=\fBRSYNC\fR
-.RS 4
-Use rsync to restore data\&.
+Internal backup method that uses an arbitrary external command to
+create a backup and restore the data.
 .RE
 .sp
-If your favourite backup software is missing from this list, please submit a patch or ask us to implement it for you\&.
+BACKUP=\fBDP\fP
+.RS 4
+Use Micro Focus Data Protector to restore the data.
+.RE
 .sp
-When using BACKUP=NETFS you must provide the backup target location through the BACKUP_URL variable\&. Possible BACKUP_URL settings are:
-.PP
-BACKUP_URL=\fBfile://\fR
+BACKUP=\fBFDRUPSTREAM\fP
 .RS 4
-To backup to local disk, use
-BACKUP_URL=file:///directory/path/
+Use FDR/Upstream to restore the data.
 .RE
-.PP
-BACKUP_URL=\fBnfs://\fR
-.RS 4
-To backup to NFS disk, use
-BACKUP_URL=nfs://nfs\-server\-name/share/path
-.RE
-.PP
-BACKUP_URL=\fBtape://\fR
-.RS 4
-To backup to tape device, use
-BACKUP_URL=tape:///dev/nst0
-or alternatively, simply define
-TAPE_DEVICE=/dev/nst0
-.RE
-.PP
-BACKUP_URL=\fBrsync://\fR
-.RS 4
-When backup method
-BACKUP=RSYNC
-is chosen then we need to define a corresponding
-BACKUP_URL
-rule:
 .sp
-.if n \{\
+BACKUP=\fBGALAXY\fP
 .RS 4
-.\}
+Use CommVault Galaxy 5 to restore the data.
+.RE
+.sp
+BACKUP=\fBGALAXY7\fP
+.RS 4
+Use CommVault Galaxy 7 to restore the data.
+.RE
+.sp
+BACKUP=\fBGALAXY10\fP
+.RS 4
+Use CommVault Galaxy 10 (or Simpana 10) to restore the data.
+.RE
+.sp
+BACKUP=\fBGALAXY11\fP
+.RS 4
+Use CommVault Galaxy 11 (or Simpana 11) to restore the data.
+.RE
+.sp
+BACKUP=\fBNBU\fP
+.RS 4
+Use Symantec NetBackup to restore the data.
+.RE
+.sp
+BACKUP=\fBTSM\fP
+.RS 4
+Use IBM Tivoli Storage Manager to restore the data. The Relax\-and\-Recover
+result files (e.g. ISO image) are also saved into TSM.
+There is a (currently experimental) first draft implementation
+that a TSM backup is created by calling \*(Aqdsmc incremental\*(Aq during \*(Aqrear mkbackup\*(Aq.
+.RE
+.sp
+BACKUP=\fBNSR\fP
+.RS 4
+Using EMC NetWorker (Legato) to restore the data.
+.RE
+.sp
+BACKUP=\fBPPDM\fP
+.RS 4
+Using Dell PowerProtect Data Manager to restore the data.
+.RE
+.sp
+BACKUP=\fBAVA\fP
+.RS 4
+Using EMC Avamar to restore the data.
+.RE
+.sp
+BACKUP=\fBSESAM\fP
+.RS 4
+Using SEP Sesam to restore the data.
+.RE
+.sp
+BACKUP=\fBNBKDC\fP
+.RS 4
+Using NovaStor DC to restore the data.
+.RE
+.sp
+BACKUP=\fBCDM\fP
+.RS 4
+Using Rubrik Cloud Data Management (CDM) to restore the data.
+.RE
+.sp
+BACKUP=\fBRBME\fP
+.RS 4
+Use Rsync Backup Made Easy (rbme) to restore the data.
+.RE
+.sp
+BACKUP=\fBBAREOS\fP
+.RS 4
+Use Open Source backup solution BAREOS (a fork a BACULA) to restore the data.
+.RE
+.sp
+BACKUP=\fBBACULA\fP
+.RS 4
+Use Open Source backup solution BACULA to restore the data.
+.RE
+.sp
+BACKUP=\fBDUPLICITY\fP
+.RS 4
+Use encrypted bandwidth\-efficient backup solution using the rsync algorithm to restore the data.
+.RE
+.sp
+BACKUP=\fBBORG\fP
+.RS 4
+Use BorgBackup (short Borg) a deduplicating backup program to restore the data.
+Executing \*(Aqrear mkbackup\*(Aq will create a Borg backup,
+see the section \*(AqReaR with Borg back end\*(Aq in the ReaR user\-guide \*(AqScenarios\*(Aq documentation.
+.RE
+.sp
+BACKUP=\fBNFS4SERVER\fP
+.RS 4
+This is a restore only method. ReaR starts a NFSv4 server in the restore stage and
+provides the to be restored filesystems as NFSv4 share. Another
+server (with a special backup sotware) can mount this share and can push the backup data into it.
+.RE
+.sp
+The following BACKUP methods are \fIinternal\fP of Relax\-and\-Recover:
+.sp
+BACKUP=\fBNETFS\fP
+.RS 4
+Internal backup method which can be used to create a simple backup
+(tar archive).
+.RE
+.sp
+BACKUP=\fBRSYNC\fP
+.RS 4
+Use rsync to restore data.
+.RE
+.sp
+If your favourite backup software is missing from this list, please submit
+a patch or ask us to implement it for you.
+.sp
+When using BACKUP=NETFS you must provide the backup target location
+through the BACKUP_URL variable. Possible BACKUP_URL settings are:
+.sp
+BACKUP_URL=\fBfile://\fP
+.RS 4
+To backup to local disk, use BACKUP_URL=file:///directory/path/
+.RE
+.sp
+BACKUP_URL=\fBnfs://\fP
+.RS 4
+To backup to NFS disk, use BACKUP_URL=nfs://nfs\-server\-name/share/path
+.RE
+.sp
+BACKUP_URL=\fBtape://\fP
+.RS 4
+To backup to tape device, use BACKUP_URL=tape:///dev/nst0 or alternatively,
+simply define TAPE_DEVICE=/dev/nst0
+.RE
+.sp
+BACKUP_URL=\fBrsync://\fP
+.RS 4
+When backup method BACKUP=RSYNC is chosen then we need to define a corresponding BACKUP_URL rule:
+.sp
+.if n .RS 4
 .nf
+.fam C
 BACKUP_URL=rsync://[user@]host[:port]/path
 BACKUP_URL=rsync://[user@]host[:port]::/path
+.fam
 .fi
-.if n \{\
+.if n .RE
 .RE
-.\}
-.RE
-.PP
-BACKUP_URL=\fBcifs://\fR
+.sp
+BACKUP_URL=\fBcifs://\fP
 .RS 4
 To backup to a Samba share (CIFS), use
-BACKUP_URL=cifs://cifs\-server\-name/share/path\&. To provide credentials for CIFS mounting use a
-\fI/etc/rear/cifs\fR
-credentials file and define
-BACKUP_OPTIONS="cred=/etc/rear/cifs"
-and pass along:
+BACKUP_URL=cifs://cifs\-server\-name/share/path. To provide credentials for
+CIFS mounting use a \fI/etc/rear/cifs\fP credentials file and define
+BACKUP_OPTIONS="cred=/etc/rear/cifs" and pass along:
 .sp
-.if n \{\
-.RS 4
-.\}
+.if n .RS 4
 .nf
+.fam C
 username=_username_
 password=_secret password_
 domain=_domain_
+.fam
 .fi
-.if n \{\
+.if n .RE
 .RE
-.\}
-.RE
-.PP
-BACKUP_URL=\fBusb://\fR
-.RS 4
-To backup to USB storage device, use
-BACKUP_URL=usb:///dev/disk/by\-label/REAR\-000
-or use a partition device node or a specific filesystem label\&. Alternatively, you may specify the partition device using
-USB_DEVICE=/dev/disk/by\-label/REAR\-000
-if needed\&.
 .sp
-If you combine this with
-OUTPUT=USB
-you will end up with a bootable USB device\&.
+BACKUP_URL=\fBusb://\fP
+.RS 4
+To backup to USB storage device, use BACKUP_URL=usb:///dev/disk/by\-label/REAR\-000
+or use a partition device node or a specific filesystem label. Alternatively, you
+may specify the partition device using USB_DEVICE=/dev/disk/by\-label/REAR\-000 if needed.
+.sp
+If you combine this with OUTPUT=USB you will end up with a bootable USB
+device.
 .RE
-.PP
-BACKUP_URL=\fBsshfs://\fR
+.sp
+BACKUP_URL=\fBsshfs://\fP
 .RS 4
 To backup to a remote server via sshfs (SSH protocol), use
-BACKUP_URL=sshfs://user@remote\-system\&.name\&.org/home/user/backup\-dir/
+BACKUP_URL=sshfs://user@remote\-system.name.org/home/user/backup\-dir/
 .sp
-It is advisable to add
-\fBServerAliveInterval 15\fR
-in the
-/root/\&.ssh/config
-file for the remote system (remote\-system\&.name\&.org)\&.
+It is advisable to add \fBServerAliveInterval 15\fP in the /root/.ssh/config
+file for the remote system (remote\-system.name.org).
 .RE
-.PP
-BACKUP_URL=\fBiso://\fR
-.RS 4
-To include the backup within the ISO image\&. It is important that the
-BACKUP_URL
-and
-OUTPUT_URL
-variables are different\&. E\&.g\&.
 .sp
-.if n \{\
+BACKUP_URL=\fBiso://\fP
 .RS 4
-.\}
+To include the backup within the ISO image. It is important that the BACKUP_URL and
+OUTPUT_URL variables are different. E.g.
+.sp
+.if n .RS 4
 .nf
+.fam C
 BACKUP_URL=iso:///backup/
 OUTPUT_URL=nfs://server/path/
+.fam
 .fi
-.if n \{\
-.RE
-.\}
+.if n .RE
 .RE
 .sp
-When using BACKUP=NETFS and BACKUP_PROG=tar there is an option to select BACKUP_TYPE=incremental or BACKUP_TYPE=differential to let rear make incremental or differential backups until the next full backup day e\&.g\&. via FULLBACKUPDAY="Mon" is reached or when the last full backup is too old after FULLBACKUP_OUTDATED_DAYS has passed\&. Incremental or differential backup is currently only known to work with BACKUP_URL=nfs\&. Other BACKUP_URL schemes may work but at least BACKUP_URL=usb requires USB_SUFFIX to be set to work with incremental or differential backup\&.
+When using BACKUP=NETFS and BACKUP_PROG=tar there is an option to select
+BACKUP_TYPE=incremental or BACKUP_TYPE=differential to let rear make
+incremental or differential backups until the next full backup day
+e.g. via FULLBACKUPDAY="Mon" is reached or when the last full backup
+is too old after FULLBACKUP_OUTDATED_DAYS has passed.
+Incremental or differential backup is currently only known to work
+with BACKUP_URL=nfs. Other BACKUP_URL schemes may work but
+at least BACKUP_URL=usb requires USB_SUFFIX to be set
+to work with incremental or differential backup.
 .SH "SUPPORT FOR SELF\-ENCRYPTING DISKS"
 .sp
-Relax\-and\-Recover supports self\-encrypting disks (SEDs) compliant with the TCG Opal 2 specification if the sedutil\-cli executable is installed\&.
+Relax\-and\-Recover supports self\-encrypting disks (SEDs) compliant with the TCG
+Opal 2 specification if the \f(CRsedutil\-cli\fP executable is installed.
 .sp
 Self\-encrypting disk support includes
 .sp
@@ -709,8 +726,8 @@ Self\-encrypting disk support includes
 \h'-04'\(bu\h'+03'\c
 .\}
 .el \{\
-.sp -1
-.IP \(bu 2.3
+.  sp -1
+.  IP \(bu 2.3
 .\}
 recovery (saving and restoring the system\(cqs SED configuration),
 .RE
@@ -720,8 +737,8 @@ recovery (saving and restoring the system\(cqs SED configuration),
 \h'-04'\(bu\h'+03'\c
 .\}
 .el \{\
-.sp -1
-.IP \(bu 2.3
+.  sp -1
+.  IP \(bu 2.3
 .\}
 setting up SEDs, including assigning a disk password,
 .RE
@@ -731,172 +748,229 @@ setting up SEDs, including assigning a disk password,
 \h'-04'\(bu\h'+03'\c
 .\}
 .el \{\
-.sp -1
-.IP \(bu 2.3
+.  sp -1
+.  IP \(bu 2.3
 .\}
-providing a pre\-boot authentication (PBA) system to unlock SEDs at boot time\&.
+providing a pre\-boot authentication (PBA) system to unlock SEDs at boot time.
 .RE
 .sp
-To prepare booting from an SED, run rear mkopalpba, then create the rescue system\&.
+To prepare booting from an SED, run rear mkopalpba, then create the rescue
+system.
 .sp
-To set up an SED, boot the Relax\-and\-Recover rescue system and run rear opaladmin setupERASE DEVICE (\fIDEVICE\fR being the disk device path like /dev/sda)\&.
+To set up an SED, boot the Relax\-and\-Recover rescue system and run \f(CRrear
+opaladmin setupERASE DEVICE\fP (\fIDEVICE\fP being the disk device path like
+\f(CR/dev/sda\fP).
 .sp
-For complete information, consult the section "Support for TCG Opal 2\-compliant Self\-Encrypting Disks" in the Relax\-and\-Recover user guide\&.
+For complete information, consult the section "Support for TCG Opal 2\-compliant
+Self\-Encrypting Disks" in the Relax\-and\-Recover user guide.
 .SH "CONFIGURATION"
 .sp
-To configure Relax\-and\-Recover you have to edit the configuration files in \fI/etc/rear/\fR\&. All \fI*\&.conf\fR files there are part of the configuration, but only \fIsite\&.conf\fR and \fIlocal\&.conf\fR are intended for the user configuration\&. All other configuration files hold defaults for various distributions and should not be changed\&.
+To configure Relax\-and\-Recover you have to edit the configuration files in
+\fI/etc/rear/\fP.  All \fI*.conf\fP files there are part of the configuration, but
+only \fIsite.conf\fP and \fIlocal.conf\fP are intended for the user configuration.
+All other configuration files hold defaults for various distributions and
+should not be changed.
 .sp
-In \fI/etc/rear/templates/\fR there are also some template files which are used by Relax\-and\-Recover to create configuration files (mostly for the boot environment)\&. Modify the templates to adjust the information contained in the emails produced by Relax\-and\-Recover\&. You can use these templates to prepend your own configurations to the configuration files created by Relax\-and\-Recover, for example you can edit \fIPXE_pxelinux\&.cfg\fR to add some general pxelinux configuration you use\&.
+In \fI/etc/rear/templates/\fP there are also some template files which are used
+by Relax\-and\-Recover to create configuration files (mostly for the boot
+environment).  Modify the templates to adjust the information contained in
+the emails produced by Relax\-and\-Recover. You can use these templates to
+prepend your own configurations to the configuration files created by
+Relax\-and\-Recover, for example you can edit \fIPXE_pxelinux.cfg\fP to add some
+general pxelinux configuration you use.
 .sp
-In almost all circumstances you have to configure two main settings and their parameters: The backup method and the output method\&.
+In almost all circumstances you have to configure two main settings and their
+parameters: The backup method and the output method.
 .sp
-The backup method defines, how your data is to be saved and whether Relax\-and\-Recover should backup your data as part of the mkrescue process or whether you use an external application, e\&.g\&. backup software to archive your data\&.
+The backup method defines, how your data is to be saved and whether Relax\-and\-Recover
+should backup your data as part of the mkbackup workflow for internal backup methods
+or whether you use 3rd party backup software to archive your data.
 .sp
-The output method defines how the rescue system is written to disk and how you plan to boot the failed computer from the rescue system\&.
+The output method defines how the rescue system is written to disk and how you
+plan to boot the failed computer from the rescue system.
 .sp
-See the default configuration file \fI/usr/share/rear/conf/default\&.conf\fR for an overview of the possible methods and their options\&.
+See the default configuration file \fI/usr/share/rear/conf/default.conf\fP for
+an overview of the possible methods and their options.
 .sp
-An example to use TSM for backup and ISO for output would be to add these lines to \fI/etc/rear/local\&.conf\fR (no need to define a BACKUP_URL when using an external backup solution):
+An example to use TSM for backup and ISO for output would be to add
+these lines to \fI/etc/rear/local.conf\fP (no need to define a BACKUP_URL
+when using an external backup solution):
 .sp
-.if n \{\
-.RS 4
-.\}
+.if n .RS 4
 .nf
+.fam C
 BACKUP=TSM
 OUTPUT=ISO
+.fam
 .fi
-.if n \{\
-.RE
-.\}
+.if n .RE
 .sp
-And if all your systems use NTP for time synchronisation, you can also add these lines to \fI/etc/rear/site\&.conf\fR
+And if all your systems use NTP for time synchronisation, you can also
+add these lines to \fI/etc/rear/site.conf\fP
 .sp
-.if n \{\
-.RS 4
-.\}
+.if n .RS 4
 .nf
+.fam C
 TIMESYNC=NTP
+.fam
 .fi
-.if n \{\
-.RE
-.\}
+.if n .RE
 .sp
-Do not forget to distribute the \fIsite\&.conf\fR to all your systems\&.
+Do not forget to distribute the \fIsite.conf\fP to all your systems.
 .sp
-The resulting ISO image will be created in \fI/var/lib/rear/output/\fR\&. You can now modify the behaviour by copying the appropriate configuration variables from \fIdefault\&.conf\fR to \fIlocal\&.conf\fR and changing them to suit your environment\&.
+The resulting ISO image will be created in \fI/var/lib/rear/output/\fP.
+You can now modify the behaviour by copying the appropriate
+configuration variables from \fIdefault.conf\fP to \fIlocal.conf\fP and
+changing them to suit your environment.
 .SH "EXIT STATUS"
-.PP
+.sp
 0
 .RS 4
-Successful program execution\&.
+Successful program execution.
 .RE
-.PP
+.sp
 >0
 .RS 4
-Usage, syntax or execution errors\&. Check the log file in
-\fI/var/log/rear/\fR
-for more information\&.
+Usage, syntax or execution errors. Check the log file in
+\fI/var/log/rear/\fP for more information.
 .RE
 .SH "EXAMPLES"
 .sp
-To print out the current settings for BACKUP and OUTPUT methods and some system information\&. This command can be used to see the supported features for the given release and platform\&.
+To print out the current settings for BACKUP and OUTPUT methods and some
+system information. This command can be used to see the supported features
+for the given release and platform.
 .sp
-.if n \{\
-.RS 4
-.\}
+.if n .RS 4
 .nf
+.fam C
 # rear dump
+.fam
 .fi
-.if n \{\
-.RE
-.\}
+.if n .RE
 .sp
-To create a new rescue environment\&. Do not forget to copy the resulting rescue system away so that you can use it in the case of a system failure\&.
+To create a new rescue environment. Do not forget to copy the resulting
+rescue system away so that you can use it in the case of a system failure.
 .sp
-.if n \{\
-.RS 4
-.\}
+.if n .RS 4
 .nf
+.fam C
 # rear \-v mkrescue
+.fam
 .fi
-.if n \{\
-.RE
-.\}
+.if n .RE
 .sp
-To create a new rescue image together with a complete archive of your local system run the command:
+To create a new rescue image together with a complete archive of your local
+system run the command:
 .sp
-.if n \{\
-.RS 4
-.\}
+.if n .RS 4
 .nf
+.fam C
 # rear \-v mkbackup
+.fam
 .fi
-.if n \{\
-.RE
-.\}
+.if n .RE
 .SH "FILES"
-.PP
+.sp
 /usr/sbin/rear
 .RS 4
-The program itself\&.
+The program itself.
 .RE
-.PP
-/etc/rear/local\&.conf
+.sp
+/etc/rear/local.conf
 .RS 4
-System specific configuration can be set here\&.
+System specific configuration can be set here.
 .RE
-.PP
-/etc/rear/site\&.conf
+.sp
+/etc/rear/site.conf
 .RS 4
-Site specific configuration can be set here (not created by default)\&.
+Site specific configuration can be set here (not created by default).
 .RE
-.PP
+.sp
 /var/log/rear/
 .RS 4
-Directory holding the log files\&.
+Directory holding the log files.
 .RE
-.PP
-/tmp/rear\&.####
+.sp
+/tmp/rear.####
 .RS 4
-Relax\-and\-Recover working directory\&. If Relax\-and\-Recover exits with an error, you must remove this directory manually\&.
+Relax\-and\-Recover working directory. If Relax\-and\-Recover exits with an error,
+you must remove this directory manually.
 .RE
-.PP
+.sp
 /usr/share/rear
 .RS 4
-Relax\-and\-Recover script components\&.
+Relax\-and\-Recover script components.
 .RE
-.PP
-/usr/share/rear/conf/default\&.conf
+.sp
+/usr/share/rear/conf/default.conf
 .RS 4
-Relax\-and\-Recover default values\&. Contains a complete set of parameters and its explanation\&. Do not edit or modify things therein but use
-\fIlocal\&.conf\fR
-or
-\fIsite\&.conf\fR
-for specific settings\&.
+Relax\-and\-Recover default values. Contains a complete set of parameters
+and its explanation. Do not edit or modify things therein but
+use \fIlocal.conf\fP or \fIsite.conf\fP for specific settings.
 .RE
 .SH "BUGS"
 .sp
-Feedback is welcome, please report issues or improvements to our issue\-tracker at: \m[blue]\fBhttp://github\&.com/rear/issues/\fR\m[]
+Feedback is welcome, please report issues or improvements to our
+issue\-tracker at: \c
+.URL "http://github.com/rear/issues/" "" ""
 .sp
-Furthermore, we welcome pull requests via GitHub\&.
+Furthermore, we welcome pull requests via GitHub.
 .SH "SEE ALSO"
 .sp
-Relax\-and\-Recover comes with extensive documentation located in \fI/usr/share/doc\fR\&.
+Relax\-and\-Recover comes with extensive documentation located in
+\fI/usr/share/doc\fP.
 .SH "AUTHORS"
 .sp
-The ReaR project was initiated in 2006 by Schlomo Schapiro (\m[blue]\fBhttps://github\&.com/schlomo\fR\m[]) and Gratien D\(cqhaese (\m[blue]\fBhttps://github\&.com/gdha\fR\m[]) and has since then seen a lot of contributions by many authors\&. As ReaR deals with bare metal disaster recovery, there is a large amount of code that was contributed by owners and users of specialized hardware and software\&. Without their combined efforts and contributions ReaR would not be the universal Linux bare metal disaster recovery solution that it is today\&.
+The ReaR project was initiated in 2006 by Schlomo Schapiro (\c
+.URL "https://github.com/schlomo" "" ")"
+and
+Gratien D\(cqhaese (\c
+.URL "https://github.com/gdha" "" ")"
+and has since then seen a lot of contributions by many authors.
+As ReaR deals with bare metal disaster recovery, there is a large amount of code
+that was contributed by owners and users of specialized hardware and software.
+Without their combined efforts and contributions ReaR would not be
+the universal Linux bare metal disaster recovery solution that it is today.
 .sp
-As time passed the project was lucky to get the support of additional developers to also help as maintainers: Dag Wieers (\m[blue]\fBhttps://github\&.com/dagwieers\fR\m[]), Jeroen Hoekx (\m[blue]\fBhttps://github\&.com/jhoekx\fR\m[]), Johannes Meixner (\m[blue]\fBhttps://github\&.com/jsmeix\fR\m[]), Vladimir Gozora (\m[blue]\fBhttps://github\&.com/gozora\fR\m[]), Sebastien Chabrolles (\m[blue]\fBhttps://github\&.com/schabrolles\fR\m[]), Renaud Metrich (\m[blue]\fBhttps://github\&.com/rmetrich\fR\m[]) and Pavel Cahyna (\m[blue]\fBhttps://github\&.com/pcahyna\fR\m[])\&. We hope that ReaR continues to prove useful and to attract more developers who agree to be maintainers\&. Refer to the MAINTAINERS (\m[blue]\fBhttps://github\&.com/rear/rear/blob/master/MAINTAINERS\fR\m[]) file for the list of active and past maintainers\&.
+As time passed the project was lucky to get the support of additional developers to also help as maintainers:
+Dag Wieers (\c
+.URL "https://github.com/dagwieers" "" "),"
+Jeroen Hoekx (\c
+.URL "https://github.com/jhoekx" "" "),"
+Johannes Meixner (\c
+.URL "https://github.com/jsmeix" "" "),"
+Vladimir Gozora (\c
+.URL "https://github.com/gozora" "" "),"
+Sebastien Chabrolles (\c
+.URL "https://github.com/schabrolles" "" "),"
+Renaud Metrich (\c
+.URL "https://github.com/rmetrich" "" ")"
+and
+Pavel Cahyna (\c
+.URL "https://github.com/pcahyna" "" ")."
+We hope that ReaR continues to prove useful and to attract more developers who agree to be maintainers.
+Refer to the MAINTAINERS (\c
+.URL "https://github.com/rear/rear/blob/master/MAINTAINERS" "" ")"
+file for the list of active and past maintainers.
 .sp
-To see the full list of authors and their contributions look at the git history (\m[blue]\fBhttps://github\&.com/rear/rear/graphs/contributors\fR\m[])\&. We are very thankful to all authors and encourage anybody interested to take a look at our source code and to contribute what you find important\&.
+To see the full list of authors and their contributions
+look at the git history (\c
+.URL "https://github.com/rear/rear/graphs/contributors" "" ")."
+We are very thankful to all authors and encourage anybody interested
+to take a look at our source code and to contribute what you find important.
 .sp
-Relax\-and\-Recover is a collaborative process using Github at \m[blue]\fBhttp://github\&.com/rear/\fR\m[]
+Relax\-and\-Recover is a collaborative process using Github at \c
+.URL "http://github.com/rear/" "" ""
 .sp
-The Relax\-and\-Recover website is located at: \m[blue]\fBhttp://relax\-and\-recover\&.org/\fR\m[]
+The Relax\-and\-Recover website is located at: \c
+.URL "http://relax\-and\-recover.org/" "" ""
 .SH "COPYRIGHT"
 .sp
 (c) 2006\-2022
 .sp
-The copyright is held by the original authors of the respective code pieces as can be seen in the git history at \m[blue]\fBhttps://github\&.com/rear/rear/graphs/contributors\fR\m[]
+The copyright is held by the original authors of the respective code pieces as can be seen in the git history at \c
+.URL "https://github.com/rear/rear/graphs/contributors" "" ""
 .sp
-Relax\-and\-Recover comes with ABSOLUTELY NO WARRANTY; for details see the GNU General Public License at \m[blue]\fBhttp://www\&.gnu\&.org/licenses/gpl\&.html\fR\m[]
+Relax\-and\-Recover comes with ABSOLUTELY NO WARRANTY; for details
+see the GNU General Public License at \c
+.URL "http://www.gnu.org/licenses/gpl.html" "" ""

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -89,6 +89,9 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 -e --expose-secrets::
     do not suppress output of confidential values (passwords, encryption keys) in particular in the log file
 
+-p --portable::
+    allow running any ReaR workflow, especially recover, from a git checkout or rear source archive
+
 -V --version::
     version information
 
@@ -194,7 +197,12 @@ Create a bootable image file named "rear-$(hostname).raw.gz", which
 * supports UEFI/Legacy BIOS dual boot if syslinux *and* one of the supported EFI
   bootloaders are installed.
 
-When using +OUTPUT=ISO+, +RAMDISK+, +OBDR+, +USB+, or +RAWDISK+ you should
+OUTPUT=*PORTABLE*::
+Create a portable ReaR archive that can be used on any rescue system to run
+any ReaR workflow, especially recover. Assumes that all required software is
+installed and usable there. This is experimental, please report any issues.
+
+When using +OUTPUT=ISO+, +RAMDISK+, +OBDR+, +USB+, +PORTABLE+ or +RAWDISK+ you should
 provide the backup target location through the +OUTPUT_URL+ variable. Possible
 +OUTPUT_URL+ settings are:
 

--- a/doc/user-guide/17-Portable-Mode.adoc
+++ b/doc/user-guide/17-Portable-Mode.adoc
@@ -1,0 +1,27 @@
+= Documentation for the Portable Recovery Mode
+
+== Summary
+
+ReaR supports a portable mode where `rear mkrescue` or `rear mkbackup` will not create a bootable rescue media but instead only a "portable" rescue archive. This archive contains a full copy of ReaR as it was installed on the source system, together with the ReaR configuration and the recovery information. It doesn't contain any other software or binaries.
+
+The purpose of the portable mode is to solve special scenarios where the ReaR rescue media either doesn't work or can't be created. It can be also used to save storage for covering a large amount of identical systems with a shared generic rescue media. The portable mode is therefore not a replacement for the ReaR rescue media, but a workaround for special cases. We developed and tested the portable mode with the https://www.system-rescue.org/[System Rescue CD] and the Ubuntu Desktop Live CD, where it worked well.
+
+== How to use the Portable Recovery Mode
+
+To create a portable rescue archive, run `rear mkrescue` or `rear mkbackup` with the `OUTPUT=PORTABLE` option. This will create a portable rescue archive in the `output/` directory. The archive is a tarball with the name `rear-<hostname>-portable.tar.gz`. It will be also copied to the `OUTPUT_URL` if it is set.
+
+To recover a system from a portable rescue archive, you need to 
+
+1. extract the archive on your rescue system into a directory
+
+2. set the machine hostname to the target machine, e.g. via `hostnamectl hostname <hostname>` or `hostname <hostname>`
+
+3. change into the directory and run `./usr/sbin/rear -p recover`
+
+The recovery process will then use the extracted ReaR installation to recover the system.
+
+== Caveats
+
+With the `-p` option you disable some sanity checks in ReaR, which can be used to run any workflow, even workflows that harm your system (e.g. recover on the source system).
+
+In portable mode ReaR assumes that all required software is available in the rescue system. There are no further checks for missing software. If you miss some software, the recovery process will fail. ReaR is not tested for this scenario as normally the rescue media is guaranteed to contain everything needed for a successful recovery.

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -140,6 +140,7 @@ DEBUG_OUTPUT_DEV="null"
 DISPENSABLE_OUTPUT_DEV="null"
 SECRET_OUTPUT_DEV="null"
 EXPOSE_SECRETS=""
+PORTABLE=""
 NON_INTERACTIVE=""
 KEEP_BUILD_DIR=""
 KERNEL_VERSION=""
@@ -151,7 +152,7 @@ WORKFLOW=""
 
 # Parse options
 help_note_text="Use '$PROGRAM --help' or 'man $PROGRAM' for more information."
-if ! OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVr:ne" -l "help,version,non-interactive,debugscripts:,expose-secrets" -- "$@" )" ; then
+if ! OPTS="$( getopt -n $PROGRAM -o "c:C:dDhsSvVr:nep" -l "help,version,non-interactive,debugscripts:,expose-secrets,portable" -- "$@" )" ; then
     echo "$help_note_text"
     exit 1
 fi
@@ -174,6 +175,9 @@ while true ; do
             ;;
         (-e|--expose-secrets)
             EXPOSE_SECRETS=1
+            ;;
+        (-p|--portable)
+            PORTABLE=1
             ;;
         (-c)
             if [[ "$2" == -* ]] ; then
@@ -594,9 +598,10 @@ if test "$WORKFLOW" != "help" ; then
     # and that those temporary files will get cleaned up "by the way"
     # via the cleanup_build_area_and_end_program() function,
     # see https://github.com/rear/rear/issues/3167
-    if ! test "$RECOVERY_MODE" ; then
-        # We set TMPDIR to ReaR's TMP_DIR only when we are not in RECOVERY_MODE
-        # because TMP_DIR does not exist in the recreated/restored system
+    if ! [[ "$RECOVERY_MODE" || "$PORTABLE" ]] ; then
+        # We set TMPDIR to ReaR's TMP_DIR only when we are not in RECOVERY_MODE and also not in PORTABLE mode
+        # because TMP_DIR does not exist in the recreated/restored system or in the foreign rescue system where
+        # the portable mode should be able to work without the need to have a TMP_DIR in the rescue system.
         # i.e. there is no /mnt/local/var/tmp/rear.XXXXXXXXXXXXXXX/tmp so that
         #   chroot /mnt/local COMMAND
         # fails when COMMAND uses TMPDIR - in particular "chroot /mnt/local dracut" fails

--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -168,7 +168,5 @@ Log "LIBS = ${LIBS[@]}"
 
 # Fix ReaR directories when running from checkout or REAR_VAR configuration:
 Log "Validating and fixing ReaR directories for non-default paths"
-test "$VAR_DIR" != /var/lib/rear && ln -v -sf "$VAR_DIR" $ROOTFS_DIR/var/lib/rear
-test "$SHARE_DIR" != /usr/share/rear && ln -v -sf "$SHARE_DIR" $ROOTFS_DIR/usr/share/rear
-
-
+test "$VAR_DIR" != /var/lib/rear && ln -v -srf "$ROOTFS_DIR/$VAR_DIR" $ROOTFS_DIR/var/lib/rear
+test "$SHARE_DIR" != /usr/share/rear && ln -v -srf "$ROOTFS_DIR/$SHARE_DIR" $ROOTFS_DIR/usr/share/rear

--- a/usr/share/rear/init/default/002_check_rear_recover_mode.sh
+++ b/usr/share/rear/init/default/002_check_rear_recover_mode.sh
@@ -1,3 +1,5 @@
+is_true "$PORTABLE" && return
+
 # In the ReaR rescue/recovery system the only possible workflows are
 # - 'recover' and its partial workflows 'layoutonly' 'restoreonly' 'finalizeonly'
 # - 'mountonly'
@@ -17,18 +19,18 @@
 if test -f /etc/rear-release ; then
     # We are in the ReaR rescue/recovery system:
     case "$WORKFLOW" in
-        (recover|layoutonly|restoreonly|finalizeonly|mountonly|opaladmin|shell|help)
+        (recover|layoutonly|restoreonly|finalizeonly|mountonly|opaladmin|shell|dump|help)
             LogPrint "Running workflow $WORKFLOW within the ReaR rescue/recovery system"
             ;;
         (*)
-            Error "The workflow $WORKFLOW is not supported in the ReaR rescue/recovery system"
+            Error "The workflow $WORKFLOW is not supported in the ReaR rescue/recovery system,${LF}use --portable to disable this check at your own risk.${LF}ReaR will probably not work as expected and potentially${LF}destroy your backup data,${LF}if you run these workflows in the rescue system!"
             ;;
     esac
 else
     # We are in the normal/original system:
     case "$WORKFLOW" in
         (recover|layoutonly|restoreonly|finalizeonly|mountonly)
-            Error "The workflow $WORKFLOW is only supported in the ReaR rescue/recovery system"
+            Error "The workflow $WORKFLOW is only supported in the ReaR rescue/recovery system,${LF}use --portable to disable this check at your own risk.${LF}ReaR will destroy your system if you run these workflows in the normal/original system!"
             ;;
         (*)
             LogPrint "Running workflow $WORKFLOW on the normal/original system"

--- a/usr/share/rear/lib/help-workflow.sh
+++ b/usr/share/rear/lib/help-workflow.sh
@@ -4,20 +4,19 @@
 #
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
-
 LOCKLESS_WORKFLOWS+=( help )
 
 function WORKFLOW_help () {
 
-# Do nothing in simulation mode, cf. https://github.com/rear/rear/issues/1939
-if is_true "$SIMULATE" ; then
-    LogPrint "${BASH_SOURCE[0]} outputs usage information"
-    return 0
-fi
+    # Do nothing in simulation mode, cf. https://github.com/rear/rear/issues/1939
+    if is_true "$SIMULATE" ; then
+        LogPrint "${BASH_SOURCE[0]} outputs usage information"
+        return 0
+    fi
 
-# Output the help text to the original STDOUT but keep STDERR in the log file:
-cat 1>&7 <<EOF
-Usage: $PROGRAM [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-C CONFIG] [-r KERNEL] [-n|--non-interactive] [-e|--expose-secrets] [--] COMMAND [ARGS...]
+    # Output the help text to the original STDOUT but keep STDERR in the log file:
+    cat 1>&7 <<EOF
+Usage: $PROGRAM [-h|--help] [-V|--version] [-dsSv] [-D|--debugscripts SET] [-c DIR] [-C CONFIG] [-r KERNEL] [-n|--non-interactive] [-e|--expose-secrets] [-p|--portable] [--] COMMAND [ARGS...]
 
 $PRODUCT comes with ABSOLUTELY NO WARRANTY; for details see
 the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
@@ -35,30 +34,30 @@ Available options:
  -v                     verbose mode; show messages what $PRODUCT is doing on the terminal or show verbose help
  -n --non-interactive   non-interactive mode; aborts when any user input is required (experimental)
  -e --expose-secrets    do not suppress output of confidential values (passwords, encryption keys) in particular in the log file
+ -p --portable          allow running any ReaR workflow, especially recover, from a git checkout or rear source archive
  -V --version           version information
 
 
 List of commands:
 EOF
 
-# Output all workflow descriptions of the currently usable workflows
-# to the original STDOUT but keep STDERR in the log file:
-currently_usable_workflows="${WORKFLOWS[@]}"
-# See init/default/050_check_rear_recover_mode.sh what the usable workflows are in the ReaR rescue/recovery system.
-# In the ReaR rescue/recovery system /etc/rear-release is unique (it does not exist otherwise):
-test -f /etc/rear-release && currently_usable_workflows="recover layoutonly restoreonly finalizeonly mountonly opaladmin help"
-for workflow in $currently_usable_workflows ; do
-    description_variable_name=WORKFLOW_${workflow}_DESCRIPTION
-    # in some workflows WORKFLOW_${workflow}_DESCRIPTION
-    # is only defined if "$VERBOSE" is set - currently (23. Oct. 2018) for those
-    # WORKFLOW_savelayout_DESCRIPTION WORKFLOW_shell_DESCRIPTION WORKFLOW_udev_DESCRIPTION
-    # WORKFLOW_layoutonly_DESCRIPTION WORKFLOW_finalizeonly_DESCRIPTION
-    # so that an empty default is used to avoid that ${!description_variable_name} is an unbound variable:
-    test "${!description_variable_name:-}" && printf " %-16s%s\n" $workflow "${!description_variable_name:-}"
-done 1>&7
+    # Output all workflow descriptions of the currently usable workflows
+    # to the original STDOUT but keep STDERR in the log file:
+    currently_usable_workflows="${WORKFLOWS[@]}"
+    # See init/default/050_check_rear_recover_mode.sh what the usable workflows are in the ReaR rescue/recovery system.
+    # In the ReaR rescue/recovery system /etc/rear-release is unique (it does not exist otherwise):
+    test -f /etc/rear-release && currently_usable_workflows="recover layoutonly restoreonly finalizeonly mountonly opaladmin help"
+    for workflow in $currently_usable_workflows ; do
+        description_variable_name=WORKFLOW_${workflow}_DESCRIPTION
+        # in some workflows WORKFLOW_${workflow}_DESCRIPTION
+        # is only defined if "$VERBOSE" is set - currently (23. Oct. 2018) for those
+        # WORKFLOW_savelayout_DESCRIPTION WORKFLOW_shell_DESCRIPTION WORKFLOW_udev_DESCRIPTION
+        # WORKFLOW_layoutonly_DESCRIPTION WORKFLOW_finalizeonly_DESCRIPTION
+        # so that an empty default is used to avoid that ${!description_variable_name} is an unbound variable:
+        test "${!description_variable_name:-}" && printf " %-16s%s\n" $workflow "${!description_variable_name:-}"
+    done 1>&7
 
-# Output the text to the original STDOUT but keep STDERR in the log file:
-test "$VERBOSE" || echo "Use 'rear -v help' for more advanced commands." 1>&7
+    # Output the text to the original STDOUT but keep STDERR in the log file:
+    test "$VERBOSE" || echo "Use 'rear -v help' for more advanced commands." 1>&7
 
 }
-

--- a/usr/share/rear/output/PORTABLE/default/450_create_portable_archive.sh
+++ b/usr/share/rear/output/PORTABLE/default/450_create_portable_archive.sh
@@ -1,0 +1,5 @@
+local archive_file="$TMP_DIR/$OUTPUT_PREFIX-portable.tar.gz"
+
+tar $v -czf "$archive_file" -C $ROOTFS_DIR --exclude="$VAR_DIR/output/*" usr/sbin/rear etc/rear usr/share/rear var/lib/rear "$SHARE_DIR" "$VAR_DIR" || Error "Failed to create portable archive '$archive_file'"
+
+RESULT_FILES+=( "$archive_file" )

--- a/usr/share/rear/prep/default/100_init_workflow_conf.sh
+++ b/usr/share/rear/prep/default/100_init_workflow_conf.sh
@@ -6,9 +6,4 @@ cat - <<EOF >> "$ROOTFS_DIR/etc/rear/rescue.conf"
 # initialize our /etc/rear/rescue.conf file sourced by the rear command in recover mode
 # also the configuration is sourced by system-setup script during booting our recovery image
 
-SHARE_DIR="/usr/share/rear"
-CONFIG_DIR="/etc/rear"
-VAR_DIR="/var/lib/rear"
-LOG_DIR="/var/log/rear"
-
 EOF

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -78,6 +78,12 @@ source /usr/share/rear/conf/default.conf || echo -e "\n'source /usr/share/rear/c
 # Sourcing user and rescue configuration as we need some variables
 # (EXCLUDE_MD5SUM_VERIFICATION right now and other variables in the system setup scripts):
 # The order of sourcing should be 'site' then 'local' and as last 'rescue'
+
+# In the rescue system these paths are always like this, either for real or as a symlink to the actual paths
+CONFIG_DIR=/etc/rear
+SHARE_DIR=/usr/share/rear
+VAR_DIR=/var/lib/rear
+LOG_DIR=/var/log/rear
 for conf in site local rescue ; do
     if test -s /etc/rear/$conf.conf ; then
         source /etc/rear/$conf.conf || echo -e "\n'source /etc/rear/$conf.conf' failed with exit code $?"


### PR DESCRIPTION
Add `OUTPUT=PORTABLE` and `--portable` command line option to faciliate using ReaR in truly portable mode.

The portable archive contains **only** ReaR, nothing else.

Tested with an OL9 restore via SystemRescueCD

I'll do some more testing both of portable usage and regular usage to ensure that this change doesn't hurt us.

Implements #3190 and should be merged after #3205, where I extracted the unrelated fixes. To review you can simply look at the last commit here.