### PR TITLE
New TRUSTED_SOURCING_VIA_DOT for trusted sourcing via '.' 

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -75,63 +75,24 @@ readonly INITIAL_BASH_FLAGS_AND_OPTIONS_COMMANDS="$( get_bash_flags_and_options_
 # and https://github.com/rear/rear/issues/3259#issuecomment-2385745545
 # and https://github.com/rear/rear/issues/3319#issuecomment-2360546784
 # and https://github.com/rear/rear/issues/3319#issuecomment-2363556217
-# For sourcing via 'source' later (see below) trusted sourcing gets set up
-# by replacing this 'source' forbid function by a 'source' wrapper function
-# in lib/_framework-setup-and-functions.sh which implements trusted sourcing
-# which is then the only allowed way to normally source a file in ReaR.
-# For exceptional cases 'builtin source' can still be used to source files
-# that are known to be trusted (e.g. with hardcoded trusted path).
-# The point is that we can reliably find all code places where 'builtin' is used
-# so we can reliably check such exceptional cases at any time to keep ReaR secure
-# (in particular we can also find where the undesirable form 'builtin .' is used):
 function source () {
     echo -e "ERROR: BUG in $PRODUCT\nForbidden usage of 'source' in\n  source $*\nPlease report it at $BUG_REPORT_SITE" >&2
     exit 1
 }
