### PR TITLE
ppc64le: Fix PReP Boot detection on GPT layouts

### DIFF
--- a/usr/share/rear/layout/save/default/445_guess_bootloader.sh
+++ b/usr/share/rear/layout/save/default/445_guess_bootloader.sh
@@ -47,6 +47,15 @@ if [ "$ARCH" = "Linux-arm" ] ; then
     return
 fi
 
+# Check if any disk contains a PPC PReP boot partition.
+# Detection taken from usr/share/rear/finalize/Linux-ppc64/680_install_PPC_bootlist.sh
+disk_device="$( awk -F ' ' '/^part / {if ($6 ~ /prep/) {print $2}}' $LAYOUT_FILE )"
+if test "$disk_device" ; then
+   LogPrint "Using guessed bootloader 'PPC' for 'rear recover' (found PPC PReP boot partition on $disk_device)"
+   echo "PPC" >$bootloader_file
+   return
+fi
+
 # Finally guess the used bootloader by inspecting the first bytes on all disks
 # and use the first one that matches a known bootloader string:
 for block_device in /sys/block/* ; do
@@ -54,12 +63,6 @@ for block_device in /sys/block/* ; do
     # Continue with the next block device when the current block device is not a disk that can be used for booting:
     [[ $blockd = hd* || $blockd = sd* || $blockd = cciss* || $blockd = vd* || $blockd = xvd* || $blockd = nvme* || $blockd = mmcblk* || $blockd = dasd*  ]] || continue
     disk_device=$( get_device_name $block_device )
-    # Check if the disk contains a PPC PreP boot partition (ID=0x41):
-    if file -s $disk_device | grep -q "ID=0x41" ; then
-       LogPrint "Using guessed bootloader 'PPC' for 'rear recover' (found PPC PreP boot partition 'ID=0x41' on $disk_device)"
-       echo "PPC" >$bootloader_file
-       return
-    fi
     # Get all strings in the first 512*4=2048 bytes on the disk:
     bootloader_area_strings_file="$TMP_DIR/bootloader_area_strings"
     block_size=$( get_block_size ${disk_device##*/} )


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL): N/A, found when playing with #3406

* How was this pull request tested? `rear -d savelayout` on RHEL 9 (MSDOS) and RHEL 10 (GPT)

* Description of the changes in this pull request:

In general, `file` output is not stable and is purely informational.  This manifested in PReP Boot partitions on GPT formatted block devices being classified as missing (apparently, `file` detects the Protective MBR instead):
```console
# file -s /dev/sdb
/dev/sdb: DOS/MBR boot sector; partition 1 : ID=0xee, active, start-CHS (0x0,0,2), end-CHS (0x3ff,255,63), startsector 1, 10485759 sectors
# parted -s /dev/sdb print
Model: AIX VDASD (scsi)
Disk /dev/sdb: 5369MB
Sector size (logical/physical): 512B/512B
Partition Table: gpt
Disk Flags: pmbr_boot

Number  Start   End     Size    File system  Name  Flags
 1      1049kB  5243kB  4194kB                     prep
 2      5243kB  1079MB  1074MB  xfs                bls_boot
 3      1079MB  5368MB  4289MB                     lvm
```
This fixes the bootloader detection on RHEL 10 PowerVM machines which use the GPT layout by default.