### PR TITLE
Copy /etc/dhcpcd.conf to the rescue system

### DIFF
--- a/usr/share/rear/prep/GNU/Linux/210_include_dhclient.sh
+++ b/usr/share/rear/prep/GNU/Linux/210_include_dhclient.sh
@@ -141,5 +141,5 @@ fi
 # as DHCP could be activated manually on the rescue system.
 # We made our own /etc/dhclient.conf and /bin/dhclient-script files (no need to copy these
 # from the local Linux system for dhclient). For dhcpcd we have /bin/dhcpcd.sh foreseen.
-COPY_AS_IS+=( "/etc/localtime" "/usr/lib/dhcpcd/*" )
+COPY_AS_IS+=( "/etc/localtime" "/usr/lib/dhcpcd/*" "/etc/dhcpcd.conf" )
 PROGS+=( arping ipcalc usleep "${dhcp_clients[@]}" )


### PR DESCRIPTION
#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/3491

* How was this pull request tested?

    Rescue ISO image on Ubuntu 24.04 was created via `rear mkrescue` and verified that `/etc/resolv.conf` was populated by `dhcpcd` during rescue system boot

* Description of the changes in this pull request:

    Some Linux distributions — e.g., Ubuntu 24.04 — use `dhcpcd` as the DHCP client. The rescue system for such distributions includes the `dhcpcd` binaries, but `/etc/dhcpcd.conf` is missing. As a result, `dhcpcd` does not populate `/etc/resolv.conf` properly, leaving it empty. Copying `/etc/dhcpcd.conf` to the rescue system resolves the issue.

    Alternatively, `/etc/dhcpcd.conf` could be created similarly to `/etc/dhclient.conf`, by providing a default configuration for the rescue system.