### PR TITLE
Automatically include firmware files for the kernel modules in the recovery system

### DIFF
--- a/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
+++ b/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
@@ -228,7 +228,7 @@ for dummy in "once" ; do
         fi
         # $module_files can be empty because modinfo_filename outputs nothing in the builtin kernel "module" case:
         test "$module_files" || continue
-        COPY_MODULES+=( modinfo -F name $module_files )
+        COPY_MODULES+=( $( modinfo -F name $module_files ) )
         if ! cp $verbose -t $ROOTFS_DIR -L --preserve=all --parents $module_files 1>&2 ; then
             Error "Failed to copy '$module_files'"
         fi

--- a/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
+++ b/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
@@ -11,13 +11,15 @@ if is_false "$FIRMWARE_FILES" ; then
     return
 fi
 
-# The by default empty FIRMWARE_FILES array means that
-# usually all files in the /lib*/firmware/ directories
-# get included in the rescue/recovery system but on certain
-# architectures like ppc64 or ppc64le FIRMWARE_FILES could be set different
-# (cf. the conf/Linux-ppc64.conf and conf/Linux-ppc64le.conf scripts)
-# or FIRMWARE_FILES was specified by the user:
-test "${FIRMWARE_FILES[*]}" || FIRMWARE_FILES=( 'yes' )
+# COPY_MODULES=( all_modules ) is set when MODULES contains 'all_modules'
+# in the previous 400_copy_modules.sh script and then usually all firmware files
+# in the /lib*/firmware/ directories should get included in the rescue/recovery system:
+if IsInArray "all_modules" "${COPY_MODULES[@]}" ; then
+    # On certain architectures like ppc64 or ppc64le FIRMWARE_FILES could be set different
+    # (cf. the conf/Linux-ppc64.conf and conf/Linux-ppc64le.conf scripts)
+    # or FIRMWARE_FILES was specified by the user so do not overwrite that here:
+    test "${FIRMWARE_FILES[*]}" || FIRMWARE_FILES=( 'yes' )
+fi
 
 # The special value FIRMWARE_FILES=( 'yes' ) or any value that
 # is recognized as 'yes' by the is_true function enforces that
@@ -33,18 +35,47 @@ if is_true "$FIRMWARE_FILES" ; then
     return
 fi
 
