### PR TITLE
Fix parsing of workflow command line arguments

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -293,8 +293,24 @@ while true ; do
     shift
 done
 
+# Set workflow to first command line argument or to "help" as fallback:
+if test -z "$WORKFLOW" ; then
+    # Usually workflow is now in $1 (after the options and its arguments were shifted above)
+    # but when rear is called without a workflow there exists no $1 here so that
+    # an empty default value is used to avoid 'set -eu' error exit if $1 is unset:
+    if test "${1:-}" ; then
+        # Not "$1" to get rid of compound commands:
+        WORKFLOW=$1
+        shift
+    else
+        WORKFLOW=help
+    fi
+fi
+
 # Keep the remaining command line arguments to feed to the workflow:
 ARGS=( "$@" )
+
+# End of handling command line options and arguments.
 
 # Set RECOVERY_MODE when we are running inside a rescue/recovery system
 # which is normally ReaR's recovery system or alternatively in PORTABLE mode
@@ -330,20 +346,6 @@ if test "$ALTERNATIVE_CONFIG_DIR" ; then
         exit 1
     fi
     CONFIG_DIR="$ALTERNATIVE_CONFIG_DIR"
-fi
-
-# Set workflow to first command line argument or to "help" as fallback:
-if test -z "$WORKFLOW" ; then
-    # Usually workflow is now in $1 (after the options and its arguments were shifted above)
-    # but when rear is called without a workflow there exists no $1 here so that
-    # an empty default value is used to avoid 'set -eu' error exit if $1 is unset:
-    if test "${1:-}" ; then
-        # Not "$1" to get rid of compound commands:
-        WORKFLOW=$1
-        shift
-    else
-        WORKFLOW=help
-    fi
 fi
 
 # The following workflows are always verbose:


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Critical**

* Reference to related issue (URL): https://github.com/rear/rear/pull/3500#issuecomment-3206558501

* How was this pull request tested? `rear format -- -y /dev/<DEVICE>` on RHEL 8 and 10

* Description of the changes in this pull request:
 Workflows expect that "$@" will not contain anything before the `--` argument.  Fixes the following failure:
```
$ rear format -- /dev/sdb
ERROR: Argument 'format' not accepted. Use 'rear format -- --help' for more information.
```

Partially reverts commit a2fe977d3cac54e1dcdad49146f822217c2b83d1.

