### PR TITLE
run-in-docker: Use /lib64/ld-linux-x86-64.so.2 to detect HW architecture

### DIFF
--- a/tools/run-in-docker
+++ b/tools/run-in-docker
@@ -170,12 +170,14 @@ if uname -a | grep -q "Darwin.*arm64"; then
 fi
 
 # Centos/stream10 requires x86-64-v3 or higher to be useful
-/lib64/ld-linux-x86-64.so.2 --help 2>&1 | grep supported | grep -qE '(x86-64-v3|x86-64-v4)'
-if [[ $? -eq 1 ]] ; then
-   echo "Hardware architecture not supported, removing incompatible Docker images matching $AMD64_V3_IMAGE_FILTER"
-   mapfile -t use_images < <(
-            printf "%s\n" "${use_images[@]}" | grep -v -E "$AMD64_V3_IMAGE_FILTER"
-        )
+if [[ -f /lib64/ld-linux-x86-64.so.2 ]] ; then
+    /lib64/ld-linux-x86-64.so.2 --help 2>&1 | grep supported | grep -qE '(x86-64-v3|x86-64-v4)'
+    if [[ $? -eq 1 ]] ; then
+       echo "Hardware architecture not supported, removing incompatible Docker images matching $AMD64_V3_IMAGE_FILTER"
+       mapfile -t use_images < <(
+                printf "%s\n" "${use_images[@]}" | grep -v -E "$AMD64_V3_IMAGE_FILTER"
+            )
+    fi
 fi
 
 if test ${#command_args[@]} -eq 0; then

--- a/tools/run-in-docker
+++ b/tools/run-in-docker
@@ -170,7 +170,7 @@ if uname -a | grep -q "Darwin.*arm64"; then
 fi
 
 # Centos/stream10 requires x86-64-v3 or higher to be useful
-if [[ -f /lib64/ld-linux-x86-64.so.2 ]] ; then
+if [[ -x /lib64/ld-linux-x86-64.so.2 ]] ; then
     /lib64/ld-linux-x86-64.so.2 --help 2>&1 | grep supported | grep -qE '(x86-64-v3|x86-64-v4)'
     if [[ $? -eq 1 ]] ; then
        echo "Hardware architecture not supported, removing incompatible Docker images matching $AMD64_V3_IMAGE_FILTER"

--- a/tools/run-in-docker
+++ b/tools/run-in-docker
@@ -169,6 +169,15 @@ if uname -a | grep -q "Darwin.*arm64"; then
     fi
 fi
 
+# Centos/stream10 requires x86-64-v3 or higher to be useful
+/lib64/ld-linux-x86-64.so.2 --help 2>&1 | grep supported | grep -qE '(x86-64-v3|x86-64-v4)'
+if [[ $? -eq 1 ]] ; then
+   echo "Hardware architecture not supported, removing incompatible Docker images matching $AMD64_V3_IMAGE_FILTER"
+   mapfile -t use_images < <(
+            printf "%s\n" "${use_images[@]}" | grep -v -E "$AMD64_V3_IMAGE_FILTER"
+        )
+fi
+
 if test ${#command_args[@]} -eq 0; then
     if test ${#use_images[@]} -eq 1; then # if only one image is given and no command then go interactive
         command_args=(-i)
@@ -208,7 +217,7 @@ test -t 0 && extra_docker_args+=(-i -t)
 #       we set both so that our startup file run-in-docker.bashrc is ALWAYS read as it sets the PATH
 for image in "${use_images[@]}"; do
     gh_actions_output "::group::Running $image"
-    printf "********** %-40s **********\n" "$image" 1>&2
+    printf "\n********** %-40s **********\n" "$image" 1>&2
     image_name="$(echo -n "$image" | tr -cs '0-9a-zA-Z-_' -)"
     dist_dest="dist-all/$image_name"
     mkdir -p "$rear_toplevel_dir/$dist_dest" || die "Could not mkdir $rear_toplevel_dir/$dist_dest"


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL): n/a

* How was this pull request tested?
```bash
$ ./run-in-docker
Hardware architecture not supported, removing incompatible Docker images matching centos:stream10

********** ubuntu:20.04                             **********
Bash is 5.0.17(1)-release
********** Copying dist to dist-all/ubuntu-20-04

********** ubuntu:22.04                             **********
Bash is 5.1.16(1)-release
********** Copying dist to dist-all/ubuntu-22-04

********** ubuntu:24.04                             **********
Bash is 5.2.21(1)-release
********** Copying dist to dist-all/ubuntu-24-04

********** debian:10                                **********
Bash is 5.0.3(1)-release
********** Copying dist to dist-all/debian-10

********** debian:11                                **********
Bash is 5.1.4(1)-release
********** Copying dist to dist-all/debian-11

********** debian:12                                **********
Bash is 5.2.15(1)-release
********** Copying dist to dist-all/debian-12

********** debian:unstable                          **********
Bash is 5.2.37(1)-release
********** Copying dist to dist-all/debian-unstable

********** opensuse/leap:15                         **********
Bash is 4.4.23(1)-release
********** Copying dist to dist-all/opensuse-leap-15

********** registry.suse.com/suse/sle15             **********
Bash is 4.4.23(1)-release
********** Copying dist to dist-all/registry-suse-com-suse-sle15

********** centos:8                                 **********
Bash is 4.4.19(1)-release
********** Copying dist to dist-all/centos-8

********** quay.io/centos/centos:stream9            **********
Bash is 5.1.8(1)-release
********** Copying dist to dist-all/quay-io-centos-centos-stream9

********** fedora:41                                **********
Bash is 5.2.32(1)-release
********** Copying dist to dist-all/fedora-41

********** fedora:42                                **********
Bash is 5.2.37(1)-release
********** Copying dist to dist-all/fedora-42

********** archlinux                                **********
Bash is 5.2.37(1)-release
********** Copying dist to dist-all/archlinux

********** manjarolinux/base                        **********
Bash is 5.2.37(1)-release
********** Copying dist to dist-all/manjarolinux-base
** SCRIPT RUN TIME 13 SECONDS **
```

* Description of the changes in this pull request:
One of my test system is rather old - see:
```bash
$ /lib64/ld-linux-x86-64.so.2 --help | grep supported
  x86-64-v2 (supported, searched)
```
And we got the error:
```bash
********** quay.io/centos/centos:stream10           **********
Fatal glibc error: CPU does not support x86-64-v3
ERROR: ############### DOCKER RUN FAILED FOR quay.io/centos/centos:stream10
```
And, the `run-in-docker` bailed out.
We want to avoid this and therefore, check the HW architecture and for centos10 we must have x86-64-v3 or x86-64-v4.
