### PR TITLE
Typo fixes: BOOT_ON_SAN -> BOOT_OVER_SAN

### DIFF
--- a/usr/share/rear/conf/examples/RHEL7-PPC64LE-Multipath-PXE-GRUB.conf
+++ b/usr/share/rear/conf/examples/RHEL7-PPC64LE-Multipath-PXE-GRUB.conf
@@ -7,13 +7,13 @@
 # set BACKUP to activate an automated (backup and) restore of your data.
 # Possible configuration values can be found in /usr/share/rear/conf/default.conf
 
-# SAN and multipath and boot on SAN specific part on PPC64/PPC64LE:
-# There is no direct link between multipath/boot_on_SAN and PXE (even on POWER).
+# SAN and multipath and boot over SAN specific part on PPC64/PPC64LE:
+# There is no direct link between multipath/boot-over-SAN and PXE (even on POWER).
 # Multipath is used in this example because PowerVM LPARs usually need multipath.
 # There is nothing special on PowerVM LPAR with single VIOS but that is not commonly used.
 # In contrast PowerVM LPAR with DUAL VIOS (HA configuration) needs multipath
 # for dual disk access (vscsi over 2 VIOS) or NPIV (Fiber Channel virtualization).
-# And NPIV (which is quite popular) needs also BOOT_ON_SAN.
+# And NPIV (which is quite popular) needs also BOOT_OVER_SAN.
 AUTOEXCLUDE_MULTIPATH=n
 BOOT_OVER_SAN=y
 

--- a/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/210_load_multipath.sh
@@ -68,7 +68,7 @@ blacklist {
             (${choices[0]})
                 # continue recovery without multipath
                 is_true "$wilful_input" && LogPrint "User confirmed continuing without multipath" || LogPrint "Continuing '$rear_workflow' by default"
-                LogPrint "You should consider removing BOOT_ON_SAN parameter from your rear configuration file if you don't need multipath on this server."
+                LogPrint "You may remove BOOT_OVER_SAN from your ReaR configuration when you do not need multipath"
 
                 # Avoid to list mpath device.
                 list_mpath_device=0


### PR DESCRIPTION
* Type: **Typo Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/1449
https://github.com/rear/rear/issues/1899#issuecomment-2084552662

* How was this pull request tested?
Not tested.
Only typo fixes in a LogPrint message
and in a example config file comment.

* Description of the changes in this pull request:

In layout/prepare/GNU/Linux/210_load_multipath.sh
fixed typo BOOT_ON_SAN -> BOOT_OVER_SAN
in LogPrint message and simplified the message.

In conf/examples/RHEL7-PPC64LE-Multipath-PXE-GRUB.conf
fixed typo BOOT_ON_SAN -> BOOT_OVER_SAN
in comment and used the wording "boot over SAN"
(i.e. with "over" instead of "on") consistently.
