### PR TITLE
Remove support for outdated `syslinux` (<4.04) and simplify the `ISOLINUX` config generator

### DIFF
--- a/doc/user-guide/02-getting-started.md
+++ b/doc/user-guide/02-getting-started.md
@@ -28,13 +28,12 @@ Optionally, some use-cases require other tools:
 
  - lsscsi and sg3_utils (for OBDR tape support)
  - mkisofs or genisoimage (for ISO output support)
- - syslinux (for ISO or USB output support)
+ - syslinux >= 4.04 (for ISO or USB output support)
  - syslinux-extlinux (for USB support)
  - ebiso (for SLES UEFI booting)
 
 In some cases having newer versions of tools may provide better support:
 
- - syslinux >= 4.00 (provides menu support)
  - parted
 
 In case we are using `BACKUP=NETFS` with nfs or cifs we might need also:

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1135,36 +1135,26 @@ ISO_PREFIX="rear-$HOSTNAME"
 #
 # Default boot option (i.e. what gets booted automatically after some timeout)
 # when SYSLINUX boots the ISO image on BIOS systems.
-# This variable ISO_DEFAULT should be better named ISO_BIOS_BOOT_DEFAULT
-# (cf. USB_BIOS_BOOT_DEFAULT below) but we won't rename existing config variables
-# to avoid regressions for users who use existing config variable names
-# cf. https://github.com/rear/rear/pull/2293#issuecomment-564439509
-# If ISO_DEFAULT is unset or empty or only blanks "boothd" is used by default.
-# ISO_DEFAULT="boothd" is an automatism that intends to boot from the original first disk.
+# If ISO_RECOVER_MODE is unset or empty or only blanks, "boothd" is used by default.
+# ISO_RECOVER_MODE="boothd" is an automatism that intends to boot from the original first disk.
 # In case of ISOLINUX "boothd" means to boot from the first disk 'boothd0' because
 # usually ISOLINUX is used for booting from CD-ROM which is usually not the first disk
 # so that the original first disk still is the first disk when booting the ISO from CD-ROM.
 # In case of EXTLINUX "boothd" would mean to boot from the second disk 'boothd1' because
 # usually when EXTLINUX is used the device with the ISO would be the first disk
 # and the original first disk would become the second disk (cf. USB_BIOS_BOOT_DEFAULT below).
-# ISO_DEFAULT="boothd0" boots from the first disk.
-# ISO_DEFAULT="boothd1" boots from the second disk.
-# The ISO_DEFAULT values 'boothd' 'boothd0' 'boothd1' are only supported
+# ISO_RECOVER_MODE="boothd0" boots from the first disk.
+# ISO_RECOVER_MODE="boothd1" boots from the second disk.
+# The ISO_RECOVER_MODE values 'boothd' 'boothd0' 'boothd1' are only supported
 # when the SYSLINUX module 'chain.c32' for chain booting is available.
-# ISO_DEFAULT="manual" boots the ReaR recovery system in normal mode
+# ISO_RECOVER_MODE="manual" boots the ReaR recovery system in normal mode
 # where one must manually log in as 'root', manually type "rear recover", and manually reboot.
-# ISO_DEFAULT="automatic" boots the ReaR recovery system with the 'auto_recover' kernel command line option
+# ISO_RECOVER_MODE="automatic" boots the ReaR recovery system with the 'auto_recover' kernel command line option
 # that runs "rear recover" automatically without automated reboot (see "man rear").
-# For details see the make_syslinux_config function in lib/bootloader-functions.sh
-ISO_DEFAULT="boothd"
-#
 # ISO_RECOVER_MODE="unattended" boots the ReaR recovery system with the 'unattended' kernel command line option
