### PR TITLE
Save copy of /etc/mdadm/mdadm.conf file

### DIFF
--- a/usr/share/rear/build/default/502_include_mdadm_conf.sh
+++ b/usr/share/rear/build/default/502_include_mdadm_conf.sh
@@ -4,8 +4,16 @@ grep -q blocks /proc/mdstat 2>/dev/null || return 0
 # for the reason behind see
 # https://github.com/rear/rear/issues/1722#issuecomment-394746478
 if [ -e "/etc/mdadm.conf" ] ; then
-	(
-		echo "AUTO -all"
-		sed "s/^ARRAY/#ARRAY/g" /etc/mdadm.conf
-	) > $ROOTFS_DIR/etc/mdadm.conf
+    (
+        echo "AUTO -all"
+       	sed "s/^ARRAY/#ARRAY/g" /etc/mdadm.conf
+    ) > $ROOTFS_DIR/etc/mdadm.conf
+fi
+# Ubuntu has /etc/mdadm/mdadm.conf instead of /etc/mdadm.conf
+if [ -e "/etc/mdadm/mdadm.conf" ] ; then
+    mkdir -p -m 0755 $ROOTFS_DIR/etc/mdadm
+    (
+        echo "AUTO -all"
+        sed "s/^ARRAY/#ARRAY/g" /etc/mdadm/mdadm.conf
+    ) > $ROOTFS_DIR/etc/mdadm/mdadm.conf
 fi


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): #3582 

* How was this pull request tested? On a VM with Ubuntu 22.04 and md devices

* Description of the changes in this pull request:
   Script `502_include_mdadm_conf.sh` did not check the presence of `/etc/mdadm/mdadm.conf` file. During recovery md did not honor the original md-device names which resulted in device busy errors.
With the updated script the recovery works fine again.

