### PR TITLE
Tell if 'use_lvmlockd = 1' in /etc/lvm/lvm.conf

### DIFF
--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -12,7 +12,7 @@ fi
 #
 
 if grep -Eq '^lvmdev |^lvmgrp |^lvmvol ' $DISKLAYOUT_FILE ; then
-    # Same code is also in layout/save/GNU/Linux/220_lvm_layout.sh
+    # Almost same code is also in layout/save/GNU/Linux/220_lvm_layout.sh (there with LogPrintError).
     # When disklayout.conf contains at least one 'lvmdev' or 'lvmgrp' or 'lvmvol' entry
     # LVM things need to be recreated during "rear recover"
     # but this fails if 'use_lvmlockd = 1' is set in /etc/lvm/lvm.conf
@@ -24,7 +24,8 @@ if grep -Eq '^lvmdev |^lvmgrp |^lvmvol ' $DISKLAYOUT_FILE ; then
     # "whitespace is not significant" so it could be e.g. '   use_lvmlockd  = 1 ' or 'use_lvmlockd=1'
     use_lvmlockd_config="$( grep -v '^[[:space:]]*#' /etc/lvm/lvm.conf | grep -o 'use_lvmlockd[[:space:]]*=.*' )"
     use_lvmlockd_config_value="$( echo $use_lvmlockd_config | tr -d '[:space:]' | cut -s -d '=' -f2 )"
-    is_true "$use_lvmlockd_config_value" && LogPrintError "Recreating LVM needs 'use_lvmlockd = 0' (there is '$use_lvmlockd_config' in /etc/lvm/lvm.conf)"
+    # Error out because LVM recreating cannot work with 'use_lvmlockd = 1' (there is no lvmlockd in the recovery system):
+    is_true "$use_lvmlockd_config_value" && Error "Recreating LVM requires 'use_lvmlockd = 0' (there is '$use_lvmlockd_config' in /etc/lvm/lvm.conf)"
 fi
 
 # Test for features in lvm.

--- a/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/110_include_lvm_code.sh
@@ -11,6 +11,22 @@ fi
 # corresponding information collected during 'mkrescue'.
 #
 
+if grep -Eq '^lvmdev |^lvmgrp |^lvmvol ' $DISKLAYOUT_FILE ; then
+    # Same code is also in layout/save/GNU/Linux/220_lvm_layout.sh
+    # When disklayout.conf contains at least one 'lvmdev' or 'lvmgrp' or 'lvmvol' entry
+    # LVM things need to be recreated during "rear recover"
+    # but this fails if 'use_lvmlockd = 1' is set in /etc/lvm/lvm.conf
+    # so we inform the user (ReaR cannot know what the user wants to do in this case)
+    # see https://github.com/rear/rear/issues/3461
+    local use_lvmlockd_config=""
+    local use_lvmlockd_config_value=""
+    # 'man lvm.conf' tells "comments begin with # and continue to the end of the line" and
+    # "whitespace is not significant" so it could be e.g. '   use_lvmlockd  = 1 ' or 'use_lvmlockd=1'
+    use_lvmlockd_config="$( grep -v '^[[:space:]]*#' /etc/lvm/lvm.conf | grep -o 'use_lvmlockd[[:space:]]*=.*' )"
+    use_lvmlockd_config_value="$( echo $use_lvmlockd_config | tr -d '[:space:]' | cut -s -d '=' -f2 )"
+    is_true "$use_lvmlockd_config_value" && LogPrintError "Recreating LVM needs 'use_lvmlockd = 0' (there is '$use_lvmlockd_config' in /etc/lvm/lvm.conf)"
+fi
+
 # Test for features in lvm.
 # Versions higher than 2.02.73 need --norestorefile if no UUID/restorefile.
 FEATURE_LVM_RESTOREFILE=

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -398,6 +398,7 @@ Log "End saving LVM layout"
 # cf. https://github.com/rear/rear/issues/1963
 if grep -Eq '^lvmdev |^lvmgrp |^lvmvol ' $DISKLAYOUT_FILE ; then
     REQUIRED_PROGS+=( lvm )
