### PR TITLE
EXCLUDE_COMPONENTS in 200_partition_layout.sh

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3517,13 +3517,20 @@ EXCLUDE_VG=()
 # - physical volumes: "pv:/dev/sda2"
 # - swap: "swap:/dev/mapper/system-swap"
 # Volume groups look like: "/dev/system".
-# For the correct syntax of a specific component see /var/lib/rear/layout/disktodo.conf
+# See /var/lib/rear/layout/disktodo.conf for the correct syntax of a specific component.
 # Because EXCLUDE_COMPONENTS excludes any component from the recovery
-# it can be used in exceptional cases to exclude unwanted whole disks from the very beginning,
-# for example to circumvent issues with unneeded problematic disks which cause issues in ReaR
-# as in https://github.com/rear/rear/issues/2995 where parted could not recognize a partition table.
-# To exclude a disk with mounted filesystems their mountpoints must be also specified
-# for example via EXCLUDE_COMPONENTS+=( /dev/sdX fs:/mountpoint1 fs:/mountpoint2 )
+# it can be used in exceptional cases to exclude unwanted whole disks.
+# For example EXCLUDE_COMPONENTS+=( /dev/sdX ) excludes the disk /dev/sdX
+# and via the dependency tracker usually also partitions and filesystems on it
+# provided the diks behaves normally (i.e. the disk and things on it can be recognized properly).
+# To exclude an unneeded problematic disk even when the disk or things on it cannot be recognized properly
+# EXCLUDE_COMPONENTS+=( /dev/sdX ) may work when there is only the plain disk without mounted filesystems.
+# To exclude a problematic disk with mounted filesystems their mountpoints may have to be also specified
+# for example via EXCLUDE_COMPONENTS+=( /dev/sdX fs:/mountpoint1 fs:/mountpoint2 ) or similar.
+# Verify that all what belongs to /dev/sdX is marked as 'done' in /var/lib/rear/layout/disktodo.conf
+# and that all what belongs to /dev/sdX is commented out in /var/lib/rear/layout/disklayout.conf
+# to ensure there is no recovery information left as 'todo' or not commented out
+# for a disk which should be excluded from the recovery.
 EXCLUDE_COMPONENTS=()
 #
 # Only include LVM2 volume groups - the opposite of EXCLUDE_VG (handy if you only want vg00 to be included)

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3523,10 +3523,11 @@ EXCLUDE_VG=()
 # For example EXCLUDE_COMPONENTS+=( /dev/sdX ) excludes the disk /dev/sdX
 # and via the dependency tracker usually also partitions and filesystems on it
 # provided the diks behaves normally (i.e. the disk and things on it can be recognized properly).
-# To exclude an unneeded problematic disk even when the disk or things on it cannot be recognized properly
-# EXCLUDE_COMPONENTS+=( /dev/sdX ) may work when there is only the plain disk without mounted filesystems.
-# To exclude a problematic disk with mounted filesystems their mountpoints may have to be also specified
-# for example via EXCLUDE_COMPONENTS+=( /dev/sdX fs:/mountpoint1 fs:/mountpoint2 ) or similar.
+# To exclude an unneeded problematic disk when the disk or things on it cannot be recognized properly
+# EXCLUDE_COMPONENTS+=( /dev/sdX ) may work to exclude the disk with its partitions and filesystems.
+# To exclude a problematic disk with higher level storage objects on it
+# its matching components may have to be specified separately for example like
+# EXCLUDE_COMPONENTS+=( /dev/sdX fs:/mountpoint pv:/dev/sdXN ) or similar as needed.
 # Verify that all what belongs to /dev/sdX is marked as 'done' in /var/lib/rear/layout/disktodo.conf
 # and that all what belongs to /dev/sdX is commented out in /var/lib/rear/layout/disklayout.conf
 # to ensure there is no recovery information left as 'todo' or not commented out

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3483,22 +3483,25 @@ DIRECTORY_ENTRIES_TO_RECOVER=()
 ####
 # How to exclude something ----- EXCLUDES -------
 #