-# To be on the safe side sourcing via '.' is forbidden in general in ReaR because
-# it is basically impossible to reliably find all code places where '.' is used for sourcing
-# see https://github.com/rear/rear/issues/3260#issuecomment-2248252572
-# except explicitly specified files by TRUSTED_SOURCING_VIA_DOT+=( /path/to/actual_file )
-# where /path/to/actual_file is the actual file with leading / and symlinks resolved
-# i.e. /path/to/actual_file is what 'readlink -e path/to/file' returns when '. path/to/file' is called
-# plus /path/to/actual_file must be located below one of the TRUSTED_PATHS
-# and the owner of /path/to/actual_file must be one of the TRUSTED_OWNERS
-# because this '.' wrapper function calls 'source' which is the 'source' wrapper function:
-TRUSTED_SOURCING_VIA_DOT=()
 function . () {
-    local file="$1"
-    local actual_path=""
-    local trusted_path=""
-    # Empty TRUSTED_SOURCING_VIA_DOT means sourcing via '.' is forbidden:
-    if test ${#TRUSTED_SOURCING_VIA_DOT[@]} -eq 0 ; then
-        echo -e "ERROR: Forbidden usage of '.' instead of 'source' in\n  . $*\nTRUSTED_SOURCING_VIA_DOT is empty" >&2
-        exit 1
-    fi
-    # It is not trusted when it is neither a regular file nor a link to a regular file:
-    if ! test -f "$file" ; then
-        echo -e "ERROR: Forbidden usage of '.' in\n  . $*\n'$file' is neither a regular file nor a link to a regular file" >&2
-        exit 1
-    fi
-    # Get the full path of the actual file (i.e. with leading / and symlinks resolved)
-    # e.g. /etc/os-release is a symbolic link to /usr/lib/os-release (at least on openSUSE Leap 15.6).
-    # It cannot be trusted when readlink fails:
-    if ! actual_path="$( readlink -e "$file" )" ; then
-        echo -e "ERROR: Forbidden usage of '.' in\n  . $*\n'$file' cannot be trusted because 'readlink -e $file' failed" >&2
-        exit 1
-    fi
-    # Check if it can be trusted because TRUSTED_SOURCING_VIA_DOT contains the actual file path:
-    for trusted_path in "${TRUSTED_SOURCING_VIA_DOT[@]}" ; do
-        test "$actual_path" = "$trusted_path" && break
-    done
-    # When after the 'for' loop "$actual_path" = "$trusted_path" then the actual file path is in TRUSTED_SOURCING_VIA_DOT:
-    if ! test "$actual_path" = "$trusted_path" ; then
-        echo -e "ERROR: Forbidden usage of '.' in\n  . $*\nbecause actual path '$actual_path' not in TRUSTED_SOURCING_VIA_DOT" >&2
-        exit 1
-    fi
-    # The actual work (source the file):
-    source "$@"
-    # The return code of this '.' wrapper function is the return code of the 'source' wrapper function.
+    echo -e "ERROR: BUG in $PRODUCT\nForbidden usage of '.' in\n  . $*\nPlease report it at $BUG_REPORT_SITE" >&2
+    exit 1
 }
+# Later when _framework-setup-and-functions.sh gets sourced
+# those two 'source' and '.' forbid functions are replaced
+# by two 'source' and '.' wrapper functions in _framework-setup-and-functions.sh
+# where the 'source' wrapper function enforces trusted sourcing and
+# the '.' wrapper function enforces trusted sourcing via '.' for exceptional cases.
+# For special cases 'builtin source' can still be used to source files
+# that are known to be trusted (e.g. with hardcoded trusted path).
+# The point is that we can reliably find all code places where 'builtin' is used
+# so we can reliably check such special cases at any time to keep ReaR secure
+# (in particular we can also find where the undesirable form 'builtin .' is used):
 
 # Set machine readable and human readable start date and time values.
 # START_SECONDS is set to have a single fixed point in time
@@ -599,7 +560,6 @@ if ! builtin source $SHARE_DIR/lib/_framework-setup-and-functions.sh ; then
     echo -e "ERROR: BUG in $PRODUCT\nFailed to source $SHARE_DIR/lib/_framework-setup-and-functions.sh\nPlease report it at $BUG_REPORT_SITE" >&2
     exit 1
 fi
-
 # Via source usr/share/rear/lib/_framework-setup-and-functions.sh
 # those final exit tasks are now set to be executed (via bash EXIT trap) in the following order:
 # "(( EXIT_FAIL_MESSAGE )) && echo '${MESSAGE_PREFIX}$PROGRAM $WORKFLOW failed, check $RUNTIME_LOGFILE for details' 1>&8"
@@ -612,8 +572,8 @@ fi
 # see https://github.com/rear/rear/issues/3259#issuecomment-2385745545
 # Additionally TRUSTED_OWNERS and TRUSTED_PATHS are set to default values
 # but TRUSTED_OWNERS and TRUSTED_PATHS are not yet set 'readonly' because this is done
-# after the normal user configuration files (site.conf local.conf rescue.conf) were sourced
-# so that the user can specify what he needs, e.g. for whatever third-party (backup) software
+# after the configuration files were sourced so that the user can specify what he needs,
+# e.g. for whatever third-party (backup) software
 # see https://github.com/rear/rear/pull/3379#issuecomment-2621021213
 
 # Set RECOVERY_MODE when we are running inside a rescue/recovery system
@@ -893,15 +853,15 @@ if test "$CONFIG_APPEND_FILES" ; then
         fi
     done
 fi
-# After the user configuration files were sourced set TRUSTED_OWNERS and TRUSTED_PATHS 'readonly':
-readonly TRUSTED_OWNERS TRUSTED_PATHS
+if [ "$saved_tmpdir" != "$TMPDIR" ] ; then
+    Error "Setting TMPDIR in a configuration file is not supported. To specify a working area directory prefix, export TMPDIR before executing '$PROGRAM'"
+fi
+# After the user configuration files were sourced set TRUSTED_OWNERS and TRUSTED_PATHS and TRUSTED_SOURCING_VIA_DOT 'readonly':
+readonly TRUSTED_OWNERS TRUSTED_PATHS TRUSTED_SOURCING_VIA_DOT
 # Show the final TRUSTED_OWNERS and TRUSTED_PATHS to the user in debug mode
 # to help him if he cannot source additional configuration files in non-default paths:
 DebugPrint "Sourced files must be owned by one of the TRUSTED_OWNERS: ${TRUSTED_OWNERS[*]:-all owners are trusted}"
 DebugPrint "Sourced files must be below one of the TRUSTED_PATHS: ${TRUSTED_PATHS[*]:-all paths are trusted}"
-if [ "$saved_tmpdir" != "$TMPDIR" ] ; then
-    Error "Setting TMPDIR in a configuration file is not supported. To specify a working area directory prefix, export TMPDIR before executing '$PROGRAM'"
-fi
 
 # Nothing else should be able to add more configuration files:
 readonly CONFIG_APPEND_FILES_PATHS

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -75,15 +75,7 @@ readonly INITIAL_BASH_FLAGS_AND_OPTIONS_COMMANDS="$( get_bash_flags_and_options_
 # and https://github.com/rear/rear/issues/3259#issuecomment-2385745545
 # and https://github.com/rear/rear/issues/3319#issuecomment-2360546784
 # and https://github.com/rear/rear/issues/3319#issuecomment-2363556217
-function . () {
-    echo -e "ERROR: BUG in $PRODUCT\nForbidden usage of '.' instead of 'source' in\n  . $*\nPlease report it at $BUG_REPORT_SITE" >&2
-    exit 1
-}
-# To be on the safe side sourcing via '.' is kept always forbidden in ReaR because
-# it is basically impossible to reliably find all code places where '.' is used for sourcing
-# see https://github.com/rear/rear/issues/3260#issuecomment-2248252572
-# In contrast to sourcing via '.' which is kept forbidden
-# for sourcing via 'source' later (see below) trusted sourcing gets set up
+# For sourcing via 'source' later (see below) trusted sourcing gets set up
 # by replacing this 'source' forbid function by a 'source' wrapper function
 # in lib/_framework-setup-and-functions.sh which implements trusted sourcing
 # which is then the only allowed way to normally source a file in ReaR.
@@ -95,6 +87,50 @@ function . () {
 function source () {
     echo -e "ERROR: BUG in $PRODUCT\nForbidden usage of 'source' in\n  source $*\nPlease report it at $BUG_REPORT_SITE" >&2
     exit 1
+}
+# To be on the safe side sourcing via '.' is forbidden in general in ReaR because
+# it is basically impossible to reliably find all code places where '.' is used for sourcing
+# see https://github.com/rear/rear/issues/3260#issuecomment-2248252572
+# except explicitly specified files by TRUSTED_SOURCING_VIA_DOT+=( /path/to/actual_file )
+# where /path/to/actual_file is the actual file with leading / and symlinks resolved
+# i.e. /path/to/actual_file is what 'readlink -e path/to/file' returns when '. path/to/file' is called
+# plus /path/to/actual_file must be located below one of the TRUSTED_PATHS
+# and the owner of /path/to/actual_file must be one of the TRUSTED_OWNERS
+# because this '.' wrapper function calls 'source' which is the 'source' wrapper function:
+TRUSTED_SOURCING_VIA_DOT=()
+function . () {
+    local file="$1"
+    local actual_path=""
+    local trusted_path=""
+    # Empty TRUSTED_SOURCING_VIA_DOT means sourcing via '.' is forbidden:
+    if test ${#TRUSTED_SOURCING_VIA_DOT[@]} -eq 0 ; then
+        echo -e "ERROR: Forbidden usage of '.' instead of 'source' in\n  . $*\nTRUSTED_SOURCING_VIA_DOT is empty" >&2
+        exit 1
+    fi
+    # It is not trusted when it is neither a regular file nor a link to a regular file:
+    if ! test -f "$file" ; then
+        echo -e "ERROR: Forbidden usage of '.' in\n  . $*\n'$file' is neither a regular file nor a link to a regular file" >&2
+        exit 1
+    fi
+    # Get the full path of the actual file (i.e. with leading / and symlinks resolved)
+    # e.g. /etc/os-release is a symbolic link to /usr/lib/os-release (at least on openSUSE Leap 15.6).
+    # It cannot be trusted when readlink fails:
+    if ! actual_path="$( readlink -e "$file" )" ; then
+        echo -e "ERROR: Forbidden usage of '.' in\n  . $*\n'$file' cannot be trusted because 'readlink -e $file' failed" >&2
+        exit 1
+    fi
+    # Check if it can be trusted because TRUSTED_SOURCING_VIA_DOT contains the actual file path:
+    for trusted_path in "${TRUSTED_SOURCING_VIA_DOT[@]}" ; do
+        test "$actual_path" = "$trusted_path" && break
+    done
+    # When after the 'for' loop "$actual_path" = "$trusted_path" then the actual file path is in TRUSTED_SOURCING_VIA_DOT:
+    if ! test "$actual_path" = "$trusted_path" ; then
+        echo -e "ERROR: Forbidden usage of '.' in\n  . $*\nbecause actual path '$actual_path' not in TRUSTED_SOURCING_VIA_DOT" >&2
+        exit 1
+    fi
+    # The actual work (source the file):
+    source "$@"
+    # The return code of this '.' wrapper function is the return code of the 'source' wrapper function.
 }
 
 # Set machine readable and human readable start date and time values.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -96,20 +96,21 @@
 #
 # The whole ReaR functionality is provided as many specific ReaR scripts
 # which get executed as needed by the ReaR main script /usr/sbin/rear
-# via the bash builtin command 'source'.
+# by calling 'source /path/to/script'.
 # In some cases also external (i.e. non-ReaR) scripts
-# need to be executed via the bash builtin 'source'.
-# To provide reasonable protection against code injection in general
-# ReaR only executes files via the bash builtin 'source'
+# need to be executed via 'source'.
+# To provide reasonable protection against code injection
+# ReaR only executes files via 'source'
 # when the file owner is one of the TRUSTED_OWNERS and
 # when the file is located below one of the TRUSTED_PATHS.
-# Sourcing via '.' is forbidden in general in ReaR
+# Executing via '.' is forbidden in general in ReaR
 # because it is basically impossible with reasonable effort
 # to find all code places where '.' is used for executing.
 # On the other hand '.' is the POSIX standard command
-# so for exceptional cases files for sourcing via '.' can be specified
-# in TRUSTED_SOURCING_VIA_DOT, for example when '. path/to/file'
-# is used in an external script which gets sourced by ReaR.
+# so for exceptional cases where files are executed via '.'
+# those files can be specified in TRUSTED_SOURCING_VIA_DOT,
+# for example when '. path/to/file' is used in an external script
+# and that external script needs to be executed by ReaR.
 # For more information see "Protecting Against Code Injections" in
 # https://relax-and-recover.org/documentation/security-architecture
 #
@@ -127,7 +128,7 @@ TRUSTED_OWNERS=()
 # which normally results that the system directories /usr/ /etc/ /lib/
 # and the ReaR directory /var/lib/rear/ are trusted by default so normally
 # TRUSTED_PATHS=( /usr/ /etc/ /var/lib/rear/ /lib/ )
-# To add paths to the default TRUSTED_PATHS specify in 
+# To add paths to the default TRUSTED_PATHS specify in /etc/rear/local.conf
 # TRUSTED_PATH+=( '/path/to/here/' '/path/to/there/' )
 # The trailing / ensures that e.g. /path/to/thereof/ is not falsely regarded as trusted path.
 # When the user sets TRUSTED_PATHS to be empty in his /etc/rear/local.conf
@@ -135,21 +136,23 @@ TRUSTED_OWNERS=()
 TRUSTED_PATHS=()
 #
 # The empty TRUSTED_SOURCING_VIA_DOT array here means
-# that sourcing via '.' is forbidden in general in ReaR.
-# Trusted files for sourcing via '.' can be specified in /etc/rear/local.conf by
-# TRUSTED_SOURCING_VIA_DOT+=( /actual_path/to/file )
+# that executing (sourcing) via '.' is forbidden in general in ReaR.
+# Trusted files for executing via '.' can be specified in /etc/rear/local.conf by
+# TRUSTED_SOURCING_VIA_DOT+=( '/actual_path/to/file' '...' )
 # where /actual_path/to/file is the actual file with leading / and symlinks resolved
-# i.e. /actual_path/to/file is what 'readlink -e path/to/file' returns
-# when for example in a third-party script '. path/to/file' is called.
+# i.e. for example /actual_path/to/file is what 'readlink -e path/to/file' returns
+# when in an external (i.e. non-ReaR) script '. path/to/file' is called.
 # Additionally /actual_path/to/file must be located below one of the TRUSTED_PATHS
 # and the owner of /actual_path/to/file must be one of the TRUSTED_OWNERS.
+# It is not possible to disable protection via TRUSTED_SOURCING_VIA_DOT.
+# Each file to be executed via '.' must be specified in TRUSTED_SOURCING_VIA_DOT.
 TRUSTED_SOURCING_VIA_DOT=()
 #
 # Because ReaR reads and executes configuration files via 'source'
 # TRUSTED_OWNERS and TRUSTED_PATHS and TRUSTED_SOURCING_VIA_DOT
 # can only be specified in a configuration file like /etc/rear/local.conf
-# where its owner is one of the default TRUSTED_OWNERS (usually 'root')
-# and it is located below one of the default TRUSTED_PATHS (usually /etc/).
+# where its owner is one of the default TRUSTED_OWNERS (usually 'root') and
+# when it is located below one of the default TRUSTED_PATHS (usually /etc/).
 ####
 
 ####

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -90,6 +90,7 @@
 ####
 # TRUSTED_OWNERS
 # TRUSTED_PATHS
+# TRUSTED_SOURCING_VIA_DOT
 #
 # General protection against code injection via 'source'.
 #
@@ -102,9 +103,13 @@
 # ReaR only executes files via the bash builtin 'source'
 # when the file owner is one of the TRUSTED_OWNERS and
 # when the file is located below one of the TRUSTED_PATHS.
-# ReaR refuses to execute files via the bash builtin '.'
+# Sourcing via '.' is forbidden in general in ReaR
 # because it is basically impossible with reasonable effort
 # to find all code places where '.' is used for executing.
+# On the other hand '.' is the POSIX standard command
+# so for exceptional cases files for sourcing via '.' can be specified
+# in TRUSTED_SOURCING_VIA_DOT, for example when '. path/to/file'
+# is used in an external script which gets sourced by ReaR.
 # For more information see "Protecting Against Code Injections" in
 # https://relax-and-recover.org/documentation/security-architecture
 #
@@ -122,17 +127,29 @@ TRUSTED_OWNERS=()
 # which normally results that the system directories /usr/ /etc/ /lib/
 # and the ReaR directory /var/lib/rear/ are trusted by default so normally
 # TRUSTED_PATHS=( /usr/ /etc/ /var/lib/rear/ /lib/ )
-# To add paths to the default TRUSTED_PATHS specify in /etc/rear/local.conf
+# To add paths to the default TRUSTED_PATHS specify in 
 # TRUSTED_PATH+=( '/path/to/here/' '/path/to/there/' )
 # The trailing / ensures that e.g. /path/to/thereof/ is not falsely regarded as trusted path.
 # When the user sets TRUSTED_PATHS to be empty in his /etc/rear/local.conf
 # then all paths are trusted which disables protection via TRUSTED_PATHS.
 TRUSTED_PATHS=()
 #
-# Because ReaR reads and executes configuration files via the bash builtin 'source'
-# TRUSTED_OWNERS and TRUSTED_PATHS can only be specified in a user configuration file
-# when the configuration file owner is one of the default TRUSTED_OWNERS (usually 'root') and
-# when the configuration file is located below one of the default TRUSTED_PATHS (usually /etc/).
+# The empty TRUSTED_SOURCING_VIA_DOT array here means
+# that sourcing via '.' is forbidden in general in ReaR.
+# Trusted files for sourcing via '.' can be specified in /etc/rear/local.conf by
+# TRUSTED_SOURCING_VIA_DOT+=( /actual_path/to/file )
+# where /actual_path/to/file is the actual file with leading / and symlinks resolved
+# i.e. /actual_path/to/file is what 'readlink -e path/to/file' returns
+# when for example in a third-party script '. path/to/file' is called.
+# Additionally /actual_path/to/file must be located below one of the TRUSTED_PATHS
+# and the owner of /actual_path/to/file must be one of the TRUSTED_OWNERS.
+TRUSTED_SOURCING_VIA_DOT=()
+#
+# Because ReaR reads and executes configuration files via 'source'
+# TRUSTED_OWNERS and TRUSTED_PATHS and TRUSTED_SOURCING_VIA_DOT
+# can only be specified in a configuration file like /etc/rear/local.conf
+# where its owner is one of the default TRUSTED_OWNERS (usually 'root')
+# and it is located below one of the default TRUSTED_PATHS (usually /etc/).
 ####
 
 ####

--- a/usr/share/rear/lib/_framework-setup-and-functions.sh
+++ b/usr/share/rear/lib/_framework-setup-and-functions.sh
@@ -1517,8 +1517,7 @@ function ProgressInfo () {
 # also 'root' is trusted by default:
 sbin_rear_owner_name="$( stat -L -c %U "$SCRIPT_FILE" )"
 test "$sbin_rear_owner_name" = "root" && TRUSTED_OWNERS=( 'root' ) || TRUSTED_OWNERS=( 'root' "$sbin_rear_owner_name" )
-# 'readonly TRUSTED_OWNERS' happens in sbin/rear
-# after the normal user configuration files (site.conf local.conf rescue.conf) were sourced
+# 'readonly TRUSTED_OWNERS' happens in sbin/rear after the configuration files were sourced
 # so that the user can specify what he needs, e.g. for whatever third-party (backup) software.
 
 # Check file owner is trusted
@@ -1631,8 +1630,7 @@ else
         TRUSTED_PATHS=( '/usr/' '/etc/' "$VAR_DIR/" '/lib/' )
     fi
 fi
-# 'readonly TRUSTED_PATHS' happens in sbin/rear
-# after the normal user configuration files (site.conf local.conf rescue.conf) were sourced
+# 'readonly TRUSTED_PATHS' happens in sbin/rear after the configuration files were sourced
 # so that the user can specify what he needs, e.g. for whatever third-party (backup) software.
 
 # Check the actual file path (i.e. with symlinks resolved) is trusted
@@ -1673,9 +1671,9 @@ function source () {
         return 1
     fi
     # Enforce source file owner is trusted:
-    is_trusted_owner "$source_file" || Error "Forbidden to source '$source_file' (not a TRUSTED_OWNERS ${TRUSTED_OWNERS[*]})"
+    is_trusted_owner "$source_file" || Error "Forbidden to source '$source_file' (not a TRUSTED_OWNERS: ${TRUSTED_OWNERS[*]})"
     # Enforce source file starts with a trusted path:
-    is_trusted_path "$source_file" || Error "Forbidden to source '$source_file' (not below TRUSTED_PATHS ${TRUSTED_PATHS[*]})"
+    is_trusted_path "$source_file" || Error "Forbidden to source '$source_file' (not below TRUSTED_PATHS: ${TRUSTED_PATHS[*]})"
   } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
     # The actual work (source the source file):
     builtin source "$@"


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL):

https://github.com/rear/rear/issues/3259#issuecomment-2730011077

* How was this pull request tested?

On a SLES15-SP6 VM "rear mkrescue" plus "rear mkbackuponly"
and then on another VM "rear recover" worked for me
with some artificial sourcing via '.' as a test
in etc/rear/local.conf
```
OUTPUT=ISO
BACKUP=NETFS
BACKUP_OPTIONS="nfsvers=3,nolock"
BACKUP_URL=nfs://192.168.178.66/nfs
REQUIRED_PROGS+=( snapper chattr lsattr )
COPY_AS_IS+=( /usr/lib/snapper/installation-helper /etc/snapper/config-templates/default )
POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | grep -q "^QGROUP.*[0-9]/[0-9]" ; then snapper --no-dbus -r $TARGET_FS_ROOT set-config QGROUP= ; snapper --no-dbus -r $TARGET_FS_ROOT setup-quota && echo snapper setup-quota done || echo snapper setup-quota failed ; else echo snapper setup-quota not used ; fi' )
SSH_ROOT_PASSWORD="rear"
USE_DHCLIENT="yes"
FIRMWARE_FILES=( 'no' )
MODULES=( 'loaded_modules' )
PROGRESS_MODE="plain"
PROGRESS_WAIT_SECONDS="5"
TRUSTED_OWNERS+=( 'johannes' )
TRUSTED_PATHS+=( '/home/johannes/' )
TRUSTED_SOURCING_VIA_DOT+=( /home/johannes/johannes.sh /etc/os-release )
source /home/johannes/johannes.sh && DebugPrint "Sourced /home/johannes/johannes.sh via 'source'" || DebugPrint "Failed to source /home/johannes/johannes.sh via 'source'"
. /home/johannes/johannes.sh && DebugPrint "Sourced /home/johannes/johannes.sh via '.'" || DebugPrint "Failed to source /home/johannes/johannes.sh via '.'"
COPY_AS_IS+=( /home/johannes/johannes.sh )
```
and also in /home/johannes/johannes.sh
```
#!/bin/bash
this_file_path=$( readlink -e ${BASH_SOURCE[0]} )
DebugPrint $this_file_path is running as $( id )
DebugPrint "sourcing /etc/os-release via 'source'"
source /etc/os-release && DebugPrint "source /etc/os-release worked" || DebugPrint "source /etc/os-release failed"
DebugPrint "sourcing /etc/os-release via '.'"
. /etc/os-release && DebugPrint ". /etc/os-release worked" || DebugPrint ". /etc/os-release failed"
```

* Description of the changes in this pull request:

Avoid the regression that I described in
https://github.com/rear/rear/issues/3259#issuecomment-2730011077
```
With https://github.com/rear/rear/pull/3424 merged
there will be regressions when third-party scripts
use '.' for sourcing because currently sourcing via '.'
is always forbidden in ReaR.
```

This is a regression so it is a bug in ReaR because
'source' is not POSIX compliant because
'.' is the POSIX standard command
so ReaR must not forbid using '.' in any case
but allow it when really needed.

To implement trusted sourcing via '.'
in _framework-setup-and-functions.sh
an additional '.' wrapper function is implemented
to enforce trusted sourcing via '.' for exceptional cases
for files which are specified in TRUSTED_SOURCING_VIA_DOT
plus the needed adaptions in sbin/rear for that and
the TRUSTED_SOURCING_VIA_DOT description in default.conf
