### PR TITLE
More consistent user messages in 310_network_devices.sh

### DIFF
--- a/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
+++ b/usr/share/rear/rescue/GNU/Linux/310_network_devices.sh
@@ -963,11 +963,14 @@ rc=
 # see https://github.com/rear/rear/issues/2902
 for network_interface in $( ls /sys/class/net/ ) ; do
     if ! is_linked_to_physical $network_interface ; then
-        LogPrint "Skipping '$network_interface': not bound to any physical interface."
+        LogPrint "Skipping network interface '$network_interface': not bound to any physical interface."
         continue
     fi
-    is_interface_up $network_interface || continue
-
+    if ! is_interface_up $network_interface ; then
+        DebugPrint "Skipping network interface '$network_interface': link state not 'up'"
+        continue
+    fi
+    
     DebugPrint "Handling network interface '$network_interface'"
 
     handle_interface $network_interface >$tmpfile


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* How was this pull request tested?

On my SLES15-SP6 test VM:
```
# usr/sbin/rear -v mkrescue
...
Skipping network interface 'lo': not bound to any physical interface.
...
```
```
# usr/sbin/rear -d mkrescue
...
Handling network interface 'eth0'
eth0 is a physical device
Handled network interface 'eth0'
Skipping network interface 'lo': not bound to any physical interface.
...
```

* Description of the changes in this pull request:

In rescue/GNU/Linux/310_network_devices.sh
show more consistent texts in user messages
in particular to avoid during "rear -v mkrescue"
the "lonely" message
```
Skipping 'lo': not bound to any physical interface.
```
without any context
in contrast to "rear -d mkrescue"
```
Handling network interface 'eth0'
eth0 is a physical device
Handled network interface 'eth0'
Skipping 'lo': not bound to any physical interface.
```
where the context (handling network interfaces) is clear.

Also do not in any case silently skip
interfaces which are not 'up'
but show that (at least) in debug mode.
