### PR TITLE
Make sourcing DUPLY_PROFILE reasonably secure

### DIFF
--- a/usr/share/rear/backup/DUPLICITY/default/500_make_duplicity_backup.sh
+++ b/usr/share/rear/backup/DUPLICITY/default/500_make_duplicity_backup.sh
@@ -11,11 +11,11 @@ if [ "$BACKUP_PROG" = "duply" ] ; then
 
     # do the backup
     LogPrint "Starting full backup with duply/duplicity"
-    # redirect command stdout to stderr which appears in the ReaR logfile only in debug modes,
+    # command stdout and stderr output appears in the ReaR logfile only in debug modes,
     # cf. https://github.com/rear/rear/wiki/Coding-Style#what-to-do-with-stdin-stdout-and-stderr
     DebugPrint "Calling 'duply $DUPLY_PROFILE backup'"
     Debug "'duply $DUPLY_PROFILE backup' output:"
-    duply "$DUPLY_PROFILE" backup 1>&2 || Error "'duply $DUPLY_PROFILE backup' returned non-zero exit code, check $RUNTIME_LOGFILE"
+    duply "$DUPLY_PROFILE" backup || Error "'duply $DUPLY_PROFILE backup' returned non-zero exit code, check $RUNTIME_LOGFILE"
 fi
 
 

--- a/usr/share/rear/backup/DUPLICITY/default/500_make_duplicity_backup.sh
+++ b/usr/share/rear/backup/DUPLICITY/default/500_make_duplicity_backup.sh
@@ -1,17 +1,21 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-if [ "$BACKUP_PROG" = "duply" ] && has_binary duply ; then
-    # we found the duply program; check if a profile was defined
-    [[ -z "$DUPLY_PROFILE" ]] && return
+if [ "$BACKUP_PROG" = "duply" ] ; then
 
-    # a real profile was detected - check if we can talk to the remote site
+    has_binary duply || Error "No 'duply' binary (BACKUP_PROG=duply)"
+
+    # error out when DUPLY_PROFILE is empty or does not exist
+    # cf. the same test in prep/DUPLICITY/default/200_find_duply_profile.sh
+    test -s "$DUPLY_PROFILE" || Error "DUPLY_PROFILE '$DUPLY_PROFILE' empty or does not exist (BACKUP_PROG=duply)"
+
+    # do the backup
     LogPrint "Starting full backup with duply/duplicity"
-    duply "$DUPLY_PROFILE" backup >&2   # output is going to logfile
-    StopIfError "Duply profile $DUPLY_PROFILE backup returned errors - see $RUNTIME_LOGFILE"
-
-    LogPrint "The last full backup taken with duply/duplicity was:"
-    LogPrint "$( tail -50 $RUNTIME_LOGFILE | grep 'Last full backup date:' )"
+    # redirect command stdout to stderr which appears in the ReaR logfile only in debug modes,
+    # cf. https://github.com/rear/rear/wiki/Coding-Style#what-to-do-with-stdin-stdout-and-stderr
+    DebugPrint "Calling 'duply $DUPLY_PROFILE backup'"
+    Debug "'duply $DUPLY_PROFILE backup' output:"
+    duply "$DUPLY_PROFILE" backup 1>&2 || Error "'duply $DUPLY_PROFILE backup' returned non-zero exit code, check $RUNTIME_LOGFILE"
 fi
 
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -2806,14 +2806,25 @@ BAREOS_FILESET=
 ####
 # BACKUP=DUPLICITY
 ##
-# DUPLICITY is a cloud based external backup method
+# DUPLICITY is a cloud based external backup method.
+#
 # The program duply is wrapper script around duplicity which makes it much easier to use
 # and script in ReaR - duply uses the concept of a profile (basically a script with vars
-# to define your settings - use it as "duply <profile> status" to see it in action)
-# By using DUPLY_PROFILE we will try an automatic restore, if duplicity directly is used
-# then you better add some restore script in the COPY_AS_IS array
+# to define your settings - use it as "duply <profile> status" to see it in action).
+# With DUPLY_PROFILE we can do backup and restore via duply. If duplicity directly is used
+# then you may better use and add some appropriate restore script via the COPY_AS_IS array.
 #
 # BACKUP_PROG="duply"
