### PR TITLE
Make issues or PRs stale only after specific labels have been set

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,22 +1,19 @@
 # See https://github.com/actions/stale/blob/main/README.md
 # for in-depth explanation of all tunables
 
-# Number of days of inactivity before an issue becomes stale
-# Let us go for 120 days
-daysUntilStale: 120
+# Number of days of inactivity before an issue or pull request becomes stale
+days-before-issue-stale: 60
+# If set to a negative number like -1, no issues or pull requests will be marked as stale automatically.
+days-before-pr-stale: -1
 
-# Number of days of inactivity before a stale issue is closed
-# Pin it to 30 days
-daysUntilClose: 30
+# Number of days of inactivity before a stale issue (or pull request) is closed
+days-before-issue-close: 30
+days-before-pr-close: 30
 
-# Issues with these labels will never be considered stale
-exemptLabels:
-  - Dedicated Priority Support
-  - critical/security bug
-  - severe improvement
-  - blocker
-  - bug
-  - minor bug
+# Only issues (or pull requests) with these labels will be considered stale after the timer expires
+only-labels:
+  - ready-to-close?
+  - waiting for info
 
 # exempt-all-assignees: If set to true, the issues or the pull requests with an assignee will not be marked as stale automatically.
 exempt-all-assignees: true
@@ -27,7 +24,7 @@ staleLabel: ready-to-close?
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
    This issue has been automatically marked as stale
-   because it has not had recent activity for 120 days.
+   because it has not had recent activity for 60 days.
    It will be closed if no further activity occurs within 30 days.
    Thank you for your contribution.
 


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Other?**

* Impact: **Low**

* Reference to related issue (URL): #3481 

* How was this pull request tested? Not tested yet

* Description of the changes in this pull request: only mark issues or pull requests stale when one of the following
 labels have been set:

              ready-to-close?
              waiting for info
