### PR TITLE
Do not exclude '/var/tmp/rear.*' in default.conf

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1534,8 +1534,8 @@ BACKUP_PROG_ARCHIVE="${BACKUP_PROG_ARCHIVE:-backup}"
 # to ensure directories get restored from the backup with right owner,group,permissions.
 # ReaR's VAR_DIR/output is excluded to avoid ISOs being backed up with OUTPUT=ISO
 # because the ISO image var/lib/rear/output/rear-HOSTNAME.iso could be rather big
-# and the ISO image is generally kept and used outside the backup (cf. OUTPUT_URL)
-# especially since the backup can be embedded inside, (cf. BACKUP_URL=iso:///backup).
+# especially since the backup can be embedded inside (cf. BACKUP_URL=iso:///backup)
+# and the ISO image is generally kept and used outside the backup (cf. OUTPUT_URL).
 # ReaR's current working/build area (see TMPDIR and KEEP_BUILD_DIR above)
 # which is normally /var/tmp/rear.XXXXXXXXXXXXXXX (by default TMPDIR is /var/tmp)
 # is automatically excluded in /usr/sbin/rear via BACKUP_PROG_EXCLUDE+=( "$BUILD_DIR" )

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1526,22 +1526,24 @@ BACKUP_PROG_DECRYPT_OPTIONS="/usr/bin/openssl des3 -d -k "
 # (i.e. during "rear recover" a dynamic name does not make sense).
 BACKUP_PROG_ARCHIVE="${BACKUP_PROG_ARCHIVE:-backup}"
 # BACKUP_PROG_EXCLUDE is an array of strings that get written into a backup-exclude.txt file
-# that is used e.g. in 'tar -X backup-exclude.txt' to get things excluded from the backup.
+# which is used e.g. in 'tar -X backup-exclude.txt' to get things excluded from the backup.
 # Quoting of the BACKUP_PROG_EXCLUDE array members avoids bash pathname expansion
-# when bash pathname expansion is not wanted for the BACKUP_PROG_EXCLUDE array members.
+# so e.g. 'tar' gets the unexpanded BACKUP_PROG_EXCLUDE array elements.
 # Via the '/directory/*' form the plain directory is still included in the backup
 # which is mandatory when directories have special owner,group,permissions set
 # to ensure directories get restored from the backup with right owner,group,permissions.
-# By default /var/tmp/rear.* is excluded because ReaR uses /var/tmp/rear.* as TMPDIR
-# (see TMPDIR and KEEP_BUILD_DIR above) to avoid that one gets ReaR's whole BUILD_DIR
-# at least of the current "rear mkbackup" run included in the backup.
-# Also ReaR's VAR_DIR/output is excluded because in particular with OUTPUT=ISO
-# the ReaR recovery system ISO image var/lib/rear/output/rear-HOSTNAME.iso
-# could be rather big and is not needed in the backup.
+# ReaR's VAR_DIR/output is excluded to avoid ISOs being backed up with OUTPUT=ISO
+# because the ISO image var/lib/rear/output/rear-HOSTNAME.iso could be rather big.
+# ReaR's current working/build area (see TMPDIR and KEEP_BUILD_DIR above)
+# which is normally /var/tmp/rear.XXXXXXXXXXXXXXX (by default TMPDIR is /var/tmp)
+# is automatically excluded in /usr/sbin/rear via BACKUP_PROG_EXCLUDE+=( "$BUILD_DIR" )
+# but the whole /var/tmp should not be excluded from the backup by default here
+# because /var/tmp is for persistent temporary files (see "man file-hierarchy")
+# so in general files in /var/tmp need to be cleaned up deliberately by the user.
 # In /etc/rear/local.conf use BACKUP_PROG_EXCLUDE+=( '/this/*' '/that/*' )
-# to specify your particular items that should be excluded from the backup in addition to what
-# gets excluded from the backup by default here (see also BACKUP_ONLY_EXCLUDE below):
-BACKUP_PROG_EXCLUDE=( '/tmp/*' '/dev/shm/*' '/var/tmp/rear.*' "$VAR_DIR/output/*" )
+# to specify your particular items that should be excluded from the backup in addition
+# to what gets excluded by default here (see also BACKUP_ONLY_EXCLUDE below):
+BACKUP_PROG_EXCLUDE=( '/tmp/*' '/dev/shm/*' "$VAR_DIR/output/*" )
 # BACKUP_PROG_INCLUDE is an array of strings that get written into a backup-include.txt file
 # that is used e.g. in 'tar -c $(cat backup-include.txt)' to get things included in the backup.
 # Quoting of the BACKUP_PROG_INCLUDE array members avoids bash pathname expansion

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1525,7 +1525,7 @@ BACKUP_PROG_DECRYPT_OPTIONS="/usr/bin/openssl des3 -d -k "
 # for "rear recover" so that the backup can be found and restored
 # (i.e. during "rear recover" a dynamic name does not make sense).
 BACKUP_PROG_ARCHIVE="${BACKUP_PROG_ARCHIVE:-backup}"
-# BACKUP_PROG_EXCLUDE is an array of strings that get written into a backup-exclude.txt file
+# BACKUP_PROG_EXCLUDE is an array of strings that get written into a backup-exclude.txt file,
 # which is used e.g. in 'tar -X backup-exclude.txt' to get things excluded from the backup.
 # Quoting of the BACKUP_PROG_EXCLUDE array members avoids bash pathname expansion
 # so e.g. 'tar' gets the unexpanded BACKUP_PROG_EXCLUDE array elements.
@@ -1533,7 +1533,9 @@ BACKUP_PROG_ARCHIVE="${BACKUP_PROG_ARCHIVE:-backup}"
 # which is mandatory when directories have special owner,group,permissions set
 # to ensure directories get restored from the backup with right owner,group,permissions.
 # ReaR's VAR_DIR/output is excluded to avoid ISOs being backed up with OUTPUT=ISO
-# because the ISO image var/lib/rear/output/rear-HOSTNAME.iso could be rather big.
+# because the ISO image var/lib/rear/output/rear-HOSTNAME.iso could be rather big
+# and the ISO image is generally kept and used outside the backup (cf. OUTPUT_URL)
+# especially since the backup can be embedded inside, (cf. BACKUP_URL=iso:///backup).
 # ReaR's current working/build area (see TMPDIR and KEEP_BUILD_DIR above)
 # which is normally /var/tmp/rear.XXXXXXXXXXXXXXX (by default TMPDIR is /var/tmp)
 # is automatically excluded in /usr/sbin/rear via BACKUP_PROG_EXCLUDE+=( "$BUILD_DIR" )


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/3224

* How was this pull request tested?

I manually reverted the actual change in
https://github.com/rear/rear/pull/3224
and then the current ReaR BUILD_DIR is not included
in the backup but a leftover ReaR BUILD_DIR from
a previous "rear -D mkbackup" gets correctly included
in the backup because it is my task to remove
my intentionally kept BUILD_DIR (via '-D').

* Description of the changes in this pull request:

Revert the actual change in
https://github.com/rear/rear/pull/3224
and have BACKUP_PROG_EXCLUDE in default.conf same as before
because the current BUILD_DIR gets automatically
excluded in usr/sbin/rear via
```
BACKUP_PROG_EXCLUDE+=( "$BUILD_DIR" )
```

It is not ReaR's task to exclude possibly lefover
older ReaR working areas because in general
files in /var/tmp are persistent which need
to be cleaned up deliberately by the user
(and not by ReaR from behind via its backup).

Also described things more clearly in the comment.
