### PR TITLE
Overhauled 400_create_include_exclude_files.sh

### DIFF
--- a/usr/share/rear/backup/NETFS/default/400_create_include_exclude_files.sh
+++ b/usr/share/rear/backup/NETFS/default/400_create_include_exclude_files.sh
@@ -2,7 +2,7 @@
 # What to include in the backup:
 cat /dev/null > "$TMP_DIR/backup-includes.txt"
 
-# First by default backup of the mounted filesystems in disklayout.conf
+# First by default backup the mounted filesystems in disklayout.conf
 # (except BACKUP_ONLY_INCLUDE or MANUAL_INCLUDE is set)
 # as defined in var/lib/rear/recovery/mountpoint_device which contains at least '/'
 # where usually '/' is first because "fs ... /" is first in disklayout.conf

--- a/usr/share/rear/backup/NETFS/default/400_create_include_exclude_files.sh
+++ b/usr/share/rear/backup/NETFS/default/400_create_include_exclude_files.sh
@@ -22,7 +22,7 @@ if ! is_true "$BACKUP_ONLY_INCLUDE" ; then
                 continue
             fi
             if ! mountpoint "$mountpoint" ; then
-                LogPrintError "Mountpoint '$mountpoint' in $VAR_DIR/recovery/mountpoint_device is no mountpoint"
+                LogPrintError "Mountpoint '$mountpoint' in $VAR_DIR/recovery/mountpoint_device is not a mountpoint"
                 continue
             fi
             echo "$mountpoint" >> "$TMP_DIR/backup-includes.txt"

--- a/usr/share/rear/backup/NETFS/default/400_create_include_exclude_files.sh
+++ b/usr/share/rear/backup/NETFS/default/400_create_include_exclude_files.sh
@@ -1,33 +1,86 @@
 
-# Backup all that is explicitly specified in BACKUP_PROG_INCLUDE:
-for backup_include_item in "${BACKUP_PROG_INCLUDE[@]}" ; do
-    test "$backup_include_item" && echo "$backup_include_item"
-done > $TMP_DIR/backup-include.txt
+# What to include in the backup:
+cat /dev/null > "$TMP_DIR/backup-includes.txt"
 
-# Implicitly also backup all local filesystems as defined in mountpoint_device
-# except BACKUP_ONLY_INCLUDE or MANUAL_INCLUDE is set:
+# First by default backup of the mounted filesystems in disklayout.conf
+# (except BACKUP_ONLY_INCLUDE or MANUAL_INCLUDE is set)
+# as defined in var/lib/rear/recovery/mountpoint_device which contains at least '/'
+# where usually '/' is first because "fs ... /" is first in disklayout.conf
+# see usr/share/rear/layout/save/default/340_generate_mountpoint_device.sh
+# so the basic system files and directories get stored first in the backup
+# see https://github.com/rear/rear/pull/3177#issuecomment-1985926458
+# and https://github.com/rear/rear/issues/3217#issue-2277985295
 if ! is_true "$BACKUP_ONLY_INCLUDE" ; then
     if [ "${MANUAL_INCLUDE:-NO}" != "YES" ] ; then
-        # Add the mountpoints that will be recovered to the backup include list
-        # unless a mountpoint is excluded:
+        # Add the mountpoints that will be recovered to the backup include list unless a mountpoint is excluded.
+        # This looks contradicting because "mountpoints that will be recovered" should not be excluded via EXCLUDE_MOUNTPOINTS
+        # which excludes filesystems from being recreated by specifying their mountpoints (see EXCLUDE_MOUNTPOINTS in default.conf)
+        # so we report suspicious cases as LogPrintError to have the user at least informed:
         while read mountpoint device junk ; do
-            if ! IsInArray "$mountpoint" "${EXCLUDE_MOUNTPOINTS[@]}" ; then
-                echo "$mountpoint"
+            if IsInArray "$mountpoint" "${EXCLUDE_MOUNTPOINTS[@]}" ; then
+                LogPrintError "Mountpoint '$mountpoint' in $VAR_DIR/recovery/mountpoint_device is excluded in EXCLUDE_MOUNTPOINTS"
+                continue
             fi