-# Finally the more complicated case,
-# cf. "Return early, return often" in https://github.com/rear/rear/wiki/Coding-Style
-LogPrint "Copying files from /lib*/firmware/ that match ${FIRMWARE_FILES[@]}"
-for find_ipath_pattern in "${FIRMWARE_FILES[@]}" ; do
-    # No need to test if find_ipath_pattern is empty because 'find' does not find anything with empty '-ipath'.
-    # The 'cp --parents' does not copy empty directories which should not matter (a directory without a firmware file is useless) and
-    # it may report "cp: omitting directory ..." so that this particular stderr message is filtered out because it is meaningless here
-    # and 'cp -L' ensures that when during 'find -ipath' only a symbolic link name matches, the actual firmware file gets copied
-    # (note that 'find -L' would not work because it still outputs the symbolic link name).
-    # Ignore errors in this complicated case because it is in practice impossible to decide what errors should be fatal.
-    # For example when 'find' does not find anything for a find_ipath_pattern 'cp' fails with "cp: missing file operand"
-    # and 'grep -v foo' results exit code 1 if 'foo' is in all input lines (i.e. when 'grep -v' results no output):
-    find /lib*/firmware -ipath "$find_ipath_pattern" | xargs cp $verbose -t $ROOTFS_DIR -p -L --parents 2>&1 | grep -v 'omitting directory' 1>&2 || true
+# FIRMWARE_FILES is set but neither 'yes' nor 'no'
+# so the user has specified which FIRMWARE_FILES should be copied.
+# In this case copy exactly what the user has specified:
+if test "${FIRMWARE_FILES[*]}" ; then
+    LogPrint "Copying files from /lib*/firmware/ that match ${FIRMWARE_FILES[@]}"
+    for find_ipath_pattern in "${FIRMWARE_FILES[@]}" ; do
+        # No need to test if find_ipath_pattern is empty because 'find' does not find anything with empty '-ipath'.
+        # The 'cp --parents' does not copy empty directories which should not matter (a directory without a firmware file is useless) and
+        # it may report "cp: omitting directory ..." so that this particular stderr message is filtered out because it is meaningless here
+        # and 'cp -L' ensures that when during 'find -ipath' only a symbolic link name matches, the actual firmware file gets copied
+        # (note that 'find -L' would not work because it still outputs the symbolic link name).
+        # Ignore errors in this complicated case because it is in practice impossible to decide what errors should be fatal.
+        # For example when 'find' does not find anything for a find_ipath_pattern 'cp' fails with "cp: missing file operand"
+        # and 'grep -v foo' results exit code 1 if 'foo' is in all input lines (i.e. when 'grep -v' results no output):
+        find /lib*/firmware -ipath "$find_ipath_pattern" | xargs cp $verbose -t $ROOTFS_DIR -p -L --parents 2>&1 | grep -v 'omitting directory' 1>&2 || true
+    done
+    return
+fi
+
+# Finally the fallback case:
+# FIRMWARE_FILES is not specified and MODULES is not the default 'all_modules'
+# for example when MODULES=( 'loaded_modules' ) and FIRMWARE_FILES is empty.
+# COPY_MODULES contains the kernel module names of the modules
+# which should have been copied in the previous 400_copy_modules.sh script.
+# Automatically also copy the matching firmware files here, see
+# https://github.com/rear/rear/issues/3551
+LogPrint "Copying firmware files that belong to the copied kernel modules (FIRMWARE_FILES not specified)"
+firmware_partial_filenames=$( modinfo -k $KERNEL_VERSION -F firmware "${COPY_MODULES[@]}" )
+for firmware_partial_filename in $firmware_partial_filenames ; do
+    # For example the command "modinfo -F firmware amdgpu" may show
+    # amdgpu/cyan_skillfish_gpu_info.bin
+    # amdgpu/navi12_gpu_info.bin
+    # ...
+    # The actual firmware files could be none for amdgpu/cyan_skillfish_gpu_info.bin
+    # because firmware files which are listed by modinfo may not exist on the system
+    # and for amdgpu/navi12_gpu_info.bin the actual firmware files could be
+    # /lib/firmware/amdgpu/navi12_gpu_info.bin.xz
+    # so what is listed by modinfo is only a part of the actual firmware file
+    # without leading path and without suffix so we need to find the actual firmware file:
+    firmware_complete_filename=$( find /lib*/firmware -path "*$firmware_partial_filename*" )
+    test -r "$firmware_complete_filename" || continue
+    cp $verbose -t $ROOTFS_DIR -p -L --parents $firmware_complete_filename
 done
 

--- a/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
+++ b/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
@@ -11,6 +11,38 @@ if is_false "$FIRMWARE_FILES" ; then
     return
 fi
 
