### PR TITLE
In sbin/rear error out if '-c' is used in recovery system

### DIFF
--- a/doc/rear.8
+++ b/doc/rear.8
@@ -339,7 +339,7 @@ usage information
 .sp
 \-c DIR
 .RS 4
-alternative config directory instead of /etc/rear
+alternative config directory instead of /etc/rear (not supported for recovery)
 .RE
 .sp
 \-C CONFIG

--- a/doc/rear.8
+++ b/doc/rear.8
@@ -339,7 +339,7 @@ usage information
 .sp
 \-c DIR
 .RS 4
-alternative config directory instead of /etc/rear (not supported for recovery)
+alternative config directory instead of /etc/rear (not supported during recovery)
 .RE
 .sp
 \-C CONFIG

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -78,7 +78,7 @@ Professional services and support are available, see https://relax-and-recover.o
     usage information
 
 -c DIR::
-    alternative config directory instead of /etc/rear
+    alternative config directory instead of /etc/rear (not supported for recovery)
 
 -C CONFIG::
     additional config files (absolute path or relative to config directory)

--- a/doc/rear.8.adoc
+++ b/doc/rear.8.adoc
@@ -78,7 +78,7 @@ Professional services and support are available, see https://relax-and-recover.o
     usage information
 
 -c DIR::
-    alternative config directory instead of /etc/rear (not supported for recovery)
+    alternative config directory instead of /etc/rear (not supported during recovery)
 
 -C CONFIG::
     additional config files (absolute path or relative to config directory)

--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -171,6 +171,8 @@ SECRET_OUTPUT_DEV="null"
 EXPOSE_SECRETS=""
 PORTABLE=""
 NON_INTERACTIVE=""
+ALTERNATIVE_CONFIG_DIR=""
+CONFIG_APPEND_FILES=""
 KEEP_BUILD_DIR=""
 KERNEL_VERSION=""
 RECOVERY_MODE=""
@@ -216,7 +218,7 @@ while true ; do
                 echo "$help_note_text"
                 exit 1
             fi
-            CONFIG_DIR="$2"
+            ALTERNATIVE_CONFIG_DIR="$2"
             shift
             ;;
         (-C)
@@ -291,6 +293,45 @@ while true ; do
     shift
 done
 
+# Keep the remaining command line arguments to feed to the workflow:
+ARGS=( "$@" )
+
+# Set RECOVERY_MODE when we are running inside a rescue/recovery system
+# which is normally ReaR's recovery system or alternatively in PORTABLE mode
+# it is a foreign rescue system like the System Rescue CD or the Ubuntu Desktop Live CD,
+# see doc/user-guide/17-Portable-Mode.adoc
+# RECOVERY_MODE is a boolean variable (cf. conf/default.conf) because we need it below
+# to set TMPDIR to ReaR's TMP_DIR only when we are not running inside a rescue/recovery system
+# but we do not yet have lib/global-functions.sh (which contains is_true/is_false) sourced there.
+# In ReaR's recovery system /etc/rear-release is unique (it does not exist otherwise)
+# see build/default/970_add_rear_release.sh that adds it to identify ReaR's rescue environment.
+# PORTABLE mode is meant to be used only to run 'rear recover' within a foreign rescue system,
+# see https://github.com/rear/rear/pull/3206#issuecomment-2122173021
+if test -e "/etc/rear-release" || test "$PORTABLE" ; then
+    RECOVERY_MODE=1
+fi
+
+# Set alternative config directory unless in recovery mode
+# because the contents of an alternative config directory
+# get stored in the ReaR recovery system in /etc/rear
+# so "rear recover" does not work with '-c'
+# see https://github.com/rear/rear/issues/512#issuecomment-68051604
+# and https://github.com/rear/rear/issues/2942#issuecomment-3132425914
+if test "$ALTERNATIVE_CONFIG_DIR" ; then
+    if test "$RECOVERY_MODE" ; then
+        # See the comment about "ReaR basic directories cases" in lib/_framework-setup-and-functions.sh
+        # that within the ReaR recovery system its config directory is always the normal directory /etc/rear
+        echo "ERROR: The '-c' option is not supported within the ReaR rescue/recovery system (its config directory is always $CONFIG_DIR)" >&2
+        exit 1
+    fi
+    if ! test -d "$ALTERNATIVE_CONFIG_DIR" ; then
+        # 'test -d something' is also true when something is a symlink to an existing directory
+        echo "ERROR: The '-c' option argument '$ALTERNATIVE_CONFIG_DIR' is not a directory" >&2
+        exit 1
+    fi
+    CONFIG_DIR="$ALTERNATIVE_CONFIG_DIR"
+fi
+
 # Set workflow to first command line argument or to "help" as fallback:
 if test -z "$WORKFLOW" ; then
     # Usually workflow is now in $1 (after the options and its arguments were shifted above)
