### PR TITLE
Reduce the matrix of CI runs: disable the Fedora rawhide and 40 tests, Koji scratch builds, openSUSE Copr builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,12 +6,6 @@ jobs:
   - centos-stream-8-x86_64
   - centos-stream-9-x86_64
   trigger: pull_request
-- job: upstream_koji_build
-  scratch: True
-  targets:
-  - fedora-latest-stable
-  - epel-all
-  trigger: pull_request
 - job: tests
   trigger: pull_request
   metadata:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,8 +5,6 @@ jobs:
   - fedora-all
   - centos-stream-8-x86_64
   - centos-stream-9-x86_64
-  - opensuse-leap-15.3-x86_64
-  - opensuse-tumbleweed-x86_64
   trigger: pull_request
 - job: upstream_koji_build
   scratch: True

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,7 +10,7 @@ jobs:
   trigger: pull_request
   metadata:
   targets:
-  - fedora-all
+  - fedora-39-x86_64
   - centos-stream-8-x86_64
   - centos-stream-9-x86_64
 specfile_path: packaging/rpm/rear.spec


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Cleanup**

* Impact: **Normal**

* Reference to related issue (URL): #3251 

* How was this pull request tested?
See CI results

* Description of the changes in this pull request:
  * Disable some builds and tests to reduce false positives and clutter:
  * openSUSE Copr builds from Packit. The opensuse-leap-15.3-x86_64 was obsolete and opensuse-tumbleweed-x86_64 is not considered very useful: https://github.com/rear/rear/pull/3239#issuecomment-2173594371 . In the past, the builds were failing several times due to some breakage in Copr unrelated to ReaR or openSUSE. Disabling them may reduce false alarms from CI.
  * Koji scratch builds from Packit. They are unlikely to uncover any other issues than the Copr builds do and the resulting RPMs have not been very useful.
  * Fedora rawhide and 40 tests. They fail due to an unknown reason, see #3175. Letting them enabled will only generate false alarms in unrelated PRs.