### PR TITLE
Update Linux.conf to make vi working with SLES 16

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -242,6 +242,11 @@ COPY_AS_IS+=( /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/ter
 # /etc/services was moved to /usr/etc/services
 COPY_AS_IS+=( /usr/etc/protocols /usr/etc/services )
 
+# Needed by vi on SLES 16,
+# see https://github.com/rear/rear/issues/3567#issuecomment-3933265707
+COPY_AS_IS+=( /usr/share/libalternatives/vi )
+PROGS+=( vim-nox11 )
+
 # Needed by vi on Fedora and derived distributions
 # where vi is a shell script that executes /usr/libexec/vi
 # see https://github.com/rear/rear/pull/2822


### PR DESCRIPTION
On SLES 16 vi in the recovery system also needs
/usr/share/libalternatives/vi and vim-nox11, see
https://github.com/rear/rear/issues/3567#issuecomment-3933265707
