### PR TITLE
Add 'timeout' to default REQUIRED_PROGS

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1708,6 +1708,7 @@ strings
 sync
 tar
 test
+timeout
 tr
 umount
 uniq


### PR DESCRIPTION
* Type: **Minor Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3386#issuecomment-2609546695

* How was this pull request tested?

"rear mkbackup" and "rear recover" worked for me
in particular with a mounted NFS share before "rear recover"

* Description of the changes in this pull request:
 
Added 'timeout' to REQUIRED_PROGS in default.conf