### PR TITLE
Include rsyslog loadable modules in LIBS

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -200,7 +200,8 @@ LIBS+=(
 /lib*/libnss_files*
 ### needed for usrfiles module on SUSE
 /lib*/libnss_usrfiles*
-### support multiarch
+### support multiarch (Debian libraries are located in a subdirectory like x86_64-linux-gnu
+### under {/lib,/usr/lib})
 /lib/*/libnss_dns*
 /lib/*/libnss_files*
 /lib/*/libnss_usrfiles*
@@ -214,34 +215,53 @@ LIBS+=(
 # In openSUSE Leap 15.6 the rsyslog loadable modules are located in /usr/lib64/rsyslog/
 # see https://github.com/rear/rear/issues/3573#issuecomment-4011572353
 /usr/lib*/rsyslog/*so
-# In Debian the rsyslog loadable modules are located in /usr/lib/x86_64-linux-gnu/rsyslog/
-# see https://github.com/rear/rear/issues/3573#issuecomment-3972176281
+# see note about multiarch and Debian above and
+# https://github.com/rear/rear/issues/3573#issuecomment-3972176281
 /usr/lib/*/rsyslog/*.so
 
 # Only copy *.so files in /usr/lib*/syslog-ng/ and skip /usr/lib*/syslog-ng/loggen/
 # because the loggen program is not included in the recovery system
 # see https://github.com/rear/rear/issues/2743
 /usr/lib*/syslog-ng/*so
+/usr/lib/*/syslog-ng/*so
 
 ### needed for curl HTTPS
 /lib*/libnsspem.so*
 /usr/lib*/libnsspem.so*
+/lib/*/libnsspem.so*
+/usr/lib/*/libnsspem.so*
 /lib*/libfreebl*.so*
 /usr/lib*/libfreebl*.so*
+/lib/*/libfreebl*.so*
+/usr/lib/*/libfreebl*.so*
 /lib*/libnss3.so*
 /usr/lib*/libnss3.so*
+/lib/*/libnss3.so*
+/usr/lib/*/libnss3.so*
 /lib*/libnssutil3.so*
 /usr/lib*/libnssutil3.so*
+/lib/*/libnssutil3.so*
+/usr/lib/*/libnssutil3.so*
 /lib*/libsoftokn3.so*
 /usr/lib*/libsoftokn3.so*
+/lib/*/libsoftokn3.so*
+/usr/lib/*/libsoftokn3.so*
 /lib*/libsqlite3.so*
 /usr/lib*/libsqlite3.so*
+/lib/*/libsqlite3.so*
+/usr/lib/*/libsqlite3.so*
 /lib*/libfreeblpriv3.so*
 /usr/lib*/libfreeblpriv3.so*
+/lib/*/libfreeblpriv3.so*
+/usr/lib/*/libfreeblpriv3.so*
 /lib*/libssl.so*
 /usr/lib*/libssl.so*
+/lib/*/libssl.so*
+/usr/lib/*/libssl.so*
 /lib*/libnssdbm3.so*
 /usr/lib*/libnssdbm3.so*
+/lib/*/libnssdbm3.so*
+/usr/lib/*/libnssdbm3.so*
 )
 
 COPY_AS_IS+=( /dev /etc/inputr[c] /etc/protocols /etc/services /etc/rpc /etc/termcap /etc/terminfo /lib*/terminfo /usr/share/terminfo /etc/netconfig /etc/mke2fs.conf /etc/*-release /etc/localtime /etc/magic /usr/share/misc/magic /etc/dracut.conf /etc/dracut.conf.d /usr/lib/dracut /sbin/modprobe.ksplice-orig /etc/sysctl.conf /etc/sysctl.d /etc/e2fsck.conf )

--- a/usr/share/rear/prep/GNU/Linux/220_include_lvm_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/220_include_lvm_tools.sh
@@ -15,7 +15,7 @@ fi
 
 if lvs --noheadings -o modules | grep -q -v "^\s*$" ; then
     # There are non-linear LVs on the system, include required libraries
-    LIBS+=( /lib64/*lvm2* )
+    LIBS+=( /lib*/*lvm2* /lib/*/*lvm2* )
 fi
 
 # vim: set et ts=4 sw=4:


### PR DESCRIPTION
In Linux.conf add /usr/lib/*/rsyslog/*.so
because at least in Debian rsyslog
loadable modules are located in
/usr/lib/x86_64-linux-gnu/rsyslog/*.so
see https://github.com/rear/rear/issues/3573
