### PR TITLE
enhance 300_map_disks.sh script to also print the disk sizes

### DIFF
--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -185,17 +185,17 @@ while read keyword orig_device orig_size junk ; do
         IsInArray "$preferred_target_device_name" "${excluded_target_device_names[@]}" && continue
         # Continue with next block device if the current one is already used as target in the mapping file:
         if is_mapping_target "$preferred_target_device_name" ; then
-            DebugPrint "Cannot use $preferred_target_device_name (same $current_size size) for recreating $orig_device ($preferred_target_device_name already exists as target in $MAPPING_FILE)"
+            DebugPrint "Cannot use $preferred_target_device_name (same size $current_size) for recreating $orig_device ($preferred_target_device_name already exists as target in $MAPPING_FILE)"
             continue
         fi
         # Ensure the determined target device is not write-protected (cf. above):
         if is_write_protected "$preferred_target_device_name" ; then
-            DebugPrint "Cannot use $preferred_target_device_name (same $current_size size) for recreating $orig_device ($preferred_target_device_name is write-protected)"
+            DebugPrint "Cannot use $preferred_target_device_name (same size $current_size) for recreating $orig_device ($preferred_target_device_name is write-protected)"
             continue
         fi
         # The first of all current block devices with same size as the original that is not yet used as target gets used:
         add_mapping "$orig_device" "$preferred_target_device_name"
-        LogPrint "Using $preferred_target_device_name (same $current_size size) for recreating $orig_device"
+        LogPrint "Using $preferred_target_device_name (same size $current_size) for recreating $orig_device"
         # Continue the outer while loop with next original device because the current one is now mapped:
         continue 2
     done


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): #3411 

* How was this pull request tested? In a real DR test

* Description of the changes in this pull request: The sizes of the disks will now also be saved in the ReaR log file which makes it easier to link the original disk with the new mapped one.
Furthermore, a new script `960_save_disk_and_vgs_mappings.sh` was added to assist further in the disk mapping process (even before we execute the recovery itself).

