### PR TITLE
In 150_wipe_disks.sh fix wrong 'device_to_be_wiped_size_byte' test

### DIFF
--- a/usr/share/rear/layout/recreate/default/150_wipe_disks.sh
+++ b/usr/share/rear/layout/recreate/default/150_wipe_disks.sh
@@ -193,7 +193,7 @@ for disk_to_be_wiped in $DISKS_TO_BE_WIPED ; do
         # cf. the "lsblk -ipo NAME,KNAME,PKNAME,TYPE,FSTYPE,SIZE,MOUNTPOINT /dev/sda" output above.
         # On some platforms like Debian 12 the command e.g. "lsblk -dbnlpo SIZE /dev/sda2"
         # returns a string that starts with space, for example " 1024", so the subsequent
-        # wiping command "dd if=/dev/zero of=/dev/sda2 count= 1024 iflag=count_bytes" failes.
+        # wiping command "dd if=/dev/zero of=/dev/sda2 count= 1024 iflag=count_bytes" fails.
         # Therefore strip non-digit characters with 'tr' to get a clean numeric value,
         # see https://github.com/rear/rear/pull/3484
         device_to_be_wiped_size_bytes="$( lsblk -dbnlpo SIZE $device_to_be_wiped | tr -c -d '[:digit:]' )"


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/3484#issuecomment-3022670414

* How was this pull request tested?
see below
https://github.com/rear/rear/pull/3487#issuecomment-3031144320

* Description of the changes in this pull request:

In layout/recreate/default/150_wipe_disks.sh
fix wrong device_to_be_wiped_size_byte test, see
https://github.com/rear/rear/pull/3484#issuecomment-3022670414