### PR TITLE
On hold: Implement SourceTrustworthy function

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -5,6 +5,7 @@ ip
 less
 parted
 readlink
+stat
 # For noninteractive confirmation in commands
 yes
 )
@@ -130,7 +131,6 @@ egrep
 fgrep
 chmod
 chown
-stat
 mkswap
 swapon
 swapoff

--- a/usr/share/rear/lib/framework-functions.sh
+++ b/usr/share/rear/lib/framework-functions.sh
@@ -46,7 +46,7 @@ function SourceTrustworthy () {
     # The actual work (source the source file):
     source "$source_file"
     source_return_code=$?
-    test "0" -eq "$source_return_code" && Debug "SourceTrustworthy: 'source $source_file' returns $source_return_code" || Debug "SourceTrustworthy function: 'source $source_file' returns $source_return_code"
+    test "0" -eq "$source_return_code" || Debug "SourceTrustworthy function: 'source $source_file' returns $source_return_code"
     # Restore the bash flags and options settings to what they have been before sourcing the source file:
     { apply_bash_flags_and_options_commands "$saved_bash_flags_and_options_commands" ; } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
     # Ensure that after each sourced file we are back in ReaR's usual working directory


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Critical**
Critical impact because with it we do no longer
basically carelessly "just source" various files
so it is security related.

* Reference to related issue (URL):
https://github.com/rear/rear/pull/3203#issuecomment-2178737640
https://github.com/rear/rear/pull/3203#issuecomment-2063439858
https://github.com/rear/rear/pull/3171#issuecomment-2082651756

* How was this pull request tested?
For now I only tested "rear -D mkrescue"
which works as before for me.

* Description of the changes in this pull request:

In lib/framework-functions.sh
new SourceTrustworthy function
to source only a trustworthy file.

A file is considered trustworthy to be sourced
when its file owner is one of the TRUSTED_FILE_OWNERS.

Because only the file owner can 'chmod'
cf. "man 2 chmod" that reads
```
The effective UID of the calling process
must match the owner of the file,
or the process must be privileged
(Linux: it must have the CAP_FOWNER capability).
```
we can sufficiently safely assume that a file
which is onwed by one of the TRUSTED_FILE_OWNERS
can be trusted to be sourced without further additional checks
(e.g. if other users may have permissions to modify the file)
and it should not be ReaR's task to prevent TRUSTED_FILE_OWNERS
from doing what they want (a.k.a. "final power to the user")
or simply put: TRUSTED_FILE_OWNERS means we do trust them.