+# Firmware files for built-in kernel drivers should get copied into the recovery system if possible
+# (preconditions: /lib/modules/$KERNEL_VERSION/modules.builtin that newer kernels provide
+#  and a sufficiently new modinfo to query even builtin modules
+#  see https://github.com/rear/rear/pull/3553#issuecomment-4129123318)
+# except explicit user setting FIRMWARE_FILES=( 'no' ) forbids ReaR to copy firmware files
+# see https://github.com/rear/rear/pull/3553#issuecomment-5425860422
+LogPrint "Copying firmware files that belong to built-in kernel drivers"
+if test -r /lib/modules/$KERNEL_VERSION/modules.builtin ; then
+    for module_path in $( cat /lib/modules/$KERNEL_VERSION/modules.builtin ) ; do
+        module=$( basename $module_path | cut -s -d '.' -f1 )
+        # Here is a copy of the code (without the comment) of the place below
+        # when "Copying firmware files that belong to the copied kernel modules":
+        firmware_partial_filenames=$( modinfo -k $KERNEL_VERSION -F firmware "$module" ) || continue
+        for firmware_partial_filename in $firmware_partial_filenames ; do
+            firmware_complete_filenames=$( find /lib*/firmware -path "*$firmware_partial_filename*" )
+            if ! test "$firmware_complete_filenames" ; then
+                DebugPrint "No file in /lib*/firmware matching '$firmware_partial_filename' (reported by modinfo for '$module')"
+                continue
+            fi
+            for firmware_complete_filename in $firmware_complete_filenames ; do
+                if ! test -r "$firmware_complete_filename" ; then
+                    Debug "Cannot copy firmware file (cannot read $firmware_complete_filename)"
+                    continue
+                fi
+                cp $verbose -t $ROOTFS_DIR -p -L --parents $firmware_complete_filename
+            done
+        done
+    done
+else
+    LogPrintError "Cannot copy firmware for built-in drivers (cannot read /lib/modules/$KERNEL_VERSION/modules.builtin)"
+fi
+
 # COPY_MODULES=( all_modules ) is set when MODULES contains 'all_modules'
 # in the previous 400_copy_modules.sh script and then usually all firmware files
 # in the /lib*/firmware/ directories should get included in the rescue/recovery system:

--- a/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
+++ b/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
@@ -41,7 +41,7 @@ fi
 #  see https://github.com/rear/rear/pull/3553#issuecomment-4129123318)
 # except explicit user setting FIRMWARE_FILES=( 'no' ) forbids to copy firmware files
 # see https://github.com/rear/rear/pull/3553#issuecomment-5425860422
-# and ecxept via FIRMWARE_FILES=( 'yes' ) all firmware files were already copied above.
+# and except via FIRMWARE_FILES=( 'yes' ) all firmware files were already copied above.
 LogPrint "Copying firmware files that belong to built-in kernel drivers"
 if test -r /lib/modules/$KERNEL_VERSION/modules.builtin ; then
     for module_path in $( cat /lib/modules/$KERNEL_VERSION/modules.builtin ) ; do

--- a/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
+++ b/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
@@ -73,12 +73,20 @@ for module in "${COPY_MODULES[@]}" ; do
         # and for amdgpu/navi12_gpu_info.bin the actual firmware files could be
         # /lib/firmware/amdgpu/navi12_gpu_info.bin.xz
         # so what is listed by modinfo is only a part of the actual firmware file
-        # without leading path and without suffix so we need to find the actual firmware file:
-        firmware_complete_filename=$( find /lib*/firmware -path "*$firmware_partial_filename*" )
-        if ! test -r "$firmware_complete_filename" ; then
+        # without leading path and without suffix so we need to find the actual firmware file.
+        # 'find' might return multiple matching files for one firmware_partial_filename
+        # cf. https://github.com/rear/rear/pull/3553#discussion_r3861464764
+        firmware_complete_filenames=$( find /lib*/firmware -path "*$firmware_partial_filename*" )
+        if ! test "$firmware_complete_filenames" ; then
             DebugPrint "No file in /lib*/firmware matching '$firmware_partial_filename' (reported by modinfo for '$module')"
             continue
         fi
-        cp $verbose -t $ROOTFS_DIR -p -L --parents $firmware_complete_filename
+        for firmware_complete_filename in $firmware_complete_filenames ; do
+            if ! test -r "$firmware_complete_filename" ; then
+                Debug "Cannot copy firmware file (cannot read $firmware_complete_filename)"
+                continue
+            fi
+            cp $verbose -t $ROOTFS_DIR -p -L --parents $firmware_complete_filename
+        done
     done
 done

