### PR TITLE
Automate ReaR Release Builds via GH Actions

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -136,8 +136,9 @@ jobs:
                     zip -0 -j -z "$distro.zip" "$distro"/* <<< "$COMMENT"
                   done
 
+                  dist_archive=$(ls -1 dist/*.tar.gz)
                   gh release create "$RELEASE" \
                     --title "ReaR Release $RELEASE_VERSION ($(git show -s --format="%cs"))" \
                     --generate-notes \
                     --draft \
-                    dist-all/*.zip dist/*.tar.gz"#Official ReaR source distribution $RELEASE_VERSION"
+                    dist-all/*.zip "${dist_archive}#Official ReaR source distribution $RELEASE_VERSION"

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -1,5 +1,11 @@
 name: Build Packages
 
+# this covers the following use cases:
+#
+# 1. build snapshot packages for every push to any branch
+# 2. publish packages as "ReaR Snapshot" for every push to master
+# 3. build official packages for every push of a tag named release/* and publish as "ReaR Release"
+
 on: push
 
 env:
@@ -140,5 +146,4 @@ jobs:
                   gh release create "$RELEASE" \
                     --title "ReaR Release $RELEASE_VERSION ($(git show -s --format="%cs"))" \
                     --generate-notes \
-                    --draft \
-                    dist-all/*.zip "${dist_archive}#Official ReaR source distribution $RELEASE_VERSION"
+                    dist-all/*.zip "${dist_archive}#Official ReaR source distribution ${dist_archive##*/}"

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -32,13 +32,6 @@ jobs:
             - id: setup
               run: sudo apt-get -qq update && sudo apt-get -qq install asciidoctor
 
-            - id: prepare
-              run: tools/run-in-docker -- --patch --continue-and-record-successful images
-
-            - id: images
-              run: cat images
-              if: always()
-
             - name: Build Snapshot dist archive
               id: dist-snapshot
               if: env.RELEASE == 'no-release'
@@ -63,6 +56,13 @@ jobs:
                   fi
 
                   make dist OFFICIAL=1
+
+            - id: prepare
+              run: tools/run-in-docker -- --patch --continue-and-record-successful images
+
+            - id: images
+              run: cat images
+              if: always()
 
             - id: build
               # make package only for images that we patched successfully

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -66,9 +66,18 @@ jobs:
               run: |
                   test -r images && cat images || :
 
-            - name: Build packages via Docker
-              # make package only for images that we patched successfully
+            - name: Build snapshot packages via Docker
+              if: env.RELEASE == 'no-release'
+              # make package only for images that we patched successfully - continue despite errors
               run: tools/run-in-docker $(<images) -- 'make package || tar -cvzf dist-all/build-$HOSTNAME.tar.gz /var/tmp/build-rear*'
+
+            - name: Build release packages via Docker
+              if: startsWith(env.RELEASE, 'release')
+              # make package for all images that we support - fail on errors
+              # we need to specify again OFFICIAL=1 as the Makefile determines the version to use before
+              # building the package, and without it wouldn't match with the dist archive created earlier
+              # TODO: make package should be able to determine the version from the dist archive instead
+              run: tools/run-in-docker -- make package OFFICIAL=1
 
             - name: List dist-all
               run: |
@@ -131,4 +140,4 @@ jobs:
                     --title "ReaR Release $RELEASE_VERSION ($(git show -s --format="%cs"))" \
                     --generate-notes \
                     --draft \