-# You cannot exclude a device (e.g. /dev/sdg) directly. Instead you have to exclude everything
-# ON that device and then the dependency tracker will automatically exclude the device from the
-# recovery (because there won't be any recovery information for that "unnecessary" device).
+# Normally a whole device (e.g. a disk device /dev/sdX) is not excluded directly
+# (for exceptional cases see EXCLUDE_COMPONENTS below).
+# Instead specific things on a device are excluded.
+# When everything on a device is excluded then via the dependency tracker
+# the whole device gets automatically excluded from the recovery
+# because there is no recovery information left for that device.
 #
-# Furthermore, you have to exclude MD devices and LVM2 volume groups separately
+# You have to exclude MD devices and LVM2 volume groups separately
 # as there is no automatic detection of these dependencies.
 #
-# Exclude filesystems by specifying their mountpoints. Will be automatically added to the
-# $BACKUP_PROG_EXCLUDE array during backup to prevent the excluded filesystems' data to
-# be backed up
-# examples: /tmp
+# Exclude filesystems by specifying their mountpoints.
+# Will be automatically added to the $BACKUP_PROG_EXCLUDE array during backup
+# to prevent the excluded filesystems' data to be backed up.
+# Examples: /tmp
 #           /media/bigdisk
 EXCLUDE_MOUNTPOINTS=()
 #
 # Exclude MD devices
-# examples: /dev/md0
+# Examples: /dev/md0
 #           /dev/md/0
 EXCLUDE_MD=()
 #
@@ -3508,13 +3511,19 @@ EXCLUDE_MD=()
 # otherwise "rear recover" would try to recreate the filesystems onto non-existing LVs.
 EXCLUDE_VG=()
 #
-# Exclude any component from the recovery image.
+# EXCLUDE_COMPONENTS: Exclude any component from the recovery.
 # Some component types need a prefix:
 # - filesystems: "fs:/var/cache"
 # - physical volumes: "pv:/dev/sda2"
 # - swap: "swap:/dev/mapper/system-swap"
 # Volume groups look like: "/dev/system".
-# If in doubt about the correct syntax, consult /var/lib/rear/layout/disktodo.conf
+# For the correct syntax of a specific component see /var/lib/rear/layout/disktodo.conf
+# Because EXCLUDE_COMPONENTS excludes any component from the recovery
+# it can be used in exceptional cases to exclude unwanted whole disks from the very beginning,
+# for example to circumvent issues with unneeded problematic disks which cause issues in ReaR
+# as in https://github.com/rear/rear/issues/2995 where parted could not recognize a partition table.
+# To exclude a disk with mounted filesystems their mountpoints must be also specified
+# for example via EXCLUDE_COMPONENTS+=( /dev/sdX fs:/mountpoint1 fs:/mountpoint2 )
 EXCLUDE_COMPONENTS=()
 #
 # Only include LVM2 volume groups - the opposite of EXCLUDE_VG (handy if you only want vg00 to be included)
@@ -3549,7 +3558,7 @@ AUTOEXCLUDE_AUTOFS=
 # Excluding files in the /tmp directory when an internal backup method is used
 # is achieved via a different default setting:
 # BACKUP_PROG_EXCLUDE=( '/tmp/*' ... ) above
-# so that /tmp filesystem will be recreated as an empty filesystem
+# so a /tmp filesystem will be recreated as an empty filesystem
 # cf. https://github.com/rear/rear/pull/2261
 AUTOEXCLUDE_PATH=( /media /run /mnt /tmp )
 #

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -424,8 +424,8 @@ Log "Saving disks and their partitions"
                 if IsInArray "$devname" "${EXCLUDE_COMPONENTS[@]}" ; then
                     # To exclude a disk with mounted filesystems one must also specify the filesystem mountpoints
                     # for example via EXCLUDE_COMPONENTS+=( /dev/sdX fs:/mountpoint1 fs:/mountpoint2 )
