### PR TITLE
LUKS2: try to handle multiple key slots

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/160_include_luks_code.sh
@@ -62,6 +62,9 @@ create_crypt() {
             (uuid)
                 test $value && cryptsetup_options+=" --uuid $value"
                 ;;
+            (pbkdf)
+                test $value && cryptsetup_options+=" --pbkdf $value"
+                ;;
             (keyfile)
                 test $value && keyfile=$value
                 ;;

--- a/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/260_crypt_layout.sh
@@ -66,26 +66,67 @@ while read target_name junk ; do
         LogPrintError "Error: Cannot get LUKS$version values for $target_name ('cryptsetup luksDump $source_device' failed)"
         continue
     fi
+    cmd="cryptsetup luksDump $source_device"
+
     uuid=$( grep "UUID" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
     keyfile_option=$( [ -f /etc/crypttab ] && awk '$1 == "'"$target_name"'" && $3 != "none" && $3 != "-" && $3 != "" { print "keyfile=" $3; }' /etc/crypttab )
+    pbkdf_option=""
+
     if test $luks_type = "luks1" ; then
+
         cipher_name=$( grep "Cipher name" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
         cipher_mode=$( grep "Cipher mode" $TMP_DIR/cryptsetup.luksDump | cut -d: -f2- | awk '{printf("%s",$1)};' )
         cipher=$cipher_name-$cipher_mode
         key_size=$( grep "MK bits" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
         hash=$( grep "Hash spec" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
+
     elif test $luks_type = "luks2" ; then
-        cipher=$( grep "cipher:" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
-        # More than one keyslot may be defined - use key_size from the first slot.
+
+        keyslots_section=$( awk '/^Keyslots:/ {include=1;next} /^[[:upper:]]/ && include {exit} include' $TMP_DIR/cryptsetup.luksDump )
+        if [ -z "$keyslots_section" ]; then
+            LogPrintError "Error: No Keyslots section found in '$cmd' output"
+            continue
+        fi
+        if [ $( grep -c -P '^\s+\d+: luks2' <<< "$keyslots_section" ) -gt 1 ]; then
+            LogPrintError "Warning: More than one luks2 keyslot found in '$cmd' output, will only consider the first keyslot during recovery"
+        fi
+        luks2_section=$( awk '/^[[:blank:]]+[[:digit:]]+:/ && include {exit} /^[[:blank:]]+[[:digit:]]+: luks2/{include=1} include' <<< "$keyslots_section")
+
+        cipher=$( grep "Cipher:" <<< "$luks2_section" | sed -r 's/^.+:\s*(.+)$/\1/' )
+        pbkdf=$( grep "PBKDF:" <<< "$luks2_section" | sed -r 's/^.+:\s*(.+)$/\1/' )
+        if [ -z "$pbkdf" ]; then
+            LogPrintError "Warning: no PBKDF found in luks2 keyslot of '$cmd' output, will use defaults during recovery"
+        else
+            pbkdf_option="pbkdf=$pbkdf"
+        fi
+
         # Depending on the version the "cryptsetup luksDump" command outputs the key_size value
         # as a line like
         #         Key:        512 bits
         # and/or as a line like
         #         Cipher key: 512 bits
         # cf. https://github.com/rear/rear/pull/2504#issuecomment-718729198 and subsequent comments
-        # so we grep for both lines but use only the first match from the first slot:
-        key_size=$( grep -E -m 1 "Key:|Cipher key:" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+) bits$/\1/' )
-        hash=$( grep "Hash" $TMP_DIR/cryptsetup.luksDump | sed -r 's/^.+:\s*(.+)$/\1/' )
+        key_size=$( grep -E "Key:|Cipher key:" <<< "$luks2_section" | sed -r 's/^.+:\s*(.+) bits$/\1/' | sort -u )
+        if [ -z "$key_size" ]; then
+            LogPrintError "Error: No key size found in luks2 keyslot of '$cmd' output"
+        elif [ $( wc -w <<< "$key_size" ) -gt 1 ]; then
+            LogPrintError "Error: Too many key sizes found in luks2 keyslot of '$cmd' output"
+            key_size=""
+        fi
+
+        hash=$( grep "AF hash:" <<< "$luks2_section" | sed -r 's/^.+:\s*(.+)$/\1/' )
+        if [ -z "$hash" ]; then
+            # Fallback to using Hash field found in Digests section
+            digests_section=$( awk '/^Digests:/ {include=1;next} /^[[:upper:]]/ && include {exit} include' $TMP_DIR/cryptsetup.luksDump )
+            hash=$( grep "Hash:" <<< "$digests_section" | sed -r 's/^.+:\s*(.+)$/\1/' | sort -u )
+            if [ -z "$hash" ]; then
+                LogPrintError "Warning: No Hash found in Digests section of '$cmd' output, will use default type during recovery"
+            elif [ $( wc -w <<< "$hash" ) -gt 1 ]; then
+                hash=$( head -1 <<< "$hash" )
+                LogPrintError "Warning: Too many Hash found in Digests section of '$cmd' output, will use '$hash' during recovery"
+            fi
+        fi
+
     fi
 
     # Basic checks that the cipher key_size hash uuid values exist
@@ -95,9 +136,9 @@ while read target_name junk ; do
     # and it seems cryptsetup fails when options with empty values are specified
     # cf. https://github.com/rear/rear/pull/2504#issuecomment-719479724
     # For example a LUKS1 crypt entry in disklayout.conf looks like
-    # crypt /dev/mapper/luks1test /dev/sda7 type=luks1 cipher=aes-xts-plain64 key_size=256 hash=sha256 uuid=1b4198c9-d9b0-4c57-b9a3-3433e391e706 
+    # crypt /dev/mapper/luks1test /dev/sda7 type=luks1 cipher=aes-xts-plain64 key_size=256 hash=sha256 uuid=1b4198c9-d9b0-4c57-b9a3-3433e391e706
     # and a LUKS1 crypt entry in disklayout.conf looks like
-    # crypt /dev/mapper/luks2test /dev/sda8 type=luks2 cipher=aes-xts-plain64 key_size=256 hash=sha256 uuid=3e874a28-7415-4f8c-9757-b3f28a96c4d2 
+    # crypt /dev/mapper/luks2test /dev/sda8 type=luks2 cipher=aes-xts-plain64 key_size=256 hash=sha256 uuid=3e874a28-7415-4f8c-9757-b3f28a96c4d2 [pbkdf=argon2id]
     # Only the keyfile_option value is optional and the luks_type value is already tested above.
     # Using plain test to ensure a value is a single non empty and non blank word
     # without quoting because test " " would return zero exit code
@@ -127,7 +168,12 @@ while read target_name junk ; do
         LogPrintError "Error: No 'uuid' value for LUKS$version volume $target_name in $source_device (mounting it or booting the recreated system may fail)"
     fi
 
-    echo "crypt /dev/mapper/$target_name $source_device type=$luks_type cipher=$cipher key_size=$key_size hash=$hash uuid=$uuid $keyfile_option" >> $DISKLAYOUT_FILE
+    (
+        echo -n "crypt /dev/mapper/$target_name $source_device type=$luks_type cipher=$cipher key_size=$key_size hash=$hash uuid=$uuid"
+        [ -n "$keyfile_option" ] && echo -n " $keyfile_option"
+        [ -n "$pbkdf_option" ] && echo -n " $pbkdf_option"
+        echo
+    ) >> $DISKLAYOUT_FILE
 
 done < <( dmsetup ls --target crypt )
 


### PR DESCRIPTION

##### Pull Request Details:

* Type: **Bug Fix** + **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):

Related to [PR 2504 - Add initial LUKS2 support](https://github.com/rear/rear/pull/2504)

* How was this pull request tested?

On RHEL9 UEFI system + TPM2 with LUKS encrypted root partition on LVM:
{code:java}
# lsblk
NAME                                          MAJ:MIN RM  SIZE RO TYPE  MOUNTPOINTS
sr0                                            11:0    1 1024M  0 rom   
vda                                           252:0    0   20G  0 disk  
├─vda1                                        252:1    0  600M  0 part  /boot/efi
├─vda2                                        252:2    0    1G  0 part  /boot
└─vda3                                        252:3    0 18.4G  0 part  
  └─luks-157c516f-a8a8-48f2-9b79-082ea905d73b 253:0    0 18.4G  0 crypt 
    ├─rhel-root                               253:1    0   10G  0 lvm   /
    ├─rhel-swap                               253:2    0    2G  0 lvm   [SWAP]
    ├─rhel-crypt                              253:3    0    1G  0 lvm   
    └─rhel-cryptpbkdf2                        253:4    0    1G  0 lvm   
{code}

The `/dev/vda3` partition is also bound to the TPM2 (which leads to having a 2nd key slot):
{code:java}
# cryptsetup luksDump /dev/vda3
[...]
Keyslots:
  0: luks2
	Key:        512 bits
	Priority:   normal
	Cipher:     aes-xts-plain64
	Cipher key: 512 bits
	PBKDF:      argon2id
	Time cost:  6
	Memory:     1048576
	Threads:    2
	Salt:       a0 fc ce ea 62 42 05 58 d6 ba 42 d4 43 7d 08 a6 
	            b4 9c ce 09 48 2a ed 7d fb 8a e0 b5 3d d6 84 52 
	AF stripes: 4000
	AF hash:    sha256
	Area offset:32768 [bytes]
	Area length:258048 [bytes]
	Digest ID:  0
  1: luks2
	Key:        512 bits
	Priority:   normal
	Cipher:     aes-xts-plain64
	Cipher key: 512 bits
	PBKDF:      pbkdf2
	Hash:       sha256
	Iterations: 1000
	Salt:       f7 60 c4 d8 cd cb 9b dc b9 6c e6 ec 94 c9 0c 97 
	            41 ef 9b 84 e8 6a 54 86 60 ca f8 71 37 dc 16 64 
	AF stripes: 4000
	AF hash:    sha256
	Area offset:290816 [bytes]
	Area length:258048 [bytes]
	Digest ID:  0
Tokens:
  0: clevis
	Keyslot:    1
Digests:
  0: pbkdf2
	Hash:       sha256
        [...]
{code}

* Description of the changes in this pull request:

The current code doesn't deal properly with multiple key slots nor extracts the Hash that was used at LUKS creation properly. With current code, when multiple key slots are found or PBKDF algorithm is "pbkdf2" (instead of default "argon2id"), the disk layout file contains 2 lines for *crypt* parameters, causing havoc during recovery because of having new UUIDs being generated due to malformed 2nd line, e.g.:
~~~
crypt /dev/mapper/luks-157c516f-a8a8-48f2-9b79-082ea905d73b /dev/vda3 type=luks2 cipher=aes-xts-plain64 key_size=512 hash=sha256
sha256 uuid=157c516f-a8a8-48f2-9b79-082ea905d73b
~~~

This new code tries to do better:
- it searches for the Hash in Keyslots section only (and falls back to Digests section if not found)
- it warns the admin if multiple keyslots are in use (e.g. because of multiple passphrases or Clevis binding)
- it handles the PBKDF algorithm
- it makes sure that the *crypt* parameters are always on one line, e.g.

  ~~~
  crypt /dev/mapper/luks-157c516f-a8a8-48f2-9b79-082ea905d73b /dev/vda3 type=luks2 cipher=aes-xts-plain64 key_size=512 hash=sha256 uuid=157c516f-a8a8-48f2-9b79-082ea905d73b
  ~~~
