### PR TITLE
Fix version test in udev start by desupporting systemd < 190

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,7 +3,6 @@ jobs:
 - job: copr_build
   targets:
   - fedora-all
-  - centos-stream-8-x86_64
   - centos-stream-9-x86_64
   - opensuse-leap-15.3-x86_64
   - opensuse-tumbleweed-x86_64
@@ -19,7 +18,6 @@ jobs:
   metadata:
   targets:
   - fedora-all
-  - centos-stream-8-x86_64
   - centos-stream-9-x86_64
 specfile_path: packaging/rpm/rear.spec
 files_to_sync:

--- a/usr/share/rear/build/GNU/Linux/600_verify_and_adjust_udev.sh
+++ b/usr/share/rear/build/GNU/Linux/600_verify_and_adjust_udev.sh
@@ -6,8 +6,10 @@ test -d $ROOTFS_DIR/etc/udev/rules.d || return 0
 
 # check systemd version
 systemd_version="$(systemd-notify --version 2>/dev/null | grep systemd | awk '{print $2}')"
-[[ -z "$systemd_version" ]] && systemd_version=0
-if version_newer "$systemd_version" 190; then
+if [[ -n "$systemd_version" ]] ; then
+   if ! version_newer "$systemd_version" 190 ; then
+       Error "systemd version is '$systemd_version', systemd versions below 190 are not supported"
+   fi
    ps ax | grep -v grep | grep -q systemd-udevd && { # check if daemon is actually running
        Log "systemd-udevd will be used - no need for udev rules rewrites"
        return 0

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh
@@ -17,11 +17,7 @@ fi
 
 # load udev or load modules manually
 # again, check if current systemd is present
-systemd_version=$( systemd-notify --version 2>/dev/null | grep systemd | awk '{ print $2; }' )
-# if $systemd_version is empty we put it 0 (no systemd present)
-test "$systemd_version" || systemd_version=0
-
-if [[ $systemd_version -gt 190 ]] || [[ -s /etc/udev/rules.d/00-rear.rules ]] ; then
+if type systemd-notify 1>/dev/null || [[ -s /etc/udev/rules.d/00-rear.rules ]] ; then
     # systemd-udevd case: systemd-udevd is started by systemd
     # Wait up to 10 seconds for systemd-udevd:
     for countdown in 4 3 2 1 0 ; do


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): #3175

* How was this pull request tested?
Together with the changes in #3175 , the backup&recovery test make-backup-and-restore-iso passes when executed locally on Fedora rawhide.

* Description of the changes in this pull request:
/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh in the rescue system examines systemd version in order to know whether it should use udev or load modules manually.

Unfortunately, at least on Fedora, the systemd version can contain a tilde (the systemd version is equal to the systemd package version, which conforms to the Fedora conventions: https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/#_handling_non_sorting_versions_with_tilde_dot_and_caret ) and the bash code that compares versions chokes on it on Fedora rawhide, as the current systemd version in Fedora rawhide is `256~rc3`:
`/etc/scripts/system-setup.d/40-start-udev-or-load-modules.sh: line 24: [[: 256~rc3: syntax error in expression (error token is "~rc3")`
and then the wrong branch is taken.

This leads at least to non-working make-backup-and-restore-iso CI test due to the ramdisk (brd) module being loaded earlier and thus not respecting the desired parameters. (A ramdisk of a pre-determined size is used to emulate the backup ISO in the test.) Probably has other unwanted consequences as well.

As reasonably modern distros should have a newer systemd (even RHEL 7 has systemd 219 and Ubuntu 16.04 has 229), delete the check and error out in a similar check during mkrescue if a too old systemd is encountered.

The check in build/GNU/Linux/600_verify_and_adjust_udev.sh is more robust, so it could be used as an alternative if desupporting old systemd is not desired. The `version_newer` function would have to be moved to a library available during boot, though, and the function does not really check for a tilde in version, thus it appears to work more by accident than by design.