### PR TITLE
Use get_disk_size to show current disk size

### DIFF
--- a/usr/share/rear/layout/prepare/default/300_map_disks.sh
+++ b/usr/share/rear/layout/prepare/default/300_map_disks.sh
@@ -260,7 +260,7 @@ while read keyword orig_device orig_size junk ; do
             Log "$preferred_target_device_name excluded from device mapping choices (is designated as write-protected)"
             continue
         fi
-        LogPrint "The size of $preferred_target_device_name is $(blockdev --getsize64 $current_device_path)"
+        LogPrint "The size of $preferred_target_device_name is $(get_disk_size $preferred_target_device_name)"
         # Add the current device as possible choice for the user:
         possible_targets+=( "$preferred_target_device_name" )
     done


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): No issue created

* How was this pull request tested?
  Manually recovered Debian 13
* Description of the changes in this pull request:
Use the `get_disk_size` function to show current disk size.

Before the fix the output is the following:
```
Switching to manual disk layout configuration (GiB sizes rounded down to integer)
/dev/vda had size 10737418240 (10 GiB) but is now 12884901888 (12 GiB)
/dev/vdb had size 10737418240 (10 GiB) but is now 12884901888 (12 GiB)
/dev/md0 was not used on the original system and has now 24747442176 (23 GiB)
Original disk /dev/vda does not exist (with same size) in the target system
The size of /dev/md0 is
The size of /dev/vda is
The size of /dev/vdb is
Choose an appropriate replacement for /dev/vda with size 10737418240
1) /dev/md0
2) /dev/vda
3) /dev/vdb
4) Do not map /dev/vda
5) Use Relax-and-Recover shell and return back to here
```
Please pay attention to lines such as `The size of /dev/vda is`. It is not very convenient to choose an appropriate replacement when sizes are not displayed.

The root cause is that `blockdev` currently returns the error `Inappropriate ioctl for device` when used with `/sys/block/*`
```
blockdev --getsize64 /sys/block/vda
blockdev: ioctl error on BLKGETSIZE64: Inappropriate ioctl for device
```

After the fix sizes are displayed as expected:
```
Switching to manual disk layout configuration (GiB sizes rounded down to integer)
/dev/vda had size 10737418240 (10 GiB) but is now 12884901888 (12 GiB)
/dev/vdb had size 10737418240 (10 GiB) but is now 12884901888 (12 GiB)
/dev/md0 was not used on the original system and has now 24747442176 (23 GiB)
Original disk /dev/vda does not exist (with same size) in the target system
The size of /dev/md0 is 24747442176
The size of /dev/vda is 12884901888
The size of /dev/vdb is 12884901888
Choose an appropriate replacement for /dev/vda with size 10737418240
1) /dev/md0
2) /dev/vda
3) /dev/vdb
4) Do not map /dev/vda
5) Use Relax-and-Recover shell and return back to here
```
