### PR TITLE
Copy installation-helper for BTRFS to the rescue system

### DIFF
--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -405,14 +405,6 @@ fi
                             echo "$subvolume_list" | grep -Ev "$snapshot_subvolumes_pattern" | grep "$snapper_base_subvolume" | sed -e "s/^/#$prefix /"
                         fi
                     fi
-
-                    COPY_AS_IS+=(
-                        /usr/lib/snapper/installation-helper
-                        /etc/snapper/config-templates
-                        # On SLE16,
-                        # /etc/snapper/config-templates was moved to /usr/share/snapper/config-templates
-                        /usr/share/snapper/config-templates
-                    )
                 fi
                 # Output btrfs normal subvolumes:
                 if test -z "$subvolumes_exclude_pattern" ; then


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): Fixes https://github.com/rear/rear/issues/3566

* How was this pull request tested?
  Manually recovered openSUSE Tumbleweed 20260209

* Description of the changes in this pull request:
  Copy `/usr/lib/snapper/installation-helper`, `/usr/share/snapper/config-templates/default` / `/etc/snapper/config-templates/default` to the rescue system

