### PR TITLE
grub2: remove broken/redundant "Secure Boot entry" with `linuxefi`/`initrdefi` commands

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3974,9 +3974,7 @@ GRUB2_MODULES_UEFI=()
 # The default GRUB2 menu entry to boot
 # when GRUB2 is used as bootloader for the ReaR recovery system.
 # Valid values are (see the create_grub2_cfg function in lib/bootloader-functions.sh):
-# rear             : Relax-and-Recover (BIOS or UEFI without Secure Boot)
-#                    Relax-and-Recover (BIOS or UEFI in legacy BIOS mode)
-# rear_secure_boot : Relax-and-Recover (UEFI and Secure Boot)
+# rear             : Relax-and-Recover
 # chainloader      : Boot next EFI
 #                    Boot from second disk hd1 (usually the original system disk)
 # reboot           : Reboot

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -668,33 +668,8 @@ function create_grub2_cfg {
     }
 
     function create_grub2_rear_boot_entry {
-        # "ReaR (BIOS or UEFI without Secure Boot)"
-        # is correct in case you don't use EFI (i.e. for BIOS)
-        # and should work for EFI with secure boot disabled.
-        # "ReaR (UEFI and Secure Boot)"
-        # only works with EFI (and you may need secure boot enabled).
-        if is_true $USING_UEFI_BOOTLOADER ; then
-            cat << EOF
-menuentry "Relax-and-Recover (BIOS or UEFI without Secure Boot)" --id=rear {
-    insmod gzio
-    insmod xzio
-    echo 'Loading kernel $grub2_kernel ...'
-    linux $grub2_kernel root=UUID=$root_uuid $KERNEL_CMDLINE
-    echo 'Loading initial ramdisk $grub2_initrd ...'
-    initrd $grub2_initrd
-}
-menuentry "Relax-and-Recover (UEFI and Secure Boot)" --id=rear_secure_boot {
-    insmod gzio
-    insmod xzio
-    echo 'Loading kernel $grub2_kernel ...'
-    linuxefi $grub2_kernel root=UUID=$root_uuid $KERNEL_CMDLINE
-    echo 'Loading initial ramdisk $grub2_initrd ...'
-    initrdefi $grub2_initrd
-}
-EOF
-        else
-            cat << EOF
-menuentry "Relax-and-Recover (BIOS or UEFI in legacy BIOS mode)" --id=rear {
+        cat << EOF
+menuentry "Relax-and-Recover" --id=rear {
     insmod gzio
     insmod xzio
     echo 'Loading kernel $grub2_kernel ...'
@@ -703,8 +678,6 @@ menuentry "Relax-and-Recover (BIOS or UEFI in legacy BIOS mode)" --id=rear {
     initrd $grub2_initrd
 }
 EOF
-        fi
-    # End of function create_grub2_rear_boot_entry
     }
 
     function create_grub2_boot_next_entry {

--- a/usr/share/rear/output/RAWDISK/Linux-i386/270_create_grub2_efi_bootloader.sh
+++ b/usr/share/rear/output/RAWDISK/Linux-i386/270_create_grub2_efi_bootloader.sh
@@ -104,7 +104,6 @@ else
     # Use the UEFI default boot loader name, so that firmware will find it without an existing boot entry.
     local boot_loader="$efi_boot_directory/BOOT${EFI_ARCH_UPPER}.EFI"
     local grub_modules=( part_gpt fat normal configfile linux video all_video )
-    [[ -f "$efi_modules_directory/linuxefi.mod" ]] && grub_modules+=("$efi_modules_directory/linuxefi.mod")
     $grub2_name-mkimage -O "$GRUB2_IMAGE_FORMAT" -o "$boot_loader" -p "/EFI/BOOT" "${grub_modules[@]}"
     StopIfError "Error occurred during $grub2_name-mkimage of $boot_loader"
 fi


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal**

* Reference to related issue (URL): https://github.com/rear/rear/issues/3423

* How was this pull request tested? x86_64 VM with UEFI and Secure Boot enabled

* Description of the changes in this pull request:

These commands were a legacy workaround applied to GRUB2 downstream by selected Linux distros on i386/x86_64 to support secure boot.  Modern GRUB2 supports secure boot using the upstream native linux/initrd commands.  Several distros still provide linuxefi/initrdefi as mere aliases to linux/initrd for backwards compatibility (e.g. RHEL 8+/SUSE).  However, others have dropped them already (e.g. Debian and its derivatives).  This makes the rear_secure_boot entry misleading/redundant in the first case, and completely broken in the latter.

Moreover, GRUB2 for other EFI-enabled architectures (e.g. aarch64 or riscv64) has never supported these commands (upstream nor downstream), therefore, the rear_secure_boot entry is broken there as well.

Assisted-by: Cursor with Claude Opus 4.6