-        done <"$VAR_DIR/recovery/mountpoint_device" >> $TMP_DIR/backup-include.txt
+            if ! mountpoint "$mountpoint" ; then
+                LogPrintError "Mountpoint '$mountpoint' in $VAR_DIR/recovery/mountpoint_device is no mountpoint"
+                continue
+            fi
+            echo "$mountpoint" >> "$TMP_DIR/backup-includes.txt"
+        done < "$VAR_DIR/recovery/mountpoint_device"
     fi
 fi
 
-# Exclude all that is explicitly specified in BACKUP_PROG_EXCLUDE:
-for backup_exclude_item in "${BACKUP_PROG_EXCLUDE[@]}" ; do
-    test "$backup_exclude_item" && echo "$backup_exclude_item"
-done > $TMP_DIR/backup-exclude.txt
+# Then also backup all that is explicitly specified in BACKUP_PROG_INCLUDE:
+for backup_include_item in "${BACKUP_PROG_INCLUDE[@]}" ; do
+    test "$backup_include_item" || continue
+    echo "$backup_include_item" >> "$TMP_DIR/backup-includes.txt"
+done
 
-# Implicitly also add excluded mountpoints to the backup exclude list
+# backup-include.txt is backup-includes.txt without duplicates but keeps the ordering
+# in particular when the user may have specified something in BACKUP_PROG_INCLUDE
+# which also gets backed up by the default backup of the mounted local filesystems
+# to avoid possibly unwanted and unexpected subtle consequences
+# see https://github.com/rear/rear/pull/3175#issuecomment-1985382738
+unique_unsorted "$TMP_DIR/backup-includes.txt" > "$TMP_DIR/backup-include.txt"
+
+# Verify that at least '/' is in backup-include.txt
+# because ReaR is meant to recreate a system so at least
+# the basic system files in the root filesystem must be backed up.
+# Examples how '/' could be missing in backup-include.txt:
+# - When BACKUP_ONLY_INCLUDE or MANUAL_INCLUDE is set
+#   the user may not have added '/' to BACKUP_PROG_INCLUDE
+#   so the '/' mountpoint will not be written into backup-include.txt
+# - When '/' is on a multipath device the default AUTOEXCLUDE_MULTIPATH=y
+#   will automatically exclude '/' and dependent components
+#   so '/' is not in var/lib/rear/recovery/mountpoint_device
+#   see https://github.com/rear/rear/issues/3189#issuecomment-2082747052
+#   and https://github.com/rear/rear/issues/3189#issuecomment-2082981807
+#   so that the above default backup of the mounted local filesystems
+#   will not write the '/' mountpoint into backup-include.txt
+# See https://github.com/rear/rear/issues/3217
+grep -q '^/$' "$TMP_DIR/backup-include.txt" || Error "At least the root filesystem must be backed up (no '/' in $TMP_DIR/backup-include.txt)"
+
+# What to exclude from the backup:
+cat /dev/null > "$TMP_DIR/backup-excludes.txt"
+
+# First exclude all that is specified to be excluded from the backup via BACKUP_PROG_EXCLUDE:
+for backup_exclude_item in "${BACKUP_PROG_EXCLUDE[@]}" ; do
+    test "$backup_exclude_item" || continue
+    echo "$backup_exclude_item" >> "$TMP_DIR/backup-excludes.txt"
+done
+
+# Then also add filesystems that are specified to be excluded from being recreated via their mountpoints
+# to the backup exclude list (see EXCLUDE_MOUNTPOINTS in default.conf)
 # except BACKUP_ONLY_EXCLUDE is set:
 if ! is_true "$BACKUP_ONLY_EXCLUDE" ; then
     for excluded_mountpoint in "${EXCLUDE_MOUNTPOINTS[@]}" ; do
-        test "$excluded_mountpoint" && echo "$excluded_mountpoint/"
-    done >> $TMP_DIR/backup-exclude.txt
+        if ! mountpoint "$excluded_mountpoint" ; then
+            LogPrintError "Mountpoint '$excluded_mountpoint' in EXCLUDE_MOUNTPOINTS is no mountpoint"
+            continue
+        fi
+        echo "$excluded_mountpoint/" >> "$TMP_DIR/backup-excludes.txt"
+    done
 fi
 