-# that runs "rear recover" automatically plus automated reboot after successful rear recover (see "man rear").
-# Together with ISO_DEFAULT="automatic" full-automated recovery happens when the ISO image is booted
-# which could result an endless full-automated recovery cycle when the ISO is booted by default
-# (e.g. when the device with the ISO is the first one in the BIOS boot order list).
-# The default ISO_RECOVER_MODE="" results the normal behaviour:
-ISO_RECOVER_MODE=""
+# that runs "rear recover" automatically with automated reboot (see "man rear").
+# For details see the make_syslinux_config function in lib/bootloader-functions.sh
+ISO_RECOVER_MODE="boothd"
 #
 # SYSLINUX timeout in 0.1 seconds units (e.g. 100 = 10 seconds) to automatically boot 
 # set this value to 0 to disable

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -224,6 +224,7 @@ function make_syslinux_config {
         cp $v "/lib/modules/$KERNEL_VERSION/modules.pcimap" "$BOOT_DIR/modules.pcimap" >&2
     fi
 
+    echo "UI menu.c32"
     function syslinux_menu {
         echo "MENU $@"
     }
@@ -246,7 +247,6 @@ function make_syslinux_config {
     syslinux_menu "TABMSG Press [Tab] to edit, [F2] for help, [F1] for version info"
 
     echo "timeout ${ISO_SYSLINUX_TIMEOUT:-$(( $USER_INPUT_TIMEOUT * 10 ))}"
-    echo "#noescape 1"
     syslinux_menu title $PRODUCT v$VERSION
 
     echo "say rear - Recover $HOSTNAME"
@@ -327,12 +327,7 @@ function make_syslinux_config {
     echo "label local"
     syslinux_menu "label Boot ^Next device"
     syslinux_menu_help "Boot from the next device in the BIOS boot order list."
-    if [[ "$flavour" == "pxelinux" ]]; then
-        echo "localboot 0"
-    else
-        # iso/extlinux support -1 for try next boot device
-        echo "localboot -1"
-    fi
+    echo "localboot -1"
     echo ""
 
     echo "say hdt - Hardware Detection Tool"
@@ -371,8 +366,6 @@ function make_syslinux_config {
     syslinux_menu_help "Power off the system now"
     echo "kernel $(basename "$poweroff_prog")"
     echo ""
-
-    echo "default menu.c32"
 }
 
 # Create configuration file for elilo

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -224,145 +224,144 @@ function make_syslinux_config {
         cp $v "/lib/modules/$KERNEL_VERSION/modules.pcimap" "$BOOT_DIR/modules.pcimap" >&2
     fi
 
-    echo "UI menu.c32"
-    function syslinux_menu {
-        echo "MENU $@"
-    }
-
-    function syslinux_menu_help {
-        echo "TEXT HELP"
-        for line in "$@" ; do echo "$line" ; done
-        echo "ENDTEXT"
-    }
-
-    echo "say ENTER - boot local hard disk"
-    echo "say --------------------------------------------------------------------------------"
-    echo "$VERSION_INFO" >$BOOT_DIR/message
-    echo "display message"
-    echo "F1 message"
-
-    cp $v $(get_template "rear.help") "$BOOT_DIR/rear.help" >&2
-    echo "F2 rear.help"
-    echo "say F2 - Show help"
-    syslinux_menu "TABMSG Press [Tab] to edit, [F2] for help, [F1] for version info"
-
-    echo "timeout ${ISO_SYSLINUX_TIMEOUT:-$(( $USER_INPUT_TIMEOUT * 10 ))}"
-    syslinux_menu title $PRODUCT v$VERSION
-
-    echo "say rear - Recover $HOSTNAME"
-    echo "label rear"
-    syslinux_menu "label ^Recover $HOSTNAME"
-    syslinux_menu_help "Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)" \
-            "${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}"
-    echo "kernel kernel"
-    echo "append initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE"
-    if [ "$ISO_DEFAULT" == "manual" ] ; then
-        echo "default rear"
-        syslinux_menu "default"
-    fi
-    echo ""
-
-    echo "say rear - Recover $HOSTNAME"
-    echo "label rear-automatic"
-    syslinux_menu "label ^Automatic Recover $HOSTNAME"
-    syslinux_menu_help "Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)" \
-            "${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}"
-    echo "kernel kernel"
-    echo "append initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover $ISO_RECOVER_MODE"
-
-    if [ "$ISO_DEFAULT" == "automatic" ] ; then
-        echo "default rear-automatic"
-        syslinux_menu "default"
-        echo "timeout 50"
-    fi
-    echo ""
-
-    syslinux_menu separator
-    echo "label -"
-    syslinux_menu "label Other actions"
-    syslinux_menu "disable"
-    echo ""
-
-    echo "label help"
-    syslinux_menu "label ^Help for $PRODUCT"
-    syslinux_menu_help "More information about Relax-and-Recover and the steps for recovering your system"
-    syslinux_menu "help rear.help"
-
-    echo "say boothd0 - boot first local disk"
-    echo "label boothd0"
-    syslinux_menu "label Boot First ^Local disk (hd0)"
-    if [[ "$flavour" == "isolinux" ]] && [ "$ISO_DEFAULT" == "boothd" ] ; then
-        # for isolinux local boot means boot from first disk
-        echo "default boothd0"
-        syslinux_menu "default"
-    fi
-    if test "boothd0" = "$ISO_DEFAULT" ; then
-        # the user has explicitly specified to boot via boothd0 by default
-        echo "default boothd0"
-        syslinux_menu "default"
-    fi
-    echo "kernel chain.c32"
-    echo "append hd0"
-    echo ""
-
-    echo "say boothd1 - boot second local disk"
-    echo "label boothd1"
-    syslinux_menu "label Boot ^Second Local disk (hd1)"
-    if [[ "$flavour" == "extlinux" ]] && [ "$ISO_DEFAULT" == "boothd" ]; then
-        # for extlinux local boot means boot from second disk because the boot disk became the first disk
-        # which usually allows us to access the original first disk as second disk
-        echo "default boothd1"
-        syslinux_menu "default"
-    fi
-    if test "boothd1" = "$ISO_DEFAULT" ; then
-        # the user has explicitly specified to boot via boothd1 by default
-        echo "default boothd1"
-        syslinux_menu "default"
-    fi
-    echo "kernel chain.c32"
-    echo "append hd1"
-    echo ""
-
-    echo "say local - Boot from next boot device"
-    echo "label local"
-    syslinux_menu "label Boot ^Next device"
-    syslinux_menu_help "Boot from the next device in the BIOS boot order list."
-    echo "localboot -1"
-    echo ""
-
-    echo "say hdt - Hardware Detection Tool"
-    echo "label hdt"
-    syslinux_menu "label ^Hardware Detection Tool"
-    syslinux_menu_help "Information about your current hardware configuration"
-    echo "kernel hdt.c32"
-    echo ""
-
+    # Optionally add memtest
     # You need the memtest86+ package installed for this to work
-    MEMTEST_BIN=$(find /boot -xdev -name 'memtest86+*' 2>/dev/null | tail -1)
-    if [[ -r "$MEMTEST_BIN" ]]; then
-        cp $v "$MEMTEST_BIN" "$BOOT_DIR/memtest" >&2
-        echo "memtest - Run memtest86+"
-        echo "label memtest"
-        syslinux_menu "label ^Memory test"
-        syslinux_menu_help "Test your memory for problems with memtest86+"
-        echo "kernel memtest"
-        echo "append -"
-        echo ""
+    local memtest_bin=$(find /boot -xdev -name 'memtest86+*' 2>/dev/null | tail -1)
+    if [[ -r "$memtest_bin" ]]; then
+        cp $v "$memtest_bin" "$BOOT_DIR/memtest" >&2
     fi
 
-    echo "say reboot - Reboot the system"
-    echo "label reboot"
-    syslinux_menu "label Re^Boot system"
-    syslinux_menu_help "Reboot the system now"
-    echo "kernel reboot.c32"
-    echo ""
+    # Add help and version info
+    cp $v $(get_template "rear.help") "$BOOT_DIR/rear.help" >&2
+    echo "$VERSION_INFO" >$BOOT_DIR/message
 
-    echo "say poweroff - Poweroff the system"
-    echo "label poweroff"
-    syslinux_menu "label ^Power off system"
-    syslinux_menu_help "Power off the system now"
-    echo "kernel $(basename "$poweroff_prog")"
-    echo ""
+    # Generate config
+    cat <<EOF
+UI menu.c32
+
+TIMEOUT ${ISO_SYSLINUX_TIMEOUT:-$(( USER_INPUT_TIMEOUT * 10 ))}
+
+SAY ENTER - boot local hard disk
+SAY --------------------------------------------------------------------------------
+DISPLAY message
+F1 message
+
+F2 rear.help
+SAY F2 - Show help
+
+MENU TABMSG Press [Tab] to edit, [F2] for help, [F1] for version info
+MENU TITLE $PRODUCT v$VERSION
+
+SAY rear - Recover $HOSTNAME
+LABEL rear
+    MENU LABEL ^Recover $HOSTNAME
+    TEXT HELP
+        Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)
+        ${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}
+    ENDTEXT
+    KERNEL kernel
+    APPEND initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE
+
+SAY rear-automatic - Automatic Recover $HOSTNAME
+LABEL rear-automatic
+    MENU LABEL ^Automatic Recover $HOSTNAME
+    TEXT HELP
+        Rescue image kernel $KERNEL_VERSION ${IPADDR:+on $IPADDR} $(date -R)
+        ${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}
+    ENDTEXT
+    KERNEL kernel
+    APPEND initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover $ISO_RECOVER_MODE
+
+MENU SEPARATOR
+LABEL -
+    MENU LABEL Other actions
+    MENU DISABLE
+
+LABEL help
+    MENU LABEL ^Help for $PRODUCT
+    TEXT HELP
+        More information about Relax-and-Recover and the steps
+        for recovering your system
+    ENDTEXT
+    MENU HELP rear.help
+
+SAY boothd0 - boot first local disk
+LABEL boothd0
+    MENU LABEL Boot First ^Local disk (hd0)
+    KERNEL chain.c32
+    APPEND hd0
+
+SAY boothd1 - boot second local disk
+LABEL boothd1
+    MENU LABEL Boot ^Second Local disk (hd1)
+    KERNEL chain.c32
+    APPEND hd1
+
+SAY local - Boot from next boot device
+LABEL local
+    MENU LABEL Boot ^Next device
+    TEXT HELP
+        Boot from the next device in the BIOS boot order list.
+    ENDTEXT
+    LOCALBOOT -1
+
+SAY hdt - Hardware Detection Tool
+LABEL hdt
+    MENU LABEL ^Hardware Detection Tool
+    TEXT HELP
+        Information about your current hardware configuration
+    ENDTEXT
+    KERNEL hdt.c32
+EOF
+
+    if [[ -r "$memtest_bin" ]]; then
+        cat <<EOF
+SAY memtest - Run memtest86+
+LABEL memtest
+    MENU LABEL ^Memory test
+    TEXT HELP
+        Test your memory for problems with memtest86+
+    ENDTEXT
+    KERNEL memtest
+EOF
+    fi
+
+    cat <<EOF
+SAY reboot - Reboot the system
+LABEL reboot
+    MENU LABEL Re^Boot system
+    TEXT HELP
+        Reboot the system now
+    ENDTEXT
+    KERNEL reboot.c32
+
+SAY poweroff - Poweroff the system
+LABEL poweroff
+    MENU LABEL ^Power off system
+    TEXT HELP
+        Power off the system now
+    ENDTEXT
+    KERNEL $poweroff_prog
+EOF
+
+    case "$ISO_DEFAULT" in
+        "manual")
+            echo "DEFAULT rear" ;;
+        "automatic")
+            echo "DEFAULT rear-automatic"
+            echo "TIMEOUT 50" ;;
+        "boothd")
+            # for isolinux local boot means boot from first disk
+            [[ "$flavour" == "isolinux" ]] && echo "DEFAULT boothd0"
+            # for extlinux local boot means boot from second disk because the boot disk became the first disk
+            # which usually allows us to access the original first disk as second disk
+            [[ "$flavour" == "extlinux" ]] && echo "DEFAULT boothd1"
+            ;;
+        "boothd0")
+            echo "DEFAULT boothd0" ;;
+        "boothd1")
+            echo "DEFAULT boothd1" ;;
+    esac
 }
 
 # Create configuration file for elilo

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -98,8 +98,8 @@ function set_syslinux_features {
     # true if syslinux supports modules sub-dir (Version > 5.00)
     FEATURE_SYSLINUX_MODULES=
 
-    # If ISO_DEFAULT is not set or empty or only blanks, set it to default 'boothd'
-    test $ISO_DEFAULT || ISO_DEFAULT="boothd"
+    # If ISO_RECOVER_MODE is not set or empty or only blanks, set it to default 'boothd'
+    test $ISO_RECOVER_MODE || ISO_RECOVER_MODE="boothd"
     # Define the syslinux directory for later usage (since version 5 the bins and c32 are in separate dirs)
     if [[ -z "$SYSLINUX_DIR" ]]; then
         ISOLINUX_BIN=$(find_syslinux_file isolinux.bin)
@@ -270,7 +270,7 @@ LABEL rear-automatic
         ${BACKUP:+BACKUP=$BACKUP} ${OUTPUT:+OUTPUT=$OUTPUT} ${BACKUP_URL:+BACKUP_URL=$BACKUP_URL}
     ENDTEXT
     KERNEL kernel
-    APPEND initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover $ISO_RECOVER_MODE
+    APPEND initrd=$REAR_INITRD_FILENAME root=/dev/ram0 vga=normal rw $KERNEL_CMDLINE auto_recover $([ "$ISO_RECOVER_MODE" = "unattended" ] && echo "unattended")
 
 MENU SEPARATOR
 LABEL -
@@ -344,10 +344,10 @@ LABEL poweroff
     KERNEL $poweroff_prog
 EOF
 
-    case "$ISO_DEFAULT" in
+    case "$ISO_RECOVER_MODE" in
         "manual")
             echo "DEFAULT rear" ;;
