### PR TITLE
Further enhance 880_check_for_mount_by_id.sh

### DIFF
--- a/usr/share/rear/finalize/default/880_check_for_mount_by_id.sh
+++ b/usr/share/rear/finalize/default/880_check_for_mount_by_id.sh
@@ -27,7 +27,7 @@ while read fs_spec fs_file fs_vfstype junk ; do
     test "$fs_vfstype" = "swap" && continue
     # Skip fstab entries which are not /dev/disk/by-id/...:
     [[ $fs_spec =~ ^/dev/disk/by-id/ ]] || continue
-    # No we have an /dev/disk/by-id/... entry which is not used as swap.
+    # Now we have an /dev/disk/by-id/... entry which is not used as swap.
     # All is well with this one when it exist as block device on the replacement hardware:
     test -b "$fs_spec" && continue
     # Remember it when it does not exist as block device on the replacement hardware:

--- a/usr/share/rear/finalize/default/880_check_for_mount_by_id.sh
+++ b/usr/share/rear/finalize/default/880_check_for_mount_by_id.sh
@@ -3,7 +3,8 @@
 # because we do not know how to set the original LUN IDs to the new / recovered hardware.
 # To help the user we check for /dev/disk/by-id entries in etc/fstab
 # and show the LUN IDs of SCSI disk devices via 'scsi_id'.
-# TODO: For non-SCSI disk devices we show nothing.
+# For non-SCSI disk devices we only show the etc/fstab '/dev/disk/by-id/...' value
+# when it does not exist as block device on the replacement hardware.
 # Non-SCSI disks are in particular NVMe devices and KVM 'VirtIO' virtual disks,
 # see https://github.com/rear/rear/issues/3383
 #


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3383#issuecomment-2652966699

* How was this pull request tested?
See below

* Description of the changes in this pull request:

In finalize/default/880_check_for_mount_by_id.sh
only when what is mounded 'by-id' does not exist
as block device on the replacement hardware,
then alert the user because then he may have to
adapt his TARGET_FS_ROOT/etc/fstab, see
https://github.com/rear/rear/issues/3383#issuecomment-2652966699
