### PR TITLE
In sbin/rear make it clear when ReaR's TMP_DIR is used

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -604,12 +604,12 @@ if test "$WORKFLOW" != "help" ; then
         # the portable mode should be able to work without the need to have a TMP_DIR in the rescue system.
         # i.e. there is no /mnt/local/var/tmp/rear.XXXXXXXXXXXXXXX/tmp so that
         #   chroot /mnt/local COMMAND
-        # fails when COMMAND uses TMPDIR - in particular "chroot /mnt/local dracut" fails
+        # fails when COMMAND uses TMPDIR = TMP_DIR - in particular "chroot /mnt/local dracut" fails
         # see https://github.com/rear/rear/pull/3168#issuecomment-1983377528
         if test "$TMPDIR_ORIG" ; then
-            tmpdir_debug_info="Changing TMPDIR to '$TMP_DIR' (was '$TMPDIR_ORIG' when ReaR was launched)"
+            tmpdir_debug_info="Changing TMPDIR to ReaR's '$TMP_DIR' (was '$TMPDIR_ORIG' when ReaR was launched)"
         else
-            tmpdir_debug_info="Setting TMPDIR to '$TMP_DIR' (was unset when ReaR was launched)"
+            tmpdir_debug_info="Setting TMPDIR to ReaR's '$TMP_DIR' (was unset when ReaR was launched)"
         fi
         export TMPDIR="$TMP_DIR"
     else


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/3175#issuecomment-2112594449
and
https://github.com/rear/rear/pull/3223#issuecomment-2114294271

* How was this pull request tested?
https://github.com/rear/rear/pull/3175#issuecomment-2114420830

* Description of the changes in this pull request:

In usr/sbin/rear make it more clear
in a comment and in DebugPrint messages
when ReaR's TMP_DIR gets used
(in contrast to the system's TMPDIR)

Details - from
https://github.com/rear/rear/pull/3223#issuecomment-2114294271

While debugging things in
https://github.com/rear/rear/pull/3175#issuecomment-2112594449
I got a bit confused because it was not clear to me
if ReaR's TMP_DIR was used versus the system's TMPDIR
so I inspected the code in usr/sbin/rear which was
```
    if ! [[ "$RECOVERY_MODE" || "$PORTABLE" ]] ; then
        ...
            tmpdir_debug_info="Setting TMPDIR to '$TMP_DIR' (was unset when ReaR was launched)"
        ...
    else
        ...
            tmpdir_debug_info="Setting TMPDIR to '$TMPDIR' (was unset when ReaR was launched)"
```
i.e. same message text like
```
Setting TMPDIR to '/var/tmp' (was unset when ReaR was launched)
```
for two different cases so it was not possible
to see from the message text which case it was.
The '/var/tmp' indicates it was the second case
but that is not 100% clear.
So that I had to reverse-engineer things
to understand what actually goes on.
With the improvement it looks like
```
Setting TMPDIR to ReaR's '/var/tmp/rear.3pc7RyD4Ki2uoMC/tmp' (was unset when ReaR was launched)
```
versus
```
Setting TMPDIR to '/var/tmp' (was unset when ReaR was launched)
```