### PR TITLE
#3601 comment line BACKUP_PROG_EXCLUDE in script RSYNC/default/250_ad…

### DIFF
--- a/usr/share/rear/backup/RSYNC/default/250_add_extra_excludes_for_rsync.sh
+++ b/usr/share/rear/backup/RSYNC/default/250_add_extra_excludes_for_rsync.sh
@@ -1,5 +1,6 @@
 # 250_add_extra_excludes_for_rsync.sh
 
-BACKUP_PROG_EXCLUDE+=( '/proc/*' '/run/*' '/sys/*' '/dev/pts/*' '/var/tmp/*' '/mnt/*' '/media/*' )
+# Seems we do not need extra excludes with RSYNC workflow besides we already have defined in ReaR (#3601)
+# BACKUP_PROG_EXCLUDE+=( '/proc/*' '/run/*' '/sys/*' '/dev/pts/*' '/var/tmp/*' '/mnt/*' '/media/*' )
 
 # script 400_create_include_exclude_files.sh will include above mentioned values in the $TMP_DIR/backup-excludes.txt file


### PR DESCRIPTION
##### Pull Request Details:

* Type: **Cleanup**

* Impact: **Low**

* Reference to related issue (URL): #3601

* How was this pull request tested? Via a Test VM the ReaR restore worked fine.

* Description of the changes in this pull request:

The line:
`BACKUP_PROG_EXCLUDE+=( '/proc/*' '/run/*' '/sys/*' '/dev/pts/*' '/var/tmp/*' '/mnt/*' '/media/*' )` is now commented as ReaR already has an exclude policy. To avoid mistakes we prefer to define excludes via the proper configuration files (instead directly in a script).
We could also remove this script, but you never know.
