### PR TITLE
Avoid that 001_verify_config_arrays.sh leaks secrets

### DIFF
--- a/usr/share/rear/init/default/001_verify_config_arrays.sh
+++ b/usr/share/rear/init/default/001_verify_config_arrays.sh
@@ -26,7 +26,7 @@ for config in "$CONFIG_DIR"/{site,local,rescue}.conf "${CONFIG_APPEND_FILES_PATH
             grep -v '^[[:space:]]*#' "$config" | sed -n -E -e "/(^|\W+)$var\+?=/p"
             )
         for line in "${var_assignments[@]}"; do
-            # Avoid that the [[ expression ]] could leak secrets into the ReaR log file in dbugscript mode
+            # Avoid that the [[ expression ]] could leak secrets into the ReaR log file in debugscript mode
             # for example when the assignment in $line assigns a secret value like
             #   { ARRAY=( 'secret_value' ) ; } 2>>/dev/$SECRET_OUTPUT_DEV
             # this assignment line would get shown in the ReaR log file via 'set -x' as

--- a/usr/share/rear/init/default/001_verify_config_arrays.sh
+++ b/usr/share/rear/init/default/001_verify_config_arrays.sh
@@ -34,9 +34,11 @@ for config in "$CONFIG_DIR"/{site,local,rescue}.conf "${CONFIG_APPEND_FILES_PATH
             # see https://github.com/rear/rear/issues/3443
             # so avoid that by using $line within { ... } 2>>/dev/$SECRET_OUTPUT_DEV
             { [[ "$line" == *$var?(+)=\(* ]] && continue
-              is_true "$EXPOSE_SECRETS" && Error "Syntax error: Variable $var not assigned as Bash array in $config:$LF  $line$LF"
-              Error "Syntax error: Variable $var not assigned as Bash array in $config"
+              LogSecret "$config : $var not assigned as array : $line"
             } 2>>/dev/$SECRET_OUTPUT_DEV
+            # Do not have secrets in the Error message because Error() calls LogToSyslog()
+            # see https://github.com/rear/rear/pull/3449#issuecomment-2786306795
+            Error "Syntax error: Variable $var not assigned as Bash array in $config"
         done
     done
 done


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **High**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3443

* How was this pull request tested?

As in
https://github.com/rear/rear/issues/3443#issue-2969329614
I have in default.conf
```
{ MY_PASSWORDS=( my_default_password ) ; } 2>>/dev/$SECRET_OUTPUT_DEV
```
and in the bash where I later run 'rear -D help' I did
```
# MY_PASSWORDS=( my_dummy_password )
```

Then (with the changes in this pull request) I get:
```
# usr/sbin/rear -D help
...

# egrep ' Including |my_.*_password' var/log/rear/rear-localhost.log.lockless
...
2025-04-07 15:39:55.021382207 Including init/default/001_verify_config_arrays.sh
2025-04-07 15:39:55.663217781 Including init/default/002_check_rear_recover_mode.sh
...

# usr/sbin/rear -e -D help
...

# egrep ' Including |my_.*_password' var/log/rear/rear-localhost.log.lockless
...
2025-04-07 15:41:19.796992543 Including init/default/001_verify_config_arrays.sh
2025-04-07 15:41:20.415675839 Including init/default/002_check_rear_recover_mode.sh
```

When I have in local.conf
```
{ MY_PASSWORDS=( my_actual_password ) ; } 2>>/dev/$SECRET_OUTPUT_DEV
```
I get
```
# usr/sbin/rear -D help
...

# egrep ' Including |my_.*_password' var/log/rear/rear-localhost.log.lockless
...
2025-04-07 15:42:59.100357881 Including init/default/001_verify_config_arrays.sh
2025-04-07 15:42:59.729373461 Including init/default/002_check_rear_recover_mode.sh
...

# usr/sbin/rear -e -D help
...

# egrep ' Including |my_.*_password' var/log/rear/rear-localhost.log.lockless
...
2025-04-07 15:43:33.114877986 Including init/default/001_verify_config_arrays.sh
++ [[ { MY_PASSWORDS=( my_actual_password ) ; } 2>>/dev/$SECRET_OUTPUT_DEV == *MY_PASSWORDS?(+)=\(* ]]
2025-04-07 15:43:33.743125157 Including init/default/002_check_rear_recover_mode.sh
```

When I have in local.conf
```
{ MY_PASSWORDS='my_actual_password' ; } 2>>/dev/$SECRET_OUTPUT_DEV
```
I get
```
# usr/sbin/rear -D help
...
ERROR: Syntax error: Variable MY_PASSWORDS not assigned as Bash array in /root/rear.github.master/etc/rear/local.conf
...

# egrep ' Including |my_.*_password' var/log/rear/rear-localhost.log.lockless
...
2025-04-07 15:45:17.094986107 Including init/default/001_verify_config_arrays.sh

# usr/sbin/rear -e -D help
...
ERROR: Syntax error: Variable MY_PASSWORDS not assigned as Bash array in /root/rear.github.master/etc/rear/local.conf:
  { MY_PASSWORDS='my_actual_password' ; } 2>>/dev/$SECRET_OUTPUT_DEV
...

# egrep ' Including |my_.*_password' var/log/rear/rear-localhost.log.lockless
...
2025-04-07 15:46:22.129633799 Including init/default/001_verify_config_arrays.sh
++ [[ { MY_PASSWORDS='my_actual_password' ; } 2>>/dev/$SECRET_OUTPUT_DEV == *MY_PASSWORDS?(+)=\(* ]]
  { MY_PASSWORDS='\''my_actual_password'\'' ; } 2>>/dev/$SECRET_OUTPUT_DEV
  { MY_PASSWORDS='\''my_actual_password'\'' ; } 2>>/dev/$SECRET_OUTPUT_DEV
  { MY_PASSWORDS='\''my_actual_password'\'' ; } 2>>/dev/$SECRET_OUTPUT_DEV
                                { MY_PASSWORDS='my_actual_password' ; } 2>>/dev/$SECRET_OUTPUT_DEV
  { MY_PASSWORDS='\''my_actual_password'\'' ; } 2>>/dev/$SECRET_OUTPUT_DEV
```

* Description of the changes in this pull request:

In init/default/001_verify_config_arrays.sh
avoid that using `$line` could leak secrets
into the ReaR log file in dbugscript mode
by using `$line` within
```
{ ... } 2>>/dev/$SECRET_OUTPUT_DEV
```
