### PR TITLE
fix: add -xdev option to find to avoid hanging NFS (#3350)

### DIFF
--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -60,7 +60,8 @@ function find_syslinux_modules_dir {
             # cf. https://github.com/rear/rear/issues/2792
             # tell the user in debug mode what is going on
             DebugPrint "Searching whole /usr for SYSLINUX modules directory (you may specify SYSLINUX_MODULES_DIR)"
-            file=$( find /usr -name "$1" 2>/dev/null | tail -1 )
+	    # issue #3350 - adding -xdev to find to avoid hanging NFS
+            file=$( find /usr -xdev -name "$1" 2>/dev/null | tail -1 )
             syslinux_modules_dir=$( dirname "$file" )        # /usr/lib/syslinux/modules/efi32
             syslinux_modules_dir=${syslinux_modules_dir%/*}  # /usr/lib/syslinux/modules
             if is_true $USING_UEFI_BOOTLOADER ; then


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): #3350 

* How was this pull request tested? On  system that was impacted.

* Description of the changes in this pull request: To avoid that ReaR hangs on NFS mount points when performing a `find /usr` searh.

