### PR TITLE
Fix calling efibootmgr on software RAID

### DIFF
--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -83,7 +83,7 @@ bootloader=$( echo $UEFI_BOOTLOADER | cut -d"/" -f4- | sed -e 's;/;\\;g' )
 # GRUB2_INSTALL_DEVICES="/dev/nvme0n1 /dev/nvme0n2"
 # See also https://github.com/rear/rear/issues/3459
 if test "$GRUB2_INSTALL_DEVICES" ; then
-    if [[ $boot_efi_parts == "/dev/md0p"* ]]; then
+    if [[ $boot_efi_parts == "/dev/md"*"p"* ]]; then
         partition_number=$( get_partition_number $boot_efi_parts )
         for disk in $GRUB2_INSTALL_DEVICES; do
             LogPrint "Creating  EFI Boot Manager entry '$OS_VENDOR $OS_VERSION' for '$bootloader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER') "

--- a/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/670_run_efibootmgr.sh
@@ -76,6 +76,29 @@ local bootloader partition_block_device partition_number disk efipart
 # EFI\fedora\shim.efi
 bootloader=$( echo $UEFI_BOOTLOADER | cut -d"/" -f4- | sed -e 's;/;\\;g' )
 
+# On a system with software RAID, it is not easily possible to determine the
+# underlying disks automatically. The following makes use of GRUB2_INSTALL_DEVICES
+# to determine the appropriate devices for calling efibootmgr, this requires for
+# example to add the following configuration:
+# GRUB2_INSTALL_DEVICES="/dev/nvme0n1 /dev/nvme0n2"
+# See also https://github.com/rear/rear/issues/3459
+if test "$GRUB2_INSTALL_DEVICES" ; then
+    if [[ $boot_efi_parts == "/dev/md0p"* ]]; then
+        partition_number=$( get_partition_number $boot_efi_parts )
+        for disk in $GRUB2_INSTALL_DEVICES; do
+            LogPrint "Creating  EFI Boot Manager entry '$OS_VENDOR $OS_VERSION' for '$bootloader' (UEFI_BOOTLOADER='$UEFI_BOOTLOADER') "
+            Log efibootmgr --create --gpt --disk $disk --part $partition_number --write-signature --label \"${OS_VENDOR} ${OS_VERSION}\" --loader \"\\${bootloader}\"
+            if efibootmgr --create --gpt --disk $disk --part $partition_number --write-signature --label "${OS_VENDOR} ${OS_VERSION}" --loader "\\${bootloader}" ; then
+                 # ok, boot loader has been set-up - continue with other disks (ESP can be on RAID)
+                 NOBOOTLOADER=''
+            else
+                 LogPrintError "efibootmgr failed to create EFI Boot Manager entry on $disk partition $partition_number (ESP $partition_block_device )"
+            fi
+        done
+        is_true $NOBOOTLOADER && return 1 || return 0
+    fi
+fi
+
 for efipart in $boot_efi_parts ; do
     # /dev/sda1 or /dev/mapper/vol34_part2 or /dev/mapper/mpath99p4
     partition_block_device=$( get_device_name $efipart )


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): https://github.com/rear/rear/issues/3459

* How was this pull request tested? Manually on OpenSUSE Leap 15.6

* Description of the changes in this pull request:

On a system with software RAID, it is not easily possible to determine the underlying disks automatically. The following makes use of GRUB2_INSTALL_DEVICES to determine the appropriate devices for calling efibootmgr, this requires for example the following configuration: GRUB2_INSTALL_DEVICES="/dev/nvme0n1 /dev/nvme0n2"
See issue #3459 for more details