### PR TITLE
Support some XFS features

### DIFF
--- a/usr/share/rear/lib/filesystems-functions.sh
+++ b/usr/share/rear/lib/filesystems-functions.sh
@@ -166,6 +166,43 @@ function xfs_parse
     xfs_param_opt[17]="-r"
     xfs_param_name[17]="extsize"
 
+    # xfs_info v4.5.0 on RHEL 7 reports 'spinodes' instead of 'sparse'
+    xfs_param_iname[18]="spinodes"
+    xfs_param_search[18]="metadata_section"
+    xfs_param_opt[18]="-i"
+    xfs_param_name[18]="sparse"
+
+    # xfs_info v5.0.0 on RHEL 8 and later versions report 'sparse'
+    xfs_param_iname[19]="sparse"
+    xfs_param_search[19]="metadata_section"
+    xfs_param_opt[19]="-i"
+    xfs_param_name[19]="sparse"
+
+    xfs_param_iname[20]="rmapbt"
+    xfs_param_search[20]="metadata_section"
+    xfs_param_opt[20]="-m"
+    xfs_param_name[20]="rmapbt"
+
+    xfs_param_iname[21]="reflink"
+    xfs_param_search[21]="metadata_section"
+    xfs_param_opt[21]="-m"
+    xfs_param_name[21]="reflink"
+
+    xfs_param_iname[22]="bigtime"
+    xfs_param_search[22]="metadata_section"
+    xfs_param_opt[22]="-m"
+    xfs_param_name[22]="bigtime"
+
+    xfs_param_iname[23]="inobtcount"
+    xfs_param_search[23]="metadata_section"
+    xfs_param_opt[23]="-m"
+    xfs_param_name[23]="inobtcount"
+
+    xfs_param_iname[24]="nrext64"
+    xfs_param_search[24]="metadata_section"
+    xfs_param_opt[24]="-i"
+    xfs_param_name[24]="nrext64"
+
     # Here we will save some variables, that will be later used for
     # calculations (block_size) or due dependencies with other options (crc).
 


### PR DESCRIPTION


#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested?
    RHEL 7, 8 and 9 systems were recovered and checked via `xfs_db`  that `features_ro_copmat` and 
`features_incompat` are left the same as on the original systems. Additionally, checked via `xfs_info` that new features keep original enablement status.

* Description of the changes in this pull request:
  Recognize the following XFS features from the `xfs_info` output: `rmapbt`, `reflink`, `bigtime`, `inobtcount`, `nrext64` and `sparse`, and preserve their original enablement status. In newer version of `mkfs.xfs`, these options are enabled by default, which is not the desired behaviour if they were intentionally disabled.

