### PR TITLE
grubenv should not be moved away by default

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3441,25 +3441,35 @@ readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/moved_away_after_backup_re
 # (because such stuff is considered as outdated leftover e.g. from a previous recovery)
 # but already existing stuff in the BACKUP_RESTORE_MOVE_AWAY_DIRECTORY that is not
 # in the current BACKUP_RESTORE_MOVE_AWAY_FILES list is kept.
-# Example:
-# Probably stuff in the /var/tmp directory is not needed after a system recovery
-# and /etc/udev/rules.d/70-persistent-net.rules is created and maintained
-# by systemd/udev (see https://github.com/rear/rear/issues/770):
-# BACKUP_RESTORE_MOVE_AWAY_FILES=( /var/tmp /etc/udev/rules.d/70-persistent-net.rules )
 #
-# Move away outdated information from previous boot via GRUB2
-# to avoid a possible GRUB2 "error: invalid environment block."
-# cf. https://github.com/rear/rear/issues/1828
+# Examples:
+#
+# Probably stuff in the /var/tmp directory is not needed after a system recovery:
+# BACKUP_RESTORE_MOVE_AWAY_FILES+=( /var/tmp )
+#
+# /etc/udev/rules.d/70-persistent-net.rules is created and maintained
+# by systemd/udev (see https://github.com/rear/rear/issues/770):
+# BACKUP_RESTORE_MOVE_AWAY_FILES+=( /etc/udev/rules.d/70-persistent-net.rules )
+#
+# Move away outdated information from a previous boot via GRUB2:
+# BACKUP_RESTORE_MOVE_AWAY_FILES+=( /boot/grub/grubenv /boot/grub2/grubenv )
+# This avoids a possible GRUB2 message "error: invalid environment block."
+# which should be harmless because the system should boot nevertheless
+# (cf. https://github.com/rear/rear/issues/1828#issuecomment-398717889).
 # GRUB2 can use /boot/grub/grubenv or /boot/grub2/grubenv
 # to remember a small amount of information from one boot to the next.
-# But on a by "rear recover" recreated system there is no such thing
-# as a meaningful previous boot (because "rear recover" recreates a system
-# by reinstalling it completely from scratch) so that there is no meaningful
-# use-case to remember any information from a possible previous boot,
-# cf. https://github.com/rear/rear/issues/1828#issuecomment-399050741
-# Nevertheless that information from the last boot on the original system
-# could be still of interest for the user so that it is not deleted:
-BACKUP_RESTORE_MOVE_AWAY_FILES=( /boot/grub/grubenv /boot/grub2/grubenv )
+# Because "rear recover" recreates the system by reinstalling it from scratch
+# it could cause booting issues when possibly outdated information from a
+# previous boot of the original system is still used in the recreated system
+# (cf. https://github.com/rear/rear/issues/1828#issuecomment-399050741).
+# On the other hand GRUB2 relies on grubenv for certain special stuff.
+# For example grubenv may contain essential information,
+# such as saved_entry, default or kernelopts.
+# So grubenv can be considered as part of the GRUB2 configuration.
+# Therefore grubenv should not be moved away by default
+# (for details see https://github.com/rear/rear/issues/3578).
+#
+BACKUP_RESTORE_MOVE_AWAY_FILES=()
 ####
 
 ####

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3461,7 +3461,7 @@ readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/moved_away_after_backup_re
 # Because "rear recover" recreates the system by reinstalling it from scratch
 # it could in theory cause booting issues when possibly outdated information from a
 # previous boot of the original system is still used in the recreated system
-# (cf. https://github.com/rear/rear/issues/1828#issuecomment-399050741).
+# (cf. https://github.com/rear/rear/issues/3578#issuecomment-4023448031).
 # On the other hand GRUB2 relies on grubenv for certain special stuff.
 # For example grubenv may contain essential information,
 # such as saved_entry, default or kernelopts.

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3459,7 +3459,7 @@ readonly BACKUP_RESTORE_MOVE_AWAY_DIRECTORY="$VAR_DIR/moved_away_after_backup_re
 # GRUB2 can use /boot/grub/grubenv or /boot/grub2/grubenv
 # to remember a small amount of information from one boot to the next.
 # Because "rear recover" recreates the system by reinstalling it from scratch
-# it could cause booting issues when possibly outdated information from a
+# it could in theory cause booting issues when possibly outdated information from a
 # previous boot of the original system is still used in the recreated system
 # (cf. https://github.com/rear/rear/issues/1828#issuecomment-399050741).
 # On the other hand GRUB2 relies on grubenv for certain special stuff.


### PR DESCRIPTION
grubenv should not be moved away by default,
see https://github.com/rear/rear/issues/3578

Therein see in particular in
https://github.com/rear/rear/issues/3578#issuecomment-4031339803
the part
```
> removing grubenv is problematic in some cases,
> so I would keep it by default and when a user knows
> that removing grubenv in the recreated system is needed,
> they can set
> BACKUP_RESTORE_MOVE_AWAY_FILES+=( /boot/grub2/grubenv )

I agree - in particular because according to
https://github.com/rear/rear/issues/1828#issuecomment-398717889
when grubenv is kept a SUSE system boots
regardless of the GRUB error message
"error: invalid environment block."
but according to this issue here a Rocky 9 system
fails to boot when grubenv is removed so this issue here
is more severe than only a GRUB error message annoyance.
```
