### PR TITLE
Request BIOS for backup and restore tests

### DIFF
--- a/tests/plans/backup-and-restore/main.fmf
+++ b/tests/plans/backup-and-restore/main.fmf
@@ -5,3 +5,8 @@ discover:
     how: fmf
     url: https://github.com/rear/rear-integration-tests
     path: tests
+
+provision:
+    hardware:
+      boot:
+        method: bios


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):  #3313 

* How was this pull request tested?
Not at all as it uses a feature that is not yet implemented in the Testing Farm infrastructure.

* Description of the changes in this pull request:
Request BIOS for backup and restore tests, they are very BIOS-specific due to the way the boot ISO is loaded via syslinux/memdisk. This change uses the documented syntax: https://tmt.readthedocs.io/en/stable/spec/hardware.html#boot , but it currently does not do anything as the Testing Farm infrastructure does not use the information yet to select the appropriate test VM. It thus merely prepares us for this feature when it gets implemented in Testing Farm and serves as a declaration of what the test needs.