+#
+# When duply is used its profile gets sourced (i.e. executed as bash script) by ReaR
+# via the prep/DUPLICITY/default/200_find_duply_profile.sh script.
+# Only an explicitly user specified DUPLY_PROFILE (with full path) gets sourced
+# to avoid that an automatism sources/executes whatever it may have found,
+# see https://github.com/rear/rear/issues/3259
+# and https://github.com/rear/rear/issues/3293
+# and https://github.com/rear/rear/pull/3345
+# ReaR errors out when DUPLY_PROFILE is empty or does not exist to ensure
+# that the user explicitly specified his correct and fully trusted DUPLY_PROFILE:
 DUPLY_PROFILE=""
 #
 ##

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -953,31 +953,4 @@ function mathlib_calculate()
     bc -ql <<<"result=$@ ; scale=0 ; result / 1 "
 }
 
-# Purpose is to find a working DUPLY profile configuration
-# Duply is a wrapper script around duplicity - this function is
-# used in the prep phase (for mkbackup) and in the verify phase
-# (to check the TEMP_DIR directory - it must be defined and cannot
-# be /tmp as this is usually a tmpfs file system which is too small)
-function find_duply_profile ()
-{
-    # there could be more then one profile present - select where SOURCE='/'
-    for CONF in $(echo "$1")
-    do
-        [[ ! -f $CONF ]] && continue
-        source $CONF    # is a normal shell configuration file
-        LogIfError "Could not source $CONF [duply profile]"
-        [[ -z "$SOURCE" ]] && continue
-        [[ -z "$TARGET" ]] && continue
-        # still here?
-        if [[ "$SOURCE" = "/" ]]; then
-            DUPLY_PROFILE_FILE=$CONF
-            DUPLY_PROFILE=$( dirname $CONF  )   # /root/.duply/mycloud/conf -> /root/.duply/mycloud
-            DUPLY_PROFILE=${DUPLY_PROFILE##*/}  # /root/.duply/mycloud      -> mycloud
-            break # the loop
-        else
-            DUPLY_PROFILE=""
-            continue
-        fi
-    done
-}
 

--- a/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
@@ -5,7 +5,7 @@
 
 # Actually this script sources (i.e. executes) the 'duply' profile.
 # The script file name is misleading because the find_duply_profile function
-# can no longer used because it is insecure to search some directories and
+# can no longer be used because it is insecure to search some directories and
 # then execute some found file which was not explicitly specified by the user,
 # cf. https://github.com/rear/rear/issues/3293
 

--- a/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
@@ -17,7 +17,7 @@ has_binary duply || return 0
 
 # If at least one of BACKUP_DUPLICITY_URL BACKUP_DUPLICITY_NETFS_URL BACKUP_DUPLICITY_NETFS_MOUNTCMD
 # is defined then we assume we are using only 'duplicity' and not the wrapper 'duply'
-# cf. the same code in prep/DUPLICITY/default/200_find_duply_profile.sh
+# cf. the same code in restore/DUPLICITY/default/110_check_temp_dir_with_duply.sh
 if [[ "$BACKUP_DUPLICITY_URL" || "$BACKUP_DUPLICITY_NETFS_URL" || "$BACKUP_DUPLICITY_NETFS_MOUNTCMD" ]] ; then
     DebugPrint "Assuming 'duplicity' is used and not 'duply' because BACKUP_DUPLICITY_URL or BACKUP_DUPLICITY_NETFS_URL or BACKUP_DUPLICITY_NETFS_MOUNTCMD is set"
     return 0

--- a/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
@@ -50,10 +50,13 @@ DebugPrint "Checking with 'duply $DUPLY_PROFILE status' if 'duply' can talk to t
 Debug "'duply $DUPLY_PROFILE status' output:"
 echo yes | duply "$DUPLY_PROFILE" status 1>&2 || Error "'duply $DUPLY_PROFILE status' failed, check $RUNTIME_LOGFILE"
 
-# We seem to use 'duply' as BACKUP_PROG - so define as such (instead of BACKUP_PROG=duplicity above):
+# We use 'duply' as BACKUP_PROG - so define as such (instead of BACKUP_PROG=duplicity above):
 BACKUP_PROG=duply
 
-echo "DUPLY_PROFILE=$DUPLY_PROFILE" >> "$ROOTFS_DIR/etc/rear/rescue.conf" || Error "Failed to add DUPLY_PROFILE to rescue.conf"
+COPY_AS_IS+=( "$DUPLY_PROFILE" )
+
+echo "DUPLY_PROFILE=$DUPLY_PROFILE" >> "$ROOTFS_DIR/etc/rear/rescue.conf" || Error "Failed to add 'DUPLY_PROFILE=$DUPLY_PROFILE' to rescue.conf"
+Log "Added 'DUPLY_PROFILE=$DUPLY_PROFILE' to rescue.conf"
 
 DebugPrint "Sourcing '$DUPLY_PROFILE'"
 source "$DUPLY_PROFILE" || Error "Failed to source $DUPLY_PROFILE"
@@ -74,7 +77,7 @@ source "$DUPLY_PROFILE" || Error "Failed to source $DUPLY_PROFILE"
 # Luckily ReaR uses TMP_DIR so sourcing DUPLY_PROFILE does not overwrite a ReaR variable,
 # cf. https://github.com/rear/rear/issues/3259 "ReaR must not carelessly 'source' files"
 local scheme="$( url_scheme "$TARGET" )"
-    case "$scheme" in
-       (sftp|rsync|scp)
-           REQUIRED_PROGS+=( "$scheme" )
-    esac
+case "$scheme" in
+    (sftp|rsync|scp)
+        REQUIRED_PROGS+=( "$scheme" )
+esac

--- a/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
@@ -44,11 +44,11 @@ test -s "$DUPLY_PROFILE" || Error "DUPLY_PROFILE '$DUPLY_PROFILE' empty or does 
 #     status     prints backup sets and chains currently in repository
 #     ...
 # the command "duply /path/to/profile status" prints backup sets and chains currently in repository
-# so we redirect its stdout to stderr which appears in the ReaR logfile only in debug modes,
+# so its stdout and stderr output appears in the ReaR logfile only in debug modes,
 # cf. https://github.com/rear/rear/wiki/Coding-Style#what-to-do-with-stdin-stdout-and-stderr
 DebugPrint "Checking with 'duply $DUPLY_PROFILE status' if 'duply' can talk to the remote site"
 Debug "'duply $DUPLY_PROFILE status' output:"
-echo yes | duply "$DUPLY_PROFILE" status 1>&2 || Error "'duply $DUPLY_PROFILE status' failed, check $RUNTIME_LOGFILE"
+echo yes | duply "$DUPLY_PROFILE" status || Error "'duply $DUPLY_PROFILE status' failed, check $RUNTIME_LOGFILE"
 
 # We use 'duply' as BACKUP_PROG - so define as such (instead of BACKUP_PROG=duplicity above):
 BACKUP_PROG=duply

--- a/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
@@ -3,78 +3,73 @@
 
 # 200_find_duply_profile.sh
 
-# If $BACKUP_DUPLICITY_URL has been defined then we may assume we are using
-# only 'duplicity' to make the backup and not the wrapper duply
-[[ "$BACKUP_DUPLICITY_URL" || "$BACKUP_DUPLICITY_NETFS_URL" || "$BACKUP_DUPLICITY_NETFS_MOUNTCMD" ]] && return
+# Actually this script sources (i.e. executes) the 'duply' profile.
+# The script file name is misleading because the find_duply_profile function
+# can no longer used because it is insecure to search some directories and
+# then execute some found file which was not explicitly specified by the user,
+# cf. https://github.com/rear/rear/issues/3293
 
-# purpose is to see we're using duply wrapper and if there is an existing profile defined
-# if that is the case then we define an internal variable DUPLY_PROFILE="profile"
-# the profile is in fact a directory name containing the conf file and exclude file
-# we shall copy this variable, if defined, to our rescue.conf file
+# Nothing to do when BACKUP_PROG is not 'duplicity':
+test "$BACKUP_PROG" = "duplicity" || return 0
 
-if [ "$BACKUP_PROG" = "duplicity" ] && has_binary duply; then
+# Nothing to do when we are not using the 'duply' wrapper for 'duplicity':
+has_binary duply || return 0
 
-    function find_duply_profile ()
-    {
-        # there could be more then one profile present - select where SOURCE='/'
-        for CONF in $(echo "$1")
-        do
-            [[ ! -f $CONF ]] && continue
-            source $CONF    # is a normal shell configuration file
-            LogIfError "Could not source $CONF [duply profile]"
-            [[ -z "$SOURCE" ]] && continue
-            [[ -z "$TARGET" ]] && continue
-            # still here?
-            if [[ "$SOURCE" = "/" ]]; then
-                DUPLY_PROFILE_FILE=$CONF
-                DUPLY_PROFILE="$( dirname "$CONF"  )"   # /root/.duply/mycloud/conf -> /root/.duply/mycloud
-                DUPLY_PROFILE=${DUPLY_PROFILE##*/}  # /root/.duply/mycloud      -> mycloud
-                break # the loop
-            else
-                DUPLY_PROFILE=""
-                continue
-            fi
-        done
-    }
-
-    # we found the duply program; check if we can find a profile defined in ReaR config file
-    if [[ -z "$DUPLY_PROFILE" ]]; then
-        # no profile pre-set in local.conf; let's try to find one
-        DUPLY_PROFILE="$( find /etc/duply $ROOT_HOME_DIR/.duply -name conf 2>&1)"
-        # above result could contain more than one profile
-        [[ -z "$DUPLY_PROFILE" ]] && return
-        find_duply_profile "$DUPLY_PROFILE"
-    fi
-
-    # if DUPLY_PROFILE="" then we only found empty profiles
-    [[ -z "$DUPLY_PROFILE" ]] && return
-
-    # retrieve the real path of DUPLY_PROFILE in case DUPLY_PROFILE was defined local.conf
-    DUPLY_PROFILE_FILE="$( ls /etc/duply/$DUPLY_PROFILE/conf $ROOT_HOME_DIR/.duply/$DUPLY_PROFILE/conf 2>/dev/null )"
-    # Assuming we have a duply configuration we must have a path, right?
-    [[ -z "$DUPLY_PROFILE_FILE" ]] && return
-    find_duply_profile "$DUPLY_PROFILE_FILE"
-
-    # a real profile was detected - check if we can talk to the remote site
-    echo yes | duply "$DUPLY_PROFILE" status >&2   # output is going to logfile
-    StopIfError "Duply profile $DUPLY_PROFILE status returned errors - see $RUNTIME_LOGFILE"
-
-    # we seem to use duply as BACKUP_PROG - so define as such too
-    BACKUP_PROG=duply
-
-    echo "DUPLY_PROFILE=$DUPLY_PROFILE" >> "$ROOTFS_DIR/etc/rear/rescue.conf"
-    LogIfError "Could not add DUPLY_PROFILE variable to rescue.conf"
-
-    LogPrint "The last full backup taken with duply/duplicity was:"
-    LogPrint "$( tail -50 $RUNTIME_LOGFILE | grep 'Last full backup date:' )"
-
-    # check the scheme of the TARGET variable in DUPLY_PROFILE ($CONF has full path)  to be
-    # sure we have all executables we need in the rescue image
-    source $DUPLY_PROFILE_FILE
-    local scheme="$( url_scheme "$TARGET" )"
-    case "$scheme" in
-       (sftp|rsync|scp)
-           PROGS+=( "$scheme" )
-    esac
+# If $BACKUP_DUPLICITY_URL has been defined then we assume we are using
+# only 'duplicity' to make the backup and not the wrapper 'duply':
+if [[ "$BACKUP_DUPLICITY_URL" || "$BACKUP_DUPLICITY_NETFS_URL" || "$BACKUP_DUPLICITY_NETFS_MOUNTCMD" ]] ; then
+    DebugPrint "Assuming 'duplicity' is used and not 'duply' because BACKUP_DUPLICITY_URL or BACKUP_DUPLICITY_NETFS_URL or BACKUP_DUPLICITY_NETFS_MOUNTCMD is set"
+    return 0
+else
+    DebugPrint "Assuming 'duply' is used and not 'duplicity' because none of BACKUP_DUPLICITY_URL BACKUP_DUPLICITY_NETFS_URL BACKUP_DUPLICITY_NETFS_MOUNTCMD is set"
 fi
 
+test -s "$DUPLY_PROFILE" || Error "DUPLY_PROFILE '$DUPLY_PROFILE' empty or does not exist (assuming 'duply' is used and not 'duplicity')"
+
+# Check if we can talk to the remote site:
+# According to the 'duply' "Manpage" on https://duply.net/Documentation
+# that reads (excerpts)
+#   PROFILE:
+#     Indicated by a path or a profile name
+#     ...
+#     example 2:   duply ~/.duply/humbug backup
+#     ...
+#   COMMANDS:
+#     ...
+#     status     prints backup sets and chains currently in repository
+#     ...
+# the command "duply /path/to/profile status" prints backup sets and chains currently in repository
+# so we redirect its stdout to stderr which appears in the ReaR logfile only in debug modes,
+# cf. https://github.com/rear/rear/wiki/Coding-Style#what-to-do-with-stdin-stdout-and-stderr
+DebugPrint "Checking with 'duply $DUPLY_PROFILE status' if 'duply' can talk to the remote site"
+Debug "'duply $DUPLY_PROFILE status' output:"
+echo yes | duply "$DUPLY_PROFILE" status 1>&2 || Error "'duply $DUPLY_PROFILE status' failed, check $RUNTIME_LOGFILE"
+
+# We seem to use 'duply' as BACKUP_PROG - so define as such (instead of BACKUP_PROG=duplicity above):
+BACKUP_PROG=duply
+
+echo "DUPLY_PROFILE=$DUPLY_PROFILE" >> "$ROOTFS_DIR/etc/rear/rescue.conf" || Error "Failed to add DUPLY_PROFILE to rescue.conf"
+
+DebugPrint "Sourcing '$DUPLY_PROFILE'"
+source "$DUPLY_PROFILE" || Error "Failed to source $DUPLY_PROFILE"
+
+# Check the scheme of the TARGET variable in DUPLY_PROFILE
+# to ensure we have all executables we need in the rescue image.
+# https://www.it3.be/2015/09/02/rear-using-duply/
+# shows an example of DUPLY_PROFILE content (excerpt):
+#   GPG_KEY='BD4A8DCC'
+#   GPG_PW='my_secret_key_phrase'
+#   TARGET='scp://root:my_secret_password@freedom//exports/archives/ubuntu-15-04'
+#   SOURCE='/'
+#   MAX_AGE=1M
+#   MAX_FULL_BACKUPS=1
+#   MAX_FULLS_WITH_INCRS=1
+#   VERBOSITY=5
+#   TEMP_DIR=/tmp
+# Luckily ReaR uses TMP_DIR so sourcing DUPLY_PROFILE does not overwrite a ReaR variable,
+# cf. https://github.com/rear/rear/issues/3259 "ReaR must not carelessly 'source' files"
+local scheme="$( url_scheme "$TARGET" )"
+    case "$scheme" in
+       (sftp|rsync|scp)
+           REQUIRED_PROGS+=( "$scheme" )
+    esac

--- a/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/200_find_duply_profile.sh
@@ -15,15 +15,20 @@ test "$BACKUP_PROG" = "duplicity" || return 0
 # Nothing to do when we are not using the 'duply' wrapper for 'duplicity':
 has_binary duply || return 0
 
-# If $BACKUP_DUPLICITY_URL has been defined then we assume we are using
-# only 'duplicity' to make the backup and not the wrapper 'duply':
+# If at least one of BACKUP_DUPLICITY_URL BACKUP_DUPLICITY_NETFS_URL BACKUP_DUPLICITY_NETFS_MOUNTCMD
+# is defined then we assume we are using only 'duplicity' and not the wrapper 'duply'
+# cf. the same code in prep/DUPLICITY/default/200_find_duply_profile.sh
 if [[ "$BACKUP_DUPLICITY_URL" || "$BACKUP_DUPLICITY_NETFS_URL" || "$BACKUP_DUPLICITY_NETFS_MOUNTCMD" ]] ; then
     DebugPrint "Assuming 'duplicity' is used and not 'duply' because BACKUP_DUPLICITY_URL or BACKUP_DUPLICITY_NETFS_URL or BACKUP_DUPLICITY_NETFS_MOUNTCMD is set"
     return 0
-else
-    DebugPrint "Assuming 'duply' is used and not 'duplicity' because none of BACKUP_DUPLICITY_URL BACKUP_DUPLICITY_NETFS_URL BACKUP_DUPLICITY_NETFS_MOUNTCMD is set"
 fi
+DebugPrint "Assuming 'duply' is used and not 'duplicity' because none of BACKUP_DUPLICITY_URL BACKUP_DUPLICITY_NETFS_URL BACKUP_DUPLICITY_NETFS_MOUNTCMD is set"
 
+# Only an explicitly user specified DUPLY_PROFILE gets sourced
+# to avoid that some automatism finds and sources whatever it may have found
+# cf. https://github.com/rear/rear/pull/3345
+# Accordingly error out when DUPLY_PROFILE is empty or does not exist
+# to make the user aware that he must explicitly specify his correct DUPLY_PROFILE:
 test -s "$DUPLY_PROFILE" || Error "DUPLY_PROFILE '$DUPLY_PROFILE' empty or does not exist (assuming 'duply' is used and not 'duplicity')"
 
 # Check if we can talk to the remote site:

--- a/usr/share/rear/prep/DUPLICITY/default/220_define_backup_prog.sh
+++ b/usr/share/rear/prep/DUPLICITY/default/220_define_backup_prog.sh
@@ -1,7 +1,5 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-echo "BACKUP_PROG=$BACKUP_PROG" >> "$ROOTFS_DIR/etc/rear/rescue.conf"
-LogIfError "Could not add BACKUP_PROG variable to rescue.conf"
-
-Log "Defined BACKUP_PROG=$BACKUP_PROG"
+echo "BACKUP_PROG=$BACKUP_PROG" >> "$ROOTFS_DIR/etc/rear/rescue.conf" || Error "Failed to add 'BACKUP_PROG=$BACKUP_PROG' to rescue.conf"
+Log "Added 'BACKUP_PROG=$BACKUP_PROG' to rescue.conf"

--- a/usr/share/rear/restore/DUPLICITY/default/110_check_temp_dir_with_duply.sh
+++ b/usr/share/rear/restore/DUPLICITY/default/110_check_temp_dir_with_duply.sh
@@ -22,7 +22,7 @@ test -s "$DUPLY_PROFILE" || Error "DUPLY_PROFILE '$DUPLY_PROFILE' empty or does 
 # should already error out in this case:
 test -d "$TARGET_FS_ROOT" || Error "No TARGET_FS_ROOT '$TARGET_FS_ROOT' directory"
 
-# We need $TARGET_FS_ROOT/tmp as temp dir during the duplicity recovery (where we have enough space).
+# We need $TARGET_FS_ROOT/tmp as temp dir during the duplicity backup restore (where we have enough space).
 # FIXME: Hopefully "mkdir -m 1777 $TARGET_FS_ROOT/tmp" is OK because it creates the /tmp directory 
 # with the usual /tmp directory owner group and permissions "drwxrwxrwt root root" in the target system.
 # But normally "rear recover" should not recreate a system different than it was before.
@@ -33,8 +33,10 @@ test -d "$TARGET_FS_ROOT/tmp" || mkdir -m 1777 "$TARGET_FS_ROOT/tmp"
 # The main task of this script is to verify the setting of TEMP_DIR in DUPLY_PROFILE:
 if grep -q "^TEMP_DIR=" "$DUPLY_PROFILE" ; then
     # When TEMP_DIR is /tmp then change it to /mnt/local/tmp
-    # but if TEMP_DIR is specified different (i.e. not /tmp) we keep it as is:
-    if grep -q "^TEMP_DIR=/tmp" "$DUPLY_PROFILE" ; then
+    # but if TEMP_DIR is specified different (i.e. not /tmp but e.g. /tmp/duply) we keep it as is
+    # (regardless that with e.g. TEMP_DIR=/tmp/duply the duplicity backup restore likely fails
+    # because normally there is no /tmp/duply directory in the ReaR recovery system):
+    if grep -q "^TEMP_DIR=/tmp$" "$DUPLY_PROFILE" ; then
         sed -i -e "s|TEMP_DIR=/tmp|TEMP_DIR=$TARGET_FS_ROOT/tmp|" "$DUPLY_PROFILE"
     fi
 else

--- a/usr/share/rear/restore/DUPLICITY/default/110_check_temp_dir_with_duply.sh
+++ b/usr/share/rear/restore/DUPLICITY/default/110_check_temp_dir_with_duply.sh
@@ -3,29 +3,42 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
-# If $BACKUP_DUPLICITY_URL has been defined then we may assume we are using
-# only 'duplicity' to make the backup and not the wrapper duply
-[[ "$BACKUP_DUPLICITY_URL" || "$BACKUP_DUPLICITY_NETFS_URL" || "$BACKUP_DUPLICITY_NETFS_MOUNTCMD" ]] && return
+# If at least one of BACKUP_DUPLICITY_URL BACKUP_DUPLICITY_NETFS_URL BACKUP_DUPLICITY_NETFS_MOUNTCMD
+# is defined then we assume we are using only 'duplicity' and not the wrapper 'duply'
+# cf. the same code in prep/DUPLICITY/default/200_find_duply_profile.sh
+if [[ "$BACKUP_DUPLICITY_URL" || "$BACKUP_DUPLICITY_NETFS_URL" || "$BACKUP_DUPLICITY_NETFS_MOUNTCMD" ]] ; then
+    DebugPrint "Assuming 'duplicity' is used and not 'duply' because BACKUP_DUPLICITY_URL or BACKUP_DUPLICITY_NETFS_URL or BACKUP_DUPLICITY_NETFS_MOUNTCMD is set"
+    return 0
+fi
+DebugPrint "Assuming 'duply' is used and not 'duplicity' because none of BACKUP_DUPLICITY_URL BACKUP_DUPLICITY_NETFS_URL BACKUP_DUPLICITY_NETFS_MOUNTCMD is set"
 
-# if DUPLY_PROFILE="" then we have nonsense defined in our ReaR configuration
-[[ -z "$DUPLY_PROFILE" ]] && return
+# It is OK to error out after the disk layout was recreated but before the backup is restored
+# because during "rear recover" the most time consuming part is usually the backup restore
+# cf. the same test in prep/DUPLICITY/default/200_find_duply_profile.sh
+test -s "$DUPLY_PROFILE" || Error "DUPLY_PROFILE '$DUPLY_PROFILE' empty or does not exist (assuming 'duply' is used and not 'duplicity')"
 
-DUPLY_PROFILE_FILE=$( ls /etc/duply/$DUPLY_PROFILE/conf $ROOT_HOME_DIR/.duply/$DUPLY_PROFILE/conf 2>/dev/null )
-# Assuming we have a duply configuration we must have a path, right?
-[[ -z "$DUPLY_PROFILE_FILE" ]] && return
-find_duply_profile "$DUPLY_PROFILE_FILE"
+# This error should never happen here because
+# layout/recreate/default/250_verify_mount.sh
+# should already error out in this case:
+test -d "$TARGET_FS_ROOT" || Error "No TARGET_FS_ROOT '$TARGET_FS_ROOT' directory"
 
-[[ ! -d $TARGET_FS_ROOT ]] && return  # must be recreated and mounted
+# We need $TARGET_FS_ROOT/tmp as temp dir during the duplicity recovery (where we have enough space).
+# FIXME: Hopefully "mkdir -m 1777 $TARGET_FS_ROOT/tmp" is OK because it creates the /tmp directory 
+# with the usual /tmp directory owner group and permissions "drwxrwxrwt root root" in the target system.
+# But normally "rear recover" should not recreate a system different than it was before.
+# So hopefully the backup contains the /tmp directory so that it would get restored
+# exactly as it was on the original system (might be different than "drwxrwxrwt root root").
+test -d "$TARGET_FS_ROOT/tmp" || mkdir -m 1777 "$TARGET_FS_ROOT/tmp"
 
-# We need $TARGET_FS_ROOT/tmp as temp dir during the duplicity recovery (where we have enough space)
-[[ ! -d $TARGET_FS_ROOT/tmp ]] && mkdir -m 1777 $TARGET_FS_ROOT/tmp
-
-# Now we are coming to the real task of this script and that is verifying the setting of TEMP_DIR in
-# the conf file and make sure that the TEMP_DIR is set to /mnt/local/tmp instead of /tmp
-# If the TEMP_DIR was already different we will *not* modify it
-if grep -q "^TEMP_DIR=/tmp" "$DUPLY_PROFILE_FILE" ; then
-    sed -i -e "s|TEMP_DIR=/tmp|TEMP_DIR=$TARGET_FS_ROOT/tmp|" "$DUPLY_PROFILE_FILE"
+# The main task of this script is to verify the setting of TEMP_DIR in DUPLY_PROFILE:
+if grep -q "^TEMP_DIR=" "$DUPLY_PROFILE" ; then
+    # When TEMP_DIR is /tmp then change it to /mnt/local/tmp
+    # but if TEMP_DIR is specified different (i.e. not /tmp) we keep it as is:
+    if grep -q "^TEMP_DIR=/tmp" "$DUPLY_PROFILE" ; then
+        sed -i -e "s|TEMP_DIR=/tmp|TEMP_DIR=$TARGET_FS_ROOT/tmp|" "$DUPLY_PROFILE"
+    fi
 else
-    # no variable found which means /tmp is used. We will define one for the restore sake.
-    echo "TEMP_DIR=$TARGET_FS_ROOT/tmp" >> "$DUPLY_PROFILE_FILE"
+    # No TEMP_DIR variable is set in DUPLY_PROFILE which means /tmp would be used
+    # so we specify TEMP_DIR in DUPLY_PROFILE as we need it for the restore:
+    echo "TEMP_DIR=$TARGET_FS_ROOT/tmp" >> "$DUPLY_PROFILE"
 fi

--- a/usr/share/rear/verify/DUPLICITY/default/250_check_duply_profile.sh
+++ b/usr/share/rear/verify/DUPLICITY/default/250_check_duply_profile.sh
@@ -3,5 +3,7 @@
 
 [[ -z "$DUPLY_PROFILE" ]] && return
 
-duply "$DUPLY_PROFILE" status >&2   # output is going to logfile
-LogPrintIfError "Duply profile $DUPLY_PROFILE status returned errors - see $RUNTIME_LOGFILE"
+# Same code in prep/DUPLICITY/default/200_find_duply_profile.sh
+DebugPrint "Checking with 'duply $DUPLY_PROFILE status' if 'duply' can talk to the remote site"
+Debug "'duply $DUPLY_PROFILE status' output:"
+echo yes | duply "$DUPLY_PROFILE" status || Error "'duply $DUPLY_PROFILE status' failed, check $RUNTIME_LOGFILE"


### PR DESCRIPTION
* Type: **Bug Fix** / **Security Enhancement**

* Impact: **Critical**

"Relatively" critical impact for two reasons:
It is a required security enhancement and
it is a backward incompatible change.

It is only "relatively" critical because
it is only when BACKUP=DUPLICITY is used
so it is not a backward incompatible change
that hits all or a lot of users.

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3293
https://github.com/rear/rear/issues/3259

* How was this pull request tested?
Cannot test it because I neither use duplicity nor duply.

* Description of the changes in this pull request:

Overhauled prep/DUPLICITY/default/200_find_duply_profile.sh
so that now only an explicitly user specified DUPLY_PROFILE
will get sourced to avoid that some automatism
finds and sources whatever it may have found.

Error out when DUPLY_PROFILE is empty or does not exist
to make the user aware that he must explicitly specify
his correct DUPLY_PROFILE.
