### PR TITLE
More clear LIBS comments in Linux.conf

### DIFF
--- a/usr/share/rear/conf/GNU/Linux.conf
+++ b/usr/share/rear/conf/GNU/Linux.conf
@@ -191,23 +191,28 @@ dmeventd
 systemd-detect-virt
 )
 
-# the lib* serves to cover both 32bit and 64bit libraries!
-#
-LIBS+=(
 
-### needed for username lookups
+LIBS+=(
+# /lib*/ or /usr/lib*/ support architecture specific directories
+# like /lib/ and /lib64/ and /lib32/ or /usr/lib/ and /usr/lib64/ and /usr/lib32/
+# cf. https://github.com/rear/rear/pull/3579#issuecomment-4075579249
+/lib*/libgcc_s*
+/lib*/libresolv*
+
+# needed for username lookups
 /lib*/libnss_dns*
 /lib*/libnss_files*
-### needed for usrfiles module on SUSE
+# needed for usrfiles module on SUSE
 /lib*/libnss_usrfiles*
-### support multiarch (Debian libraries are located in a subdirectory like x86_64-linux-gnu
-### under {/lib,/usr/lib})
+
+# /lib/*/ and /usr/lib/*/ support architecture specific subdirectories.
+# On certain distributions like Debian and related distributions
+# libraries are located in subdirectories like 'x86_64-linux-gnu'
+# below /lib/ (this case here) or below /usr/lib/ (the rsyslog case below)
+# cf. https://github.com/rear/rear/pull/3579#issuecomment-4075579249
 /lib/*/libnss_dns*
 /lib/*/libnss_files*
 /lib/*/libnss_usrfiles*
-
-/lib*/libgcc_s*
-/lib*/libresolv*
 
 # rsyslogd is not "normally linked" to its rsyslog specific libraries (rsyslog loadable modules)
 # because those are loeded via dlopen() see https://www.rsyslog.com/?s=error+2066
@@ -215,8 +220,8 @@ LIBS+=(
 # In openSUSE Leap 15.6 the rsyslog loadable modules are located in /usr/lib64/rsyslog/
 # see https://github.com/rear/rear/issues/3573#issuecomment-4011572353
 /usr/lib*/rsyslog/*so
-# see note about multiarch and Debian above and
-# https://github.com/rear/rear/issues/3573#issuecomment-3972176281
+# See the note about Debian and related distributions above
+# and https://github.com/rear/rear/issues/3573#issuecomment-3972176281
 /usr/lib/*/rsyslog/*.so
 
 # Only copy *.so files in /usr/lib*/syslog-ng/ and skip /usr/lib*/syslog-ng/loggen/


### PR DESCRIPTION
The comments about /lib*/ and /lib/*/
were technically right but not really clear.

* Reference to related issue (URL):
https://github.com/rear/rear/pull/3579#issuecomment-4076194790
https://github.com/rear/rear/pull/3579#issuecomment-4075579249