+    # Same code is also in layout/prepare/GNU/Linux/110_include_lvm_code.sh
     # When disklayout.conf contains at least one 'lvmdev' or 'lvmgrp' or 'lvmvol' entry
     # LVM things need to be recreated during "rear recover"
     # but this fails if 'use_lvmlockd = 1' is set in /etc/lvm/lvm.conf

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -398,7 +398,7 @@ Log "End saving LVM layout"
 # cf. https://github.com/rear/rear/issues/1963
 if grep -Eq '^lvmdev |^lvmgrp |^lvmvol ' $DISKLAYOUT_FILE ; then
     REQUIRED_PROGS+=( lvm )
-    # Same code is also in layout/prepare/GNU/Linux/110_include_lvm_code.sh
+    # Almost same code is also in layout/prepare/GNU/Linux/110_include_lvm_code.sh (there with Error).
     # When disklayout.conf contains at least one 'lvmdev' or 'lvmgrp' or 'lvmvol' entry
     # LVM things need to be recreated during "rear recover"
     # but this fails if 'use_lvmlockd = 1' is set in /etc/lvm/lvm.conf

--- a/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/220_lvm_layout.sh
@@ -396,7 +396,21 @@ Log "End saving LVM layout"
 # see the create_lvmdev create_lvmgrp create_lvmvol functions in layout/prepare/GNU/Linux/110_include_lvm_code.sh
 # what program calls are written to diskrestore.sh
 # cf. https://github.com/rear/rear/issues/1963
-grep -Eq '^lvmdev |^lvmgrp |^lvmvol ' $DISKLAYOUT_FILE && REQUIRED_PROGS+=( lvm ) || true
+if grep -Eq '^lvmdev |^lvmgrp |^lvmvol ' $DISKLAYOUT_FILE ; then
+    REQUIRED_PROGS+=( lvm )
+    # When disklayout.conf contains at least one 'lvmdev' or 'lvmgrp' or 'lvmvol' entry
+    # LVM things need to be recreated during "rear recover"
+    # but this fails if 'use_lvmlockd = 1' is set in /etc/lvm/lvm.conf
+    # so we inform the user (ReaR cannot know what the user wants to do in this case)
+    # see https://github.com/rear/rear/issues/3461
+    local use_lvmlockd_config=""
+    local use_lvmlockd_config_value=""
+    # 'man lvm.conf' tells "comments begin with # and continue to the end of the line" and
+    # "whitespace is not significant" so it could be e.g. '   use_lvmlockd  = 1 ' or 'use_lvmlockd=1'
+    use_lvmlockd_config="$( grep -v '^[[:space:]]*#' /etc/lvm/lvm.conf | grep -o 'use_lvmlockd[[:space:]]*=.*' )"
+    use_lvmlockd_config_value="$( echo $use_lvmlockd_config | tr -d '[:space:]' | cut -s -d '=' -f2 )"
+    is_true "$use_lvmlockd_config_value" && LogPrintError "Recreating LVM needs 'use_lvmlockd = 0' (there is '$use_lvmlockd_config' in /etc/lvm/lvm.conf)"
+fi
 
 # vim: set et ts=4 sw=4:
 


### PR DESCRIPTION

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/3461#issuecomment-2830111347

* How was this pull request tested?

On my test VM with LVM and
'use_lvmlockd = 1' in /etc/lvm/lvm.conf
```
# usr/sbin/rear -D mkrescue
...
Running 'layout/save' stage ======================
Creating disk layout
Overwriting existing disk layout file /root/rear.github.master/var/lib/rear/layout/disklayout.conf
Recreating LVM needs 'use_lvmlockd = 0' (there is 'use_lvmlockd = 1' in /etc/lvm/lvm.conf)
...
```

* Description of the changes in this pull request:

In layout/save/GNU/Linux/220_lvm_layout.sh
show LogPrintError message to inform the user
when 'use_lvmlockd = 1' was found in /etc/lvm/lvm.conf
but recreating LVM things needs 'use_lvmlockd = 0'
