### PR TITLE
default.conf example for COPY_AS_IS_EXCLUDE_TSM

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2406,7 +2406,7 @@ COPY_AS_IS_TSM=( /etc/adsm
 #                  /opt/tivoli/tsm/client/api/bin64/libdmapi.so
 #                  /opt/tivoli/tsm/client/ba/bin/EN_US/dsmclientV3.cat
 #                  /usr/local/ibm/gsk8* )
-# This example is from 2017 so it needs to be adapted to newer TSM versions,
+# This example is dated 2017 so it needs to be adapted to newer TSM versions,
 # cf. https://github.com/rear/rear/pull/1566
 # Additionally you need to add your custom configuration files like Includes and Excludes files.
 # An alternative method to reduce the size of the TSM client in ReaR recovery system initrd
@@ -2418,10 +2418,13 @@ COPY_AS_IS_TSM=( /etc/adsm
 # excludes in particular all language files except the EN_US language subdirectory,
 # cf. https://github.com/rear/rear/issues/3189#issuecomment-2079811746
 COPY_AS_IS_EXCLUDE_TSM=( )
-# To further reduce the size of the ReaR recovery system initrd in particular on POWER architecture
-# kernel modules that are not required to run the ReaR recovery system on replacement hardware or VM
-# are not needed in the ReaR recovery system initrd so MODULES=( 'loaded_modules' ) could be used,
-# see the MODULES description above.
+# Generic methods to reduce the size of the ReaR recovery system initrd in particular on POWER architecture:
+# Kernel modules that are not required to run the ReaR recovery system on replacement hardware or VM
+# are not needed in the ReaR recovery system initrd so on fully compatible replacement hardware
+# MODULES=( 'loaded_modules' ) could be used, see the MODULES description above.
+# Better (but slower) compression for the ReaR recovery system initrd like
+# REAR_INITRD_COMPRESSION="lzma" could be used, see REAR_INITRD_COMPRESSION above,
+# cf. https://github.com/rear/rear/issues/3189#issuecomment-2079794186
 #
 PROGS_TSM=(dsmc)
 #

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1787,9 +1787,12 @@ LD_LIBRARY_PATH_FOR_BACKUP_TOOL=""
 MODULES=( 'all_modules' )
 #
 # Enforce to load these modules in the given order in the rescue/recovery system.
-# We also load modules listed in /etc/modules. The order is 1) /etc/modules and
-# 2) MODULES_LOAD and 3) modules loaded by udev or systemd. ReaR also takes the list
-# of modules from your initrd and adds that to MODULES_LOAD.
+# We also load modules listed in /etc/modules.
+# The order is
+# 1) /etc/modules
+# 2) MODULES_LOAD
+# 3) modules loaded by udev or systemd.
+# ReaR also takes the list of modules from your initrd and adds that to MODULES_LOAD.
 MODULES_LOAD=()
 #
 # Kernel modules to exclude from the rescue/recovery system.
@@ -2411,20 +2414,25 @@ COPY_AS_IS_TSM=( /etc/adsm
 # Additionally you need to add your custom configuration files like Includes and Excludes files.
 # An alternative method to reduce the size of the TSM client in ReaR recovery system initrd
 # is to exclude what is not needed from the above specified COPY_AS_IS_TSM via COPY_AS_IS_EXCLUDE_TSM.
-# For example language files (except for the EN_US language) are not needed so for example
+# Usually language files (except for the EN_US language) are not needed so for example
 # COPY_AS_IS_EXCLUDE_TSM=( /opt/tivoli/tsm/client/ba/bin/*.jar
 #                          /opt/tivoli/tsm/client/ba/bin/*.log*
 #                          /opt/tivoli/tsm/client/*/*/[A-Z][!N]_?? )
-# excludes in particular all language files except the EN_US language subdirectory,
+# excludes in particular language file subdirectories except the EN_US language subdirectory,
 # cf. https://github.com/rear/rear/issues/3189#issuecomment-2079811746
 COPY_AS_IS_EXCLUDE_TSM=( )
 # Generic methods to reduce the size of the ReaR recovery system initrd in particular on POWER architecture:
-# Kernel modules that are not required to run the ReaR recovery system on replacement hardware or VM
-# are not needed in the ReaR recovery system initrd so on fully compatible replacement hardware
-# MODULES=( 'loaded_modules' ) could be used, see the MODULES description above.
-# Better (but slower) compression for the ReaR recovery system initrd like
-# REAR_INITRD_COMPRESSION="lzma" could be used, see REAR_INITRD_COMPRESSION above,
-# cf. https://github.com/rear/rear/issues/3189#issuecomment-2079794186
+# - Kernel modules that are not required to run the ReaR recovery system on replacement hardware or VM
+#   are not needed in the ReaR recovery system initrd so on fully compatible replacement hardware
+#   MODULES=( 'loaded_modules' ) could be used, see the MODULES description above.
+# - On POWER architecture (e.g. PowerVM LPAR) normally no firmware files are required to run the system
+#   so we set FIRMWARE_FILES=( 'no' ) in usr/share/rear/conf/Linux-ppc64.conf and .../Linux-ppc64le.conf
+#   when the default FIRMWARE_FILES=() is used (see FIRMWARE_FILES above)
+#   so on POWER by default no firmware files are included in the ReaR recovery system initrd
+#   cf. https://github.com/rear/rear/issues/3189#issuecomment-2076960341
+# - Better (but slower) compression for the ReaR recovery system initrd like
+#   REAR_INITRD_COMPRESSION="lzma" could be used (see REAR_INITRD_COMPRESSION above),
+#   cf. https://github.com/rear/rear/issues/3189#issuecomment-2079794186
 #
 PROGS_TSM=(dsmc)
 #

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2381,21 +2381,54 @@ GALAXY11_Q_ARGUMENTFILE=
 GALAXY11_USER=${GALAXY11_USER:-}
 { GALAXY11_PASSWORD=${GALAXY11_PASSWORD:-} ; } 2>>/dev/$SECRET_OUTPUT_DEV
 
-##
-# BACKUP=TSM stuff
+####
+# BACKUP=TSM (Tivoli Storage Manager 2015 renamed into IBM Spectrum Protect)
 ##
 #
-COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client /usr/local/ibm/gsk8* )
-# TSM client can be big (~300MB). If you need to reduce the size of the rescue image initrd (which can be a
-# good idea for PowerVM based partition),
-# you can use the following COPY_AS_IS_TSM which will only copy what is needed to start a TSM restore.
-# Don't forget to add your custom configuration files like Includes and Excludes files.
-# COPY_AS_IS_TSM=( /etc/adsm /opt/tivoli/tsm/client/ba/bin/dsmc /opt/tivoli/tsm/client/ba/bin/dsm.sys /opt/tivoli/tsm/client/ba/bin/dsm.opt /opt/tivoli/tsm/client/api/bin64/libgpfs.so /opt/tivoli/tsm/client/api/bin64/libdmapi.so /opt/tivoli/tsm/client/ba/bin/EN_US/dsmclientV3.cat /usr/local/ibm/gsk8* )
+# To restore a TSM backup during "rear recover" the TSM client must be included in the ReaR rescue/recovery system:
+COPY_AS_IS_TSM=( /etc/adsm 
+                 /opt/tivoli/tsm/client
+                 /usr/local/ibm/gsk8* )
+# The complete TSM client can be big (~300MB) which results a rather big ReaR recovery system
+# cf. https://github.com/rear/rear/discussions/2640#discussioncomment-908335
+# The ReaR recovery system is stored (compressed) in ReaR's initrd. 
+# On POWER architecture (e.g. PowerVM LPAR) there is a maximum size of the initrd that can be booted
+# cf. https://github.com/rear/rear/issues/3189
+# That limit is 128 MiB minus about 4 MiB for some additional prep boot data
+# so in practice the maximum remaining size for the initrd is about 123 MiB or even less.
+# To reduce the size of the initrd something like the following COPY_AS_IS_TSM example
+# could be used to copy only what is needed for a TSM restore into the ReaR recovery system:
+# COPY_AS_IS_TSM=( /etc/adsm
+#                  /opt/tivoli/tsm/client/ba/bin/dsmc
+#                  /opt/tivoli/tsm/client/ba/bin/dsm.sys
+#                  /opt/tivoli/tsm/client/ba/bin/dsm.opt
+#                  /opt/tivoli/tsm/client/api/bin64/libgpfs.so
+#                  /opt/tivoli/tsm/client/api/bin64/libdmapi.so
+#                  /opt/tivoli/tsm/client/ba/bin/EN_US/dsmclientV3.cat
+#                  /usr/local/ibm/gsk8* )
+# This example is from 2017 so it needs to be adapted to newer TSM versions,
+# cf. https://github.com/rear/rear/pull/1566
+# Additionally you need to add your custom configuration files like Includes and Excludes files.
+# An alternative method to reduce the size of the TSM client in ReaR recovery system initrd
+# is to exclude what is not needed from the above specified COPY_AS_IS_TSM via COPY_AS_IS_EXCLUDE_TSM.
+# For example language files (except for the EN_US language) are not needed so for example
+# COPY_AS_IS_EXCLUDE_TSM=( /opt/tivoli/tsm/client/ba/bin/*.jar
+#                          /opt/tivoli/tsm/client/ba/bin/*.log*
+#                          /opt/tivoli/tsm/client/*/*/[A-Z][!N]_?? )
+# excludes in particular all language files except the EN_US language subdirectory,
+# cf. https://github.com/rear/rear/issues/3189#issuecomment-2079811746
 COPY_AS_IS_EXCLUDE_TSM=( )
+# To further reduce the size of the ReaR recovery system initrd in particular on POWER architecture
+# kernel modules that are not required to run the ReaR recovery system on replacement hardware or VM
+# are not needed in the ReaR recovery system initrd so MODULES=( 'loaded_modules' ) could be used,
+# see the MODULES description above.
+#
 PROGS_TSM=(dsmc)
+#
 # TSM library PATH that need to be added to LD_LIBRARY_PATH.
 # gsk lib PATH are detected and automatically added by usr/share/rear/prep/TSM/default/400_prep_tsm.sh
 TSM_LD_LIBRARY_PATH="/opt/tivoli/tsm/client/ba/bin:/opt/tivoli/tsm/client/api/bin64:/opt/tivoli/tsm/client/api/bin:/opt/tivoli/tsm/client/api/bin64/cit/bin"
+#
 # where to copy the resulting files to and save them with TSM
 TSM_RESULT_FILE_PATH=/opt/tivoli/tsm/rear
 #
@@ -2403,10 +2436,8 @@ TSM_RESULT_FILE_PATH=/opt/tivoli/tsm/rear
 # input is also added to this array.
 TSM_DSMC_RESTORE_OPTIONS=( )
 #
-# Tell if the result from mkbackup/mkrescue (Rescue image: ISO image, PXE, kernel and initrd)
-# should be saved via TSM.
-# You can disable these saving when the result is saved on an different way (ISO_URL, PXE_TFTP_UPLOAD_URL....)
-# (y/n) default to y
+# Tell if the result from mkbackup/mkrescue (Rescue image: ISO image, PXE, kernel and initrd) should be saved via TSM.
+# You can disable these saving when the result is saved on an different way (ISO_URL, PXE_TFTP_UPLOAD_URL....):
 TSM_RESULT_SAVE=y
 #
 # TSM archive management class definition


### PR DESCRIPTION

* Type: **Documentation**

* Impact: **High**
High impact when needed, cf.
https://github.com/rear/rear/issues/3189
how long it could take until one finds out
that booting fails because the initrd is too big.

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3189
https://github.com/rear/rear/pull/1566

* How was this pull request tested?
Only descriptions.
See also
https://github.com/rear/rear/issues/3189#issuecomment-2079794186

* Description of the changes in this pull request:

In default.conf explain how one could reduce
the size of the ReaR recovery system initrd
in particular on POWER architecture
via COPY_AS_IS_TSM and alternatively
via COPY_AS_IS_EXCLUDE_TSM and additionally
via MODULES=( 'loaded_modules' ),
see https://github.com/rear/rear/issues/3189
