### PR TITLE
Apply XFS options from configs in non-debug mode

### DIFF
--- a/usr/share/rear/layout/prepare/default/319_rename_xfs_configs.sh
+++ b/usr/share/rear/layout/prepare/default/319_rename_xfs_configs.sh
@@ -24,7 +24,7 @@ while read source target junk ; do
     # LAYOUT_XFS_OPT_DIR_RESTORE.
     if [ -e "$LAYOUT_XFS_OPT_DIR/$base_source.xfs" ]; then
         Log "Migrating XFS configuration file $base_source.xfs to $base_target.xfs"
-        cp "$v" "$LAYOUT_XFS_OPT_DIR/$base_source.xfs" \
+        cp $v "$LAYOUT_XFS_OPT_DIR/$base_source.xfs" \
          "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_target.xfs"
 
         # Replace old device name in meta-data= option in XFS
@@ -48,7 +48,7 @@ while read source target junk ; do
 
             if [ -e "$LAYOUT_XFS_OPT_DIR/$base_src_layout_partition.xfs" ]; then
                 Log "Migrating XFS configuration $base_src_layout_partition.xfs to $base_dst_layout_partition.xfs"
-                cp "$v" "$LAYOUT_XFS_OPT_DIR/$base_src_layout_partition.xfs" \
+                cp $v "$LAYOUT_XFS_OPT_DIR/$base_src_layout_partition.xfs" \
                  "$LAYOUT_XFS_OPT_DIR_RESTORE/$base_dst_layout_partition.xfs"
 
                 # Replace old device name in meta-data= option in XFS


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): No issue created

* How was this pull request tested?
  Manually recovered Debian 10 with XFS

* Description of the changes in this pull request:
  Currently XFS configs are not copied correctly in non-debug mode (not verbose mode) due to these quotes - `"$v"`.
  However, applying XFS options is crucial in cases when XFS was created on old software and during the recovery newer software is used. In some cases it may lead to failures during GRUB installation. GRUB checks XFS features and returns an error when encounters unknown one.