-                    dist-all/*.zip "dist/*.tar.gz#Official ReaR source distribution $RELEASE_VERSION"
+                    dist-all/*.zip dist/*.tar.gz"#Official ReaR source distribution $RELEASE_VERSION"

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -29,17 +29,15 @@ jobs:
                   tee -a $GITHUB_ENV <<< "RELEASE_VERSION=${RELEASE#release/}"
                   tee -a $GITHUB_ENV <<< "RELEASE_FILENAME=${RELEASE//\//-}"
 
-            - id: setup
+            - name: Setup build environment
               run: sudo apt-get -qq update && sudo apt-get -qq install asciidoctor
 
             - name: Build Snapshot dist archive
-              id: dist-snapshot
               if: env.RELEASE == 'no-release'
               run: make dist
 
               # check if the release version matches the source version before building official release dist archive
             - name: Check and build Release dist archive
-              id: dist-release
               if: startsWith(env.RELEASE, 'release')
               run: |
                   if [ -z "$RELEASE_VERSION" ] ; then
@@ -51,24 +49,30 @@ jobs:
                   if [ "$SOURCE_VERSION" != "$RELEASE_VERSION" ] ; then
                     # Find the line where VERSION is set
                     VERSION_LINE=$(grep -n "^readonly VERSION=" usr/sbin/rear | cut -d: -f1)
+                    echo "### Version Check Failed" >> $GITHUB_STEP_SUMMARY
+                    echo "* Expected version: $RELEASE_VERSION" >> $GITHUB_STEP_SUMMARY
+                    echo "* Current version: $SOURCE_VERSION" >> $GITHUB_STEP_SUMMARY
                     echo "::error file=usr/sbin/rear,line=$VERSION_LINE::Version mismatch: Source version in rear script ($SOURCE_VERSION) does not match release tag version ($RELEASE_VERSION)"
                     exit 1
                   fi
 
                   make dist OFFICIAL=1
 
-            - id: prepare
+            - name: Prepare Docker images
               run: tools/run-in-docker -- --patch --continue-and-record-successful images
 
-            - id: images
-              run: cat images
+            - name: List available Docker images
               if: always()
+              run: |
+                  test -r images && cat images || :
 
-            - id: build
+            - name: Build packages via Docker
               # make package only for images that we patched successfully
               run: tools/run-in-docker $(<images) -- 'make package || tar -cvzf dist-all/build-$HOSTNAME.tar.gz /var/tmp/build-rear*'
 
-            - run: ls -lR dist-all
+            - name: List dist-all
+              run: |
+                  test -d dist-all && ls -lR dist-all || :
               if: always()
 
             - name: Upload Artifacts

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -39,11 +39,13 @@ jobs:
               run: cat images
               if: always()
 
-            - id: dist-snapshot
+            - name: Build Snapshot dist archive
+              id: dist-snapshot
               if: env.RELEASE == 'snapshot'
               run: make dist
 
-            - id: dist-release
+            - name: Check and build Release dist archive
+              id: dist-release
               # check if the release version matches the source version before building official release dist archive
               if: env.RELEASE != 'snapshot'
               run: |

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -4,7 +4,7 @@ on: push
 
 env:
     # Set RELEASE to the release tag or to snapshot
-    RELEASE: ${{ startsWith(github.ref, 'refs/tags/release/') && github.ref_name || 'snapshot' }}
+    RELEASE: ${{ startsWith(github.ref, 'refs/tags/release/') && github.ref_name || 'no-release' }}
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
@@ -24,7 +24,7 @@ jobs:
             - name: Extract release version
               # Set release version and filename from the release tag
               # e.g. 2.8.0 -> RELEASE_VERSION=2.8.0 RELEASE_FILENAME=release-2.8.0
-              if: startsWith(github.ref, 'refs/tags/release/')
+              if: startsWith(env.RELEASE, 'release')
               run: |
                   tee -a $GITHUB_ENV <<< "RELEASE_VERSION=${RELEASE#release/}"
                   tee -a $GITHUB_ENV <<< "RELEASE_FILENAME=${RELEASE//\//-}"
@@ -41,22 +41,24 @@ jobs:
 
             - name: Build Snapshot dist archive
               id: dist-snapshot
-              if: env.RELEASE == 'snapshot'
+              if: env.RELEASE == 'no-release'
               run: make dist
 
+              # check if the release version matches the source version before building official release dist archive
             - name: Check and build Release dist archive
               id: dist-release
-              # check if the release version matches the source version before building official release dist archive
-              if: env.RELEASE != 'snapshot'
+              if: startsWith(env.RELEASE, 'release')
               run: |
                   if [ -z "$RELEASE_VERSION" ] ; then
-                    echo "ERROR: Release version not set"
+                    echo "::error::Release version not set in RELEASE_VERSION"
                     exit 1
                   fi
 
                   SOURCE_VERSION=$(make version OFFICIAL=1)
                   if [ "$SOURCE_VERSION" != "$RELEASE_VERSION" ] ; then
-                    echo "ERROR: Release version $RELEASE_VERSION does not match source version $SOURCE_VERSION"
+                    # Find the line where VERSION is set
+                    VERSION_LINE=$(grep -n "^readonly VERSION=" usr/sbin/rear | cut -d: -f1)
+                    echo "::error file=usr/sbin/rear,line=$VERSION_LINE::Version mismatch: Source version in rear script ($SOURCE_VERSION) does not match release tag version ($RELEASE_VERSION)"
                     exit 1
                   fi
 
@@ -81,7 +83,8 @@ jobs:
               run: tools/run-in-docker $(<images) -- rear dump
 
             - name: Create Snapshot Archives and Update GitHub Snapshot Release
-              if: env.RELEASE == 'snapshot'
+              # only create snapshot release for master branch
+              if: github.ref == 'refs/heads/master'
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: |
@@ -105,7 +108,7 @@ jobs:
                     dist-all/*.zip dist/*.tar.gz
 
             - name: Create Release Archives and Update GitHub Release
-              if: env.RELEASE != 'snapshot'
+              if: startsWith(env.RELEASE, 'release')
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: |
@@ -120,8 +123,7 @@ jobs:
                     zip -0 -j -z "$distro.zip" "$distro"/* <<< "$COMMENT"
                   done
 
-                  gh release create snapshot \
-                    --target ${{ github.sha }} \
+                  gh release create "$RELEASE" \
                     --title "ReaR Release $RELEASE_VERSION ($(git show -s --format="%cs"))" \
                     --generate-notes \
                     --draft \

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ rearbin = usr/sbin/rear
 name = rear
 version := $(shell awk 'BEGIN { FS="=" } /^readonly VERSION=/ { print $$2}' $(rearbin))
 
-BUILD_DIR = /var/tmp/build-$(name)-$(version)
-
 ifneq ($(OFFICIAL),)
 	distversion = $(version)
 	debrelease = 0
@@ -62,6 +60,8 @@ else
 	release_date := $(shell date --date="$(git_date)" +%Y-%m-%d)
 endif
 
+
+BUILD_DIR = /var/tmp/build-$(name)-$(distversion)
 
 prefix = /usr
 sysconfdir = /etc
@@ -128,8 +128,11 @@ dump:
 	$(foreach V, $(sort $(.VARIABLES)), $(if $(filter-out environment% default automatic, $(origin $V)),$(info $V=$($V) defined as >$(value $V)<)))
 
 clean:
-	rm -Rf dist $(BUILD_DIR) etc/os.conf etc/site.conf var build-stamp
+	rm -Rf dist etc/os.conf etc/site.conf var build-stamp
 	$(MAKE) -C doc clean
+
+clean-all: clean
+	rm -Rf $(BUILD_DIR)
 
 ### You can call 'make validate' directly from your .git/hooks/pre-commit script
 validate:
@@ -242,6 +245,10 @@ dist-install: dist/$(name)-$(distversion).tar.gz
 
 package-clean:
 	rm -f dist/*.rpm dist/*.deb dist/*.pkg.*
+
+# TODO: It might be better to set BUILD_DIR=/tmp/rear-<packagetype>-$(distversion) to separate
+# outer build dir from the package build dir, thereby enabling the make clean to also delete
+# the BUILD_DIR correctly.
 
 ifneq ($(shell type -p pacman),)
 package: package-clean pacman

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -38,7 +38,7 @@ build() {
 
 package() {
   cd "$srcdir/$_gitname-build"
-  make DESTDIR="$pkgdir/" install
+  make DESTDIR="$pkgdir/" install OFFICIAL=1
 }
 
 # vim:set ts=2 sw=2 et:

--- a/packaging/arch/PKGBUILD.local
+++ b/packaging/arch/PKGBUILD.local
@@ -16,7 +16,7 @@ md5sums=(MD5SUM)
 
 package() {
   cd $srcdir/rear-*/
