### PR TITLE
Reenable CentOS Stream 8 CI builds and tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,7 @@ jobs:
 - job: copr_build
   targets:
   - fedora-all
+  - centos-stream-8-x86_64
   - centos-stream-9-x86_64
   - opensuse-leap-15.3-x86_64
   - opensuse-tumbleweed-x86_64
@@ -18,6 +19,7 @@ jobs:
   metadata:
   targets:
   - fedora-all
+  - centos-stream-8-x86_64
   - centos-stream-9-x86_64
 specfile_path: packaging/rpm/rear.spec
 files_to_sync:


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): #3239

* How was this pull request tested?
See the testing-farm:centos-stream-8-x86_64 check.

* Description of the changes in this pull request:

Looks like CentOS Stream 8 repo locations are fixed: https://gitlab.com/testing-farm/infrastructure/-/merge_requests/610/diffs so we can reenable the build and test.
