### PR TITLE
regenerate all initramfs on SLES

### DIFF
--- a/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
+++ b/usr/share/rear/finalize/SUSE_LINUX/i386/550_rebuild_initramfs.sh
@@ -56,7 +56,7 @@ if test $dracut_binary ; then
     # nevertheless we set PATH to be on the safe side in general.
     # The --force option is needed because plain 'dracut' (at least in SLES15-SP5) fails with a message like
     # "dracut: Will not override existing initramfs (/boot/initrd-5.14.21-150500.55.28-default) without --force"
-    if chroot $TARGET_FS_ROOT /bin/bash -c "PATH=/sbin:/usr/sbin:/usr/bin:/bin $dracut_binary --force" ; then
+    if chroot $TARGET_FS_ROOT /bin/bash -c "PATH=/sbin:/usr/sbin:/usr/bin:/bin $dracut_binary --force --regenerate-all" ; then
         LogPrint "Recreated initrd with $dracut_binary"
     else
         LogPrintError "Warning:


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): #3263

* How was this pull request tested? recover SLES12 and SLES15 with portable mode (systemrescue) and verified, that initramfs was regenerated.

* Description of the changes in this pull request: In order to fix recovery in portable mode, where the running kernel does not match the version installed in the recovered chroot regenerate all initramfs images. This eliminates the need to parse present kernels from /boot.

fixes #3263