--- a/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
+++ b/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
@@ -11,38 +11,6 @@ if is_false "$FIRMWARE_FILES" ; then
     return
 fi
 
-# Firmware files for built-in kernel drivers should get copied into the recovery system if possible
-# (preconditions: /lib/modules/$KERNEL_VERSION/modules.builtin that newer kernels provide
-#  and a sufficiently new modinfo to query even builtin modules
-#  see https://github.com/rear/rear/pull/3553#issuecomment-4129123318)
-# except explicit user setting FIRMWARE_FILES=( 'no' ) forbids ReaR to copy firmware files
-# see https://github.com/rear/rear/pull/3553#issuecomment-5425860422
-LogPrint "Copying firmware files that belong to built-in kernel drivers"
-if test -r /lib/modules/$KERNEL_VERSION/modules.builtin ; then
-    for module_path in $( cat /lib/modules/$KERNEL_VERSION/modules.builtin ) ; do
-        module=$( basename $module_path | cut -s -d '.' -f1 )
-        # Here is a copy of the code (without the comment) of the place below
-        # when "Copying firmware files that belong to the copied kernel modules":
-        firmware_partial_filenames=$( modinfo -k $KERNEL_VERSION -F firmware "$module" ) || continue
-        for firmware_partial_filename in $firmware_partial_filenames ; do
-            firmware_complete_filenames=$( find /lib*/firmware -path "*$firmware_partial_filename*" )
-            if ! test "$firmware_complete_filenames" ; then
-                DebugPrint "No file in /lib*/firmware matching '$firmware_partial_filename' (reported by modinfo for '$module')"
-                continue
-            fi
-            for firmware_complete_filename in $firmware_complete_filenames ; do
-                if ! test -r "$firmware_complete_filename" ; then
-                    Debug "Cannot copy firmware file (cannot read $firmware_complete_filename)"
-                    continue
-                fi
-                cp $verbose -t $ROOTFS_DIR -p -L --parents $firmware_complete_filename
-            done
-        done
-    done
-else
-    LogPrintError "Cannot copy firmware for built-in drivers (cannot read /lib/modules/$KERNEL_VERSION/modules.builtin)"
-fi
-
 # COPY_MODULES=( all_modules ) is set when MODULES contains 'all_modules'
 # in the previous 400_copy_modules.sh script and then usually all firmware files
 # in the /lib*/firmware/ directories should get included in the rescue/recovery system:
@@ -67,9 +35,43 @@ if is_true "$FIRMWARE_FILES" ; then
     return
 fi
 
+# Firmware files for built-in kernel drivers should get copied into the recovery system if possible
+# (preconditions: /lib/modules/$KERNEL_VERSION/modules.builtin that newer kernels provide
+#  and a sufficiently new modinfo to query even builtin modules
+#  see https://github.com/rear/rear/pull/3553#issuecomment-4129123318)
+# except explicit user setting FIRMWARE_FILES=( 'no' ) forbids to copy firmware files
+# see https://github.com/rear/rear/pull/3553#issuecomment-5425860422
+# and ecxept via FIRMWARE_FILES=( 'yes' ) all firmware files were already copied above.
+LogPrint "Copying firmware files that belong to built-in kernel drivers"
+if test -r /lib/modules/$KERNEL_VERSION/modules.builtin ; then
+    for module_path in $( cat /lib/modules/$KERNEL_VERSION/modules.builtin ) ; do
+        module=$( basename $module_path | cut -s -d '.' -f1 )
+        # Here is a copy of the code (without comment) from the place below
+        # when "Copying firmware files that belong to the copied kernel modules":
+        firmware_partial_filenames=$( modinfo -k $KERNEL_VERSION -F firmware "$module" ) || continue
+        for firmware_partial_filename in $firmware_partial_filenames ; do
+            firmware_complete_filenames=$( find /lib*/firmware -path "*$firmware_partial_filename*" )
+            if ! test "$firmware_complete_filenames" ; then
+                DebugPrint "No file in /lib*/firmware matching '$firmware_partial_filename' (reported by modinfo for '$module')"
+                continue
+            fi
+            for firmware_complete_filename in $firmware_complete_filenames ; do
+                if ! test -r "$firmware_complete_filename" ; then
+                    Debug "Cannot copy firmware file (cannot read $firmware_complete_filename)"
+                    continue
+                fi
+                cp $verbose -t $ROOTFS_DIR -p -L --parents $firmware_complete_filename
+            done
+        done
+    done
+else
+    LogPrintError "Cannot copy firmware for built-in drivers (cannot read /lib/modules/$KERNEL_VERSION/modules.builtin)"
+fi
+
 # FIRMWARE_FILES is set but neither 'yes' nor 'no'
 # so the user has specified which FIRMWARE_FILES should be copied.
