### PR TITLE
ci: run Differential ShellCheck only on push to master

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -3,6 +3,7 @@
 name: Differential ShellCheck
 on:
   push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
This will resolve issues similar to this:

`git: base SHA1 (0000000000000000000000000000000000000000) doesn't exist. Make sure that the base branch is up-to-date.`

Related to https://github.com/rear/rear/pull/3416

