### PR TITLE
Change all ReaR scripts that mention the old name _input-output-functions.sh

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -33,7 +33,7 @@ if is_true "$BACKUP_PROG_CRYPT_ENABLED" ; then
     test "tar" = "$BACKUP_PROG" || Error "Backup archive encryption is only supported with BACKUP_PROG=tar"
     # Backup archive encryption is impossible without a BACKUP_PROG_CRYPT_KEY value.
     # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode
-    # cf. the comment of the UserInput function in lib/_input-output-functions.sh
+    # cf. the comment of the UserInput function in lib/_framework-setup-and-functions.sh
     # how to keep things confidential when usr/sbin/rear is run in debugscript mode
     # ('2>>/dev/$SECRET_OUTPUT_DEV' should be sufficient here because 'test' does not output on stdout):
     { test "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive encryption"
@@ -106,7 +106,7 @@ FAILING_BACKUP_PROG_RC_FILE="$TMP_DIR/failing_backup_prog_rc"
 # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
 # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
 # so that stderr of the confidential command is redirected to /dev/null
-# cf. the comment of the UserInput function in lib/_input-output-functions.sh
+# cf. the comment of the UserInput function in lib/_framework-setup-and-functions.sh
 # how to keep things confidential when rear is run in debugscript mode
 # because it is more important to not leak out user secrets into a log file
 # than having stderr error messages when a confidential command fails

--- a/usr/share/rear/backup/YUM/default/500_make_backup.sh
+++ b/usr/share/rear/backup/YUM/default/500_make_backup.sh
@@ -71,7 +71,7 @@ if is_true "$YUM_BACKUP_FILES_FULL_EXCL" ; then
         	curCmdLen=$(( ${#cmd2} + 1 ))
         	[ $curCmdLen -gt $maxArgLen ] && {
 			# Simple "something is still going on" indicator by printing dots
-			# directly to stdout which is fd7 (see lib/_input-output-functions.sh)
+			# directly to stdout which is fd7 (see lib/_framework-setup-and-functions.sh)
 			# and not using a Print function to always print to the original stdout
 			# i.e. to the terminal wherefrom the user has started "rear recover":
 			echo -n "." >&7

--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -133,7 +133,7 @@ local copy_as_is_file=""
 # then 'tar' copies things in /path/to/somedir/subdir two times
 # and reports them twice in the copy_as_is_filelist_file
 # cf. https://github.com/rear/rear/pull/2378
-# It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_input-output-functions.sh):
+# It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_framework-setup-and-functions.sh):
 while read -r copy_as_is_file ; do
     # Skip non-regular files like directories, device files, and 'tar' error messages (e.g. in case of non-existent files, see above)
     # but do not skip symbolic links. Their targets will be copied later by build/default/490_fix_broken_links.sh.
@@ -151,7 +151,7 @@ Log "copy_as_is_executables = ${copy_as_is_executables[@]}"
 # add them to the LIBS list if they are not yet included in the copied files:
 Log "Adding required libraries of executables in all the copied files to LIBS"
 local required_library=""
-# It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_input-output-functions.sh):
+# It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_framework-setup-and-functions.sh):
 for required_library in $( RequiredSharedObjects "${copy_as_is_executables[@]}" ) ; do
     # Skip when the required library was already actually copied by 'tar' above.
     # grep for a full line (copy_as_is_filelist_file contains 1 file name per line)

--- a/usr/share/rear/build/GNU/Linux/390_copy_binaries_libraries.sh
+++ b/usr/share/rear/build/GNU/Linux/390_copy_binaries_libraries.sh
@@ -13,7 +13,7 @@ function copy_binaries () {
     local destdir="$1"
     test -d "$destdir" || BugError "copy_binaries destination '$destdir' is not a directory"
     local binary=""
-    # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_input-output-functions.sh):
+    # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_framework-setup-and-functions.sh):
     while (( $# > 1 )) ; do
         shift
         binary="$1"
@@ -62,7 +62,7 @@ LogPrint "Copying binaries and libraries"
 Log "Determining binaries from PROGS and REQUIRED_PROGS"
 local bin=""
 local bin_path=""
-# It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_input-output-functions.sh):
+# It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_framework-setup-and-functions.sh):
 local all_binaries=( $( for bin in "${PROGS[@]}" "${REQUIRED_PROGS[@]}" ; do
                             bin_path="$( get_path "$bin" )"
                             if test -x "$bin_path" ; then
@@ -91,7 +91,7 @@ local all_libs=( "${LIBS[@]}" $( RequiredSharedObjects "${all_binaries[@]}" "${L
 Log "Libraries being copied: ${all_libs[@]}"
 local lib=""
 local link_target=""
-# It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_input-output-functions.sh):
+# It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_framework-setup-and-functions.sh):
 for lib in "${all_libs[@]}" ; do
     if test -L $lib ; then
         # Because $lib is a symbolic link on the original system

--- a/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
+++ b/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
@@ -89,7 +89,7 @@ for dummy in "once" ; do
         # The '--parents' is needed to get the '/lib/modules/' directory in the copy.
         # The '-L' copies the actual content to avoid dangling symlinks in the recovery system
         # cf. https://github.com/rear/rear/issues/2677#issuecomment-997859219
-        # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_input-output-functions.sh):
+        # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_framework-setup-and-functions.sh):
         if ! cp $verbose -t $ROOTFS_DIR -a -L --parents /lib/modules/$KERNEL_VERSION 2>>/dev/$DISPENSABLE_OUTPUT_DEV 1>&2 ; then
             # Do not error out if 'cp -a -L' failed to to copy all contents of /lib/modules/$KERNEL_VERSION
             # because dangling symlinks let 'cp -L' fail and there is no cp option to let it skip broken symlinks

--- a/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
+++ b/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
@@ -28,7 +28,7 @@ if is_true "$FIRMWARE_FILES" ; then
     # Use a simple 'cp -a' for this case to be safe against possible issues
     # with the more complicated 'find ... | xargs cp' method below.
     # The '--parents' is needed to get the '/lib*/' directory in the copy.
-    # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_input-output-functions.sh):
+    # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_framework-setup-and-functions.sh):
     cp $verbose -t $ROOTFS_DIR -a --parents /lib*/firmware 2>>/dev/$DISPENSABLE_OUTPUT_DEV 1>&2
     return
 fi

--- a/usr/share/rear/build/default/960_remove_encryption_keys.sh
+++ b/usr/share/rear/build/default/960_remove_encryption_keys.sh
@@ -8,7 +8,7 @@
 
 # Nothing to do when there is no BACKUP_PROG_CRYPT_KEY value.
 # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode
-# cf. the comment of the UserInput function in lib/_input-output-functions.sh
+# cf. the comment of the UserInput function in lib/_framework-setup-and-functions.sh
 # how to keep things confidential when usr/sbin/rear is run in debugscript mode
 # ('2>>/dev/$SECRET_OUTPUT_DEV' should be sufficient here because 'test' does not output on stdout):
 { test "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV || return 0

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -348,7 +348,7 @@ PROGRESS_WAIT_SECONDS="1"
 # Relax-and-Recover UserInput function default behaviour
 #
 # see the UserInput function description in
-# usr/share/rear/lib/_input-output-functions.sh
+# usr/share/rear/lib/_framework-setup-and-functions.sh
 #
 # USER_INPUT_TIMEOUT
 # USER_INPUT_INTERRUPT_TIMEOUT
@@ -4297,7 +4297,7 @@ DRLM_ID="$HOSTNAME"
 # not be deprecated - or when or under which conditions it can be removed.
 # 
 # Every deprecation has a keyword that is shown in the deprecation error message
-# (see the ErrorIfDeprecated function in lib/_input-output-functions.sh).
+# (see the ErrorIfDeprecated function in lib/_framework-setup-and-functions.sh).
 # The deprecation keyword can be added to the DISABLE_DEPRECATION_ERRORS array
 # to override the deprecation error and continue to use the deprecated feature.
 # Users who do this without talking to the ReaR project via a GitHub issue

--- a/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
@@ -148,7 +148,7 @@ function create_fs () {
             # even in case of complicated device nodes e.g. things like /dev/mapper/SIBM_2810XIV_78033E7012F-part3
             # cf. current_orig_device_basename_alnum_uppercase in layout/prepare/default/300_map_disks.sh
             local xfs_device_basename_alnum_uppercase="$( echo $xfs_device_basename | tr -d -c '[:alnum:]' | tr '[:lower:]' '[:upper:]' )"
-            # cf. predefined_input_variable_name in the function UserInput in lib/_input-output-functions.sh
+            # cf. predefined_input_variable_name in the function UserInput in lib/_framework-setup-and-functions.sh
             local mkfs_xfs_options_variable_name="MKFS_XFS_OPTIONS_$xfs_device_basename_alnum_uppercase"
             # Set which options to use for mkfs.xfs:
             if test "${!mkfs_xfs_options_variable_name:-}" ; then

--- a/usr/share/rear/lib/authtoken-functions.sh
+++ b/usr/share/rear/lib/authtoken-functions.sh
@@ -22,8 +22,8 @@
 # instead of using ReaR functions like LogPrint, UserOutput,... and UserInput
 # which is correct here because those ReaR user input/output functions
 # cannot be made available at ReaR system startup time
-# because lib/lib/_input-output-functions.sh cannot be sourced there
-# because lib/_input-output-functions.sh does also some special stuff
+# because lib/lib/_framework-setup-and-functions.sh cannot be sourced there
+# because lib/_framework-setup-and-functions.sh does also some special stuff
 # (like adding EXIT_TASKS and STDIN STDOUT and STDERR redirections)
 # cf. https://github.com/rear/rear/pull/2956#discussion_r1133701768
 # and https://github.com/rear/rear/pull/2956#discussion_r1133714369

--- a/usr/share/rear/lib/linux-functions.sh
+++ b/usr/share/rear/lib/linux-functions.sh
@@ -176,7 +176,7 @@ function RequiredSharedObjects () {
     #  6. Line: "        /path/to/lib (mem-addr)"                  -> print $1 '/path/to/lib'
     local file_for_ldd=""
     local file_owner_name=""
-    # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_input-output-functions.sh):
+    # It is crucial to append to /dev/$DISPENSABLE_OUTPUT_DEV (cf. 'Print' in lib/_framework-setup-and-functions.sh):
     for file_for_ldd in "$@" ; do
         # Skip non-regular files like directories, device files, and non-existent files
         # cf. similar code in build/GNU/Linux/100_copy_as_is.sh
@@ -240,7 +240,7 @@ alias shutdown=ask_exit
 cd $VAR_DIR
 EOF
     # Run 'bash' with the original STDIN STDOUT and STDERR when 'rear' was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     HISTFILE="$histfile" bash --noprofile --rcfile $bashrc 0<&6 1>&7 2>&8
 }
 

--- a/usr/share/rear/lib/progresssubsystem.nosh
+++ b/usr/share/rear/lib/progresssubsystem.nosh
@@ -1,6 +1,6 @@
 
 # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-# to get input from the user and to show output to the user (cf. _input-output-functions.sh).
+# to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh).
 ####################### BEGIN Progress Indicator
 # Call StartProgressSubsystem to get more detailed progress reports:
 if tty -s <&7 ; then

--- a/usr/share/rear/lib/rear-shell.bashrc
+++ b/usr/share/rear/lib/rear-shell.bashrc
@@ -27,8 +27,8 @@ source $SHARE_DIR/lib/progresssubsystem.nosh
 
 # Set EXIT_FAIL_MESSAGE to 0 to avoid a false exit failure message from the exit task
 # "(( EXIT_FAIL_MESSAGE )) && echo '${MESSAGE_PREFIX}$PROGRAM $WORKFLOW failed, check $RUNTIME_LOGFILE for details' 1>&8"
-# that is set in lib/_input-output-functions.sh which is sourced above for this shell here.
-# Because we have two shells where ReaR's exit tasks are set (both via lib/_input-output-functions.sh)
+# that is set in lib/_framework-setup-and-functions.sh which is sourced above for this shell here.
+# Because we have two shells where ReaR's exit tasks are set (both via lib/_framework-setup-and-functions.sh)
 # exiting this bash here runs ReaR's exit tasks and then this workflow finishes
 # which lets the outer bash that runs rear finish which also runs ReaR's exit tasks:
 #   # usr/sbin/rear -v shell

--- a/usr/share/rear/lib/validate-workflow.sh
+++ b/usr/share/rear/lib/validate-workflow.sh
@@ -25,7 +25,7 @@ to improve $PRODUCT.
 --- The $PRODUCT development team
 "
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     read -e -p "Press ENTER to continue ... " 0<&6 1>&7 2>&8
 
 Print "
@@ -44,7 +44,7 @@ should only include information that you are willing to see published on the
 $PRODUCT website and contained within $PRODUCT.
 "
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     read -e -p "Press ENTER to continue ... " 0<&6 1>&7 2>&8
 
     Print "
@@ -59,7 +59,7 @@ will be...
 Example: Your Name <email-address>, Company/Organisation, Country
 "
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     read -e -p "Submitted By: " 0<&6 1>&7 2>&8
     SUBMITTED_BY="$REPLY"
 
@@ -73,7 +73,7 @@ as configuration types like LVM, MD etc.
 Example: LVM, MD, SCSI, $BACKUP, $OUTPUT, EMAIL, ...
 "
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     read -e -p "Features: " 0<&6 1>&7 2>&8
     FEATURES="$REPLY"
 
@@ -92,7 +92,7 @@ Example: Works out-of-the-box flawless with all features
 Example: We modified path/to/file in order to support foo-bar better
 "
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     read -e -p "Comments: " 0<&6 1>&7 2>&8
     COMMENTS="$REPLY"
 

--- a/usr/share/rear/restore/BACULA/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/BACULA/default/400_restore_backup.sh
@@ -53,7 +53,7 @@ Do not exit 'bextract' until all files are restored.
 WARNING: The new root is mounted under '$TARGET_FS_ROOT'.
 "
         # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-        # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+        # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
         read -p "Press ENTER to start bextract" 0<&6 1>&7 2>&8
 
         bextract$exclude_list -V$BEXTRACT_VOLUME /backup $TARGET_FS_ROOT

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -134,7 +134,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
     # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
     # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
     # so that stderr of the confidential command is redirected to SECRET_OUTPUT_DEV (normally /dev/null)
-    # cf. the comment of the UserInput function in lib/_input-output-functions.sh
+    # cf. the comment of the UserInput function in lib/_framework-setup-and-functions.sh
     # how to keep things confidential when rear is run in debugscript mode
     # because it is more important to not leak out user secrets into a log file
     # than having stderr error messages when a confidential command fails

--- a/usr/share/rear/restore/YUM/default/400_restore_packages.sh
+++ b/usr/share/rear/restore/YUM/default/400_restore_packages.sh
@@ -55,7 +55,7 @@ local rpm_package=""
 local rpm_package_name_version=""
 for rpm_package in $rpms_in_installion_order ; do
     # Simple "something is still going on" indicator by printing dots
-    # directly to stdout which is fd7 (see lib/_input-output-functions.sh)
+    # directly to stdout which is fd7 (see lib/_framework-setup-and-functions.sh)
     # and not using a Print function to always print to the original stdout
     # i.e. to the terminal wherefrom the user has started "rear recover":
     echo -n "." >&7
@@ -87,7 +87,7 @@ if test "independent_RPMs" = "$YUM_INSTALL_RPMS" ; then
     # because therein the latest installed RPMs are listed topmost:
     for rpm_package in $( tac $yum_backup_dir/independent_RPMs ) ; do
         # Simple "something is still going on" indicator by printing dots
-        # directly to stdout which is fd7 (see lib/_input-output-functions.sh)
+        # directly to stdout which is fd7 (see lib/_framework-setup-and-functions.sh)
         # and not using a Print function to always print to the original stdout
         # i.e. to the terminal wherefrom the user has started "rear recover":
         echo -n "." >&7
@@ -119,7 +119,7 @@ else
     # because therein the latest installed RPMs are listed topmost:
     for rpm_package in $( tac $yum_backup_dir/installed_RPMs | cut -d ' ' -f1 ) ; do
         # Simple "something is still going on" indicator by printing dots
-        # directly to stdout which is fd7 (see lib/_input-output-functions.sh)
+        # directly to stdout which is fd7 (see lib/_framework-setup-and-functions.sh)
         # and not using a Print function to always print to the original stdout
         # i.e. to the terminal wherefrom the user has started "rear recover":
         echo -n "." >&7

--- a/usr/share/rear/restore/YUM/default/405_recreate_users_and_groups.sh
+++ b/usr/share/rear/restore/YUM/default/405_recreate_users_and_groups.sh
@@ -28,7 +28,7 @@ fi
 # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
 # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
 # so that stderr of the confidential command is redirected to SECRET_OUTPUT_DEV (normally /dev/null)
-# cf. the comment of the UserInput function in lib/_input-output-functions.sh
+# cf. the comment of the UserInput function in lib/_framework-setup-and-functions.sh
 # how to keep things confidential when rear is run in debugscript mode
 # because it is more important to not leak out user secrets into a log file
 # than having stderr error messages when a confidential command fails

--- a/usr/share/rear/restore/YUM/default/410_restore_backup.sh
+++ b/usr/share/rear/restore/YUM/default/410_restore_backup.sh
@@ -106,7 +106,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
     # but '$BACKUP_PROG_CRYPT_KEY' must be used in the actual command call which means
     # the BACKUP_PROG_CRYPT_KEY value would appear in the log when rear is run in debugscript mode
     # so that stderr of the confidential command is redirected to /dev/null
-    # cf. the comment of the UserInput function in lib/_input-output-functions.sh
+    # cf. the comment of the UserInput function in lib/_framework-setup-and-functions.sh
     # how to keep things confidential when rear is run in debugscript mode
     # because it is more important to not leak out user secrets into a log file
     # than having stderr error messages when a confidential command fails

--- a/usr/share/rear/restore/ZYPPER/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/ZYPPER/default/400_restore_backup.sh
@@ -59,7 +59,7 @@ local rpm_package=""
 local rpm_package_name_version=""
 for rpm_package in $rpms_in_installion_order ; do
     # Simple "something is still going on" indicator by printing dots
-    # directly to stdout which is fd7 (see lib/_input-output-functions.sh)
+    # directly to stdout which is fd7 (see lib/_framework-setup-and-functions.sh)
     # and not using a Print function to always print to the original stdout
     # i.e. to the terminal wherefrom the user has started "rear recover":
     echo -n "." >&7
@@ -90,7 +90,7 @@ if test "independent_RPMs" = "$ZYPPER_INSTALL_RPMS" ; then
     # because therein the latest installed RPMs are listed topmost:
     for rpm_package in $( tac $zypper_backup_dir/independent_RPMs ) ; do
         # Simple "something is still going on" indicator by printing dots
-        # directly to stdout which is fd7 (see lib/_input-output-functions.sh)
+        # directly to stdout which is fd7 (see lib/_framework-setup-and-functions.sh)
         # and not using a Print function to always print to the original stdout
         # i.e. to the terminal wherefrom the user has started "rear recover":
         echo -n "." >&7
@@ -118,7 +118,7 @@ else
     # because therein the latest installed RPMs are listed topmost:
     for rpm_package in $( tac $zypper_backup_dir/installed_RPMs | cut -d ' ' -f1 ) ; do
         # Simple "something is still going on" indicator by printing dots
-        # directly to stdout which is fd7 (see lib/_input-output-functions.sh)
+        # directly to stdout which is fd7 (see lib/_framework-setup-and-functions.sh)
         # and not using a Print function to always print to the original stdout
         # i.e. to the terminal wherefrom the user has started "rear recover":
         echo -n "." >&7

--- a/usr/share/rear/verify/DP/default/450_request_gui_restore.sh
+++ b/usr/share/rear/verify/DP/default/450_request_gui_restore.sh
@@ -9,7 +9,7 @@ rm -f $TMP_DIR/DP_GUI_RESTORE
 if [ $ARCH == "Linux-i386" ] || [ $ARCH == "Linux-ia64" ]; then
     unset REPLY
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     read -t $WAIT_SECS -r -n 1 -p "press 'G' to fall back to Data Protector GUI-based restore [$WAIT_SECS secs]: " 0<&6 1>&7 2>&8
 
     if test "$REPLY" = "g" -o "$REPLY" = "G" ; then

--- a/usr/share/rear/verify/DP/default/500_select_dp_restore.sh
+++ b/usr/share/rear/verify/DP/default/500_select_dp_restore.sh
@@ -72,7 +72,7 @@ DPChooseBackup() {
     LogPrint ""
     unset REPLY
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     read -t $WAIT_SECS -r -n 1 -p "press ENTER or choose C,D,S [$WAIT_SECS secs]: " 0<&6 1>&7 2>&8
 
     if test -z "${REPLY}"; then
@@ -115,7 +115,7 @@ DPChangeHost() {
   while test $valid -eq 0; do
     UserOutput ""
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     read -r -p "Enter client name: " 0<&6 1>&7 2>&8
     if test -z "${REPLY}"; then
       DPChooseBackup
@@ -145,7 +145,7 @@ DPChangeDataList() {
     i=$(cat $TMP_DIR/backup.list | while read s; do echo "$s" | cut -f 2; done | sort -u | wc -l)
     LogPrint ""
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     read -r -p "Please choose datalist [1-$i]: " 0<&6 1>&7 2>&8
     if test "${REPLY}" -ge 1 -a "${REPLY}" -le $i 2>/dev/null ; then
       DL=$(cat $TMP_DIR/backup.list | while read s; do echo "$s" | cut -f 2; done | sort -u | head -${REPLY} | tail -1)
@@ -172,7 +172,7 @@ DPChangeSession() {
     i=$(cat $TMP_DIR/backup.list.part | while read s; do echo "$s" | cut -f 1; done | sort -u -r -V | wc -l)
     echo
     # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-    # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+    # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
     read -r -p "Please choose session [1-$i]: " 0<&6 1>&7 2>&8
     if test "${REPLY}" -ge 1 -a "${REPLY}" -le $i 2>/dev/null ; then
       SESS=$(cat $TMP_DIR/backup.list.part | while read s; do echo "$s" | cut -f 1; done | sort -u -r -V | head -${REPLY} | tail -1)

--- a/usr/share/rear/verify/GALAXY10/default/500_select_backupset.sh
+++ b/usr/share/rear/verify/GALAXY10/default/500_select_backupset.sh
@@ -16,7 +16,7 @@ $(
 	)"
 
 	# Use the original STDIN STDOUT and STDERR when rear was launched by the user
-	# to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+	# to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
 	read -p "Please select the backupset to use: " answer 0<&6 1>&7 2>&8
 	test $answer -ge 0 -a $answer -lt $c ||\
 		Error "You must specify the backupset with its number."

--- a/usr/share/rear/verify/GALAXY7/default/500_select_backupset.sh
+++ b/usr/share/rear/verify/GALAXY7/default/500_select_backupset.sh
@@ -16,7 +16,7 @@ $(
 	)"
 
 	# Use the original STDIN STDOUT and STDERR when rear was launched by the user
-	# to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+	# to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
 	read -p "Please select the backupset to use: " answer 0<&6 1>&7 2>&8
 	test $answer -ge 0 -a $answer -lt $c ||\
 		Error "You must specify the backupset with its number."

--- a/usr/share/rear/verify/NBU/default/380_request_client_destination.sh
+++ b/usr/share/rear/verify/NBU/default/380_request_client_destination.sh
@@ -18,7 +18,7 @@ LogPrint "Netbackup Client Source For This Restore is:  $NBU_CLIENT_SOURCE"
 LogPrint "If this is a normal restore to the same client press ENTER."
 LogPrint "If this is a restore to a CLONE enter the new client name."
 # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-# to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+# to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
 read -t $WAIT_SECS -r -p "Enter Cloned Client name or press ENTER [$WAIT_SECS secs]: " 0<&6 1>&7 2>&8
 
 # validate input
@@ -40,7 +40,7 @@ else
         LogPrint "bp.conf defined servers: " ; cat /usr/openv/netbackup/bp.conf | grep -i server
         LogPrint ""
         # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-        # to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+        # to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
         # FIXME: Is it right to let 'read' timeout here which makes 'rear recover' automatically proceed after WAIT_SECS?
         # I <jsmeix@suse.de> think at this point during 'rear recover' the user may not yet have been able to
         # "Ensure all servers defined in bp.conf can connect to this RESCUE system using the hostname: ${NBU_CLIENT_NAME}"

--- a/usr/share/rear/verify/NETFS/default/600_check_encryption_key.sh
+++ b/usr/share/rear/verify/NETFS/default/600_check_encryption_key.sh
@@ -9,7 +9,7 @@ is_true "$BACKUP_PROG_CRYPT_ENABLED" || return 0
 # (it was removed by build/default/960_remove_encryption_keys.sh see the comment there)
 # so we need to ensure the BACKUP_PROG_CRYPT_KEY value was manually set again.
 # Avoid that the BACKUP_PROG_CRYPT_KEY value is shown in debugscript mode
-# cf. the comment of the UserInput function in lib/_input-output-functions.sh
+# cf. the comment of the UserInput function in lib/_framework-setup-and-functions.sh
 # how to keep things confidential when usr/sbin/rear is run in debugscript mode
 # ('2>>/dev/$SECRET_OUTPUT_DEV' should be sufficient here because 'test' does not output on stdout):
 { test "$BACKUP_PROG_CRYPT_KEY" ; } 2>>/dev/$SECRET_OUTPUT_DEV || Error "BACKUP_PROG_CRYPT_KEY must be set for backup archive decryption"

--- a/usr/share/rear/verify/RBME/default/540_choose_backup.sh
+++ b/usr/share/rear/verify/RBME/default/540_choose_backup.sh
@@ -38,7 +38,7 @@ fi
 # The user has to choose the backup
 LogPrint "Select a backup to restore."
 # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-# to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+# to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
 select choice in "${backups[@]}" "Abort"; do
     [ "$choice" != "Abort" ]
     StopIfError "User chose to abort recovery."

--- a/usr/share/rear/verify/TSM/default/400_verify_tsm.sh
+++ b/usr/share/rear/verify/TSM/default/400_verify_tsm.sh
@@ -72,7 +72,7 @@ Please enter the numbers of the filespaces we should restore.
 Pay attention to enter the filesystems in the correct order
 (like restore / before /var/log)"
 # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-# to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+# to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
 read -t $WAIT_SECS -p "(default: ${TSM_FILESPACE_INCLUDED_NUMS[*]}): [$WAIT_SECS secs] " -r TSM_RESTORE_FILESPACE_NUMS 0<&6 1>&7 2>&8
 if test -z "$TSM_RESTORE_FILESPACE_NUMS" ; then
     # Set default on ENTER:
@@ -89,7 +89,7 @@ for num in $TSM_RESTORE_FILESPACE_NUMS ; do
     LogPrint "${TSM_FILESPACES[$num]}"
 done
 # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-# to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+# to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
 read -t $WAIT_SECS -r -p "Is this selection correct ? (Y|n) [$WAIT_SECS secs] " 0<&6 1>&7 2>&8
 case "$REPLY" in
     (""|y|Y)

--- a/usr/share/rear/verify/USB/NETFS/default/540_choose_backup_archive.sh
+++ b/usr/share/rear/verify/USB/NETFS/default/540_choose_backup_archive.sh
@@ -71,14 +71,14 @@ LogPrint "Select a backup archive."
 # shows that when 'set -x' is set calling '{ set +x ; } 2>/dev/null' runs silently:
 { set +x ; } 2>/dev/null
 # Use the original STDIN STDOUT and STDERR when rear was launched by the user
-# to get input from the user and to show output to the user (cf. _input-output-functions.sh):
+# to get input from the user and to show output to the user (cf. _framework-setup-and-functions.sh):
 select choice in "${backup_times[@]}" ; do
     # trim blanks from reply
     n=( $REPLY )
     # bash arrays count from 0
     let n--
     if [ "$n" -lt 0 ] || [ "$n" -ge "${#backup_times[@]}" ] ; then
-        # direct output to stdout which is fd7 (see lib/_input-output-functions.sh)
+        # direct output to stdout which is fd7 (see lib/_framework-setup-and-functions.sh)
         # and not using a Print function to always print to the original stdout
         # i.e. to the terminal wherefrom the user has started "rear recover":
         echo "Invalid choice $REPLY, try again (or press [Ctrl]+[C] to abort)." >&7

--- a/usr/share/rear/wrapup/default/990_copy_logfile.sh
+++ b/usr/share/rear/wrapup/default/990_copy_logfile.sh
@@ -45,7 +45,7 @@ ln $verbose -s $log_file_symlink_target $log_file_symlink || true
 # Copy backup restore related files (in particular the backup restore log file) if exists.
 # This will be done as the last one of the exit tasks of this script because
 # the exit tasks are executed in reverse ordering of how AddExitTask is called
-# (see AddExitTask in _input-output-functions.sh) the ordering of how AddExitTask is called
+# (see AddExitTask in _framework-setup-and-functions.sh) the ordering of how AddExitTask is called
 # must begin with the to-be-last-run exit task and end with the to-be-first-run exit task:
 if test "$( echo $VAR_DIR/restore/* )" ; then
     # Using 'mkdir -p' primarily because that causes no error if the directory already exists


### PR DESCRIPTION
* Type: **Cleanup**

* Impact: **Low**
changes only comments

* Reference to related issue (URL):
https://github.com/rear/rear/pull/3424#issuecomment-2729935559

* Description of the changes in this pull request:

Change all ReaR scripts that mention the old name
_input-output-functions.sh (happens only in comments)
to show the new name _framework-setup-and-functions.sh
