### PR TITLE
skel/default/etc/rsyslog.conf : others should not have read permissions

### DIFF
--- a/usr/share/rear/skel/default/etc/rsyslog.conf
+++ b/usr/share/rear/skel/default/etc/rsyslog.conf
@@ -6,8 +6,8 @@ $ModLoad imklog.so
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 $FileOwner root
 $FileGroup root
-$FileCreateMode 0644
-$DirCreateMode 0755
+$FileCreateMode 0640
+$DirCreateMode 0750
 
 *.*							/dev/tty12
 *.*							/var/log/messages


### PR DESCRIPTION
##### Pull Request Details:

* Type:  **Enhancement** 

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested? Not at all

* Description of the changes in this pull request: We have scanners that check that no log is world readable for compliance reasons. The default as it is set now violates this. I currently solve it by fixing the mode with ansible after package install. But since the possibly sensitive nature of this log I think it others should not have read permissions. This is something only a system adminstrator should have a look at.

