### PR TITLE
Do not remove dotfiles from the release archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ RUNASUSER :=
 endif
 
 # .gitignore is optional, avoid tar errors if it does not exist, e.g. in a dist archive
-tarparams = $(shell test -f .gitignore && echo --exclude-from=.gitignore --exclude=.gitignore) --exclude=".??*" $(DIST_CONTENT)
+tarparams = $(shell test -f .gitignore && echo --exclude-from=.gitignore --exclude=.gitignore) $(DIST_CONTENT)
 
 DIST_FILES := $(shell tar -cv -f /dev/null $(tarparams))
 


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
Closes #3368.

* How was this pull request tested?
```
make OFFICIAL=1 dist
tar tzf dist/rear-2.7.tar.gz > unpatched.list
# here apply the change

make OFFICIAL=1 dist
tar tzf dist/rear-2.7.tar.gz > patched.list
diff -u unpatched.list patched.list
```
Result is at  https://github.com/rear/rear/issues/3368#issuecomment-2551465625

* Description of the changes in this pull request:
Do not remove dotfiles from the release archive. Avoids dropping .vimrc from /root of the rescue ramdisk. This also adds .shellcheckrc to the release tarballs, so package builds using static analyzers (OpenScanHub) will know what ShellCheck warnings to ignore.