### PR TITLE
New umount_mountpoint_retry_lazy function

### DIFF
--- a/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
@@ -45,7 +45,7 @@ mount $v -o loop -t vfat $TMP_DIR/efiboot.img $TMP_DIR/efi_virt || Error "Failed
 cp $v -r $TMP_DIR/mnt/. $TMP_DIR/efi_virt
 
 # Umounting the EFI virtual image:
-local what_is_mounted="EFI virtual image $TMP_DIR/efiboot.img at $TMP_DIR/efi_virt"
+local what_is_mounted="EFI virtual image $TMP_DIR/efiboot.img on $TMP_DIR/efi_virt"
 # When umounting the EFI virtual image fails it is no hard error so only inform the user
 # so he can understand why later cleanup_build_area_and_end_program() may show
 # "Could not remove build area" (when lazy umount could not clean up things until then)

--- a/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
@@ -46,45 +46,11 @@ cp $v -r $TMP_DIR/mnt/. $TMP_DIR/efi_virt
 
 # Umounting the EFI virtual image:
 local what_is_mounted="EFI virtual image $TMP_DIR/efiboot.img at $TMP_DIR/efi_virt"
-if ! umount $v $TMP_DIR/efiboot.img ; then
-    # Normal umounting something directly after some I/O command (like 'cp' above)
-    # may sometimes fail with "target is busy" (cf. 'busy' and 'lazy' in "man umount")
-    # so we retry after one second to increase likelihood that it then succeeds
-    # cf. https://github.com/rear/rear/issues/2908#issuecomment-1382000811 ("sleep 1 works fine")
-    # because normal umount is preferred over more sophisticated attempts
-    # like lazy umount or enforced umount which raise their own specific troubles
-    # and the -M option for fuser which is used below is not available on older
-    # Linux distributions like RHEL6 and SLES11 so 'sleep 1' and retry is best:
-    Log "Failed to umount $what_is_mounted (will retry after one second)"
-    sleep 1
-    if ! umount $v $TMP_DIR/efiboot.img ; then
-        Log "Again failed to umount $what_is_mounted"
-        Log "$what_is_mounted is still in use by ('kernel mount' is always there)"
-        # The -M option avoids that fuser may show all processes using the '/' filesystem
-        # ( $TMP_DIR is $BUILD_DIR/tmp which is /var/tmp/rear.XXXXXXXXXXXXXXX/tmp/ )
-        # when $TMP_DIR/efiboot.img got umounted just before fuser starts, see "man fuser":
-        #   The mount -m option will match any file within the same device as the specified file,
-        #   use the -M option as well if you mean to specify only the mount point.
-        # So when $TMP_DIR/efiboot.img is umounted 'fuser -v -M -m $TMP_DIR/efi_virt' only shows
-        #   "Specified filename /var/tmp/rear.XXXXXXXXXXXXXXX/tmp/efi_virt is not a mountpoint"
-        # instead of all processes using '/' (or /var/ or /var/tmp/ if one is a mountpoint)
-        # which would be misleading information that may even look scaring and cause false alarm.
-        # Older systems do not support -M but we must use it to avoid misleading information or false alarm.
-        # Since this code path is exceptional and the output is used only for information purposes,
-        # we do not care when fuser fails with "M: unknown signal; fuser -l lists signals":
-        fuser -v -M -m $TMP_DIR/efi_virt 1>&2 || Log "Presumably 'fuser' does not support the -M option"
-        DebugPrint "Trying 'umount --lazy $TMP_DIR/efiboot.img' (normal umount failed)"
-        # Do only plain 'umount --lazy' without additional '--force'
-        # so we do not use the umount_mountpoint_lazy() function here:
-        if ! umount $v --lazy $TMP_DIR/efiboot.img ; then
-            # When umounting the EFI virtual image fails it is no hard error so only inform the user
-            # so he can understand why later cleanup_build_area_and_end_program() may show
-            # "Could not remove build area" (when lazy umount could not clean up things until then)
-            # cf. https://github.com/rear/rear/issues/2908
-            LogPrintError "Could not umount $what_is_mounted"
-        fi
-    fi
-fi
+# When umounting the EFI virtual image fails it is no hard error so only inform the user
+# so he can understand why later cleanup_build_area_and_end_program() may show
+# "Could not remove build area" (when lazy umount could not clean up things until then)
+# cf. https://github.com/rear/rear/issues/2908
+umount_mountpoint_retry_lazy "$TMP_DIR/efi_virt" "$what_is_mounted" || LogPrintError "Could not umount $what_is_mounted"
 
 # Move efiboot.img into ISO directory:
 mv $v -f $TMP_DIR/efiboot.img $TMP_DIR/isofs/boot/efiboot.img || Error "Failed to move efiboot.img to isofs/boot/efiboot.img"

--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -153,8 +153,13 @@ EOF
 fi
 
 # Cleanup of EFI temporary mount point:
-if umount $efi_mpt ; then
-    rmdir $efi_mpt || LogPrintError "Could not remove temporary directory '$efi_mpt' (you should do it manually)"
+local what_is_mounted="EFI partition '$efi_part' at '$efi_mpt'"
+# When umounting the EFI partition fails it is no hard error so only inform the user
+# so he can understand why later cleanup_build_area_and_end_program() may show
+# "Could not remove build area" (when lazy umount could not clean up things until then)
+# cf. https://github.com/rear/rear/issues/3397
+if umount_mountpoint_retry_lazy "$efi_mpt" "$what_is_mounted" ; then
+    rmdir "$efi_mpt" || LogPrintError "Could not remove temporary directory '$efi_mpt' (you should do it manually)"
 else
-    LogPrintError "Could not umount EFI partition '$efi_part' at '$efi_mpt' (you should do it manually)"
+    LogPrintError "Could not umount $what_is_mounted' (you should do it manually)"
 fi

--- a/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
+++ b/usr/share/rear/output/USB/Linux-i386/100_create_efiboot.sh
@@ -153,7 +153,7 @@ EOF
 fi
 
 # Cleanup of EFI temporary mount point:
-local what_is_mounted="EFI partition '$efi_part' at '$efi_mpt'"
+local what_is_mounted="EFI partition '$efi_part' on '$efi_mpt'"
 # When umounting the EFI partition fails it is no hard error so only inform the user
 # so he can understand why later cleanup_build_area_and_end_program() may show
 # "Could not remove build area" (when lazy umount could not clean up things until then)


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/2909
https://github.com/rear/rear/issues/2908
https://github.com/rear/rear/issues/3397

* How was this pull request tested?
see below: https://github.com/rear/rear/pull/3408#issuecomment-2687620899

* Description of the changes in this pull request:

In lib/global-functions.sh added a new
umount_mountpoint_retry_lazy function
which is basically a copy of the code in
output/ISO/Linux-i386/700_create_efibootimg.sh
which had been added there
via https://github.com/rear/rear/pull/2909

Use the umount_mountpoint_retry_lazy function
in output/ISO/Linux-i386/700_create_efibootimg.sh
and also
in output/USB/Linux-i386/100_create_efiboot.sh
see https://github.com/rear/rear/issues/3397
