### PR TITLE
Avoid returning 1 from a script if all is OK

### DIFF
--- a/usr/share/rear/output/ISO/Linux-i386/850_check_for_errors.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/850_check_for_errors.sh
@@ -1,2 +1,4 @@
 [[ $DEBUGSCRIPTS -eq 1 ]] && return   # to avoid throwing an error in DEBUG mode
 grep -iq "no space left" $RUNTIME_LOGFILE && Error "write error: No space left on device"
+# do not return 1 if grep fails - that's normal and expected
+return 0


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested?
CI has tested it - the message does not appear in the log https://artifacts.dev.testing-farm.io/54b1e241-c626-4dfb-92d4-bb369ae023db/work-backup-and-restoretjfz53h9/tests/plans/backup-and-restore/execute/data/guest/default-0/make-backup-and-restore-iso-1/data/rear-mkbackup.log anymore

* Description of the changes in this pull request:

If an error is not found in log, return 0. Not finding an error is good, so don't return 1 from the output/ISO/Linux-i386/850_check_for_errors.sh script.

Avoids the message
`Source function: 'source /usr/share/rear/output/ISO/Linux-i386/850_check_for_errors.sh' returns 1`
in the log.
