### PR TITLE
Call 'lsblk' with 'MOUNTPOINTS' to show all mounted btrfs subvolumes

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/100_create_layout_file.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/100_create_layout_file.sh
@@ -24,7 +24,9 @@ test -e "$DISKLAYOUT_FILE" && LogPrint "Overwriting existing disk layout file $D
 echo "Disk layout dated $START_DATE_TIME_NUMBER (YYYYmmddHHMMSS)" >$DISKLAYOUT_FILE
 # Have the actual storage layout as header comment in disklayout.conf
 # so that it is easier to make sense of the values in the subsequent entries.
-# First try the command (which works on SLES12 and SLES15)
+# First try the command ('MOUNTPOINTS' with plural 'S' shows all mounted btrfs subvolumes)
+#   lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,LABEL,SIZE,MOUNTPOINTS,UUID,WWN
+# then try the command (e.g. on SLES12 only 'MOUNTPOINT' works which shows a random one of the mounted btrfs subvolumes)
 #   lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,LABEL,SIZE,MOUNTPOINT,UUID,WWN
 # but on older systems (like SLES11) that do not support all that lsblk things
 # cf. https://github.com/rear/rear/pull/2626#issuecomment-856700823
@@ -32,7 +34,7 @@ echo "Disk layout dated $START_DATE_TIME_NUMBER (YYYYmmddHHMMSS)" >$DISKLAYOUT_F
 #   lsblk -io NAME,KNAME,FSTYPE,LABEL,SIZE,MOUNTPOINT,UUID
 # and as fallback try 'lsblk -i' and finally try plain 'lsblk'.
 # When there is no 'lsblk' command there is no output (bad luck, no harm):
-{ lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,LABEL,SIZE,MOUNTPOINT,UUID,WWN || lsblk -io NAME,KNAME,FSTYPE,LABEL,SIZE,MOUNTPOINT,UUID || lsblk -i || lsblk ; } >>$DISKLAYOUT_FILE
+{ lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,LABEL,SIZE,MOUNTPOINTS,UUID,WWN || lsblk -ipo NAME,KNAME,PKNAME,TRAN,TYPE,FSTYPE,LABEL,SIZE,MOUNTPOINT,UUID,WWN || lsblk -io NAME,KNAME,FSTYPE,LABEL,SIZE,MOUNTPOINT,UUID || lsblk -i || lsblk ; } >>$DISKLAYOUT_FILE
 # Make all lines in disklayout.conf up to now as header comments:
 sed -i -e 's/^/# /' $DISKLAYOUT_FILE
 


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* How was this pull request tested?
Tested "by the way" in
https://github.com/rear/rear/pull/3347

* Description of the changes in this pull request:

In layout/save/GNU/Linux/100_create_layout_file.sh
call 'lsblk' with 'MOUNTPOINTS' with plural 'S'
to show all mounted btrfs subvolumes
in contrast to 'MOUNTPOINT' that shows only
a random one of the mounted btrfs subvolumes.