### PR TITLE
Set BACKUP_PROG_COMPRESS_OPTIONS as an empty array

### DIFF
--- a/usr/share/rear/verify/OBDR/NETFS/default/540_set_backup_compression.sh
+++ b/usr/share/rear/verify/OBDR/NETFS/default/540_set_backup_compression.sh
@@ -1,4 +1,4 @@
 # Disable compression (as tape drive does compression already)
 Log "Disable compression for backup (BACKUP_PROG_COMPRESS_*)"
-BACKUP_PROG_COMPRESS_OPTIONS=
-BACKUP_PROG_COMPRESS_SUFFIX=
+BACKUP_PROG_COMPRESS_OPTIONS=()
+BACKUP_PROG_COMPRESS_SUFFIX=""


### PR DESCRIPTION
* Type: **Bug Fix**

This might be even a rather severe issue because
scripts in usr/share/rear/verify/ are run for "rear recover"
so the syntactically false setting of BACKUP_PROG_COMPRESS_OPTIONS
in verify/OBDR/NETFS/default/540_set_backup_compression.sh
may let "rear recover" inexplicably fail for example as in
https://github.com/rear/rear/issues/2911#issuecomment-1385563456
https://github.com/rear/rear/issues/2911#issuecomment-1386862853

* Impact: **Normal**

* Related issues:

https://github.com/rear/rear/issues/3448#issuecomment-2785472035
https://github.com/rear/rear/pull/2963
https://github.com/rear/rear/issues/2637
https://github.com/rear/rear/issues/2911

* How was this pull request tested?

I cannot test OBDR, see
https://github.com/rear/rear/issues/3448#issuecomment-2785428051

* Description of the changes in this pull request:

In verify/OBDR/NETFS/default/540_set_backup_compression.sh
set BACKUP_PROG_COMPRESS_OPTIONS as an empty array
same as in output/OBDR/default/840_write_image.sh
