### PR TITLE
Specify path to sbindir during RPM build

### DIFF
--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -159,7 +159,7 @@ fi
 
 %install
 %{__rm} -rf %{buildroot}
-%{__make} install DESTDIR="%{buildroot}"
+%{__make} install DESTDIR="%{buildroot}" sbindir="%{_sbindir}"
 
 %check
 %{__make} validate


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* How was this pull request tested?  See CI results below.

* Description of the changes in this pull request:

This fixes the build failure on Fedora 42+ related to the following Fedora change: https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin