### PR TITLE
default.conf add '/var/tmp/rear.*' to BACKUP_PROG_EXCLUDE

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1529,10 +1529,19 @@ BACKUP_PROG_ARCHIVE="${BACKUP_PROG_ARCHIVE:-backup}"
 # that is used e.g. in 'tar -X backup-exclude.txt' to get things excluded from the backup.
 # Quoting of the BACKUP_PROG_EXCLUDE array members avoids bash pathname expansion
 # when bash pathname expansion is not wanted for the BACKUP_PROG_EXCLUDE array members.
+# Via the '/directory/*' form the plain directory is still included in the backup
+# which is mandatory when directories have special owner,group,permissions set
+# to ensure directories get restored from the backup with right owner,group,permissions.
+# By default /var/tmp/rear.* is excluded because ReaR uses /var/tmp/rear.* as TMPDIR
+# (see TMPDIR and KEEP_BUILD_DIR above) to avoid that one gets ReaR's whole BUILD_DIR
+# at least of the current "rear mkbackup" run included in the backup.
+# Also ReaR's VAR_DIR/output is excluded because in particular with OUTPUT=ISO
+# the ReaR recovery system ISO image var/lib/rear/output/rear-HOSTNAME.iso
+# could be rather big and is not needed in the backup.
 # In /etc/rear/local.conf use BACKUP_PROG_EXCLUDE+=( '/this/*' '/that/*' )
 # to specify your particular items that should be excluded from the backup in addition to what
 # gets excluded from the backup by default here (see also BACKUP_ONLY_EXCLUDE below):
-BACKUP_PROG_EXCLUDE=( '/tmp/*' '/dev/shm/*' "$VAR_DIR/output/*" )
+BACKUP_PROG_EXCLUDE=( '/tmp/*' '/dev/shm/*' '/var/tmp/rear.*' "$VAR_DIR/output/*" )
 # BACKUP_PROG_INCLUDE is an array of strings that get written into a backup-include.txt file
 # that is used e.g. in 'tar -c $(cat backup-include.txt)' to get things included in the backup.
 # Quoting of the BACKUP_PROG_INCLUDE array members avoids bash pathname expansion


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
see at the end of
https://github.com/rear/rear/pull/3175#issuecomment-2114478980

* How was this pull request tested?
see
https://github.com/rear/rear/pull/3175#issuecomment-2114478980

* Description of the changes in this pull request:

In default.conf add `/var/tmp/rear.*` to BACKUP_PROG_EXCLUDE
because since ReaR uses `/var/tmp/rear.*` as BUILD_DIR
one would get at least the whole BUILD_DIR
of the current "rear mkbackup" run
in the backup by default.

Additionally describe why ReaR's VAR_DIR/output is excluded.

Also describe why the `'/directory/*'` form is used, cf.
https://github.com/rear/rear/pull/3175#issuecomment-2114478980
