### PR TITLE
Autodetect secure boot via mokutil and guess the secure boot shim

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3916,6 +3916,9 @@ UEFI_BOOTLOADER=""
 # so when for example SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi" is specified
 # then all /boot/efi/EFI/BOOT/grub*.efi files are made available as second stage bootloader.
 # For more details see the output/ISO/Linux-i386/250_populate_efibootimg.sh script.
+#
+# If the mokutil tool is available on the system, and if it reports that secure boot is enabled,
+# then ReaR will try to guess the shim.efi and set it as SECURE_BOOT_BOOTLOADER.
 SECURE_BOOT_BOOTLOADER=""
 #
 # Some backup tools cannot store vfat filesystems and therefore also cannot

--- a/usr/share/rear/prep/Linux-i386/370_detect_secure_boot.sh
+++ b/usr/share/rear/prep/Linux-i386/370_detect_secure_boot.sh
@@ -8,7 +8,7 @@ test "$SECURE_BOOT_BOOTLOADER" && return 0
 #
 # The code in usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
 # could be used as a starting point for this, however currently
-# it tries to read the actual boot loader# used only as a last resort
+# it tries to read the actual boot loader used only as a last resort
 # if well-known files are not found.
 #
 if type -p mokutil ; then
@@ -19,16 +19,19 @@ if type -p mokutil ; then
             # Check first for arch-specific and then generic shim file, nullglob will give us the first one found and we ignore the others.
             # shellcheck disable=SC2206
             SECURE_BOOT_BOOTLOADER=( /boot/efi/EFI/*/shim$EFI_ARCH.efi /boot/efi/EFI/*/shim.efi )
+            test -z "$SECURE_BOOT_BOOTLOADER" && BugError "Secure Boot is active, cannot auto-configure Secure Boot support:$LF" \
+            "No shim.efi or shim$EFI_ARCH.efi found in /boot/efi/EFI/*/ directory.$LF$LF" \
+            "As a workaround you can set SECURE_BOOT_BOOTLOADER to the correct shim.efi or shim$EFI_ARCH.efi file"
             # shellcheck disable=SC2128
             LogPrint "Secure Boot auto-configuration using '$SECURE_BOOT_BOOTLOADER' as UEFI bootloader"
         else
-            DebugPrint "Secure Boot is disabled:$LF$secureboot_status"
+            DebugPrint "Secure Boot is disabled, not using Secure Boot shim:$LF$secureboot_status"
         fi
     else
-        DebugPrint "Secure Boot is not supported:$LF$secureboot_status"
+        DebugPrint "Secure Boot is not supported, not using Secure Boot shim:$LF$secureboot_status"
     fi
 else
-    DebugPrint "mokutil not found, cannot detect Secure Boot status"
+    DebugPrint "mokutil not found, cannot detect Secure Boot status, not using Secure Boot shim"
 fi
 
 return 0

--- a/usr/share/rear/prep/Linux-i386/370_detect_secure_boot.sh
+++ b/usr/share/rear/prep/Linux-i386/370_detect_secure_boot.sh
@@ -1,0 +1,34 @@
+test "$SECURE_BOOT_BOOTLOADER" && return 0
+
+# Note:
+# this is more of a hack than a really good solution.
+# The good solution would check the EFI variables for the bootloader
+# that is used to boot the system. But this is not implemented yet for
+# secure boot.
+#
+# The code in usr/share/rear/rescue/default/850_save_sysfs_uefi_vars.sh
+# could be used as a starting point for this, however currently
+# it tries to read the actual boot loader# used only as a last resort
+# if well-known files are not found.
+#
+if type -p mokutil ; then
+    PROGS+=( mokutil )
+    local secureboot_status
+    if secureboot_status=$(mokutil --sb-state 2>&1) ; then
+        if grep -q "SecureBoot enabled" <<<"$secureboot_status" ; then
+            # Check first for arch-specific and then generic shim file, nullglob will give us the first one found and we ignore the others.
+            # shellcheck disable=SC2206
+            SECURE_BOOT_BOOTLOADER=( /boot/efi/EFI/*/shim$EFI_ARCH.efi /boot/efi/EFI/*/shim.efi )
+            # shellcheck disable=SC2128
+            LogPrint "Secure Boot auto-configuration using '$SECURE_BOOT_BOOTLOADER' as UEFI bootloader"
+        else
+            DebugPrint "Secure Boot is disabled:$LF$secureboot_status"
+        fi
+    else
+        DebugPrint "Secure Boot is not supported:$LF$secureboot_status"
+    fi
+else
+    DebugPrint "mokutil not found, cannot detect Secure Boot status"
+fi
+
+return 0


### PR DESCRIPTION
Fixes #3276

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):

#3276 

* How was this pull request tested?

Manually on OL9u3 with secure boot and on Ubuntu 22 and openSUSE Leap 15.4 without secure boot

* Description of the changes in this pull request:

use `mokutil` to check for secure boot and guess the shim file - failing back to the previous behaviour if this doesn't work.

probably #3277 is a better or more complete implementation, however this one just adds a single file to automate the configuration that I had to add manually so far.