### PR TITLE
Disable the backup & recovery test on Fedora

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,7 +10,6 @@ jobs:
   trigger: pull_request
   metadata:
   targets:
-  - fedora-39-x86_64
   - centos-stream-8-x86_64
   - centos-stream-9-x86_64
 specfile_path: packaging/rpm/rear.spec


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): fixes #3313

* How was this pull request tested?
See the CI results

* Description of the changes in this pull request:
The test is BIOS-specific and Fedora AWS images recently switched to UEFI, preventing the test from running correctly. As there is no way (yet) to ask the infrastructure for BIOS machines, disable the test. (In the future, this ability is planned to be provided via https://tmt.readthedocs.io/en/stable/spec/hardware.html#boot .)

