### PR TITLE
BCF-5527: [Rear] Space in the variable device_to_be_wiped_size_bytes

### DIFF
--- a/usr/share/rear/layout/recreate/default/150_wipe_disks.sh
+++ b/usr/share/rear/layout/recreate/default/150_wipe_disks.sh
@@ -191,7 +191,7 @@ for disk_to_be_wiped in $DISKS_TO_BE_WIPED ; do
         # Get the size of the device in bytes which could be smaller than 16 MiB.
         # For example a 'bios_grub' partition could be smaller (e.g only 8 MiB on SUSE systems)
         # cf. the "lsblk -ipo NAME,KNAME,PKNAME,TYPE,FSTYPE,SIZE,MOUNTPOINT /dev/sda" output above.
-        device_to_be_wiped_size_bytes="$( lsblk -dbnlpo SIZE $device_to_be_wiped )"
+        device_to_be_wiped_size_bytes="$( lsblk -dbnlpo SIZE $device_to_be_wiped | tr -c -d '[:digit:]' )"
         if ! test -b $device_to_be_wiped_size_byte ; then
             LogPrintError "Skip wiping $device_to_be_wiped (no output for 'lsblk -dbnlpo SIZE $device_to_be_wiped' or failed)"
             continue


### PR DESCRIPTION
On some platforms like Debian 12
command `lsblk -dbnlpo SIZE /dev/sda2`
can return the string that starts with space.
For example, " 1024".

As the result command
```
dd if=/dev/zero of=/dev/sda2 count= 1024 iflag=count_bytes
```
will be failed.

Strips non-digit characters with tr to return a clean numeric value.
