### PR TITLE
#3400 to avoid disks mounted without partition getting excluded

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/210_raid_layout.sh
@@ -149,6 +149,7 @@ mdadm --detail --scan --config=partitions | while read array raiddevice junk ; d
     fi
 
     container=$( grep "Container" $mdadm_details | tr -d " " | cut -d ":" -f "2" | cut -d "," -f "1")
+    container_size=0 # initialize with 0 to avoid "-gt: unary operator expected" errors when no container used #3425
     line=( $( grep "Used Dev Size :" $mdadm_details ) )
     used_dev_size=${line[4]}
     line=( $( grep "Array Size :" $mdadm_details ) )

--- a/usr/share/rear/layout/save/default/305_uniq_disktodo.sh
+++ b/usr/share/rear/layout/save/default/305_uniq_disktodo.sh
@@ -1,4 +1,3 @@
-# Script 305_uniq_disktodo.sh
 # make LAYOUT_TODO file uniq, but we do not change the order in any way
 # See details in issue #3400
 unique_unsorted  $LAYOUT_TODO >${LAYOUT_TODO}.new

--- a/usr/share/rear/layout/save/default/305_uniq_disktodo.sh
+++ b/usr/share/rear/layout/save/default/305_uniq_disktodo.sh
@@ -1,0 +1,5 @@
+# Script 305_uniq_disktodo.sh
+# make LAYOUT_TODO file uniq, but we do not change the order in any way
+# See details in issue #3400
+unique_unsorted  $LAYOUT_TODO >${LAYOUT_TODO}.new
+mv -f ${LAYOUT_TODO}.new $LAYOUT_TODO

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -530,7 +530,12 @@ get_partition_start() {
 
 # Get the type of a layout component
 get_component_type() {
-    grep -E "^[^ ]+ $1 " $LAYOUT_TODO | cut -d " " -f 3
+    local component="$1"
+    local component_types=()
+    component_types=( $( grep -E "^[^ ]+ $component " $LAYOUT_TODO | cut -d " " -f 3 | uniq ) )
+    test ${#component_types[@]} -lt 1 && return 1
+    test ${#component_types[@]} -gt 1 && BugError "Layout component '$component' has more than one type in $LAYOUT_TODO"
+    echo "${component_types[0]}"
 }
 
 # Get the disklabel (partition table) type of the disk $1 from the layout file

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -530,10 +530,14 @@ get_partition_start() {
 
 # Get the type of a layout component
 get_component_type() {
+    # function replies with 'disk', 'part', 'lvmgrp', 'lvmvol', 'lvmdev', 'fs'
     local component="$1"
     local component_types=()
+    # component_types array can contain only 'one' entry (hence the 'uniq' parsing)
     component_types=( $( grep -E "^[^ ]+ $component " $LAYOUT_TODO | cut -d " " -f 3 | uniq ) )
+    # if there are no entries in array component_types then return with code 1, but do not exit ReaR
     test ${#component_types[@]} -lt 1 && return 1
+    # if there are more than 1 entries in the array then we hit a bug, therefore, the BugError exit
     test ${#component_types[@]} -gt 1 && BugError "Layout component '$component' has more than one type in $LAYOUT_TODO"
     echo "${component_types[0]}"
 }


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): #3400 

* How was this pull request tested? on a Kubernetes system (on AWS)

* Description of the changes in this pull request: Disks that were mounted on a filesystem as a whole disk (no partition) were excluded in the disklayout.conf file.