@@ -304,9 +345,6 @@ if test -z "$WORKFLOW" ; then
         WORKFLOW=help
     fi
 fi
-
-# Keep the remaining command line arguments to feed to the workflow:
-ARGS=( "$@" )
 
 # The following workflows are always verbose:
 case "$WORKFLOW" in
@@ -347,10 +385,11 @@ test "$EXPOSE_SECRETS" && SECRET_OUTPUT_DEV="stderr"
 # WORKFLOW because for the udev workflow WORKFLOW is set to the actual workflow
 # KERNEL_VERSION because if empty it is set when sourcing config files below:
 readonly ARGS
-readonly CONFIG_APPEND_FILES
+readonly ALTERNATIVE_CONFIG_DIR CONFIG_APPEND_FILES
 readonly DEBUG DEBUGSCRIPTS DEBUGSCRIPTS_ARGUMENT DEBUG_OUTPUT_DEV DISPENSABLE_OUTPUT_DEV
 readonly EXPOSE_SECRETS SECRET_OUTPUT_DEV
 readonly SIMULATE STEPBYSTEP VERBOSE
+readonly RECOVERY_MODE
 
 # The udev workflow is a special case because it is only a wrapper workflow
 # that calls an actual workflow that is specified as $UDEV_WORKFLOW
@@ -580,22 +619,6 @@ fi
 # so that the user can specify what he needs, e.g. for whatever third-party (backup) software
 # see https://github.com/rear/rear/pull/3379#issuecomment-2621021213
 
-# Set RECOVERY_MODE when we are running inside a rescue/recovery system
-# which is normally ReaR's recovery system or alternatively in PORTABLE mode
-# it is a foreign rescue system like the System Rescue CD or the Ubuntu Desktop Live CD,
-# see doc/user-guide/17-Portable-Mode.adoc
-# RECOVERY_MODE is a boolean variable (cf. conf/default.conf) because we need it below
-# to set TMPDIR to ReaR's TMP_DIR only when we are not running inside a rescue/recovery system
-# but we do not yet have lib/global-functions.sh (which contains is_false) sourced here.
-# In ReaR's recovery system /etc/rear-release is unique (it does not exist otherwise)
-# see build/default/970_add_rear_release.sh that adds it to identify ReaR's rescue environment.
-# PORTABLE mode is meant to be used only to run 'rear recover' within a foreign rescue system,
-# see https://github.com/rear/rear/pull/3206#issuecomment-2122173021
-if test -e "/etc/rear-release" || test "$PORTABLE" ; then
-    RECOVERY_MODE='y'
-fi
-readonly RECOVERY_MODE
-
 # Create a sufficiently safe temporary working area BUILD_DIR for ReaR and
 # additionally set TMPDIR to TMP_DIR within BUILD_DIR for programs that are called by ReaR
 # (the latter only when ReaR runs on the original system i.e. when we are not in RECOVERY_MODE):
@@ -751,6 +774,7 @@ if test "$WORKFLOW" != "help" ; then
     LogPrint "$PRODUCT $VERSION / $RELEASE_DATE"
     LogPrint "Running $PROGRAM $WORKFLOW (PID $MASTER_PID date $START_DATE_TIME_STRING)"
     DebugPrint "Command line options: $0 ${CMD_OPTS[*]}"
+    test "$ALTERNATIVE_CONFIG_DIR" && LogPrint "Using config directory '$ALTERNATIVE_CONFIG_DIR'"
     LogPrint "Using log file: $RUNTIME_LOGFILE"
     DebugPrint "Using build area: $BUILD_DIR"
     DebugPrint "$tmpdir_debug_info"