-        "automatic")
+        "automatic"|"unattended")
             echo "DEFAULT rear-automatic"
             echo "TIMEOUT 50" ;;
         "boothd")

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -220,14 +220,10 @@ function make_syslinux_config {
     echo "display message"
     echo "F1 message"
 
-    if [[ -s $(get_template "rear.help") ]]; then
-        cp $v $(get_template "rear.help") "$BOOT_DIR/rear.help" >&2
-        echo "F2 rear.help"
-        echo "say F2 - Show help"
-        syslinux_menu "TABMSG Press [Tab] to edit, [F2] for help, [F1] for version info"
-    else
-        syslinux_menu "TABMSG Press [Tab] to edit options and [F1] for version info"
-    fi
+    cp $v $(get_template "rear.help") "$BOOT_DIR/rear.help" >&2
+    echo "F2 rear.help"
+    echo "say F2 - Show help"
+    syslinux_menu "TABMSG Press [Tab] to edit, [F2] for help, [F1] for version info"
 
     echo "timeout ${ISO_SYSLINUX_TIMEOUT:-$(( $USER_INPUT_TIMEOUT * 10 ))}"
     echo "#noescape 1"
@@ -267,12 +263,10 @@ function make_syslinux_config {
     syslinux_menu "disable"
     echo ""
 
-    if [[ -r $(get_template "rear.help") ]]; then
-        echo "label help"
-        syslinux_menu "label ^Help for $PRODUCT"
-        syslinux_menu_help "More information about Relax-and-Recover and the steps for recovering your system"
-        syslinux_menu "help rear.help"
-    fi
+    echo "label help"
+    syslinux_menu "label ^Help for $PRODUCT"
+    syslinux_menu_help "More information about Relax-and-Recover and the steps for recovering your system"
+    syslinux_menu "help rear.help"
 
     # Use chain booting for booting disk, if chain.c32 is available
     if [[ -r "$SYSLINUX_DIR/chain.c32" ]]; then

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -337,12 +337,9 @@ function make_syslinux_config {
     echo "kernel hdt.c32"
     echo ""
 
-    # Because usr/sbin/rear sets 'shopt -s nullglob' the 'ls' command will list all files
-    # in the current working directory if nothing matches the globbing pattern '/boot/memtest86+-*'
-    # which results '.' in MEMTEST_BIN (the plain 'ls -d' output in the current working directory).
     # You need the memtest86+ package installed for this to work
-    MEMTEST_BIN=$(ls -d /boot/memtest86+-* 2>/dev/null | tail -1)
-    if [[ "$MEMTEST_BIN" != "." && -r "$MEMTEST_BIN" ]]; then
+    MEMTEST_BIN=$(find /boot -xdev -name 'memtest86+*' 2>/dev/null | tail -1)
+    if [[ -r "$MEMTEST_BIN" ]]; then
         cp $v "$MEMTEST_BIN" "$BOOT_DIR/memtest" >&2
         echo "memtest - Run memtest86+"
         echo "label memtest"

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -136,6 +136,7 @@ function make_syslinux_config {
 
     local BOOT_DIR="$1" ; shift
     local flavour="${1:-isolinux}" ; shift
+    local syslinux_version=$(get_syslinux_version)
     # syslinux v5 and higher has now its modules in a separate directory structure
     local syslinux_modules_dir=
 
@@ -191,22 +192,41 @@ function make_syslinux_config {
             done
         fi
     fi
-    
-    # if we have the menu.c32 available we use it
-    # if not we make sure that there will be no menu lines in the result
-    # so that we don't confuse older syslinux
-    if [[ -r "$SYSLINUX_DIR/menu.c32" ]] ; then
-        cp $v "$SYSLINUX_DIR/menu.c32" "$BOOT_DIR/menu.c32" >&2
-        function syslinux_menu {
-            echo "MENU $@"
-        }
-    else
-        # without menu we don't set a default but we ask syslinux to prompt for user input
-        echo "prompt 1"
-        function syslinux_menu {
-            : #noop
-        }
+
+    # Add necessary modules
+    cp $v "$SYSLINUX_DIR/chain.c32" "$BOOT_DIR/chain.c32" >&2
+    cp $v "$SYSLINUX_DIR/hdt.c32" "$BOOT_DIR/hdt.c32" >&2
+    cp $v "$SYSLINUX_DIR/menu.c32" "$BOOT_DIR/menu.c32" >&2
+    cp $v "$SYSLINUX_DIR/reboot.c32" "$BOOT_DIR/reboot.c32" >&2
+
+    # poweroff.c32 was added in 5.10
+    # https://wiki.syslinux.org/wiki/index.php?title=Syslinux_5_Changelog
+    local poweroff_prog="poweroff.com"
+    version_newer "$syslinux_version" 5.10 && poweroff_prog="poweroff.c32"
+    cp $v "$SYSLINUX_DIR/$poweroff_prog" "$BOOT_DIR/" >&2
+
+    # Add needed libraries for syslinux v5 and hdt
+    if version_newer "$syslinux_version" 5.00; then
+        cp $v "$SYSLINUX_DIR/ldlinux.c32" "$BOOT_DIR/ldlinux.c32" >&2
+        cp $v "$SYSLINUX_DIR/libcom32.c32" "$BOOT_DIR/libcom32.c32" >&2
+        cp $v "$SYSLINUX_DIR/libgpl.c32" "$BOOT_DIR/libgpl.c32" >&2
+        cp $v "$SYSLINUX_DIR/libmenu.c32" "$BOOT_DIR/libmenu.c32" >&2
+        cp $v "$SYSLINUX_DIR/libutil.c32" "$BOOT_DIR/libutil.c32" >&2
     fi
+
+    # Add resources for HDT
+    if [[ -r "/usr/share/hwdata/pci.ids" ]]; then
+        cp $v "/usr/share/hwdata/pci.ids" "$BOOT_DIR/pci.ids" >&2
+    elif [[ -r "/usr/share/pci.ids" ]]; then
+        cp $v "/usr/share/pci.ids" "$BOOT_DIR/pci.ids" >&2
+    fi
+    if [[ -r "/lib/modules/$KERNEL_VERSION/modules.pcimap" ]]; then
+        cp $v "/lib/modules/$KERNEL_VERSION/modules.pcimap" "$BOOT_DIR/modules.pcimap" >&2
+    fi
+
+    function syslinux_menu {
+        echo "MENU $@"
+    }
 
     function syslinux_menu_help {
         echo "TEXT HELP"
@@ -268,72 +288,40 @@ function make_syslinux_config {
     syslinux_menu_help "More information about Relax-and-Recover and the steps for recovering your system"
     syslinux_menu "help rear.help"
 
-    # Use chain booting for booting disk, if chain.c32 is available
-    if [[ -r "$SYSLINUX_DIR/chain.c32" ]]; then
-        cp $v "$SYSLINUX_DIR/chain.c32" "$BOOT_DIR/chain.c32" >&2
-
-        echo "say boothd0 - boot first local disk"
-        echo "label boothd0"
-        syslinux_menu "label Boot First ^Local disk (hd0)"
-        if [[ "$flavour" == "isolinux" ]] && [ "$ISO_DEFAULT" == "boothd" ] ; then
-            # for isolinux local boot means boot from first disk
-            echo "default boothd0"
-            syslinux_menu "default"
-        fi
-        if test "boothd0" = "$ISO_DEFAULT" ; then
-            # the user has explicitly specified to boot via boothd0 by default
-            echo "default boothd0"
-            syslinux_menu "default"
-        fi
-        echo "kernel chain.c32"
-        echo "append hd0"
-        echo ""
-
-        echo "say boothd1 - boot second local disk"
-        echo "label boothd1"
-        syslinux_menu "label Boot ^Second Local disk (hd1)"
-        if [[ "$flavour" == "extlinux" ]] && [ "$ISO_DEFAULT" == "boothd" ]; then
-            # for extlinux local boot means boot from second disk because the boot disk became the first disk
-            # which usually allows us to access the original first disk as second disk
-            echo "default boothd1"
-            syslinux_menu "default"
-        fi
-        if test "boothd1" = "$ISO_DEFAULT" ; then
-            # the user has explicitly specified to boot via boothd1 by default
-            echo "default boothd1"
-            syslinux_menu "default"
-        fi
-        echo "kernel chain.c32"
-        echo "append hd1"
-        echo ""
-
+    echo "say boothd0 - boot first local disk"
+    echo "label boothd0"
+    syslinux_menu "label Boot First ^Local disk (hd0)"
+    if [[ "$flavour" == "isolinux" ]] && [ "$ISO_DEFAULT" == "boothd" ] ; then
+        # for isolinux local boot means boot from first disk
+        echo "default boothd0"
+        syslinux_menu "default"
     fi
-
-    if [[ ! -r "$SYSLINUX_DIR/chain.c32" ]]; then
-        # this should be above under the if chain.c32 section but it comes here because it will work only if localboot is supported
-        # if you use old extlinux then you cannot boot from other device unless chain.c32 is available :-(
-        echo "say boot80 - Boot from first BIOS disk 0x80"
-        echo "label boot80"
-        syslinux_menu "label Boot First ^Local BIOS disk (0x80)"
-        if [[ "$flavour" == "isolinux" ]]; then
-            # for isolinux local boot means boot from first disk
-            echo "default boot80"
-            syslinux_menu default
-        fi
-        echo "localboot 0x80"
-        echo
-        echo "say boot81 - Boot from second BIOS disk 0x81"
-        echo "label boot81"
-        syslinux_menu "label Boot Second ^Local BIOS disk (0x81)"
-        if [[ "$flavour" == "extlinux" ]]; then
-            # for extlinux local boot means boot from second disk because the boot disk became the first disk
-            # which usually allows us to access the original first disk as second disk
-            echo "default boot81"
-            syslinux_menu default
-        fi
-        echo "localboot 0x81"
-        echo ""
+    if test "boothd0" = "$ISO_DEFAULT" ; then
+        # the user has explicitly specified to boot via boothd0 by default
+        echo "default boothd0"
+        syslinux_menu "default"
     fi
+    echo "kernel chain.c32"
+    echo "append hd0"
+    echo ""
+
+    echo "say boothd1 - boot second local disk"
+    echo "label boothd1"
+    syslinux_menu "label Boot ^Second Local disk (hd1)"
+    if [[ "$flavour" == "extlinux" ]] && [ "$ISO_DEFAULT" == "boothd" ]; then
+        # for extlinux local boot means boot from second disk because the boot disk became the first disk
+        # which usually allows us to access the original first disk as second disk
+        echo "default boothd1"
+        syslinux_menu "default"
+    fi
+    if test "boothd1" = "$ISO_DEFAULT" ; then
+        # the user has explicitly specified to boot via boothd1 by default
+        echo "default boothd1"
+        syslinux_menu "default"
+    fi
+    echo "kernel chain.c32"
+    echo "append hd1"
+    echo ""
 
     echo "say local - Boot from next boot device"
     echo "label local"
@@ -347,43 +335,12 @@ function make_syslinux_config {
     fi
     echo ""
 
-    # Add needed libraries for syslinux v5 and hdt
-    if [[ -r "$SYSLINUX_DIR/ldlinux.c32" ]]; then
-        cp $v "$SYSLINUX_DIR/ldlinux.c32" "$BOOT_DIR/ldlinux.c32" >&2
-    fi
-    if [[ -r "$SYSLINUX_DIR/libcom32.c32" ]]; then
-        cp $v "$SYSLINUX_DIR/libcom32.c32" "$BOOT_DIR/libcom32.c32" >&2
-    fi
-    if [[ -r "$SYSLINUX_DIR/libgpl.c32" ]]; then
-        cp $v "$SYSLINUX_DIR/libgpl.c32" "$BOOT_DIR/libgpl.c32" >&2
-    fi
-    if [[ -r "$SYSLINUX_DIR/libmenu.c32" ]]; then
-        cp $v "$SYSLINUX_DIR/libmenu.c32" "$BOOT_DIR/libmenu.c32" >&2
-    fi
-    if [[ -r "$SYSLINUX_DIR/libutil.c32" ]]; then
-        cp $v "$SYSLINUX_DIR/libutil.c32" "$BOOT_DIR/libutil.c32" >&2
-    fi
-    if [[ -r "$SYSLINUX_DIR/vesamenu.c32" ]]; then
-        cp $v "$SYSLINUX_DIR/vesamenu.c32" "$BOOT_DIR/vesamenu.c32" >&2
-    fi
-
-    if [[ -r "$SYSLINUX_DIR/hdt.c32" ]]; then
-        cp $v "$SYSLINUX_DIR/hdt.c32" "$BOOT_DIR/hdt.c32" >&2
-        if [[ -r "/usr/share/hwdata/pci.ids" ]]; then
-            cp $v "/usr/share/hwdata/pci.ids" "$BOOT_DIR/pci.ids" >&2
-        elif [[ -r "/usr/share/pci.ids" ]]; then
-            cp $v "/usr/share/pci.ids" "$BOOT_DIR/pci.ids" >&2
-        fi
-        if [[ -r "/lib/modules/$KERNEL_VERSION/modules.pcimap" ]]; then
-            cp $v "/lib/modules/$KERNEL_VERSION/modules.pcimap" "$BOOT_DIR/modules.pcimap" >&2
-        fi
-        echo "say hdt - Hardware Detection Tool"
-        echo "label hdt"
-        syslinux_menu "label ^Hardware Detection Tool"
-        syslinux_menu_help "Information about your current hardware configuration"
-        echo "kernel hdt.c32"
-        echo ""
-    fi
+    echo "say hdt - Hardware Detection Tool"
+    echo "label hdt"
+    syslinux_menu "label ^Hardware Detection Tool"
+    syslinux_menu_help "Information about your current hardware configuration"
+    echo "kernel hdt.c32"
+    echo ""
 
     # Because usr/sbin/rear sets 'shopt -s nullglob' the 'ls' command will list all files
     # in the current working directory if nothing matches the globbing pattern '/boot/memtest86+-*'
@@ -401,36 +358,21 @@ function make_syslinux_config {
         echo ""
     fi
 
-    if [[ -r "$SYSLINUX_DIR/reboot.c32" ]] ; then
-        cp $v "$SYSLINUX_DIR/reboot.c32" "$BOOT_DIR/reboot.c32" >&2
-        echo "say reboot - Reboot the system"
-        echo "label reboot"
-        syslinux_menu "label Re^Boot system"
-        syslinux_menu_help "Reboot the system now"
-        echo "kernel reboot.c32"
-        echo ""
-    fi
+    echo "say reboot - Reboot the system"
+    echo "label reboot"
+    syslinux_menu "label Re^Boot system"
+    syslinux_menu_help "Reboot the system now"
+    echo "kernel reboot.c32"
+    echo ""
 
-    local prog=
-    if [[ -r "$SYSLINUX_DIR/poweroff.com" ]] ; then
-        prog="$SYSLINUX_DIR/poweroff.com"
-    elif [[ -r "$SYSLINUX_DIR/poweroff.c32" ]] ; then
-        prog="$SYSLINUX_DIR/poweroff.c32"
-    fi
+    echo "say poweroff - Poweroff the system"
+    echo "label poweroff"
+    syslinux_menu "label ^Power off system"
+    syslinux_menu_help "Power off the system now"
+    echo "kernel $(basename "$poweroff_prog")"
+    echo ""
 
-    if [[ -n "$prog" ]] ; then
-        cp $v "$prog" "$BOOT_DIR/" >&2
-        echo "say poweroff - Poweroff the system"
-        echo "label poweroff"
-        syslinux_menu "label ^Power off system"
-        syslinux_menu_help "Power off the system now"
-        echo "kernel $(basename "$prog")"
-        echo ""
-    fi
-
-    if [[ -r "$SYSLINUX_DIR/menu.c32" ]]; then
-        echo "default menu.c32"
-    fi
+    echo "default menu.c32"
 }
 
 # Create configuration file for elilo

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -13,7 +13,7 @@ function get_syslinux_version {
     fi
 
     if [[ -z "$syslinux_version" ]]; then
-        Log "Could not detect syslinux version, assuming it is old"
+        Log "Could not detect syslinux version, assuming it is at least 4.04"
     fi
 
     echo "$syslinux_version"
@@ -60,7 +60,7 @@ function find_syslinux_modules_dir {
             # cf. https://github.com/rear/rear/issues/2792
             # tell the user in debug mode what is going on
             DebugPrint "Searching whole /usr for SYSLINUX modules directory (you may specify SYSLINUX_MODULES_DIR)"
-	    # issue #3350 - adding -xdev to find to avoid hanging NFS
+            # issue #3350 - adding -xdev to find to avoid hanging NFS
             file=$( find /usr -xdev -name "$1" 2>/dev/null | tail -1 )
             syslinux_modules_dir=$( dirname "$file" )        # /usr/lib/syslinux/modules/efi32
             syslinux_modules_dir=${syslinux_modules_dir%/*}  # /usr/lib/syslinux/modules
@@ -95,30 +95,9 @@ function find_yaboot_file {
 
 function set_syslinux_features {
     # Test for features in syslinux
-    # true if isolinux supports booting from /boot/syslinux, /boot or only from / of the ISO
-    FEATURE_ISOLINUX_BOOT_SYSLINUX=
-    # true if syslinux supports booting from /boot/syslinux, /boot or only from / of the USB media
-    FEATURE_SYSLINUX_BOOT_SYSLINUX=
-    # true if syslinux and extlinux support localboot
-    FEATURE_SYSLINUX_EXTLINUX_WITH_LOCALBOOT=
-    # true if extlinux supports the -i option
-    FEATURE_SYSLINUX_EXTLINUX_INSTALL=
-    # true if syslinux supports INCLUDE directive
-    FEATURE_SYSLINUX_INCLUDE=
-    # true if syslinux supports advanced label names (eg. linux-2.6.18)
-    FEATURE_SYSLINUX_LABEL_NAMES=
-    # true if syslinux supports MENU DEFAULT directive
-    FEATURE_SYSLINUX_MENU_DEFAULT=
-    # true if syslinux supports MENU HELP directive
-    FEATURE_SYSLINUX_MENU_HELP=
-    # true if syslinux supports MENU BEGIN/MENU END/MENU QUIT directives
-    FEATURE_SYSLINUX_SUBMENU=
-    # true if syslinux supports MENU HIDDEN directive
-    FEATURE_SYSLINUX_MENU_HIDDEN=
-    # true if syslinux supports TEXT HELP directive
-    FEATURE_SYSLINUX_TEXT_HELP=
     # true if syslinux supports modules sub-dir (Version > 5.00)
     FEATURE_SYSLINUX_MODULES=
+
     # If ISO_DEFAULT is not set or empty or only blanks, set it to default 'boothd'
     test $ISO_DEFAULT || ISO_DEFAULT="boothd"
     # Define the syslinux directory for later usage (since version 5 the bins and c32 are in separate dirs)
@@ -137,43 +116,11 @@ function set_syslinux_features {
     fi
     Log "Features based on syslinux version: $syslinux_version"
 
-    if version_newer "$syslinux_version" 4.00; then
-        FEATURE_SYSLINUX_MENU_HELP="y"
-        FEATURE_ISOLINUX_BOOT_SYSLINUX="y"
-    fi
-    if version_newer "$syslinux_version" 3.72; then
-        FEATURE_SYSLINUX_MENU_DEFAULT="y"
-    fi
-    if version_newer "$syslinux_version" 3.70; then
-        FEATURE_SYSLINUX_EXTLINUX_WITH_LOCALBOOT="y"
-    fi
-    if version_newer "$syslinux_version" 3.62; then
-        FEATURE_SYSLINUX_SUBMENU="y"
-    fi
-    if version_newer "$syslinux_version" 3.52; then
-        FEATURE_SYSLINUX_MENU_HIDDEN="y"
-    fi
-    if version_newer "$syslinux_version" 3.50; then
-        FEATURE_SYSLINUX_INCLUDE="y"
-        FEATURE_SYSLINUX_TEXT_HELP="y"
-    fi
-    if version_newer "$syslinux_version" 3.35; then
-        FEATURE_SYSLINUX_BOOT_SYSLINUX="y"
-        FEATURE_SYSLINUX_LABEL_NAMES="y"
-    fi
-    if version_newer "$syslinux_version" 3.20; then
-        FEATURE_SYSLINUX_EXTLINUX_INSTALL="y"
-    fi
-
     if version_newer "$syslinux_version" 5.00; then
         FEATURE_SYSLINUX_MODULES="y"
     fi
 
-    if [[ "$FEATURE_SYSLINUX_BOOT_SYSLINUX" ]]; then
-        SYSLINUX_PREFIX="boot/syslinux"
-    else
-        SYSLINUX_PREFIX=
-    fi
+    SYSLINUX_PREFIX="boot/syslinux"
     Log "Using syslinux prefix: $SYSLINUX_PREFIX"
 
     FEATURE_SYSLINUX_IS_SET=1
@@ -262,11 +209,9 @@ function make_syslinux_config {
     fi
 
     function syslinux_menu_help {
-        if [[ "$FEATURE_SYSLINUX_MENU_HELP" ]]; then
-            echo "TEXT HELP"
-            for line in "$@" ; do echo "$line" ; done
-            echo "ENDTEXT"
-        fi
+        echo "TEXT HELP"
+        for line in "$@" ; do echo "$line" ; done
+        echo "ENDTEXT"
     }
 
     echo "say ENTER - boot local hard disk"
@@ -322,7 +267,7 @@ function make_syslinux_config {
     syslinux_menu "disable"
     echo ""
 
-    if [[ "$FEATURE_SYSLINUX_MENU_HELP" && -r $(get_template "rear.help") ]]; then
+    if [[ -r $(get_template "rear.help") ]]; then
         echo "label help"
         syslinux_menu "label ^Help for $PRODUCT"
         syslinux_menu_help "More information about Relax-and-Recover and the steps for recovering your system"
@@ -370,48 +315,43 @@ function make_syslinux_config {
 
     fi
 
-    if [[ "$flavour" != "extlinux" || "$FEATURE_SYSLINUX_EXTLINUX_WITH_LOCALBOOT" ]]; then
-        # localboot is a isolinux and pxelinux feature only, see http://syslinux.zytor.com/wiki/index.php/SYSLINUX#LOCALBOOT_type_.5BISOLINUX.2C_PXELINUX.5D
-        # but extlinux >= 3.70 actually also supports localboot, see http://syslinux.zytor.com/wiki/index.php/Syslinux_3_Changelog#Changes_in_3.70
-
-        if [[ ! -r "$SYSLINUX_DIR/chain.c32" ]]; then
-            # this should be above under the if chain.c32 section but it comes here because it will work only if localboot is supported
-            # if you use old extlinux then you cannot boot from other device unless chain.c32 is available :-(
-            echo "say boot80 - Boot from first BIOS disk 0x80"
-            echo "label boot80"
-            syslinux_menu "label Boot First ^Local BIOS disk (0x80)"
-            if [[ "$flavour" == "isolinux" ]]; then
-                # for isolinux local boot means boot from first disk
-                echo "default boot80"
-                syslinux_menu default
-            fi
-            echo "localboot 0x80"
-            echo
-            echo "say boot81 - Boot from second BIOS disk 0x81"
-            echo "label boot81"
-            syslinux_menu "label Boot Second ^Local BIOS disk (0x81)"
-            if [[ "$flavour" == "extlinux" ]]; then
-                # for extlinux local boot means boot from second disk because the boot disk became the first disk
-                # which usually allows us to access the original first disk as second disk
-                echo "default boot81"
-                syslinux_menu default
-            fi
-            echo "localboot 0x81"
-            echo ""
+    if [[ ! -r "$SYSLINUX_DIR/chain.c32" ]]; then
+        # this should be above under the if chain.c32 section but it comes here because it will work only if localboot is supported
+        # if you use old extlinux then you cannot boot from other device unless chain.c32 is available :-(
+        echo "say boot80 - Boot from first BIOS disk 0x80"
+        echo "label boot80"
+        syslinux_menu "label Boot First ^Local BIOS disk (0x80)"
+        if [[ "$flavour" == "isolinux" ]]; then
+            # for isolinux local boot means boot from first disk
+            echo "default boot80"
+            syslinux_menu default
         fi
-
-        echo "say local - Boot from next boot device"
-        echo "label local"
-        syslinux_menu "label Boot ^Next device"
-        syslinux_menu_help "Boot from the next device in the BIOS boot order list."
-        if [[ "$flavour" == "pxelinux" ]]; then
-            echo "localboot 0"
-        else
-            # iso/extlinux support -1 for try next boot device
-            echo "localboot -1"
+        echo "localboot 0x80"
+        echo
+        echo "say boot81 - Boot from second BIOS disk 0x81"
+        echo "label boot81"
+        syslinux_menu "label Boot Second ^Local BIOS disk (0x81)"
+        if [[ "$flavour" == "extlinux" ]]; then
+            # for extlinux local boot means boot from second disk because the boot disk became the first disk
+            # which usually allows us to access the original first disk as second disk
+            echo "default boot81"
+            syslinux_menu default
         fi
+        echo "localboot 0x81"
         echo ""
     fi
+
+    echo "say local - Boot from next boot device"
+    echo "label local"
+    syslinux_menu "label Boot ^Next device"
+    syslinux_menu_help "Boot from the next device in the BIOS boot order list."
+    if [[ "$flavour" == "pxelinux" ]]; then
+        echo "localboot 0"
+    else
+        # iso/extlinux support -1 for try next boot device
+        echo "localboot -1"
+    fi
+    echo ""
 
     # Add needed libraries for syslinux v5 and hdt
     if [[ -r "$SYSLINUX_DIR/ldlinux.c32" ]]; then

--- a/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
+++ b/usr/share/rear/output/USB/Linux-i386/300_create_extlinux.sh
@@ -303,14 +303,12 @@ Log "Creating $SYSLINUX_PREFIX/extlinux.conf"
     syslinux_has "libmenu.c32"
     syslinux_has "libutil.c32"
 
-    if [ -r $(get_template "rear.help") ]; then
-        cp $v $(get_template "rear.help") "$BUILD_DIR/outputfs/$SYSLINUX_PREFIX/rear.help" >/dev/null
-        syslinux_write <<EOF
+    cp $v $(get_template "rear.help") "$BUILD_DIR/outputfs/$SYSLINUX_PREFIX/rear.help" >/dev/null
+    syslinux_write <<EOF
 say F1 - Show help
 F1 /boot/syslinux/rear.help
 menu tabmsg Press [Tab] to edit options or [F1] for help
 EOF
-    fi
 
     # Use menu system, if menu.c32 is available
     if syslinux_has "menu.c32"; then
@@ -341,8 +339,7 @@ label -
 
 EOF
 
-    if [[ -r $(get_template "rear.help") ]]; then
-        syslinux_write <<EOF
+    syslinux_write <<EOF
 label help
     menu label ^Help for Relax-and-Recover
     text help
@@ -351,7 +348,6 @@ Information about Relax-and-Recover and steps for recovering your system
     menu help rear.help
 
 EOF
-    fi
 
     # Use chain booting for booting disk, if chain.c32 is available
     if syslinux_has "chain.c32" ; then

--- a/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
+++ b/usr/share/rear/output/USB/Linux-i386/850_make_USB_bootable.sh
@@ -52,11 +52,7 @@ case "$usb_filesystem" in
     # See https://github.com/rear/rear/issues/2884
     # and https://github.com/rear/rear/pull/2904
     (ext?|vfat)
-        if [[ "$FEATURE_SYSLINUX_EXTLINUX_INSTALL" ]] ; then
-            extlinux -i "$BUILD_DIR/outputfs/$SYSLINUX_PREFIX" || Error "'extlinux -i $BUILD_DIR/outputfs/$SYSLINUX_PREFIX' failed"
-        else
-            extlinux "$BUILD_DIR/outputfs/$SYSLINUX_PREFIX" || Error "'extlinux $BUILD_DIR/outputfs/$SYSLINUX_PREFIX' failed"
-        fi
+        extlinux -i "$BUILD_DIR/outputfs/$SYSLINUX_PREFIX" || Error "'extlinux -i $BUILD_DIR/outputfs/$SYSLINUX_PREFIX' failed"
         ;;
     ("")
         LogPrintError "Could not find a filesystem in /proc/mounts for $BUILD_DIR/outputfs"

--- a/usr/share/rear/prep/ISO/default/310_check_iso_recover_mode.sh
+++ b/usr/share/rear/prep/ISO/default/310_check_iso_recover_mode.sh
@@ -1,0 +1,3 @@
+# Check for deprecated ISO configuration variables
+
+test "$ISO_DEFAULT" && Error "ISO_DEFAULT is no longer supported. Use ISO_RECOVER_MODE instead."

--- a/usr/share/rear/prep/USB/Linux-i386/340_find_mbr_bin.sh
+++ b/usr/share/rear/prep/USB/Linux-i386/340_find_mbr_bin.sh
@@ -1,6 +1,3 @@
-# The file mbr.bin is only added since syslinux 3.08
-# The extlinux -i option is only added since syslinux 3.20
-
 # Find out what the actual USB disk partition table type is
 # of the USB disk that is the parent device of the USB data partition
 # that is the value of the USB_DEVICE variable.
@@ -60,4 +57,4 @@ esac
 
 SYSLINUX_MBR_BIN=$( find_syslinux_file $mbr_image_file )
 
-test -s "$SYSLINUX_MBR_BIN" || Error "Could not find SYSLINUX MBR image file '$mbr_image_file' (at least SYSLINUX 3.08 is required, 4.x preferred)"
+test -s "$SYSLINUX_MBR_BIN" || Error "Could not find SYSLINUX MBR image file '$mbr_image_file'"


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Clean-up**

* Impact: **Normal**

* How was this pull request tested? Boot of `OUTPUT=ISO` in RHEL 7-10 and Fedora Rawhide.

* Description of the changes in this pull request:

    - drop support for syslinux <4.04 because 4.04 is the oldest release in distros supported by ReaR 2.9, see https://repology.org/project/syslinux/versions for details.
    - fix detection of memtest86 for isolinux on RHEL and Fedora
    - simplify the isolinux config generator

The plan is to merge the PXELINUX and EXTLINUX generators into `lib/bootloader-functions.sh` in subsequent pull requests as well.

At the moment, HDT entry is not bootable on RHEL8+ and Fedora but that is an issue not caused by these changes and is tracked in https://issues.redhat.com/browse/RHEL-114110.

(Note that I've used Claude Code to detect relevant code to be removed/changed.  However, all edits and commits were done solely by me.)