### PR TITLE
Various `systemd` and `getty` related improvements

### DIFF
--- a/usr/share/rear/skel/default/usr/lib/systemd/system-preset/90-systemd.preset
+++ b/usr/share/rear/skel/default/usr/lib/systemd/system-preset/90-systemd.preset
@@ -1,0 +1,58 @@
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+# Settings for systemd units distributed with systemd itself. Most of these
+# should be enabled by default, even if the distribution follows a general
+# default-off policy.
+
+enable remote-fs.target
+enable remote-cryptsetup.target
+enable remote-integritysetup.target
+enable remote-veritysetup.target
+enable machines.target
+
+enable getty@.service
+
+enable systemd-boot-clear-sysfail.service
+enable systemd-boot-update.service
+enable systemd-confext.service
+enable systemd-homed.service
+enable systemd-homed-activate.service
+enable systemd-journald-audit.socket
+enable systemd-mountfsd.socket
+enable systemd-network-generator.service
+enable systemd-networkd.service
+enable systemd-networkd-wait-online.service
+enable systemd-nsresourced.socket
+enable systemd-pstore.service
+enable systemd-resolved.service
+enable systemd-sysext.service
+enable systemd-timesyncd.service
+enable systemd-tpm2-clear.service
+enable systemd-userdbd.socket
+
+disable console-getty.service
+disable debug-shell.service
+
+disable exit.target
+disable halt.target
+disable kexec.target
+disable poweroff.target
+enable reboot.target
+disable rescue.target
+
+disable proc-sys-fs-binfmt_misc.mount
+
+disable syslog.socket
+
+disable systemd-boot-check-no-failures.service
+disable systemd-journal-gatewayd.*
+disable systemd-journal-remote.*
+disable systemd-journal-upload.*
+disable systemd-time-wait-sync.service

--- a/usr/share/rear/skel/default/usr/lib/systemd/system/ctrl-alt-del.target
+++ b/usr/share/rear/skel/default/usr/lib/systemd/system/ctrl-alt-del.target
@@ -1,1 +1,0 @@
-reboot.target

--- a/usr/share/rear/skel/default/usr/lib/systemd/system/getty.target.wants/getty@tty0.service
+++ b/usr/share/rear/skel/default/usr/lib/systemd/system/getty.target.wants/getty@tty0.service
@@ -1,1 +1,0 @@
-../getty@.service

--- a/usr/share/rear/skel/default/usr/lib/systemd/system/getty.target.wants/serial-getty@ttyS0.service
+++ b/usr/share/rear/skel/default/usr/lib/systemd/system/getty.target.wants/serial-getty@ttyS0.service
@@ -1,1 +1,0 @@
-../serial-getty@.service

--- a/usr/share/rear/skel/default/usr/lib/systemd/system/getty@.service
+++ b/usr/share/rear/skel/default/usr/lib/systemd/system/getty@.service
@@ -43,4 +43,4 @@ KillSignal=SIGHUP
 
 [Install]
 WantedBy=getty.target
-DefaultInstance=%I
+DefaultInstance=tty1


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**/**Enhancement**

* Impact: **Normal**

* Reference to related issue (URL): N/A

* How was this pull request tested? Fedora Rawhide aarch64 VM and RHEL 7 x86_64 VM

* Description of the changes in this pull request:

  * Remove `serial-getty@ttyS0.service` unit file
  * Fix invalid `DefaultInstance` in the `getty@.service` template unit
  * Remove redundant `getty@tty0.service`
  * Remove redundant `ctrl-alt-del.target`
  * systemd: add a default systemd preset

See the related commit messages for additional rationale.  This PR contains no AI contributions.