-  make DESTDIR="${pkgdir}/" install
+  make DESTDIR="${pkgdir}/" install OFFICIAL=1
   mv ${pkgdir}/usr/sbin ${pkgdir}/usr/bin
 }
 

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -8,3 +8,12 @@
 
 override_dh_fixperms:
 	dh_fixperms --exclude debian/rear/etc/rear
+
+override_dh_auto_build:
+	dh_auto_build -- OFFICIAL=1
+
+override_dh_auto_clean:
+	dh_auto_clean -- OFFICIAL=1
+
+override_dh_auto_install:
+	dh_auto_install -- OFFICIAL=1

--- a/packaging/rpm/rear.spec
+++ b/packaging/rpm/rear.spec
@@ -159,10 +159,10 @@ fi
 
 %install
 %{__rm} -rf %{buildroot}
-%{__make} install DESTDIR="%{buildroot}" sbindir="%{_sbindir}"
+%{__make} install DESTDIR="%{buildroot}" sbindir="%{_sbindir}" OFFICIAL=1
 
 %check
-%{__make} validate
+%{__make} validate OFFICIAL=1
 
 %files
 # defattr: is required for SLES 11 and RHEL/CentOS 5 builds on openSUSE Build Service (#2135)
@@ -176,6 +176,9 @@ fi
 %{_sbindir}/rear
 
 %changelog
