### PR TITLE
Replace '/tmp/rear.XXX...' by '/var/tmp/rear.XXX...' in comments

### DIFF
--- a/usr/share/rear/build/GNU/Linux/390_copy_binaries_libraries.sh
+++ b/usr/share/rear/build/GNU/Linux/390_copy_binaries_libraries.sh
@@ -21,12 +21,12 @@ function copy_binaries () {
         contains_visible_char "$binary" || continue
         if ! cp $verbose --archive --dereference --force "$binary" "$destdir" 1>&2 ; then
             # When a binary should be copied where its target already exists as dangling symlink
-            # e.g. when /sbin/lvcreate should be copied to /tmp/rear.XXX/rootfs/bin/lvcreate
-            # but there is already the dangling symlink /tmp/rear.XXX/rootfs/bin/lvcreate -> lvm
+            # e.g. when /sbin/lvcreate should be copied to /var/tmp/rear.XXX/rootfs/bin/lvcreate
+            # but there is already the dangling symlink /var/tmp/rear.XXX/rootfs/bin/lvcreate -> lvm
             # because its link target was not yet copied into the recovery system
             # cf. "create LVM symlinks" in build/GNU/Linux/005_create_symlinks.sh
             # then cp fails (regardless of the --force option) with an error message like
-            # cp: not writing through dangling symlink '/tmp/rear.XXX/rootfs/bin/lvcreate'
+            # cp: not writing through dangling symlink '/var/tmp/rear.XXX/rootfs/bin/lvcreate'
             # so we silently skip cp errors here regardless what the reason is why cp failed here
             # and add it to REQUIRED_PROGS to error out later if it is actually missing in the recovery system
             # (for binaries in PROGS copy_binaries is only called when it exists in the original system)

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2970,7 +2970,7 @@ NETFS_KEEP_OLD_BACKUP_COPY=
 # For backup program that do not support to save and restore file capabilities
 # the user can manually specify NETFS_RESTORE_CAPABILITIES as a workaround
 # cf. https://github.com/rear/rear/issues/1175
-# Furthermore BUILD_DIR (i.e. usually /tmp/rear.XXXXXXXXXXXXXXX cf. TMPDIR above) and
+# Furthermore BUILD_DIR (i.e. usually /var/tmp/rear.XXXXXXXXXXXXXXX cf. TMPDIR above) and
 # ISO_DIR are automatically excluded cf. rescue/NETFS/default/610_save_capabilities.sh
 NETFS_RESTORE_CAPABILITIES=( 'No' )
 ####

--- a/usr/share/rear/layout/compare/default/500_compare_layout.sh
+++ b/usr/share/rear/layout/compare/default/500_compare_layout.sh
@@ -1,7 +1,7 @@
 # Test if ORIG_LAYOUT and TEMP_LAYOUT are the same.
 
 # Usually ORIG_LAYOUT is of the form var/lib/rear/layout/disklayout.conf
-# and TEMP_LAYOUT is of the form /tmp/rear.XXXX/tmp/checklayout.conf
+# and TEMP_LAYOUT is of the form /var/tmp/rear.XXXX/tmp/checklayout.conf
 # see lib/checklayout-workflow.sh
 
 # In case of btrfs the ordering of the btrfsmountedsubvol entries is random

--- a/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
@@ -11,7 +11,7 @@ is_true $USING_UEFI_BOOTLOADER || return 0 # empty or 0 means NO UEFI
 efi_img_sz=( $( du --block-size=32M --summarize $TMP_DIR/mnt ) ) || Error "Failed to determine disk usage of EFI virtual image content directory."
 
 # We add 2 more 32MiB blocks to be on the safe side against inexplicable failures like
-# "cp: error writing '/tmp/rear.XXX/tmp/efi_virt/./EFI/BOOT/...': No space left on device"
+# "cp: error writing '/var/tmp/rear.XXX/tmp/efi_virt/./EFI/BOOT/...': No space left on device"
 # where the above calculated $efi_img_sz is a bit too small in practice
 # cf. https://github.com/rear/rear/issues/2552
 (( efi_img_sz += 2 ))

--- a/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
+++ b/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
@@ -26,7 +26,7 @@ LogPrint "Making $RAW_USB_DEVICE bootable with syslinux/extlinux"
 # and USB_DEVICE is e.g. /dev/disk/by-label/REAR-000 (from BACKUP_URL=usb:///dev/disk/by-label/REAR-000) which is also the data partition
 # but here we need the filesystem where the booting related files are which are on the data partition or on the boot partition if exists
 # and that filesystem was mounted by output/default/100_mount_output_path.sh at $BUILD_DIR/outputfs which is shown in /proc/mounts like
-# /dev/sdb1 /tmp/rear.gfYZXbLIa2Xjult/outputfs ext2 rw,noatime 0 0
+# /dev/sdb1 /var/tmp/rear.XXXXXXXXXXXXXXX/outputfs ext2 rw,noatime 0 0
 # so we search for " $BUILD_DIR/outputfs " in /proc/mounts to get the filesystem (third field) where the booting related files are:
 usb_filesystem=$( grep " $BUILD_DIR/outputfs " /proc/mounts | cut -d' ' -f3 | tail -1 )
 case "$usb_filesystem" in

--- a/usr/share/rear/output/default/950_copy_result_files.sh
+++ b/usr/share/rear/output/default/950_copy_result_files.sh
@@ -77,7 +77,7 @@ if scheme_supports_filesystem $scheme ; then
     # Copy each result file one by one to avoid usually false error exits as in
     # https://github.com/rear/rear/issues/1711#issuecomment-380009044
     # where in case of an improper RESULT_FILES array member 'cp' can error out with something like
-    #   cp: will not overwrite just-created '/tmp/rear.XXX/outputfs/f121/rear-f121.log' with '/tmp/rear.XXX/tmp/rear-f121.log'
+    #   cp: will not overwrite just-created '/var/tmp/rear.XXX/outputfs/f121/rear-f121.log' with '/var/tmp/rear.XXX/tmp/rear-f121.log'
     # See
     # https://stackoverflow.com/questions/4669420/have-you-ever-got-this-message-when-moving-a-file-mv-will-not-overwrite-just-c
     # which is about the same for 'mv', how to reproduce it:

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -106,7 +106,7 @@ fi
 # The actual restoring:
 for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
     # Create backup restore log file name (a different one for each restore_input).
-    # Each restore_input is a path like '/tmp/rear.XXXX/outputfs/f121/backup.tar.gz':
+    # Each restore_input is a path like '/var/tmp/rear.XXXX/outputfs/f121/backup.tar.gz':
     restore_input_basename=$( basename $restore_input )
     backup_restore_log_file=$backup_restore_log_dir/$backup_restore_log_prefix.$restore_input_basename.$MASTER_PID.$backup_restore_log_suffix
     cat /dev/null >$backup_restore_log_file


### PR DESCRIPTION
Replace '/tmp/rear.XXX...' by '/var/tmp/rear.XXX...' in comments:

Current master code:
```
# find usr/sbin/rear usr/share/rear/ -type f | xargs grep -i 'tmp/rear\.' | grep -v '/var/tmp/rear\.'

usr/share/rear/conf/default.conf:
# Furthermore BUILD_DIR (i.e. usually /tmp/rear.XXXXXXXXXXXXXXX cf. TMPDIR above) and

usr/share/rear/restore/NETFS/default/400_restore_backup.sh:
    # Each restore_input is a path like '/tmp/rear.XXXX/outputfs/f121/backup.tar.gz':

usr/share/rear/layout/compare/default/500_compare_layout.sh:
# and TEMP_LAYOUT is of the form /tmp/rear.XXXX/tmp/checklayout.conf

usr/share/rear/build/GNU/Linux/390_copy_binaries_libraries.sh:
            # e.g. when /sbin/lvcreate should be copied to /tmp/rear.XXX/rootfs/bin/lvcreate

# but there is already the dangling symlink /tmp/rear.XXX/rootfs/bin/lvcreate -> lvm

# cp: not writing through dangling symlink '/tmp/rear.XXX/rootfs/bin/lvcreate'

usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh:
# /dev/sdb1 /tmp/rear.gfYZXbLIa2Xjult/outputfs ext2 rw,noatime 0 0

usr/share/rear/output/default/950_copy_result_files.sh:
    #   cp: will not overwrite just-created '/tmp/rear.XXX/outputfs/f121/rear-f121.log' with '/tmp/rear.XXX/tmp/rear-f121.log'

usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh:
# "cp: error writing '/tmp/rear.XXX/tmp/efi_virt/./EFI/BOOT/...': No space left on device"
```
