### PR TITLE
Unbreak the srpm build with recent rpmbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ srpm: dist/$(name)-$(distversion).tar.gz
 	tar -xz -C $(BUILD_DIR)/ -f dist/$(name)-$(distversion).tar.gz $(dir $(effectivespecfile))
 	cp $(BUILD_DIR)/$(dir $(effectivespecfile))/* $(BUILD_DIR)/
 	if test "$(savedspecfile)"; then cp $(BUILD_DIR)/$(notdir $(effectivespecfile)) "$(savedspecfile)"; fi
-	rpmbuild -bs --clean --nodeps \
+	rpmbuild -bs --nodeps \
 		--define="_sourcedir $(BUILD_DIR)/" \
 		--define="_srcrpmdir $(CURDIR)/dist" \
 		$(rpmdefines) \


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):

* How was this pull request tested?
`make srpm` on Fedora 41.
* Description of the changes in this pull request:

rpmbuild started to generate cleanup code for SRPM builds that assumes existence of a directory that it does not create, causing the build to fail and thus failing the srpm Makefile target.
The error message is like
```
Executing(rmbuild): /bin/sh -e /var/tmp/rpm-tmp.BFfEcM
+ umask 022
+ cd /var/tmp/build-rear-2.9-git.5699.8831a249.fixautomaticrearmismerge.changed/rpmbuild/BUILD/rear-2.9-build
/var/tmp/rpm-tmp.BFfEcM: line 33: cd: /var/tmp/build-rear-2.9-git.5699.8831a249.fixautomaticrearmismerge.changed/rpmbuild/BUILD/rear-2.9-build: No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.BFfEcM (rmbuild)

RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.BFfEcM (rmbuild)
make: *** [Makefile:275: srpm] Error 1
```
Fix by removing --clean from rpmbuild invocation when building SRPM. I don't think there is anything to clean up anyway since the SRPM build does not extract sources.