-# In this case copy exactly what the user has specified:
+# In this case copy exactly what the user has specified
+# (plus firmware for built-in drivers in any case if possible, see above):
 if test "${FIRMWARE_FILES[*]}" ; then
     LogPrint "Copying files from /lib*/firmware/ that match ${FIRMWARE_FILES[@]}"
     for find_ipath_pattern in "${FIRMWARE_FILES[@]}" ; do

--- a/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
+++ b/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
@@ -44,37 +44,56 @@ fi
 # and except via FIRMWARE_FILES=( 'yes' ) all firmware files were already copied above.
 LogPrint "Copying firmware files that belong to built-in kernel drivers"
 if test -r /lib/modules/$KERNEL_VERSION/modules.builtin ; then
+    modinfo_success="yes"
     for module_path in $( cat /lib/modules/$KERNEL_VERSION/modules.builtin ) ; do
         module=$( basename $module_path | cut -s -d '.' -f1 )
         # Here is a copy of the code (without comment) from the place below
         # when "Copying firmware files that belong to the copied kernel modules":
-        firmware_partial_filenames=$( modinfo -k $KERNEL_VERSION -F firmware "$module" ) || continue
+        if ! firmware_partial_filenames=$( modinfo -k $KERNEL_VERSION -F firmware "$module" ) ; then
+            DebugPrint "modinfo failed to determine firmware for built-in kernel driver '$module'"
+            modinfo_success="no"
+            continue
+        fi
         for firmware_partial_filename in $firmware_partial_filenames ; do
             firmware_complete_filenames=$( find /lib*/firmware -path "*$firmware_partial_filename*" )
             if ! test "$firmware_complete_filenames" ; then
-                DebugPrint "No file in /lib*/firmware matching '$firmware_partial_filename' (reported by modinfo for '$module')"
+                DebugPrint "No file in /lib*/firmware matching '$firmware_partial_filename' (reported by modinfo for built-in kernel driver '$module')"
                 continue
             fi
             for firmware_complete_filename in $firmware_complete_filenames ; do
                 if ! test -r "$firmware_complete_filename" ; then
-                    Debug "Cannot copy firmware file (cannot read $firmware_complete_filename)"
+                    Debug "Cannot copy firmware file for built-in kernel driver '$module' (cannot read $firmware_complete_filename)"
                     continue
                 fi
                 cp $verbose -t $ROOTFS_DIR -p -L --parents $firmware_complete_filename
             done
         done
     done