+* Wed Jan 29 2025 Schlomo Schapiro <schlomo@schapiro.org>
+- Always set OFFICIAL=1 to install ReaR from SPEC file, as the git version magic happens earlier
+
 * Thu Jul 30 2015 Johannes Meixner <jsmeix@suse.de>
 - For a changelog see the rear-release-notes.txt file.
 

--- a/tools/run-in-docker
+++ b/tools/run-in-docker
@@ -15,8 +15,7 @@ declare -r IMAGES=(
     debian:{10,11,unstable}
     opensuse/leap:15
     registry.suse.com/suse/sle15
-    centos:{7,8} # discontinued
-    sl:7           # discontinued
+    centos:8       # discontinued
     quay.io/centos/centos:stream9
     # registry.access.redhat.com/ubi{7,8,9} basic packages like parted are missing
     fedora:{40,41} # rawhide Docker image is broken, see https://github.com/fedora-cloud/docker-brew-fedora/issues/109

--- a/tools/run-in-docker
+++ b/tools/run-in-docker
@@ -45,7 +45,15 @@ Architecture defaults to the host platform, specify architecture via
 -a <architecture>, e.g. -a amd64 on M1 Mac as part of the image selection
 "
 
+
+function gh_actions_output {
+    if test "$GITHUB_ACTIONS"; then
+        echo "$*"
+    fi
+}
+
 function die {
+    gh_actions_output "::error::$*"
     echo -e "ERROR: $*" 1>&2
     exit 1
 }
@@ -117,6 +125,7 @@ RUN git config --global --add safe.directory /rear
 "
 
         # TODO: Add support for GRUB2
+        gh_actions_output "::group::Patching $image"
         printf "********** PATCHING %-40s **********\n" "$image" 1>&2
         read oldsize junk < <(docker images --format '{{.VirtualSize}}' "$image")
         docker buildx build -t "$image" \
@@ -135,6 +144,7 @@ RUN git config --global --add safe.directory /rear
         fi
         read newsize junk < <(docker images --format '{{.VirtualSize}}' "$image")
         test "$oldsize" != "$newsize" && printf "********** %-35s %7s -> %-7s *****\n" "$image" "$oldsize" "$newsize"
+        gh_actions_output "::endgroup::"
     done
 }
 
@@ -214,6 +224,7 @@ esac
 #       bash reads the file specified in BASH_ENV for non-interactive shells
 #       we set both so that our startup file run-in-docker.bashrc is ALWAYS read as it sets the PATH
 for image in "${use_images[@]}"; do
+    gh_actions_output "::group::Running $image"
     printf "********** %-40s **********\n" "$image" 1>&2
     image_name="$(echo -n "$image" | tr -cs '0-9a-zA-Z-_' -)"
     dist_dest="dist-all/$image_name"
@@ -233,4 +244,5 @@ for image in "${use_images[@]}"; do
         echo "********** Copying dist to ${dist_dest}"
         cp -R -x "$rear_toplevel_dir/dist/." "$rear_toplevel_dir/$dist_dest/" || die "Could not copy dist to $dist_dest"
     fi
