### PR TITLE
Fix partition naming on RHEL when migrating devices

### DIFF
--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -1044,24 +1044,10 @@ function get_part_device_name_format() {
                 ;;
 
                 (Fedora)
-                    if is_false "$user_friendly_names" ; then
-                        # RHEL 7 and above seems to named partitions on multipathed devices with
-                        # [mpath device UUID/WWID] + p + [part number] when "user_friendly_names"
-                        # option is FALSE.
-                        # For example: /dev/mapper/3600507680c82004cf8000000000000d8p1
-                        part_name="${device_name}p" # append p between main device and partitions
-                    else
-                        # RHEL 7 and above seems to named partitions on multipathed devices with
-                        # [mpath device name] + [part number] like standard disk when "user_friendly_names"
-                        # option is used (default).
-                        # For example: /dev/mapper/mpatha1
-                        # But the scheme in RHEL 6 need a "p" between [mpath device name] and [part number].
-                        # For example: /dev/mapper/mpathap1
-                        if (( $OS_MASTER_VERSION < 7 )) ; then
-                            part_name="${device_name}p" # append p between main device and partitions
-                        else
-                            part_name="${device_name}"
-                        fi
+                    # RHEL 7 and above add a "p" after the device name when the device name ends
+                    # by a digit, see https://access.redhat.com/solutions/2354631.
+                    if (( $OS_MASTER_VERSION < 7 )) || [[ ${device_name: -1} =~ [0-9] ]]; then
+                        part_name="${device_name}p"
                     fi
                 ;;
 


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested? Code tested in the following cases.

With QEMU SCSI disk ID "0000a":
~~~
rear> lsblk
NAME                           MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS
sda                              8:0    0    20G  0 disk
|-sda1                           8:1    0     1G  0 part
|-sda2                           8:2    0    19G  0 part
`-0QEMU_QEMU_HARDDISK_0000a    253:0    0    20G  0 mpath
  |-0QEMU_QEMU_HARDDISK_0000a1 253:1    0     1G  0 part
  `-0QEMU_QEMU_HARDDISK_0000a2 253:2    0    19G  0 part
sdb                              8:16   0    20G  0 disk
|-sdb1                           8:17   0     1G  0 part
|-sdb2                           8:18   0    19G  0 part
`-0QEMU_QEMU_HARDDISK_0000a    253:0    0    20G  0 mpath
  |-0QEMU_QEMU_HARDDISK_0000a1 253:1    0     1G  0 part
  `-0QEMU_QEMU_HARDDISK_0000a2 253:2    0    19G  0 part
sr0                             11:0    1 614.7M  0 rom
~~~

With QEMU SCSI disk ID "0000":
~~~
rear> lsblk
NAME                           MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS
sda                              8:0    0    20G  0 disk
|-sda1                           8:1    0     1G  0 part
|-sda2                           8:2    0    19G  0 part
`-0QEMU_QEMU_HARDDISK_0000     253:0    0    20G  0 mpath
  |-0QEMU_QEMU_HARDDISK_0000p1 253:1    0     1G  0 part
  `-0QEMU_QEMU_HARDDISK_0000p2 253:2    0    19G  0 part
sdb                              8:16   0    20G  0 disk
|-sdb1                           8:17   0     1G  0 part
|-sdb2                           8:18   0    19G  0 part
`-0QEMU_QEMU_HARDDISK_0000     253:0    0    20G  0 mpath
  |-0QEMU_QEMU_HARDDISK_0000p1 253:1    0     1G  0 part
  `-0QEMU_QEMU_HARDDISK_0000p2 253:2    0    19G  0 part
sr0                             11:0    1 614.7M  0 rom
~~~

With default friendly name ("mpatha"):
~~~
rear> lsblk
NAME        MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS
sda           8:0    0    20G  0 disk
|-sda1        8:1    0     1G  0 part
|-sda2        8:2    0    19G  0 part
`-mpatha    253:0    0    20G  0 mpath
  |-mpatha1 253:1    0     1G  0 part
  `-mpatha2 253:2    0    19G  0 part
sdb           8:16   0    20G  0 disk
|-sdb1        8:17   0     1G  0 part
|-sdb2        8:18   0    19G  0 part
`-mpatha    253:0    0    20G  0 mpath
  |-mpatha1 253:1    0     1G  0 part
  `-mpatha2 253:2    0    19G  0 part
sr0          11:0    1 614.7M  0 rom
~~~

With friendly name ending with a digit ("disk0"):
~~~
rear> lsblk
NAME        MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS
sda           8:0    0    20G  0 disk
|-sda1        8:1    0     1G  0 part
|-sda2        8:2    0    19G  0 part
`-disk0     253:0    0    20G  0 mpath
  |-disk0p1 253:1    0     1G  0 part
  `-disk0p2 253:2    0    19G  0 part
sdb           8:16   0    20G  0 disk
|-sdb1        8:17   0     1G  0 part
|-sdb2        8:18   0    19G  0 part
`-disk0     253:0    0    20G  0 mpath
  |-disk0p1 253:1    0     1G  0 part
  `-disk0p2 253:2    0    19G  0 part
sr0          11:0    1 614.7M  0 rom
~~~

* Description of the changes in this pull request:

The previous code was appending a "p" to the device name unconditionally, which ended up having partition names such as 'wwidp0' instead of 'wwid1', when the device name (e.g. 'wwid') ended with a letter and not a digit.
The new code applies the proper naming, which is 'wwid1' when device doesn't end with a digit (e.g. 'wwid'), and 'wwid0000p1' when the device (e.g. 'wwid0000') ends with a digit.

See also [When WWID does not end in digit, no `p` is added to the partition name of a multipath device in RHEL7](https://access.redhat.com/solutions/2354631)