### PR TITLE
In default.conf remove outdated info about partial UEFI support

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -4017,11 +4017,7 @@ GRUB2_SEARCH_ROOT_COMMAND=""
 #
 # USING_UEFI_BOOTLOADER
 #
-# UEFI (Secure booting) support is partly available in ReaR (at least for Fedora, RHEL)
-# SLES, openSUSE do not work out of the box due to issues with making an UEFI bootable ISO image.
-# SLES, openSUSE need the additional tool 'ebiso' to make an UEFI bootable ISO image
-# (via ISO_MKISOFS_BIN=/usr/bin/ebiso - see the ISO_MKISOFS_BIN variable above).
-# The next variable can explicitly specify whether or not an UEFI bootloader should be used:
+# To explicitly specify whether or not an UEFI bootloader should be used:
 # USING_UEFI_BOOTLOADER=   means let ReaR try to find it out by itself (default)
 # USING_UEFI_BOOTLOADER=0  means we do not want UEFI capable ISO and no efi tools in ReaR image
 # USING_UEFI_BOOTLOADER=1  means we want UEFI ISO image and all efi tools to recreate the secure boot


### PR DESCRIPTION
In default.conf remove outdated info that
"UEFI (Secure booting) support is partly available in ReaR".
In particular since
https://github.com/rear/rear/pull/3306
SLES and openSUSE do no longer need 'ebiso'.
Since SLES15 it works with /usr/bin/xorrisofs
to make a UEFI bootable ISO image
that could boot even with Secure Boot.

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/3306