-                    DebugPrint "Skipping $devname in EXCLUDE_COMPONENTS (does not also exclude mounted filesystems on it)"
-                    echo "# Skipped $devname in EXCLUDE_COMPONENTS (does not also exclude mounted filesystems on it)"
+                    DebugPrint "Skipping $devname in EXCLUDE_COMPONENTS (does not automatically exclude mounted filesystems on it)"
+                    echo "# Skipped $devname in EXCLUDE_COMPONENTS (does not automatically exclude mounted filesystems on it)"
                     continue
                 fi
                 devsize=$(get_disk_size ${disk#/sys/block/})


### PR DESCRIPTION
* Type: **Enhancement**

The intent is to provide a feasible way out for the user
in particular for exceptional cases when there is
an unwanted and unneeded disk in his system
which causes trouble for ReaR - for example as in
https://github.com/rear/rear/issues/2995 and
https://github.com/rear/rear/issues/3433
where parted failed because of incorrect partitioning
which as a consequence makes ReaR fail.

* Impact: **Normal**

* Reference to related issues (URLs):

https://github.com/rear/rear/issues/2995
https://github.com/rear/rear/issues/3433

* Description of the changes in this pull request:

My current changes are described below starting at
https://github.com/rear/rear/pull/3455#issuecomment-2821188937

My initial and meanwhile outdated changes
caused a regression which I described below in
https://github.com/rear/rear/pull/3455#issuecomment-2812436548

Because of the regression
I had to completely change the implementation
from my initial dirty hack makeshift
towards a (hopefully) proper solution.

My initial and meanwhile outdated changes were:

In layout/save/GNU/Linux/200_partition_layout.sh
added a makeshift to exclude unwanted disks
from the very beginning via EXCLUDE_COMPONENTS
to help the user to avoid issues with unneeded disks
where the subsequent code fails e.g. as in
https://github.com/rear/rear/issues/2995
where parted did not recognize a partition table
that is recognized both by the kernel and fdisk
or as in
https://github.com/rear/rear/issues/3433
where also parted failed for an unused disk
which has somewhat incorrect partitioning.

* How was this pull request tested?

For the test on a SLES15 VM
I added second disk sdb with two partitions
each one with ext4 filesystem that is mounted
```
# lsblk -ipo NAME,TRAN,TYPE,FSTYPE,SIZE,MOUNTPOINTS
NAME        TRAN TYPE FSTYPE   SIZE MOUNTPOINTS
/dev/sda    ata  disk           15G 
|-/dev/sda1      part            8M 
|-/dev/sda2      part btrfs     13G /var
|                                   /usr/local
|                                   /tmp
|                                   /root
|                                   /srv
|                                   /opt
|                                   /home
|                                   /boot/grub2/x86_64-efi
|                                   /boot/grub2/i386-pc
|                                   /.snapshots
|                                   /
`-/dev/sda3      part swap       2G [SWAP]
/dev/sdb    ata  disk            2G 
|-/dev/sdb1      part ext4    1020M /mountpoint1
`-/dev/sdb2      part ext4     512M /mountpoint2
/dev/sr0    ata  rom  iso9660 14.1G
```

My current test results are described below starting at
https://github.com/rear/rear/pull/3455#issuecomment-2821459892
and subsequent comments.

My meanwhile outdated test results from my initial changes were:

My local.conf contains
```
EXCLUDE_COMPONENTS+=( /dev/sdb fs:/mountpoint1 fs:/mountpoint2 )
```
With that I get
```
# usr/sbin/rear -D mkrescue
...
Running 'layout/save' stage ======================
Creating disk layout
Overwriting existing disk layout file /root/rear.github.master/var/lib/rear/layout/disklayout.conf
Skipping /dev/sdb in EXCLUDE_COMPONENTS (does not also exclude mounted filesystems on it)
SLES12-SP1 (and later) btrfs subvolumes setup needed for /dev/sda2 (default subvolume path contains '@/.snapshots/')
Added  /dev/sda2 to BTRFS_SUBVOLUME_SLES_SETUP in /var/tmp/rear.VDl9jDl9fKeBaAX/rootfs/etc/rear/rescue.conf
Excluding component /dev/sdb in EXCLUDE_COMPONENTS
Excluding component fs:/mountpoint1 in EXCLUDE_COMPONENTS
Marking component 'fs:/mountpoint1' as done in /root/rear.github.master/var/lib/rear/layout/disktodo.conf
Excluding component fs:/mountpoint2 in EXCLUDE_COMPONENTS
Marking component 'fs:/mountpoint2' as done in /root/rear.github.master/var/lib/rear/layout/disktodo.conf
Disabling excluded components in /root/rear.github.master/var/lib/rear/layout/disklayout.conf
Disabling component 'fs ... /mountpoint1' in /root/rear.github.master/var/lib/rear/layout/disklayout.conf
Disabling component 'fs ... /mountpoint2' in /root/rear.github.master/var/lib/rear/layout/disklayout.conf
Using sysconfig bootloader 'grub2' for 'rear recover'
Skip saving storage layout as 'barrel' devicegraph (no 'barrel' command)
Verifying that the entries in /root/rear.github.master/var/lib/rear/layout/disklayout.conf are correct
Created disk layout (check the results in /root/rear.github.master/var/lib/rear/layout/disklayout.conf)
...

# cat var/lib/rear/layout/disktodo.conf
todo /dev/sda disk
todo /dev/sda1 part
todo /dev/sda2 part
todo /dev/sda3 part
todo fs:/ fs
done fs:/mountpoint1 fs
done fs:/mountpoint2 fs
todo btrfsmountedsubvol:/ btrfsmountedsubvol
todo btrfsmountedsubvol:/.snapshots btrfsmountedsubvol
todo btrfsmountedsubvol:/boot/grub2/i386-pc btrfsmountedsubvol
todo btrfsmountedsubvol:/boot/grub2/x86_64-efi btrfsmountedsubvol
todo btrfsmountedsubvol:/home btrfsmountedsubvol
todo btrfsmountedsubvol:/opt btrfsmountedsubvol
todo btrfsmountedsubvol:/srv btrfsmountedsubvol
todo btrfsmountedsubvol:/root btrfsmountedsubvol
todo btrfsmountedsubvol:/tmp btrfsmountedsubvol
todo btrfsmountedsubvol:/usr/local btrfsmountedsubvol
todo btrfsmountedsubvol:/var btrfsmountedsubvol
todo swap:/dev/sda3 swap

# cat var/lib/rear/layout/disklayout.conf
...
disk /dev/sda 16106127360 gpt
...
part /dev/sda 8388608 1048576 rear-noname bios_grub /dev/sda1
part /dev/sda 13949206528 9437184 rear-noname legacy_boot /dev/sda2
part /dev/sda 2147466752 13958643712 rear-noname swap /dev/sda3
# Skipped /dev/sdb in EXCLUDE_COMPONENTS (does not also exclude mounted filesystems on it)
...
fs /dev/sda2 / btrfs uuid=bdec53c2-1ee8-4268-90f9-5ec523774035 label= ...
#fs /dev/sdb1 /mountpoint1 ext4 uuid=058cb383-20e1-4237-abf5-c53ce27325ae label= ...
#fs /dev/sdb2 /mountpoint2 ext4 uuid=670b47d9-31b3-4483-9409-43116e16b0ac label= ..
...
swap /dev/sda3 uuid=921157bc-e4d6-4869-8796-7e09207e49a9 label=
```

I also did "rear mkbackuponly"
and then tested "rear recover"
on another VM without a second disk sdb
and - at least for me - it "just worked"
(i.e. nothing about 'sdb' during "rear recover")
so sdb is really completely skipped for recovery.
