### PR TITLE
Make .codespellignore ASCII

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -6,7 +6,6 @@ Relax-and-Recover
 nd
 optionA
 optionB
-für
 hda
 Cruzer
 splitted


### PR DESCRIPTION
In .codespellignore the word 'für'
is likely no longer needed, see
https://github.com/rear/rear/commit/765c389ad97b7976b1a686a00e2323e74bd9137d#r146036920