+    if is_false "$modinfo_success" ; then
+        if test "${FIRMWARE_FILES[*]}" ; then
+            # When FIRMWARE_FILES are specified (here FIRMWARE_FILES is neither 'yes' nor 'no')
+            # and there was a modinfo failure when determining firmware files for built-in kernel drivers,
+            # we inform the user to ensure firmware for built-in drivers is specified in FIRMWARE_FILES
+            # but we cannot know if the user had such firmware already specified in FIRMWARE_FILES:
+            LogPrint "Ensure firmware for built-in drivers is specified in FIRMWARE_FILES (modinfo failed to determine firmware)"
+        else
+            # When FIRMWARE_FILES is empty and when there was a modinfo failure when determining firmware files for built-in kernel drivers,
+            # we error out to be on the safe side to avoid missing firmware for built-in drivers in the recovery system
+            # see https://github.com/rear/rear/pull/3553#issuecomment-5452724929
+            Error "If built-in drivers need firmware it is missing (FIRMWARE_FILES not specified and modinfo failed to determine firmware)"
+        fi
+    fi
 else
     if test "${FIRMWARE_FILES[*]}" ; then
         # When FIRMWARE_FILES are specified (here FIRMWARE_FILES is neither 'yes' nor 'no')
-        # and when we cannot determine firmware files for built-in kernel drivers
+        # and when we cannot determine firmware files for built-in kernel drivers,
         # we inform the user to ensure firmware for built-in drivers is specified in FIRMWARE_FILES
         # but we cannot know if the user had such firmware already specified in FIRMWARE_FILES:
         LogPrint "Ensure firmware for built-in drivers is specified in FIRMWARE_FILES (cannot read /lib/modules/$KERNEL_VERSION/modules.builtin)"
     else
-        # When FIRMWARE_FILES is empty and when we cannot determine firmware files for built-in kernel drivers
+        # When FIRMWARE_FILES is empty and when we cannot determine firmware files for built-in kernel drivers,
         # we error out to be on the safe side to avoid missing firmware for built-in drivers in the recovery system
-        # see https://github.com/rear/rear/pull/3553#issuecomment-5425860422
+        # see https://github.com/rear/rear/pull/3553#issuecomment-5452724929
         Error "If built-in drivers need firmware it is missing (FIRMWARE_FILES not specified)"
     fi
 fi
@@ -106,8 +125,13 @@ fi
 # Automatically also copy the matching firmware files here, see
 # https://github.com/rear/rear/issues/3551
 LogPrint "Copying firmware files that belong to the copied kernel modules (FIRMWARE_FILES not specified)"
+modinfo_success="yes"
 for module in "${COPY_MODULES[@]}" ; do
-    firmware_partial_filenames=$( modinfo -k $KERNEL_VERSION -F firmware "$module" ) || continue
+    if ! firmware_partial_filenames=$( modinfo -k $KERNEL_VERSION -F firmware "$module" ) ; then
+        DebugPrint "modinfo failed to determine firmware for kernel module '$module'"
+        modinfo_success="no"
+        continue
+    fi
     for firmware_partial_filename in $firmware_partial_filenames ; do
         # For example the command "modinfo -F firmware amdgpu" may show
         # amdgpu/cyan_skillfish_gpu_info.bin
@@ -123,15 +147,22 @@ for module in "${COPY_MODULES[@]}" ; do
         # cf. https://github.com/rear/rear/pull/3553#discussion_r3861464764
         firmware_complete_filenames=$( find /lib*/firmware -path "*$firmware_partial_filename*" )
         if ! test "$firmware_complete_filenames" ; then
-            DebugPrint "No file in /lib*/firmware matching '$firmware_partial_filename' (reported by modinfo for '$module')"
+            DebugPrint "No file in /lib*/firmware matching '$firmware_partial_filename' (reported by modinfo for kernel module '$module')"
             continue
         fi
         for firmware_complete_filename in $firmware_complete_filenames ; do
             if ! test -r "$firmware_complete_filename" ; then
-                Debug "Cannot copy firmware file (cannot read $firmware_complete_filename)"
+                Debug "Cannot copy firmware file for kernel module '$module' (cannot read $firmware_complete_filename)"
                 continue
             fi
             cp $verbose -t $ROOTFS_DIR -p -L --parents $firmware_complete_filename
         done
     done
 done
