### PR TITLE
Do not show secrets in the dump workflow without --expose-secrets

### DIFF
--- a/usr/share/rear/lib/dump-workflow.sh
+++ b/usr/share/rear/lib/dump-workflow.sh
@@ -19,6 +19,12 @@ WORKFLOW_dump () {
     function output_variable_assignment () {
         local variable_name=$1
         test -v "$variable_name" || return 1
+        # Do not show the value of variables which could contain secret values
+        # unless sbin/rear was called with --expose-secrets
+        # see https://github.com/rear/rear/issues/3444
+        if ! is_true "$EXPOSE_SECRETS" ; then
+            IsInArray $variable_name "${SECRET_VARIABLES[@]}" && return 1
+        fi
         if test "$DEBUG" ; then
             # In debug mode show the 'declare -p' output as is (only indented by two spaces):
             LogUserOutput "$( declare -p $variable_name | sed -e 's/^/  /' )"


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3444

* How was this pull request tested?

With
```
{ BACKUP_PROG_CRYPT_KEY='my_backup_crypt_key' ; } 2>>/dev/$SECRET_OUTPUT_DEV
```
in local.conf
I get
```
# usr/sbin/rear dump | egrep 'BACKUP_PROG_CRYPT_KEY|OUTPUT_LFTP_PASSWORD'

[no output]
```
versus
```
# usr/sbin/rear -e dump | egrep 'BACKUP_PROG_CRYPT_KEY|OUTPUT_LFTP_PASSWORD'

  BACKUP_PROG_CRYPT_KEY="my_backup_crypt_key"
  OUTPUT_LFTP_PASSWORD=""
```

* Description of the changes in this pull request:

In lib/dump-workflow.sh
do not show the value of variables
which could contain secret values
unless sbin/rear was called with --expose-secrets
