### PR TITLE
SourceStage() : Use 'sort -k 2 | uniq' instead of 'sort -k 2 -u'

### DIFF
--- a/usr/share/rear/lib/_framework-setup-and-functions.sh
+++ b/usr/share/rear/lib/_framework-setup-and-functions.sh
@@ -1878,7 +1878,7 @@ function SourceStage () {
     # In debug modes show what stage is run also on the user's terminal:
     test "$DEBUG" && Print "Running '$stage' stage ======================"
     # We always source scripts in the same subdirectory structure.
-    # All script in a single stage with a given number get executed before any script with a higher number.
+    # All scripts in a single stage with a given number get executed before any script with a higher number.
     # Within a single stage the order of scripts with same number should not matter.
     # The ls -d {...,...,...} within the $SHARE_DIR/$stage directory expands as intended.
     # The intent is to only list those scripts below the $SHARE_DIR/$stage directory


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: *High**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/3171
starting at
https://github.com/rear/rear/pull/3171#issuecomment-3581232814
also https://github.com/rear/rear/issues/3522#issuecomment-3590066618

* How was this pull request tested?
not yet tested

* Description of the changes in this pull request:

In the SourceStage function
use 'sort -k 2 | uniq' instead of 'sort -k 2 -u'
to avoid that scripts with same number_name
but under different paths get ignored.