+if is_false "$modinfo_success" ; then
+    # When FIRMWARE_FILES is empty and when there was a modinfo failure when determining firmware files for kernel modules,
+    # we error out to be on the safe side to avoid missing firmware for kernel modules in the recovery system
+    # see https://github.com/rear/rear/pull/3553#issuecomment-5452724929
+    Error "If kernel modules need firmware it is missing (FIRMWARE_FILES not specified and modinfo failed to determine firmware)"
+fi
+

--- a/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
+++ b/usr/share/rear/build/GNU/Linux/420_copy_firmware_files.sh
@@ -65,7 +65,18 @@ if test -r /lib/modules/$KERNEL_VERSION/modules.builtin ; then
         done
     done
 else
-    LogPrintError "Cannot copy firmware for built-in drivers (cannot read /lib/modules/$KERNEL_VERSION/modules.builtin)"
+    if test "${FIRMWARE_FILES[*]}" ; then
+        # When FIRMWARE_FILES are specified (here FIRMWARE_FILES is neither 'yes' nor 'no')
+        # and when we cannot determine firmware files for built-in kernel drivers
+        # we inform the user to ensure firmware for built-in drivers is specified in FIRMWARE_FILES
+        # but we cannot know if the user had such firmware already specified in FIRMWARE_FILES:
+        LogPrint "Ensure firmware for built-in drivers is specified in FIRMWARE_FILES (cannot read /lib/modules/$KERNEL_VERSION/modules.builtin)"
+    else
+        # When FIRMWARE_FILES is empty and when we cannot determine firmware files for built-in kernel drivers
+        # we error out to be on the safe side to avoid missing firmware for built-in drivers in the recovery system
+        # see https://github.com/rear/rear/pull/3553#issuecomment-5425860422
+        Error "If built-in drivers need firmware it is missing (FIRMWARE_FILES not specified)"
+    fi
 fi
 
 # FIRMWARE_FILES is set but neither 'yes' nor 'no'

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1906,11 +1906,25 @@ EXCLUDE_MODULES=( scsi_debug )
 # is recognized as 'yes' by the is_true function enforces that
 # all files from the /lib*/firmware/ directories get included
 # in the rescue/recovery system.
-# The by default empty FIRMWARE_FILES array means that
-# usually all files in the /lib*/firmware/ directories
-# get included in the rescue/recovery system but on certain
-# architectures like ppc64 or ppc64le the default could be different
-# cf. the conf/Linux-ppc64.conf and conf/Linux-ppc64le.conf scripts:
+# The by default empty FIRMWARE_FILES array
+# together with the default MODULES=( 'all_modules' )
+# results that normally all files in the /lib*/firmware/
+# directories get included in the rescue/recovery system.
+# When MODULES does not contain 'all_modules'
+# (e.g. when MODULES=( 'loaded_modules' ) is specified),
+# then an empty FIRMWARE_FILES array results that
+# firmware files which belong to those kernel modules
+# which get included in the rescue/recovery system
+# get also included in the rescue/recovery system
+# (i.e. files that are listed by "modinfo -F firmware"
+# for kernel modules in the rescue/recovery system
+# are automatically added to the rescue/recovery system).
+# On certain architectures like ppc64 or ppc64le
+# the default could be different, in particular see the
+# conf/Linux-ppc64.conf and conf/Linux-ppc64le.conf scripts.
+# Also things work special for the 'mkopalpba' workflow,
+# see OPAL_PBA_FIRMWARE_FILES above and see the
+# prep/OPALPBA/Linux-i386/001_configure_workflow.sh script.
 FIRMWARE_FILES=()
 
 # UDEV_NET_MAC_RULE_FILES:

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1918,7 +1918,8 @@ EXCLUDE_MODULES=( scsi_debug )
 # get also included in the rescue/recovery system
 # (i.e. files that are listed by "modinfo -F firmware"
 # for kernel modules in the rescue/recovery system
