### PR TITLE
enable default ramdisk if not set to satisfy Veeam 12.1 requirements

### DIFF
--- a/usr/share/rear/prep/VEEAM/default/400_prep_veeam.sh
+++ b/usr/share/rear/prep/VEEAM/default/400_prep_veeam.sh
@@ -4,3 +4,5 @@
 
 COPY_AS_IS+=("${COPY_AS_IS_VEEAM[@]}")
 REQUIRED_PROGS+=("${REQUIRED_PROGS_VEEAM[@]}")
+# enable default ramdisk if not set to satisfy Veeam 12.1ff requirements 
+is_true "$USE_RAMDISK" || USE_RAMDISK=yes


### PR DESCRIPTION
Closes #3213

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement** 

* Impact: **Normal**

* How was this pull request tested?
Manually on RHEL8. Tests with other distributions will follow.

* Description of the changes in this pull request:
enable default ramdisk if not set to satisfy Veeam 12.1ff requirements to check for sufficient free disk space
