### PR TITLE
Fix get_disklabel_type() not returning anything for multipath devices

### DIFF
--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -542,7 +542,7 @@ function get_disklabel_type () {
 
     disk=''
 
-    read component disk size label junk < <(grep "^disk $1 " "$LAYOUT_FILE")
+    read component disk size label junk < <(grep -E "^(disk|multipath) $1 " "$LAYOUT_FILE")
     test $disk || return 1
 
     echo $label


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* How was this pull request tested?

Tested on RHEL9 with a QEMU/KVM system having the disks in multipath:
~~~
$ virsh dumpxml multipath9
[...]
    <disk type='file' device='disk'>
      <driver name='qemu' type='raw' cache='none' discard='unmap'/>
      <source file='/var/lib/libvirt/images/multipath9.img' index='2'/>
      <backingStore/>
      <target dev='sdb' bus='scsi'/>
      <shareable/>
      <serial>OSDISK</serial>
      <alias name='scsi0-0-0-1'/>
      <address type='drive' controller='0' bus='0' target='0' unit='1'/>
    </disk>
    <disk type='file' device='disk'>
      <driver name='qemu' type='raw' cache='none' discard='unmap'/>
      <source file='/var/lib/libvirt/images/multipath9.img' index='1'/>
      <backingStore/>
      <target dev='sdc' bus='scsi'/>
      <shareable/>
      <serial>OSDISK</serial>
      <alias name='scsi0-0-0-2'/>
      <address type='drive' controller='0' bus='0' target='0' unit='2'/>
    </disk>
[...]

# cat /etc/rear/local.conf
[...]
ONLY_INCLUDE_VG=( "rhel" )
AUTOEXCLUDE_MULTIPATH=n
FIRMWARE_FILES=( 'no' )
[...]
~~~

* Description of the changes in this pull request:

Without this fix, `get_disklabel_type()` used to find the Grub device to install Grub on was returning nothing when the disk was a multipath device, leading to the error below:
~~~
2024-10-22 10:10:05.114081935 Determining where to install GRUB2 (no GRUB2_INSTALL_DEVICES specified)
 :
+++ get_disklabel_type /dev/mapper/0QEMU_QEMU_HARDDISK_OSDISK +++ local component disk size label junk
+++ disk=
+++ read component disk size label junk
++++ grep '^disk /dev/mapper/0QEMU_QEMU_HARDDISK_OSDISK ' /var/lib/rear/layout/disklayout.conf
+++ test
+++ return 1
++ label=
++ return 1
 :
2024-10-22 10:10:05.148970198 Failed to install GRUB2 - you may have to manually install it
~~~

The reason for this is the disklayout contains a line starting with **multipath** but ReaR code searches for **disk** only.
