### PR TITLE
Describe enforced umount problem in umount_mountpoint_retry_lazy function

### DIFF
--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -890,6 +890,7 @@ function umount_mountpoint_retry_lazy() {
     # because normal umount is preferred over more sophisticated attempts
     # like lazy umount or enforced umount which raise their own specific troubles
     # for example enforced umount may corrupt data when it disrupts a writing process
+    # cf. https://stackoverflow.com/questions/7878707/how-to-unmount-a-busy-device
     # and the -M option for fuser which is used below is not available on older
     # Linux distributions like RHEL6 and SLES11 so 'sleep 1' and retry is best:
     sleep 1

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -889,6 +889,7 @@ function umount_mountpoint_retry_lazy() {
     # and https://github.com/rear/rear/issues/3397#issuecomment-2656911018 (sleep also worked here)
     # because normal umount is preferred over more sophisticated attempts
     # like lazy umount or enforced umount which raise their own specific troubles
+    # for example enforced umount may corrupt data when it disrupts a writing process
     # and the -M option for fuser which is used below is not available on older
     # Linux distributions like RHEL6 and SLES11 so 'sleep 1' and retry is best:
     sleep 1
@@ -913,7 +914,7 @@ function umount_mountpoint_retry_lazy() {
     fuser -v -M -m "$mountpoint" 1>&2 || Log "Presumably 'fuser' does not support the -M option"
     DebugPrint "Trying 'umount --lazy $mountpoint' (normal umount failed)"
     # Do only plain 'umount --lazy' without additional '--force'
-    # because enforced umount raises its own specific troubles
+    # because enforced umount raises its own specific troubles (see above)
     # so we cannot use the umount_mountpoint_lazy() function here:
     umount $v --lazy "$mountpoint" && return 0
     # Lazy umount also failed:


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Low**

* Description of the changes in this pull request:

In lib/global-functions.sh
for the umount_mountpoint_retry_lazy function
add a comment that shows an example
why enforced umount raises its own specific troubles:
Enforced umount may corrupt data
when it disrupts a writing process, e.g. see
https://stackoverflow.com/questions/7878707/how-to-unmount-a-busy-device
which reads (excerpts)
```
umount -l /PATH/OF/BUSY-DEVICE
umount -f /PATH/OF/BUSY-NFS
...
NOTE/CAUTION
These commands can disrupt a running process,
cause data loss OR corrupt open files.
Programs accessing target DEVICE/NFS files
may throw errors OR could not work properly
after force unmount.
```
