### PR TITLE
s390: remove the deprecated `OUTPUT=IPL` value

### DIFF
--- a/usr/share/rear/prep/Linux-s390/034_check_config.sh
+++ b/usr/share/rear/prep/Linux-s390/034_check_config.sh
@@ -1,8 +1,3 @@
-if [ "$OUTPUT" = "IPL" ]; then
-    LogPrintError "Warning: OUTPUT=IPL is deprecated. Use OUTPUT=RAMDISK instead."
-    OUTPUT=RAMDISK
-fi
-
 if [ "$OUTPUT" != "RAMDISK" ] ; then
    Error "Currently, only OUTPUT=RAMDISK is supported on s390/s390x"
 fi


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Clean-up**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/commit/32fe8dd7b0eac35534b28b10dd1b541397aa8bbf

* How was this pull request tested? N/A

* Description of the changes in this pull request:

Let's remove the deprecated s390-only `OUTPUT=IPL` value.  The deprecation warning has been in place for the last two releases and a change like this should be fine for ReaR 3.0.