### PR TITLE
Extend the umount_mountpoint function to try normal, forced and lazy umounts

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -7,6 +7,7 @@ parted
 readlink
 # For noninteractive confirmation in commands
 yes
+fuser
 )
 
 PROGS+=(

--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -18,6 +18,7 @@ sfdisk
 
 # progs to take along
 PROGS+=(
+fuser
 rpc.statd
 rpcbind
 mknod

--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -7,6 +7,7 @@ parted
 readlink
 # For noninteractive confirmation in commands
 yes
+fuser
 )
 
 PROGS+=(
@@ -18,7 +19,6 @@ sfdisk
 
 # progs to take along
 PROGS+=(
-fuser
 rpc.statd
 rpcbind
 mknod

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -503,7 +503,7 @@ function mount_url() {
 
     # The cases where we return 0 are those that do not need umount and also do not need ExitTask handling.
     # They thus need to be kept in sync with umount_url() so that RemoveExitTasks is used
-    # iff AddExitTask was used in mount_url().
+    # iff (if and only if) AddExitTask was used in mount_url().
 
     if ! scheme_supports_filesystem "$scheme" ; then
         ### Stuff like null|tape|rsync|fish|ftp|ftps|hftp|http|https|sftp
@@ -707,7 +707,7 @@ function umount_url() {
 
     # The cases where we return 0 are those that do not need umount and also do not need ExitTask handling.
     # They thus need to be kept in sync with mount_url() so that RemoveExitTasks is used
-    # iff AddExitTask was used in mount_url().
+    # iff (if and only if) AddExitTask was used in mount_url().
 
     if ! scheme_supports_filesystem "$scheme" ; then
         ### Stuff like null|tape|rsync|fish|ftp|ftps|hftp|http|https|sftp
@@ -821,37 +821,64 @@ function umount_davfs() {
 function umount_mountpoint() {
     local mountpoint="$1"
     local lazy="${2:-}"
+    local timeout_secs=2
 
+    contains_visible_char "$mountpoint" || BugError "umount_mountpoint() called with empty mountpoint argument '$mountpoint'"
+    test -d "$mountpoint" -o -b "$mountpoint" || Error "umount_mountpoint mountpoint '$mountpoint' neither directory nor block device"
+
+    # TODO: remove the test $lazy section after all mount functions and calls are fixed (or removed)
     if test $lazy ; then
         if test $lazy != "lazy" ; then
             BugError "lazy = $lazy, but it must have the value of 'lazy' or empty"
         fi
     fi
 
-    ### First, try a normal unmount,
+    ### First, try a normal unmount using a timeout in case mountpoint became unresponsive
+    ### due to QoS squeezing or due to stale NFS as the NFS server became unreachable (during mkbackup)
+    ### That is the reason why we use a timeout in front of the umount command.
+    ### However, when tar is busy and the NFS becomes stale then ReaR processes will just hang forever
+    ### until we kill them manually.
     Log "Unmounting '$mountpoint'"
-    umount $v "$mountpoint" >&2
-    if [[ $? -eq 0 ]] ; then
-        return 0
-    fi
-
-    ### otherwise, try to kill all processes that opened files on the mount.
-    # TODO: actually implement this
+    timeout $timeout_secs umount $v "$mountpoint" && return 0
 
     ### If that still fails, force unmount.
-    Log "Forced unmount of '$mountpoint'"
-    umount $v -f "$mountpoint" >&2
-    if [[ $? -eq 0 ]] ; then
-        return 0
-    fi
+    Log "Forcing unmount of '$mountpoint'"
+    timeout $timeout_secs umount $v --force "$mountpoint" && return 0
 
-    Log "Unmounting '$mountpoint' failed."
+    Log "Unmounting '$mountpoint' failed (after force umount)."
 
-    if test $lazy ; then
-        umount_mountpoint_lazy "$mountpoint"
-    else
-        return 1
-    fi
+    Log "$mountpoint is still in use by ('kernel mount' is always there)"
+    # The -M option avoids that fuser may show all processes using the '/' filesystem
+    # e.g. for mountpoint $TMP_DIR/somedir ($TMP_DIR = $BUILD_DIR/tmp = /var/tmp/rear.XXXXXXXXXXXXXXX/tmp/)
+    # when $TMP_DIR/somedir got umounted just before fuser starts, see "man fuser":
+    #   The mount -m option will match any file within the same device as the specified file,
+    #   use the -M option as well if you mean to specify only the mount point.
+    # So when $TMP_DIR/somedir is umounted 'fuser -v -M -m $TMP_DIR/somedir' only shows
+    #   "Specified filename /var/tmp/rear.XXXXXXXXXXXXXXX/tmp/somedir is not a mountpoint"
+    # instead of all processes using '/' (or /var/ or /var/tmp/ if one is a mountpoint)
+    # which would be misleading information that may even look scaring and cause false alarm.
+    # Older systems do not support -M but we must use it to avoid misleading information or false alarm.
+    # Since this code path is exceptional and the output is used only for information and only in the log file
+    # we do not care when fuser fails with "M: unknown signal; fuser -l lists signals":
+    fuser -v -M -m "$mountpoint" || Log "'fuser' failed (presumably it may not support the -M option)"
+
+    # Lazy umount only hides the filesystem from new processes.
+    LogPrint "Trying a 'lazy' umount on '$mountpoint' (as it could be stale)."
+    timeout $timeout_secs umount $v --lazy "$mountpoint" && return 0
+
+    LogPrintError "Unmounting '$mountpoint' failed even after a force and lazy umount."
+    return 1
+}
+
+# Perform a check if mountpoint got stale per accident?
+function is_mountpoint_stale() {
+    local mountpoint="$1"
+    local timeout_secs="$2"
+
+    test "$timeout_secs" -gt 0 || timeout_secs="5"
+    timeout "$timeout_secs" df "$mountpoint" && return 0
+    # Mountpoint seems to be stale, therefore, return 1
+    return 1
 }
 
 ### Unmount mountpoint $1 lazily
@@ -907,7 +934,7 @@ function umount_mountpoint_retry_lazy() {
     # Older systems do not support -M but we must use it to avoid misleading information or false alarm.
     # Since this code path is exceptional and the output is used only for information and only in the log file
     # we do not care when fuser fails with "M: unknown signal; fuser -l lists signals":
-    fuser -v -M -m "$mountpoint" 1>&2 || Log "Presumably 'fuser' does not support the -M option"
+    fuser -v -M -m "$mountpoint" || Log "'fuser' failed (presumably it may not support the -M option)"
     DebugPrint "Trying 'umount --lazy $mountpoint' (normal umount failed)"
     # Do only plain 'umount --lazy' without additional '--force'
     # because enforced umount raises its own specific troubles

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -870,17 +870,17 @@ function umount_mountpoint() {
     fuser -v -M -m "$mountpoint" || Log "'fuser' failed (presumably it may not support the -M option)"
 
     # Lazy umount only hides the filesystem from new processes.
-    LogPrint "Trying a 'lazy' umount on '$mountpoint' (as it could be stale)."
-    timeout $timeout_secs umount $v --lazy "$mountpoint" && return 0
+    LogPrint "A final attempt to umount '$mountpoint' (as it could be stale)."
+    timeout $timeout_secs umount $v "$mountpoint" && return 0
 
     sleep $timeout_secs
     is_mounted "$mountpoint" "$timeout_secs" || return 0
 
     ### If that still fails, force unmount.
-    Log "Forcing unmount of '$mountpoint'"
-    timeout $timeout_secs umount $v --force "$mountpoint" && return 0
+    #Log "Forcing unmount of '$mountpoint'"
+    #timeout $timeout_secs umount $v --force "$mountpoint" && return 0
 
-    LogPrintError "Unmounting '$mountpoint' failed even after a force and lazy umount."
+    LogPrintError "Unmounting '$mountpoint' failed even after several retries."
     return 1
 }
 
@@ -890,9 +890,9 @@ function is_mountpoint_stale() {
     local timeout_secs="$2"
 
     test "$timeout_secs" -gt 0 || timeout_secs="5"
-    timeout "$timeout_secs" df "$mountpoint" && return 0
-    # Mountpoint seems to be stale, therefore, return 1
-    return 1
+    timeout "$timeout_secs" df "$mountpoint" && return 1
+    # Mountpoint seems to be stale, therefore, return 0
+    return 0
 }
 
 # Check if file system is mounted or not. Return 0 if mounted, otherwise 1.
@@ -901,7 +901,7 @@ function is_mounted() {
     local timeout_secs="$2"
 
     test "$timeout_secs" -gt 0 || timeout_secs="5"
-    timeout "$timeout_secs" mountpoint --quiet --nofollow -- "$1" && return 0
+    timeout "$timeout_secs" mountpoint --quiet -- "$1" && return 0
     return 1
 }
 

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -839,10 +839,9 @@ function umount_mountpoint() {
     fi
 
     ### otherwise, try to kill all processes that opened files on the mount.
-    # TODO: actually implement this
-    sleep 1
+    # Most of the times it is due hanging NFS mounts (stale?)
     # We could use fuser to kill the PID holding the mount?
-    # That would mean that the 'fuser' command would become required, no?
+    # Therefore, we added 'fuser' to the PROGS array in conf/GNU/Linux.conf
     # $ fuser -v -M -m /mnt
     #                 USER        PID ACCESS COMMAND
     #/mnt:                root     kernel mount /mnt
@@ -851,8 +850,23 @@ function umount_mountpoint() {
     ## In above example that would be PID 3408944
     PIDs_2_kill="$(fuser -v -M -m $mountpoint 2>&1 | grep -v -E '(PID|kernel)' | awk '{print $2}')"
     if [[ -n "$PIDs_2_kill" ]] ; then
-	Log "Kill processes that prevent the umount of $mountpoint - PIDs $PIDs_2_kill"
-        kill -USR1 "$PIDs_2_kill"
+	Log "Kill (with TERM) processes that prevent the umount of $mountpoint - PIDs $PIDs_2_kill"
+        kill -TERM "$PIDs_2_kill"
+        sleep 1 # to give some time for the processes to stop
+    fi
+    # first check it $mountpoint is still mounted
+    grep -i ' nfs' /proc/mounts | grep -q "$mountpoint"
+    if [[ $? -eq 0 ]] ; then
+        # check again if the process(es) holding the mount point are gone or not
+        PIDs_2_kill="$(fuser -v -M -m $mountpoint 2>&1 | grep -v -E '(PID|kernel)' | awk '{print $2}')"
+        if [[ -n "$PIDs_2_kill" ]] ; then
+	    Log "Kill (with KILL) processes that prevent the umount of $mountpoint - PIDs $PIDs_2_kill"
+            kill -KILL "$PIDs_2_kill"
+	    sleep 1
+        fi
+    else
+        # mountpoint seems te be unmounted
+        return 0
     fi
 
     ### If that still fails, force unmount.

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -865,7 +865,7 @@ function umount_mountpoint() {
 	    sleep 1
         fi
     else
-        # mountpoint seems te be unmounted
+        # mountpoint seems to be unmounted in the meantime
         return 0
     fi
 


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): #3429

* How was this pull request tested? Basic test performed with normal umount so far.

* Description of the changes in this pull request:
Issue #3429 is about "The new umount_mountpoint_retry_lazy function https://github.com/rear/rear/pull/3408 versus the already existing umount_mountpoint_lazy function - try to make a single generic ReaR umount function for all cases"
However, after carefully looking at the code we feel it would be better to merge all kind if umounts in one function and that is within the main function "**umount_mountpoint**".

In this first version of the PR we did not (yet) remove the 'lazy' argument with the function umount_mountpoint, nor the two remaining _lazy_ functions "umount_mountpoint_lazy " and "umount_mountpoint_retry_lazy" to protect the existing calls to these functions in ReaR.

When the ReaR maintainers agree with the new code (or after updates) we can start cleaning up the remaining lazy functions.
