### PR TITLE
Replace obsolete `egrep` with `grep -E`

### DIFF
--- a/doc/user-guide/14-ZYPPER-and-YUM.adoc
+++ b/doc/user-guide/14-ZYPPER-and-YUM.adoc
@@ -95,7 +95,7 @@ longer required after other RPMs had been removed (those are probably orphans).
 *Option: COPY_AS_IS_ZYPPER and COPY_AS_IS_EXCLUDE_ZYPPER*
 
 The COPY_AS_IS_ZYPPER array contains by default basically what `rpm -qc 
-zypper ; rpm -ql libzypp | egrep -v 'locale|man'` shows (currently determined 
+zypper ; rpm -ql libzypp | grep -Ev 'locale|man'` shows (currently determined 
 on openSUSE Leap 42.1) plus the special _/etc/products.d/baseproduct_ link 
 and whereto it points and rpm because that is required by zypper/libzypp and
 finally all kernel modules because otherwise modules like 'isofs' and some 

--- a/doc/user-guide/15-EFISTUB.adoc
+++ b/doc/user-guide/15-EFISTUB.adoc
@@ -140,7 +140,7 @@ BACKUP_PROG_EXCLUDE+=( /mnt )
 #BTRFS stuff
 REQUIRED_PROGS+=( snapper chattr lsattr xfs_repair )
 COPY_AS_IS+=( /usr/lib/snapper/installation-helper /etc/snapper/config-templates/default )
-BACKUP_PROG_INCLUDE=( $(findmnt -n -r -t btrfs | cut -d ' ' -f 1 | grep -v '^/$' | egrep -v 'snapshots|crash' ) )
+BACKUP_PROG_INCLUDE=( $(findmnt -n -r -t btrfs | cut -d ' ' -f 1 | grep -v '^/$' | grep -Ev 'snapshots|crash' ) )
 
 EFI_STUB=y
 ```

--- a/tests/setup1/verify.sh
+++ b/tests/setup1/verify.sh
@@ -10,7 +10,7 @@ echo
 echo "CASE $CASE"
 echo
 
-DEVICES="$( ls /sys/class/net/ | egrep -wv "(bonding_masters|eth0|lo)" )"
+DEVICES="$( ls /sys/class/net/ | grep -Ewv "(bonding_masters|eth0|lo)" )"
 
 # Cleanup of network interfaces
 for dev in $DEVICES; do
@@ -28,11 +28,11 @@ sleep 3
 tmpfile_ipa=$( mktemp /tmp/REARXXX )
 tmpfile_ipr=$( mktemp /tmp/REARXXX )
 
-DEVICES="$( ls /sys/class/net/ | egrep -wv "(bonding_masters|eth0|lo)" )"
+DEVICES="$( ls /sys/class/net/ | grep -Ewv "(bonding_masters|eth0|lo)" )"
 
 for dev in $DEVICES; do
 	ip addr show dev $dev
-done 2>/dev/null | egrep -w "(mtu|inet)" | sed -e "s/^[0-9]*: //" -e "s/ group \S* / /" > $tmpfile_ipa
+done 2>/dev/null | grep -Ew "(mtu|inet)" | sed -e "s/^[0-9]*: //" -e "s/ group \S* / /" > $tmpfile_ipa
 
 for dev in $DEVICES; do
 	ip r show dev $dev

--- a/tools/run-in-docker.bashrc
+++ b/tools/run-in-docker.bashrc
@@ -1,6 +1,6 @@
 PATH=/rear/tools:$PATH:/rear/usr/sbin
 
-alias egrep='egrep --color=auto'
+alias egrep='grep -E --color=auto'
 alias grep='grep --color=auto'
 alias l='ls -CF'
 alias la='ls -A'

--- a/usr/share/rear/backup/YUM/default/600_capture_selinux_contexts.sh
+++ b/usr/share/rear/backup/YUM/default/600_capture_selinux_contexts.sh
@@ -24,7 +24,7 @@ set -e -u -o pipefail
 local yum_backup_dir=$( dirname "$backuparchive" )
 test -d $yum_backup_dir || mkdir $verbose -p -m 755 $yum_backup_dir
 
-find $(cat $TMP_DIR/backup-include.txt) -xdev -exec stat -c "%C %n" {} \; | egrep -w -v -f $TMP_DIR/backup-exclude.txt > $yum_backup_dir/selinux_contexts.dat
+find $(cat $TMP_DIR/backup-include.txt) -xdev -exec stat -c "%C %n" {} \; | grep -E -w -v -f $TMP_DIR/backup-exclude.txt > $yum_backup_dir/selinux_contexts.dat
 
 # Go back from "set -e -u -o pipefail" to the defaults:
 apply_bash_flags_and_options_commands "$DEFAULT_BASH_FLAGS_AND_OPTIONS_COMMANDS"

--- a/usr/share/rear/build/default/490_fix_broken_links.sh
+++ b/usr/share/rear/build/default/490_fix_broken_links.sh
@@ -66,7 +66,7 @@ pushd $ROOTFS_DIR
             # finalize/GNU/Linux/250_migrate_lun_wwid.sh
             # finalize/GNU/Linux/280_migrate_uuid_tags.sh
             # finalize/GNU/Linux/320_migrate_network_configuration_files.sh
-            if echo $link_target | egrep -q '^/(proc|sys|dev|run)/' ; then
+            if echo $link_target | grep -Eq '^/(proc|sys|dev|run)/' ; then
                 DebugPrint "Skip copying broken symlink '$broken_symlink' target '$link_target' on /proc/ /sys/ /dev/ or /run/"
                 continue
             fi

--- a/usr/share/rear/build/default/990_verify_rootfs.sh
+++ b/usr/share/rear/build/default/990_verify_rootfs.sh
@@ -99,7 +99,7 @@ for binary in $( find $ROOTFS_DIR -type f \( -executable -o -name '*.so' -o -nam
     # Skip the ldd test for ReaR files (mainly bash scripts) where it does not make sense
     # (programs in the recovery system get all copied into /bin/ so it is /bin/rear)
     # cf. https://github.com/rear/rear/issues/2519#issuecomment-731196820
-    egrep -q "/lib/modules/|/lib.*/firmware/|$SHARE_DIR|/bin/rear$" <<<"$binary" && continue
+    grep -Eq "/lib/modules/|/lib.*/firmware/|$SHARE_DIR|/bin/rear$" <<<"$binary" && continue
     # Skip the ldd test for files that are not owned by a trusted user to mitigate possible ldd security issues
     # because some versions of ldd may directly execute the file (see "man ldd") as user 'root' here
     # cf. the RequiredSharedObjects code in usr/share/rear/lib/linux-functions.sh

--- a/usr/share/rear/build/default/995_md5sums_rootfs.sh
+++ b/usr/share/rear/build/default/995_md5sums_rootfs.sh
@@ -50,6 +50,6 @@ pushd $ROOTFS_DIR 1>&2
     # firmware/brcm/brcmfmac43430a0-sdio.ONDA-V80 PLUS.txt
     # firmware/brcm/brcmfmac43455-sdio.MINIX-NEO Z83-4.txt
     # cf. https://github.com/rear/rear/issues/2407
-    find . -xdev -type f -print0 | egrep -z -v '/md5sums\.txt|/\.gitignore|~$|/dev/' | xargs -0 md5sum -b >>$md5sums_file || cat /dev/null >$md5sums_file
+    find . -xdev -type f -print0 | grep -E -z -v '/md5sums\.txt|/\.gitignore|~$|/dev/' | xargs -0 md5sum -b >>$md5sums_file || cat /dev/null >$md5sums_file
 popd 1>&2
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3098,7 +3098,7 @@ ZYPPER_REPOSITORIES=( "cd:///?devices=/dev/sr0" )
 # or are no longer required after other RPMs had been removed (those are probably orphans):
 ZYPPER_INSTALL_RPMS=""
 # The COPY_AS_IS_ZYPPER array contains by default basically what
-#   rpm -qc zypper ; rpm -ql libzypp | egrep -v 'locale|man'
+#   rpm -qc zypper ; rpm -ql libzypp | grep -Ev 'locale|man'
 # shows (currently determined on openSUSE Leap 42.1)
 # plus the special /etc/products.d/baseproduct link and where to it points
 # and rpm because that is required by zypper/libzypp and

--- a/usr/share/rear/conf/examples/SLE12-SP1-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-SP1-btrfs-example.conf
@@ -57,7 +57,7 @@ COPY_AS_IS+=( /usr/lib/snapper/installation-helper /etc/snapper/config-templates
 #   /.snapshots  /var/crash
 # but files in /home are included to be in the backup.
 # You may use a command like
-#   findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash'
+#   findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | grep -Ev 'snapshots|crash'
 # to generate the values:
 BACKUP_PROG_INCLUDE=( /var/tmp /srv /var/lib/pgsql /var/spool /var/lib/libvirt/images /var/opt/ /tmp /var/lib/named /var/log /boot/grub2/i386 /var/lib/mariadb /home /var/lib/mailman /opt /usr/local /boot/grub2/x86_64 )
 # Set a root password for the ReaR recovery system in a confidential way

--- a/usr/share/rear/conf/examples/SLE12-SP2-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-SP2-btrfs-example.conf
@@ -59,7 +59,7 @@ COPY_AS_IS+=( /usr/lib/snapper/installation-helper /etc/snapper/config-templates
 #   /.snapshots  /var/crash
 # but files in /home are included to be in the backup.
 # You may use a command like
-#   findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash'
+#   findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | grep -Ev 'snapshots|crash'
 # to generate the values:
 BACKUP_PROG_INCLUDE=( /var/cache /var/lib/mailman /var/tmp /var/lib/pgsql /usr/local /opt /var/lib/libvirt/images /boot/grub2/i386-pc /var/opt /srv /boot/grub2/x86_64-efi /var/lib/mariadb /var/spool /var/lib/mysql /tmp /home /var/log /var/lib/named /var/lib/machines )
 # The following POST_RECOVERY_SCRIPT implements during "rear recover"

--- a/usr/share/rear/conf/examples/SLE12-btrfs-example.conf
+++ b/usr/share/rear/conf/examples/SLE12-btrfs-example.conf
@@ -35,7 +35,7 @@ NETFS_KEEP_OLD_BACKUP_COPY=yes
 #   /.snapshots  /var/crash
 # but files in /home are included to be in the backup.
 # You may use a command like
-#   findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash'
+#   findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | grep -Ev 'snapshots|crash'
 # to generate the values:
 BACKUP_PROG_INCLUDE=( /home /var/tmp /var/spool /var/opt /var/log /var/lib/pgsql /var/lib/mailman /var/lib/named /usr/local /tmp /srv /boot/grub2/x86_64-efi /opt /boot/grub2/i386-pc )
 # Set a root password for the ReaR recovery system in a confidential way

--- a/usr/share/rear/finalize/Fedora/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/Fedora/550_rebuild_initramfs.sh
@@ -67,10 +67,10 @@ WITH_INITRD_MODULES=$( printf '%s\n' $INITRD_MODULES | awk '{printf "--add-drive
 # kdump images as they are build by kdump
 # initramfs rescue images (>= Rhel 7), which need all modules and are created by new-kernel-pkg
 # initrd-plymouth.img (>= Rhel 7), which contains only files needed for graphical boot via plymouth
-for INITRD_IMG in $( ls $TARGET_FS_ROOT/boot/initramfs-*.img $TARGET_FS_ROOT/boot/initrd-*.img | egrep -v '(kdump|rescue|plymouth)' ) ; do
+for INITRD_IMG in $( ls $TARGET_FS_ROOT/boot/initramfs-*.img $TARGET_FS_ROOT/boot/initrd-*.img | grep -Ev '(kdump|rescue|plymouth)' ) ; do
     # Do not use KERNEL_VERSION here because that is readonly in the rear main script:
     kernel_version=$( basename $( echo $INITRD_IMG ) | cut -f2- -d"-" | sed s/"\.img"// )
-    INITRD=$( echo $INITRD_IMG | egrep -o "/boot/.*" )
+    INITRD=$( echo $INITRD_IMG | grep -Eo "/boot/.*" )
     LogPrint "Running dracut..."
     # Run dracut directly in chroot without a login shell in between (see https://github.com/rear/rear/issues/862).
     # We need the dracut binary in the chroot environment i.e. the dracut binary in the recreated system.

--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_disk_devices_layout.sh
@@ -56,7 +56,7 @@ do
             # If the symlink target contains /proc/ /sys/ /dev/ or /run/ we skip it because then
             # the symlink target is considered to not be a restored file that needs to be patched
             # cf. https://github.com/rear/rear/pull/2047#issuecomment-464846777
-            if echo $symlink_target | egrep -q '/proc/|/sys/|/dev/|/run/' ; then
+            if echo $symlink_target | grep -Eq '/proc/|/sys/|/dev/|/run/' ; then
                 LogPrint "Skip patching symlink $restored_file target $symlink_target on /proc/ /sys/ /dev/ or /run/"
                 continue
             fi

--- a/usr/share/rear/finalize/GNU/Linux/250_migrate_lun_wwid.sh
+++ b/usr/share/rear/finalize/GNU/Linux/250_migrate_lun_wwid.sh
@@ -51,7 +51,7 @@ do
             # If the symlink target contains /proc/ /sys/ /dev/ or /run/ we skip it because then
             # the symlink target is considered to not be a restored file that needs to be patched
             # cf. https://github.com/rear/rear/pull/2047#issuecomment-464846777
-            if echo $symlink_target | egrep -q '/proc/|/sys/|/dev/|/run/' ; then
+            if echo $symlink_target | grep -Eq '/proc/|/sys/|/dev/|/run/' ; then
                 LogPrint "Skip patching symlink $restored_file target $symlink_target on /proc/ /sys/ /dev/ or /run/"
                 continue
             fi

--- a/usr/share/rear/finalize/GNU/Linux/260_rename_diskbyid.sh
+++ b/usr/share/rear/finalize/GNU/Linux/260_rename_diskbyid.sh
@@ -97,7 +97,7 @@ for file in $FILES; do
             # If the symlink target contains /proc/ /sys/ /dev/ or /run/ we skip it because then
             # the symlink target is considered to not be a restored file that needs to be patched
             # cf. https://github.com/rear/rear/pull/2047#issuecomment-464846777
-            if echo $symlink_target | egrep -q '/proc/|/sys/|/dev/|/run/' ; then
+            if echo $symlink_target | grep -Eq '/proc/|/sys/|/dev/|/run/' ; then
                 LogPrint "Skip patching symlink $realfile target $symlink_target on /proc/ /sys/ /dev/ or /run/"
                 continue
             fi

--- a/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
+++ b/usr/share/rear/finalize/GNU/Linux/280_migrate_uuid_tags.sh
@@ -50,7 +50,7 @@ do
             # If the symlink target contains /proc/ /sys/ /dev/ or /run/ we skip it because then
             # the symlink target is considered to not be a restored file that needs to be patched
             # cf. https://github.com/rear/rear/pull/2047#issuecomment-464846777
-            if echo $symlink_target | egrep -q '/proc/|/sys/|/dev/|/run/' ; then
+            if echo $symlink_target | grep -Eq '/proc/|/sys/|/dev/|/run/' ; then
                 LogPrint "Skip patching symlink $restored_file target $symlink_target on /proc/ /sys/ /dev/ or /run/"
                 continue
             fi

--- a/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
+++ b/usr/share/rear/finalize/GNU/Linux/320_migrate_network_configuration_files.sh
@@ -81,7 +81,7 @@ function valid_restored_file_for_patching () {
     # If the symlink target contains /proc/ /sys/ /dev/ or /run/ we skip it because then
     # the symlink target is considered to not be a restored file that needs to be patched
     # cf. https://github.com/rear/rear/pull/2047#issuecomment-464846777
-    if echo $symlink_target | egrep -q '/proc/|/sys/|/dev/|/run/' ; then
+    if echo $symlink_target | grep -Eq '/proc/|/sys/|/dev/|/run/' ; then
         Log "Skip patching symlink $restored_file target $symlink_target on /proc/ /sys/ /dev/ or /run/"
         return 1
     fi

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -474,5 +474,5 @@ Log "Saving disks and their partitions"
 # what program calls are written to diskrestore.sh and which programs will be run during "rear recover" in any case
 # e.g. mdadm is not called in any case and sfdisk is only used in case of BLOCKCLONE_STRICT_PARTITIONING
 # cf. https://github.com/rear/rear/issues/1963
-egrep -q '^disk |^part ' $DISKLAYOUT_FILE && REQUIRED_PROGS+=( parted partprobe ) || true
+grep -Eq '^disk |^part ' $DISKLAYOUT_FILE && REQUIRED_PROGS+=( parted partprobe ) || true
 

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -396,7 +396,7 @@ Log "End saving LVM layout"
 # see the create_lvmdev create_lvmgrp create_lvmvol functions in layout/prepare/GNU/Linux/110_include_lvm_code.sh
 # what program calls are written to diskrestore.sh
 # cf. https://github.com/rear/rear/issues/1963
-egrep -q '^lvmdev |^lvmgrp |^lvmvol ' $DISKLAYOUT_FILE && REQUIRED_PROGS+=( lvm ) || true
+grep -Eq '^lvmdev |^lvmgrp |^lvmvol ' $DISKLAYOUT_FILE && REQUIRED_PROGS+=( lvm ) || true
 
 # vim: set et ts=4 sw=4:
 

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -308,8 +308,8 @@ fi
             if test $( btrfs subvolume list -a $btrfs_mountpoint | wc -l ) -gt 0 ; then
                 subvolume_list=$( btrfs subvolume list -a $btrfs_mountpoint | tr -s '[:blank:]' ' ' | cut -d ' ' -f 2,9 | sed -e 's/<FS_TREE>\///' )
                 prefix=$( echo "btrfsnormalsubvol $btrfs_device $btrfs_mountpoint" | sed -e 's/\//\\\//g' )
-                # Get the IDs of the snapshot subvolumes as pattern for "egrep -v" e.g. like
-                #   egrep -v '^279 |^280 |^281 |^282 |^285 |^286 |^289 |^290 '
+                # Get the IDs of the snapshot subvolumes as pattern for "grep -Ev" e.g. like
+                #   grep -Ev '^279 |^280 |^281 |^282 |^285 |^286 |^289 |^290 '
                 # to exclude snapshot subvolume lines to get only the normal subvolumes.
                 # btrfs subvolume IDs are only unique for one same btrfs filesystem
                 # which is the case here because the btrfs_device_and_mountpoint is fixed herein
@@ -320,7 +320,7 @@ fi
                 # When there are no snapshot subvolumes $snapshot_subvolumes_pattern variable will be empty.
                 # This special case must be handled properly when setting up $subvolumes_exclude_pattern
                 # otherwise ReaR would not recreate the btrfs subvolumes during recovery
-                # because an empty pattern in the below egrep -v '|...' command would
+                # because an empty pattern in the below grep -Ev '|...' command would
                 # exclude all lines (see https://github.com/rear/rear/pull/1435):
                 if test -z "$snapshot_subvolumes_pattern" ; then
                     subvolumes_exclude_pattern=""
@@ -366,7 +366,7 @@ fi
                     # $snapshot_subvolumes_pattern variable will be empty. This special case
                     # must be handled properly when setting up $subvolumes_exclude_pattern
                     # otherwise ReaR would not recreate the btrfs subvolumes during recovery
-                    # because an empty pattern in the below egrep -v '|...' command would
+                    # because an empty pattern in the below grep -Ev '|...' command would
                     # exclude all lines (see https://github.com/rear/rear/pull/1435):
                     if test -z "$snapshot_subvolumes_pattern" ; then
                         subvolumes_exclude_pattern="$snapper_base_subvolume"
@@ -391,19 +391,19 @@ fi
                         echo "# Because any '@/.snapshots' subvolume would let 'snapper/installation-helper --step 1' fail"
                         echo "# such subvolumes are deactivated here to not let 'rear recover' fail:"
                         if test -z "$snapshot_subvolumes_pattern" ; then
-                            # With an empty snapshot_subvolumes_pattern egrep -v '' would exclude all lines:
+                            # With an empty snapshot_subvolumes_pattern grep -Ev '' would exclude all lines:
                             echo "$subvolume_list" | grep "$snapper_base_subvolume" | sed -e "s/^/#$prefix /"
                         else
-                            echo "$subvolume_list" | egrep -v "$snapshot_subvolumes_pattern" | grep "$snapper_base_subvolume" | sed -e "s/^/#$prefix /"
+                            echo "$subvolume_list" | grep -Ev "$snapshot_subvolumes_pattern" | grep "$snapper_base_subvolume" | sed -e "s/^/#$prefix /"
                         fi
                     fi
                 fi
                 # Output btrfs normal subvolumes:
                 if test -z "$subvolumes_exclude_pattern" ; then
-                    # With an empty subvolumes_exclude_pattern egrep -v '' would exclude all lines:
+                    # With an empty subvolumes_exclude_pattern grep -Ev '' would exclude all lines:
                     echo "$subvolume_list" | sed -e "s/^/$prefix /"
                 else
-                    echo "$subvolume_list" | egrep -v "$subvolumes_exclude_pattern" | sed -e "s/^/$prefix /"
+                    echo "$subvolume_list" | grep -Ev "$subvolumes_exclude_pattern" | sed -e "s/^/$prefix /"
                 fi
             fi
         done
@@ -455,8 +455,8 @@ fi
                     # the subvolume path can be specified with or without leading '/'.
                     # Aviod SC1087 by using ${subvolume_mountpoint} with curly brackets because
                     # we need the subsequent square brackets literally (subvolume_mountpoint is a string, not an array):
-                    btrfs_subvolume_path=$( egrep "[[:space:]]${subvolume_mountpoint}[[:space:]]+btrfs[[:space:]]" /etc/fstab \
-                                            | egrep -v '^[[:space:]]*#' \
+                    btrfs_subvolume_path=$( grep -E "[[:space:]]${subvolume_mountpoint}[[:space:]]+btrfs[[:space:]]" /etc/fstab \
+                                            | grep -E -v '^[[:space:]]*#' \
                                             | grep -o 'subvol=[^ ]*' | cut -s -d '=' -f 2 )
                 fi
                 # Remove leading '/' from btrfs_subvolume_path (except it is only '/') to have same syntax for all entries and

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -84,7 +84,7 @@ while read target_name junk ; do
         #         Cipher key: 512 bits
         # cf. https://github.com/rear/rear/pull/2504#issuecomment-718729198 and subsequent comments
         # so we grep for both lines but use only the first match from the first slot:
-        key_size=$( egrep -m 1 "Key:|Cipher key:" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+) bits$/\1/' )
+        key_size=$( grep -E -m 1 "Key:|Cipher key:" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+) bits$/\1/' )
         hash=$( grep "Hash" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
     fi
 

--- a/usr/share/rear/layout/save/GNU/Linux/270_hpraid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/270_hpraid_layout.sh
@@ -121,5 +121,5 @@ done
 # see the create_logicaldrive and create_smartarray functions in layout/prepare/GNU/Linux/170_include_hpraid_code.sh
 # what program calls are written to diskrestore.sh
 # cf. https://github.com/rear/rear/issues/1963
-egrep -q '^logicaldrive |^smartarray ' $DISKLAYOUT_FILE && REQUIRED_PROGS+=( $HPSSACLI ) || true
+grep -E -q '^logicaldrive |^smartarray ' $DISKLAYOUT_FILE && REQUIRED_PROGS+=( $HPSSACLI ) || true
 

--- a/usr/share/rear/layout/save/GNU/Linux/510_current_disk_usage.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/510_current_disk_usage.sh
@@ -9,7 +9,7 @@ local original_disk_space_usage_file="$VAR_DIR/layout/config/df.txt"
 contains_visible_char "$USB_DEVICE_FILESYSTEM_LABEL" || USB_DEVICE_FILESYSTEM_LABEL="REAR-000"
 local rear_USB_data_partition="$( readlink -f "/dev/disk/by-label/$USB_DEVICE_FILESYSTEM_LABEL" )"
 local rear_USB_ESP_partition="$( readlink -f /dev/disk/by-label/REAR-EFI )"
-# Careful with "egrep -v" patterns because with an empty pattern egrep -v '' discards all lines:
+# Careful with "grep -Ev" patterns because with an empty pattern grep -Ev '' discards all lines:
 local egrep_pattern=""
 test "$rear_USB_data_partition" && egrep_pattern="^$rear_USB_data_partition"
 if test "$rear_USB_ESP_partition" ; then
@@ -19,7 +19,7 @@ fi
 # because the values are used in 420_autoresize_last_partitions.sh to calculate whether or not
 # the current disk usage still fits on a smaller disk when the last partition must be shrinked:
 if test "$egrep_pattern" ; then
-    df -Pl -BM -x encfs -x tmpfs -x devtmpfs | egrep -v "$egrep_pattern" >$original_disk_space_usage_file
+    df -Pl -BM -x encfs -x tmpfs -x devtmpfs | grep -Ev "$egrep_pattern" >$original_disk_space_usage_file
 else
     df -Pl -BM -x encfs -x tmpfs -x devtmpfs >$original_disk_space_usage_file
 fi

--- a/usr/share/rear/layout/save/default/490_check_files_to_patch.sh
+++ b/usr/share/rear/layout/save/default/490_check_files_to_patch.sh
@@ -28,7 +28,7 @@ for file in $FILES_TO_PATCH_PATTERNS ; do
             # the symlink target is considered to not be a restored file that needs to be patched
             # and thus we don't need to generate and check its hash, either
             # cf. https://github.com/rear/rear/pull/2047#issuecomment-464846777
-            if echo $symlink_target | egrep -q '/proc/|/sys/|/dev/|/run/' ; then
+            if echo $symlink_target | grep -Eq '/proc/|/sys/|/dev/|/run/' ; then
                 Log "Skip adding symlink $final_file target $symlink_target on /proc/ /sys/ /dev/ or /run/ to CHECK_CONFIG_FILES"
                 continue
             fi

--- a/usr/share/rear/lib/_input-output-functions.sh
+++ b/usr/share/rear/lib/_input-output-functions.sh
@@ -692,7 +692,7 @@ function Error () {
     # Add two spaces indentation for better readability what those extracted log file lines are.
     # Some messages could be too long to be usefully shown on the user's terminal so that they are truncated after 200 bytes:
     if test -s "$RUNTIME_LOGFILE" ; then
-        { local last_sourced_script_log_messages="$( sed -n -e "/Including .*$last_sourced_script_filename/,/+ [Bug]*Error /p" $RUNTIME_LOGFILE | egrep -v "^\+|Including .*$last_sourced_script_filename" | tail -n 8 | sed -e 's/^/  /' | cut -b-200 )" ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
+        { local last_sourced_script_log_messages="$( sed -n -e "/Including .*$last_sourced_script_filename/,/+ [Bug]*Error /p" $RUNTIME_LOGFILE | grep -E -v "^\+|Including .*$last_sourced_script_filename" | tail -n 8 | sed -e 's/^/  /' | cut -b-200 )" ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
         if test "$last_sourced_script_log_messages" ; then
             PrintError "Some latest log messages since the last called script $last_sourced_script_filename:"
             PrintError "$last_sourced_script_log_messages"
@@ -704,7 +704,7 @@ function Error () {
     if test -f "$STDOUT_STDERR_FILE" ; then
         # We use the same extraction pipe as above because STDOUT_STDERR_FILE may also contain 'set -x' and things like that
         # because scripts could use 'set -x' and things like that as needed (e.g. diskrestore.sh runs with 'set -x'):
-        { local last_sourced_script_stdout_stderr_messages="$( sed -n -e "/Including .*$last_sourced_script_filename/,/+ [Bug]*Error /p" $STDOUT_STDERR_FILE | egrep -v "^\+|Including .*$last_sourced_script_filename" | tail -n 8 | sed -e 's/^/  /' | cut -b-200 )" ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
+        { local last_sourced_script_stdout_stderr_messages="$( sed -n -e "/Including .*$last_sourced_script_filename/,/+ [Bug]*Error /p" $STDOUT_STDERR_FILE | grep -E -v "^\+|Including .*$last_sourced_script_filename" | tail -n 8 | sed -e 's/^/  /' | cut -b-200 )" ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
         if test "$last_sourced_script_stdout_stderr_messages" ; then
             # When stdout and stderr are redirected to STDOUT_STDERR_FILE messages of the last called programs cannot be in the log
             # so we use LogPrintError and 'echo "string of messages" >>$RUNTIME_LOGFILE' (the latter avoids the timestamp prefix)

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -156,7 +156,7 @@ generate_layout_dependencies() {
                 vgrp=$(echo "$remainder" | cut -d " " -f "1")
                 lvol=$(echo "$remainder" | cut -d " " -f "2")
                 # When a LV is a Thin, then we need to create the Thin Pool first
-                pool=$(echo "$remainder" | egrep -ow "thinpool:\\S+" | cut -d ":" -f 2)
+                pool=$(echo "$remainder" | grep -Eow "thinpool:\\S+" | cut -d ":" -f 2)
 
                 # Vgs and Lvs containing - in their name have a double dash in DM
                 dm_vgrp=${vgrp//-/--}
@@ -195,7 +195,7 @@ generate_layout_dependencies() {
                     if [ "${mp#$temp_dep_mp}" != "${mp}" ] && [ "$mp" != "$dep_mp" ]; then
                         add_dependency "$type:$mp" "$dep_type:$dep_mp"
                     fi
-                done < <( egrep '^fs |^btrfsmountedsubvol ' $LAYOUT_FILE )
+                done < <( grep -E '^fs |^btrfsmountedsubvol ' $LAYOUT_FILE )
                 ;;
             swap)
                 dev=$(echo "$remainder" | cut -d " " -f "1")

--- a/usr/share/rear/lib/linux-functions.sh
+++ b/usr/share/rear/lib/linux-functions.sh
@@ -186,7 +186,7 @@ function RequiredSharedObjects () {
         # Skip the ldd test for kernel modules and firmware files
         # which could happen via COPY_AS_IS+=( /lib/firmware/my_hardware )
         # cf. the code in build/default/990_verify_rootfs.sh
-        egrep -q '/lib/modules/|/lib.*/firmware/' <<<"$file_for_ldd" && continue
+        grep -Eq '/lib/modules/|/lib.*/firmware/' <<<"$file_for_ldd" && continue
         # Skip files that are not owned by a trusted user to mitigate possible ldd security issues
         # because some versions of ldd may directly execute the file (see "man ldd")
         # which could lead to the execution of arbitrary programs as user 'root'

--- a/usr/share/rear/lib/mkrescue-functions.sh
+++ b/usr/share/rear/lib/mkrescue-functions.sh
@@ -170,7 +170,7 @@ FixSfdiskPartitionFile () {
 # makes sfdisk fail at restore time (we will remove those lines)
 # parameter: $1 is the sfdisk output file to fix
 
-egrep -vi '(^warning|^dos)'  "$1" > "${TMP_DIR}/partitions.tmp"
+grep -Evi '(^warning|^dos)'  "$1" > "${TMP_DIR}/partitions.tmp"
 
 # If LANG is not set to C (it should be) and sfdisk is producing locale specific comments
 # for example in French something like "N<degree sign (U+00B0)> table de partition de "

--- a/usr/share/rear/lib/rsync-functions.sh
+++ b/usr/share/rear/lib/rsync-functions.sh
@@ -25,7 +25,7 @@ function rsync_proto () {
     local url="$1"
 
     rsync_validate "$url"
-    if egrep -q '(::)' <<< $url ; then # new style '::' means rsync protocol
+    if grep -Eq '(::)' <<< $url ; then # new style '::' means rsync protocol
         echo rsync
     else
         echo ssh

--- a/usr/share/rear/prep/default/320_include_uefi_env.sh
+++ b/usr/share/rear/prep/default/320_include_uefi_env.sh
@@ -54,7 +54,7 @@ test "$( find /boot -maxdepth 1 -iname efi -type d )" || return 0
 # Next step is to get the EFI (Extensible Firmware Interface) system partition (ESP):
 local esp_proc_mounts_line=()
 # The output of
-#   egrep ' /boot/efi | /boot ' /proc/mounts
+#   grep -E ' /boot/efi | /boot ' /proc/mounts
 # may look like the following examples
 # on a openSUSE Leap 15.0 system
 #   /dev/sda1 /boot/efi vfat rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro 0 0

--- a/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
+++ b/usr/share/rear/rescue/NETFS/default/610_save_capabilities.sh
@@ -14,7 +14,7 @@ cat /dev/null > $VAR_DIR/recovery/capabilities
 # getcap and setcap are mandatory when NETFS_RESTORE_CAPABILITIES has a non-empty array member:
 has_binary getcap && has_binary setcap || Error "getcap and setcap are needed when NETFS_RESTORE_CAPABILITIES is non-empty"
 
-# Empty values must be avoided for egrep -v because egrep -v '' or egrep -v 'something|' matches all:
+# Empty values must be avoided for grep -Ev because grep -Ev '' or grep -Ev 'something|' matches all:
 exclude_directories="$BUILD_DIR"
 test "$ISO_DIR" && exclude_directories+="|$ISO_DIR"
 
@@ -26,6 +26,6 @@ LogPrint "Saving file capabilities (NETFS_RESTORE_CAPABILITIES)"
 for directory in "${NETFS_RESTORE_CAPABILITIES[@]}" ; do
     # Ignore stderr to avoid thousands of 'Failed to get capabilities of file'
     # stderr messages for directories like /proc /sys /dev in case of 'getcap -r /':
-    getcap -r $directory 2>/dev/null | egrep -v "$exclude_directories" >> $VAR_DIR/recovery/capabilities
+    getcap -r $directory 2>/dev/null | grep -Ev "$exclude_directories" >> $VAR_DIR/recovery/capabilities
 done
 

--- a/usr/share/rear/restore/BAREOS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/BAREOS/default/400_restore_backup.sh
@@ -124,7 +124,7 @@ else
         while true
         do
             sleep 3
-            echo "status client=$BAREOS_CLIENT" | bconsole | egrep "^JobId.* running." && break
+            echo "status client=$BAREOS_CLIENT" | bconsole | grep -E "^JobId.* running." && break
         done
 
         # wait for job to finish
@@ -132,7 +132,7 @@ else
         while true
         do
             sleep 10
-            echo "status client=$BAREOS_CLIENT" | bconsole | egrep "^No Jobs running" >/dev/null && break
+            echo "status client=$BAREOS_CLIENT" | bconsole | grep -E "^No Jobs running" >/dev/null && break
         done
         LogPrint "Restore job finished."
     else

--- a/usr/share/rear/restore/YUM/default/940_generate_fstab.sh
+++ b/usr/share/rear/restore/YUM/default/940_generate_fstab.sh
@@ -29,7 +29,7 @@ while read keyword device_node junk ; do
     # Do not use a possibly outdated UUID from LAYOUT_FILE but determine the actual one in the current system:
     uuid=$( for uuid in * ; do readlink -e $uuid | grep -q $device_node && echo $uuid || true ; done  )
     # If fstab already contains an entry for this swap device, do nothing
-    if egrep -q "^UUID=$uuid\s+swap" $TARGET_FS_ROOT/etc/fstab || egrep -q "^$device_node\s+swap" $TARGET_FS_ROOT/etc/fstab ; then
+    if grep -Eq "^UUID=$uuid\s+swap" $TARGET_FS_ROOT/etc/fstab || grep -Eq "^$device_node\s+swap" $TARGET_FS_ROOT/etc/fstab ; then
         LogPrint "Skipping addition of swap device $device_node (UUID=$uuid) - already in etc/fstab of the target system"
 	continue
     fi
@@ -57,7 +57,7 @@ while read keyword device_node mountpoint filesystem_type junk ; do
     # Do not use a possibly outdated UUID from LAYOUT_FILE but determine the actual one in the current system:
     uuid=$( for uuid in * ; do readlink -e $uuid | grep -q $device_node && echo $uuid || true ; done  )
     # If fstab already contains an entry for this filesystem, do nothing
-    if egrep -q "^UUID=$uuid\s+$mountpoint" $TARGET_FS_ROOT/etc/fstab || egrep -q "^$device_node\s+$mountpoint" $TARGET_FS_ROOT/etc/fstab ; then
+    if grep -Eq "^UUID=$uuid\s+$mountpoint" $TARGET_FS_ROOT/etc/fstab || grep -Eq "^$device_node\s+$mountpoint" $TARGET_FS_ROOT/etc/fstab ; then
         LogPrint "Skipping addition of swap device $device_node (UUID=$uuid) - already in etc/fstab of the target system"
 	continue
     fi


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Description of the changes in this pull request:

Replace obsolete `egrep` with `grep -E` to fix the following warning from GNU grep
```console
$ egrep ...
egrep: warning: egrep is obsolescent; using grep -E
...
```
present in the `rear mkbackup` logs in Testing Farm.

Related: https://www.shellcheck.net/wiki/SC2196
Related: https://artifacts.dev.testing-farm.io/c02f01a7-83d0-4187-b69e-91dc043a457a/work-backup-and-restorez5wihv38/tests/plans/backup-and-restore/execute/data/guest/default-0/make-backup-and-restore-iso-1/data/rear-mkbackup.log
