### PR TITLE
Renamed BindTo within systemd/system/serial-getty@.service into BindsTo

### DIFF
--- a/usr/share/rear/skel/default/usr/lib/systemd/system/serial-getty@.service
+++ b/usr/share/rear/skel/default/usr/lib/systemd/system/serial-getty@.service
@@ -2,7 +2,7 @@
 #
 [Unit]
 Description=Serial Getty on %I
-BindTo=dev-%i.device
+BindsTo=dev-%i.device
 After=dev-%i.device
 
 # We must wait for ReaR boot script to finish.


### PR DESCRIPTION
* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL): #3537 

* How was this pull request tested? By the end-user

* Description of the changes in this pull request: Systemd uses BindsTo directive. It obsoletes the old BindTo directive.

