### PR TITLE
In 400_save_directories.sh mkdir $VAR_DIR/recovery/ when not existing

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -604,12 +604,12 @@ if test "$WORKFLOW" != "help" ; then
         # the portable mode should be able to work without the need to have a TMP_DIR in the rescue system.
         # i.e. there is no /mnt/local/var/tmp/rear.XXXXXXXXXXXXXXX/tmp so that
         #   chroot /mnt/local COMMAND
-        # fails when COMMAND uses TMPDIR - in particular "chroot /mnt/local dracut" fails
+        # fails when COMMAND uses TMPDIR = TMP_DIR - in particular "chroot /mnt/local dracut" fails
         # see https://github.com/rear/rear/pull/3168#issuecomment-1983377528
         if test "$TMPDIR_ORIG" ; then
-            tmpdir_debug_info="Changing TMPDIR to '$TMP_DIR' (was '$TMPDIR_ORIG' when ReaR was launched)"
+            tmpdir_debug_info="Changing TMPDIR to ReaR's '$TMP_DIR' (was '$TMPDIR_ORIG' when ReaR was launched)"
         else
-            tmpdir_debug_info="Setting TMPDIR to '$TMP_DIR' (was unset when ReaR was launched)"
+            tmpdir_debug_info="Setting TMPDIR to ReaR's '$TMP_DIR' (was unset when ReaR was launched)"
         fi
         export TMPDIR="$TMP_DIR"
     else

--- a/usr/share/rear/prep/default/400_save_directories.sh
+++ b/usr/share/rear/prep/default/400_save_directories.sh
@@ -8,6 +8,15 @@
 # those directories if they were not already recreated (e.g. via backup restore)
 # and all other code or scripts that also does this could/should be deleted.
 
+# When "rear mkrescue" is run for the very first time on a system or within a 'git clone' directory
+# this script would fail because $VAR_DIR/recovery/ is not yet created when this script runs
+# because $VAR_DIR/recovery/ gets normally created later in
+# layout/save/GNU/Linux/100_create_layout_file.sh ('prep' runs before 'layout/save')
+# so we create $VAR_DIR/recovery here same as it is done in 100_create_layout_file.sh
+# see https://github.com/rear/rear/issues/3222
+Log "Creating recovery directory (when not existing)"
+mkdir -p $v $VAR_DIR/recovery
+
 local directories_permissions_owner_group_file="$VAR_DIR/recovery/directories_permissions_owner_group"
 : >"$directories_permissions_owner_group_file"
 


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3222

* How was this pull request tested?

* Description of the changes in this pull request:

In prep/default/400_save_directories.sh
create $VAR_DIR/recovery/ when not existing