--- a/usr/share/rear/lib/help-workflow.sh
+++ b/usr/share/rear/lib/help-workflow.sh
@@ -23,20 +23,19 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 Available options:
  -h --help              usage information (this text)
- -c DIR                 alternative config directory; instead of $CONFIG_DIR
- -C CONFIG              additional config files; absolute path or relative to config directory
- -d                     debug mode; run many commands verbosely with debug messages in log file (also sets -v)
- -D                     debugscript mode; log executed commands via 'set -x' (also sets -v and -d)
- --debugscripts SET     same as -d -v -D but debugscript mode with 'set -SET'
- -r KERNEL              kernel version to use; currently '$KERNEL_VERSION'
- -s                     simulation mode; show what scripts are run (without executing them)
- -S                     step-by-step mode; acknowledge each script individually
- -v                     verbose mode; show messages what $PRODUCT is doing on the terminal or show verbose help
- -n --non-interactive   non-interactive mode; aborts when any user input is required (experimental)
+ -c DIR                 alternative config directory instead of $CONFIG_DIR (not supported for recovery)
+ -C CONFIG              additional config files (absolute path or relative to config directory)
+ -d                     debug mode: run many commands verbosely with debug messages in the log file (also sets -v)
+ -D                     debugscript mode: log executed commands via 'set -x' (also sets -v and -d)
+ --debugscripts SET     same as -D but debugscript mode with 'set -SET'
+ -r KERNEL              kernel version to use (by default the version of the running kernel) currently '$KERNEL_VERSION'
+ -s                     simulation mode: show what scripts are run without executing them
+ -S                     step-by-step mode: acknowledge each script individually
+ -v                     verbose mode: show messages what $PRODUCT is doing on the terminal or show verbose help
+ -n --non-interactive   non-interactive mode: abort in UserInput() if default input does not make ReaR proceed (experimental)
  -e --expose-secrets    do not suppress output of confidential values (passwords, encryption keys) in particular in the log file
  -p --portable          allow running any ReaR workflow, especially recover, from a git checkout or rear source archive
  -V --version           version information
-
 
 List of commands:
 EOF

--- a/usr/share/rear/lib/help-workflow.sh
+++ b/usr/share/rear/lib/help-workflow.sh
@@ -23,7 +23,7 @@ the GNU General Public License at: http://www.gnu.org/licenses/gpl.html
 
 Available options:
  -h --help              usage information (this text)
- -c DIR                 alternative config directory instead of $CONFIG_DIR (not supported for recovery)
+ -c DIR                 alternative config directory instead of $CONFIG_DIR (not supported during recovery)
  -C CONFIG              additional config files (absolute path or relative to config directory)
  -d                     debug mode: run many commands verbosely with debug messages in the log file (also sets -v)
  -D                     debugscript mode: log executed commands via 'set -x' (also sets -v and -d)


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):
https://github.com/rear/rear/issues/2942#issuecomment-3132425914
https://github.com/rear/rear/issues/512#issuecomment-68051604

* How was this pull request tested?
 
I tested it on my SLES15-SP6 test VM in a Git clone.

On the original test system VM:
```
# usr/sbin/rear -D -c /foor/bar mkbackup
ERROR: The '-c' option argument '/foor/bar' is not a directory

# mkdir /etc/myrear

# cp -av etc/rear/* /etc/myrear
'etc/rear/local.conf' -> '/etc/myrear/local.conf'

# usr/sbin/rear -D -c /etc/myrear mkbackup
Relax-and-Recover 2.9 / 2025-01-31
Running rear mkbackup (PID 3681 date 2025-07-30 16:43:01)
Command line options: usr/sbin/rear -D -c /etc/myrear mkbackup
Using config directory '/etc/myrear'
...
```

In the ReaR recovery system on a replacement VM:
```
RESCUE localhost:~ # rear -D -c /etc/myrear recover
ERROR: The '-c' option is not supported within the ReaR rescue/recovery system (its config directory is always /etc/rear)

RESCUE localhost:~ # find / -xdev | grep myrear
[no output]

RESCUE localhost:~ # rear -D recover
...
```
The recovery "just worked" for me
and the recreated system boots and works normally.

* Description of the changes in this pull request:

In sbin/rear error out
when '-c' is used inside the ReaR recovery system
because the '-c' option is not supported within
the ReaR recovery system because
its config directory is always /etc/rear
