### PR TITLE
remove zram swap from disklayout.conf 

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/240_swaps_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/240_swaps_layout.sh
@@ -8,7 +8,10 @@ Log "Saving Swap information."
     echo "# Format: swap <filename> uuid=<uuid> label=<label>"
 
     while read filename type junk ; do
-        if [ "$filename" = "Filename" ] || [ "$type" = "file" ] ; then
+        # "$filename" = "Filename" is the header line of /proc/swaps
+        # "$filename" =~ ^/dev/zram skips /dev/zram* swap entries from disklayout.conf
+        # see https://github.com/rear/rear/issues/3343
+        if [ "$filename" = "Filename" ] || [ "$type" = "file" ] || [[ "$filename" =~ ^/dev/zram ]] ; then
             continue
         fi
         # if filename is on a lv, try to find the DM name


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): #3343

* How was this pull request tested? via `rear savelayout` on a Fedora Silverblue system

* Description of the changes in this pull request: Avoid having zram swap entry in the disklayout.conf file as it is memory based and not disk based swap.