-# are automatically added to the rescue/recovery system).
+# are automatically added to the rescue/recovery system
+# provided a matching file is found in /lib*/firmware/).
 # On certain architectures like ppc64 or ppc64le
 # the default could be different, in particular see the
 # conf/Linux-ppc64.conf and conf/Linux-ppc64le.conf scripts.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1908,11 +1908,11 @@ EXCLUDE_MODULES=( scsi_debug )
 # in the rescue/recovery system.
 # The by default empty FIRMWARE_FILES array
 # together with the default MODULES=( 'all_modules' )
-# results that normally all files in the /lib*/firmware/
+# means that normally all files in the /lib*/firmware/
 # directories get included in the rescue/recovery system.
 # When MODULES does not contain 'all_modules'
 # (e.g. when MODULES=( 'loaded_modules' ) is specified),
-# then an empty FIRMWARE_FILES array results that
+# then an empty FIRMWARE_FILES array means that
 # firmware files which belong to those kernel modules
 # which get included in the rescue/recovery system
 # get also included in the rescue/recovery system

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1892,34 +1892,40 @@ MODULES_LOAD=()
 EXCLUDE_MODULES=( scsi_debug )
 ####
 
-# Firmware files to include in the rescue/recovery system.
+# Firmware files to include in the rescue/recovery system:
 # The FIRMWARE_FILES array contains filename globbing patterns
 # that are used as '-ipath' arguments for 'find' calls to find
 # firmware files in the /lib*/firmware/ directories that will
-# get included in the rescue/recovery system for example like
-# FIRMWARE_FILES=( '*rtl*' '*nvidia*' '*radeon*' )
+# get included in the recovery system for example like
+# FIRMWARE_FILES=( '*rtl*' '*nvidia*' '*radeon*' '*amdgpu*' )
 # The special value FIRMWARE_FILES=( 'no' ) or any value that
 # is recognized as 'no' by the is_false function enforces that
 # no files from the /lib*/firmware/ directories get included
-# in the rescue/recovery system.
+# in the recovery system.
 # The special value FIRMWARE_FILES=( 'yes' ) or any value that
 # is recognized as 'yes' by the is_true function enforces that
 # all files from the /lib*/firmware/ directories get included
-# in the rescue/recovery system.
+# in the recovery system.
 # The by default empty FIRMWARE_FILES array
 # together with the default MODULES=( 'all_modules' )
 # means that normally all files in the /lib*/firmware/
-# directories get included in the rescue/recovery system.
+# directories get included in the recovery system.
 # When MODULES does not contain 'all_modules'
 # (e.g. when MODULES=( 'loaded_modules' ) is specified),
-# then an empty FIRMWARE_FILES array means that
-# firmware files which belong to those kernel modules
-# which get included in the rescue/recovery system
-# get also included in the rescue/recovery system
+# then an empty FIRMWARE_FILES array means that firmware files
+# which belong to kernel modules in the recovery system
+# get also included in the recovery system
 # (i.e. files that are listed by "modinfo -F firmware"
-# for kernel modules in the rescue/recovery system
-# are automatically added to the rescue/recovery system
+# for kernel modules in the recovery system
+# are automatically added to the recovery system
 # provided a matching file is found in /lib*/firmware/).
+# When FIRMWARE_FILES is empty and there is a 'modinfo' failure,
+# we error out to avoid missing firmware in the recovery system.
+# Firmware files for built-in kernel modules get automatically included
+# in the recovery system (unless FIRMWARE_FILES=( 'no' ) is specified)
+# provided the following preconditions are met:
+# /lib/modules/$KERNEL_VERSION/modules.builtin exists and
+# there is an up-to-date 'modinfo' to query built-in modules.
 # On certain architectures like ppc64 or ppc64le
 # the default could be different, in particular see the
 # conf/Linux-ppc64.conf and conf/Linux-ppc64le.conf scripts.


### PR DESCRIPTION
In build/GNU/Linux/420_copy_firmware_files.sh
automatically include firmware files
for the kernel modules in the recovery system
see https://github.com/rear/rear/issues/3551