+# backup-exclude.txt is backup-excludes.txt without duplicates but keeps the ordering:
+unique_unsorted "$TMP_DIR/backup-excludes.txt" > "$TMP_DIR/backup-exclude.txt"

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -42,11 +42,11 @@ fi
 
 # Log what is included in the backup and what is excluded from the backup
 # cf. backup/NETFS/default/400_create_include_exclude_files.sh
-Log "Backup include list (backup-include.txt contents without subsequent duplicates):"
+Log "Backup include list $TMP_DIR/backup-include.txt"
 while read -r backup_include_item ; do
     test "$backup_include_item" && Log "  $backup_include_item"
 done < $TMP_DIR/backup-include.txt
-Log "Backup exclude list (backup-exclude.txt contents):"
+Log "Backup exclude list $TMP_DIR/backup-exclude.txt"
 while read -r backup_exclude_item ; do
     test "$backup_exclude_item" && Log "  $backup_exclude_item"
 done < $TMP_DIR/backup-exclude.txt

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -45,7 +45,7 @@ fi
 Log "Backup include list (backup-include.txt contents without subsequent duplicates):"
 while read -r backup_include_item ; do
     test "$backup_include_item" && Log "  $backup_include_item"
-done < <( cat $TMP_DIR/backup-include.txt )
+done < $TMP_DIR/backup-include.txt
 Log "Backup exclude list (backup-exclude.txt contents):"
 while read -r backup_exclude_item ; do
     test "$backup_exclude_item" && Log "  $backup_exclude_item"
@@ -151,7 +151,7 @@ case "$(basename ${BACKUP_PROG})" in
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                                      \
                 "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                               \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f -                                        \
-                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |                  \
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |                              \
             { $BACKUP_PROG_CRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV | \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
@@ -160,14 +160,14 @@ case "$(basename ${BACKUP_PROG})" in
                 "$(basename $(echo "$BACKUP_PROG" | awk '{ print $1 }'))"
                 "$(basename $(echo "$SPLIT_COMMAND" | awk '{ print $1 }'))"
             )
-            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose  \
-                --no-wildcards-match-slash --one-file-system                      \
-                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                  \
-                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                 \
-                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                     \
-                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                              \
-                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                       \
-                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE | \
+            $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
+                --no-wildcards-match-slash --one-file-system                     \
+                --ignore-failed-read "${BACKUP_PROG_OPTIONS[@]}"                 \
+                $BACKUP_PROG_CREATE_NEWER_OPTIONS                                \
+                ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                    \
+                "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                             \
+                -X $TMP_DIR/backup-exclude.txt -C / -c -f -                      \
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |            \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
         fi

--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -45,7 +45,7 @@ fi
 Log "Backup include list (backup-include.txt contents without subsequent duplicates):"
 while read -r backup_include_item ; do
     test "$backup_include_item" && Log "  $backup_include_item"
-done < <( unique_unsorted $TMP_DIR/backup-include.txt )
+done < <( cat $TMP_DIR/backup-include.txt )
 Log "Backup exclude list (backup-exclude.txt contents):"
 while read -r backup_exclude_item ; do
     test "$backup_exclude_item" && Log "  $backup_exclude_item"
@@ -127,7 +127,7 @@ case "$(basename ${BACKUP_PROG})" in
                 $BACKUP_PROG_CREATE_NEWER_OPTIONS \
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
-                $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $BACKUP_PROG_CRYPT_OPTIONS BACKUP_PROG_CRYPT_KEY \| $SPLIT_COMMAND
         else
             Log $BACKUP_PROG $TAR_OPTIONS --sparse --block-number --totals --verbose \
                 --no-wildcards-match-slash --one-file-system \
@@ -135,7 +135,7 @@ case "$(basename ${BACKUP_PROG})" in
                 $BACKUP_PROG_CREATE_NEWER_OPTIONS \
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS} "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f - \
-                $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $SPLIT_COMMAND
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE \| $SPLIT_COMMAND
         fi
 
         if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