+    gh_actions_output "::endgroup::"
 done

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -62,7 +62,7 @@ readonly INITIAL_BASH_FLAGS_AND_OPTIONS_COMMANDS="$( get_bash_flags_and_options_
 # Versioning
 readonly PRODUCT="Relax-and-Recover"
 readonly PROGRAM=${0##*/}
-readonly VERSION=2.8.104
+readonly VERSION=2.8.105
 readonly RELEASE_DATE="2025-01-28"
 
 # Where users should report bugs:

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -62,7 +62,7 @@ readonly INITIAL_BASH_FLAGS_AND_OPTIONS_COMMANDS="$( get_bash_flags_and_options_
 # Versioning
 readonly PRODUCT="Relax-and-Recover"
 readonly PROGRAM=${0##*/}
-readonly VERSION=2.8.99
+readonly VERSION=2.8.101
 readonly RELEASE_DATE="2025-01-28"
 
 # Where users should report bugs:

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -62,7 +62,7 @@ readonly INITIAL_BASH_FLAGS_AND_OPTIONS_COMMANDS="$( get_bash_flags_and_options_
 # Versioning
 readonly PRODUCT="Relax-and-Recover"
 readonly PROGRAM=${0##*/}
-readonly VERSION=2.8.103
+readonly VERSION=2.8.104
 readonly RELEASE_DATE="2025-01-28"
 
 # Where users should report bugs:

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -62,7 +62,7 @@ readonly INITIAL_BASH_FLAGS_AND_OPTIONS_COMMANDS="$( get_bash_flags_and_options_
 # Versioning
 readonly PRODUCT="Relax-and-Recover"
 readonly PROGRAM=${0##*/}
-readonly VERSION=2.8.101
+readonly VERSION=2.8.102
 readonly RELEASE_DATE="2025-01-28"
 
 # Where users should report bugs:

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -62,7 +62,7 @@ readonly INITIAL_BASH_FLAGS_AND_OPTIONS_COMMANDS="$( get_bash_flags_and_options_
 # Versioning
 readonly PRODUCT="Relax-and-Recover"
 readonly PROGRAM=${0##*/}
-readonly VERSION=2.8.102
+readonly VERSION=2.8.103
 readonly RELEASE_DATE="2025-01-28"
 
 # Where users should report bugs:

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -62,8 +62,8 @@ readonly INITIAL_BASH_FLAGS_AND_OPTIONS_COMMANDS="$( get_bash_flags_and_options_
 # Versioning
 readonly PRODUCT="Relax-and-Recover"
 readonly PROGRAM=${0##*/}
-readonly VERSION=2.8
-readonly RELEASE_DATE="2024-12-19"
+readonly VERSION=2.8.99
+readonly RELEASE_DATE="2025-01-28"
 
 # Where users should report bugs:
 readonly BUG_REPORT_SITE="https://github.com/rear/rear/issues"


### PR DESCRIPTION
Here is my suggestion for automation the ReaR release builds.

Pushing a tag named like `release/x.y` will build a ReaR release with `make ... OFFICIAL=1` after validating that the version in `rear` matches the release tag version.

The result is then published to our releases, where we can also manually update the release notes if we like so.

The release notes are auto generated and should - in theory - contain a list of PRs. I've seen that in my first attempt but not in the subsequent ones, and I'm happy to look at improving that in a future iteration. For now it works and in any case we can then go and paste our release notes into the GH release after it is created.

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/9616d90d-9e34-4417-9eeb-88a618736c9c" />

The download URL of the "Official source dist archive" is like this: `https://github.com/rear/rear/releases/download/release/2.8.105/rear-2.8.105.tar.gz` which is IMHO a fairly nice URL.

The download URL of the auto-generated source archives is unfortunately `https://github.com/rear/rear/archive/refs/tags/release/2.8.105.tar.gz` which is not so nice. I'm afraid that changing that would require including `rear-` as the prefix to the version in the release tag.

As we want to encourage people to use the official dist archive instead of the auto-generated release tag source archive I would like to suggest to simply accept that as it is. I think that people downloading such auto-generated source snapshots know what they do and it seems to be common practice to not prefix the software name to the tag, e.g. see https://github.com/fish-shell/fish-shell/tags for another example with the same behaviour.

I'll merge this this afternoon if I don't hear from you so that #3389 can proceed. Please excuse the stupid branch name, it will be gone then. I'll also squash all commits for merging to mask my bumping the version in the rear script.