@@ -151,7 +151,7 @@ case "$(basename ${BACKUP_PROG})" in
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                                      \
                 "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                                               \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f -                                        \
-                $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |                  \
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE |                  \
             { $BACKUP_PROG_CRYPT_OPTIONS "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV | \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
@@ -167,7 +167,7 @@ case "$(basename ${BACKUP_PROG})" in
                 ${BACKUP_PROG_BLOCKS:+-b $BACKUP_PROG_BLOCKS}                     \
                 "${BACKUP_PROG_COMPRESS_OPTIONS[@]}"                              \
                 -X $TMP_DIR/backup-exclude.txt -C / -c -f -                       \
-                $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE | \
+                $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE | \
             $SPLIT_COMMAND
             pipes_rc=( ${PIPESTATUS[@]} )
         fi
@@ -213,21 +213,21 @@ case "$(basename ${BACKUP_PROG})" in
         mkdir -p $v "$backuparchive" >&2
         Log $BACKUP_PROG --verbose "${BACKUP_RSYNC_OPTIONS[@]}" --one-file-system --delete \
             --exclude-from=$TMP_DIR/backup-exclude.txt --delete-excluded \
-            $(unique_unsorted $TMP_DIR/backup-include.txt) "$backuparchive"
+            $(cat $TMP_DIR/backup-include.txt) "$backuparchive"
         $BACKUP_PROG --verbose "${BACKUP_RSYNC_OPTIONS[@]}" --one-file-system --delete \
             --exclude-from=$TMP_DIR/backup-exclude.txt --delete-excluded \
-            $(unique_unsorted $TMP_DIR/backup-include.txt) "$backuparchive" >&2
+            $(cat $TMP_DIR/backup-include.txt) "$backuparchive" >&2
     ;;
     (*)
         Log "Using unsupported backup program '$BACKUP_PROG'"
         Log $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
             $BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
             "${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
-            $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
+            $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
         $BACKUP_PROG "${BACKUP_PROG_COMPRESS_OPTIONS[@]}" \
             $BACKUP_PROG_OPTIONS_CREATE_ARCHIVE $TMP_DIR/backup-exclude.txt \
             "${BACKUP_PROG_OPTIONS[@]}" $backuparchive \
-            $(unique_unsorted $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
+            $(cat $TMP_DIR/backup-include.txt) $RUNTIME_LOGFILE > $backuparchive
     ;;
 esac 2> "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log"
 # For the rsync and default case the backup prog is the last in the case entry


### PR DESCRIPTION
Overhauled 400_create_include_exclude_files.sh

* Type: **Cleanup** / **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3217

* How was this pull request tested?

https://github.com/rear/rear/pull/3175#issuecomment-2111776529

* Description of the changes in this pull request:

In backup/NETFS/default/400_create_include_exclude_files.sh

Now do first backup the mounted filesystems
to backup '/' first so the basic system files
get stored first in the backup and
then backup what is specified in BACKUP_PROG_INCLUDE
see https://github.com/rear/rear/pull/3177#issuecomment-1985926458
and https://github.com/rear/rear/issues/3217#issue-2277985295

Report suspicious cases as LogPrintError
to have the user at least informed.

Remove duplicates but keep the ordering (via unique_unsorted)
to avoid possibly unwanted and unexpected subtle consequences,
see https://github.com/rear/rear/pull/3175#issuecomment-1985382738

Verify that at least '/' is in backup-include.txt
see https://github.com/rear/rear/issues/3217

Redirect stdout into files exactly at the command where needed
instead of more global redirections, cf. "horrible coding style"
in https://github.com/rear/rear/pull/3175#issuecomment-2109554865

In backup/NETFS/default/500_make_backup.sh
unique_unsorted is no longer needed because
backup-include.txt is already without duplicates
because unique_unsorted is now called in
backup/NETFS/default/400_create_include_exclude_files.sh
so replaced unique_unsorted calls back to 'cat', cf.
https://github.com/rear/rear/commit/ec9080664303165799a215cef062826b65f6a6f8
