### PR TITLE
BORG: Add opt-in node-specific restore filter and hard-fail mechanism

### DIFF
--- a/usr/share/rear/restore/BORG/default/300_load_archives.sh
+++ b/usr/share/rear/restore/BORG/default/300_load_archives.sh
@@ -63,25 +63,21 @@ local archive_cache_lines_last_shown=0
 # This block is fully backward compatible: if ENABLE_BORG_NODE_FILTER is not "yes",
 # ReaR shows all available BORG archives as before.
 # -----------------------------------------------------------------------------
-if [[ "${ENABLE_BORG_NODE_FILTER}" == "yes" ]]; then
-  if [ -n "$BORGBACKUP_ARCHIVE_PREFIX" ] && [ -f "$BORGBACKUP_ARCHIVE_CACHE" ]; then
-    # Find highest-numbered archive for this node prefix
-    latest_archive=$(grep "^${BORGBACKUP_ARCHIVE_PREFIX}_" "$BORGBACKUP_ARCHIVE_CACHE" | sort -t_ -k2,2n | tail -n 1)
-    if [ -n "$latest_archive" ]; then
-      echo "$latest_archive" > "$BORGBACKUP_ARCHIVE_CACHE"
-      archive_cache_lines_total=1
-      export BORGBACKUP_ARCHIVE_TO_RECOVER=1
+if is_true "$ENABLE_BORG_NODE_FILTER"; then
+    [[ -n $BORGBACKUP_ARCHIVE_PREFIX ]] || Error "ENABLE_BORG_NODE_FILTER=yes but BORGBACKUP_ARCHIVE_PREFIX is empty"
+    [[ -s $BORGBACKUP_ARCHIVE_CACHE ]] || Error "ENABLE_BORG_NODE_FILTER=yes but Borg archive cache '$BORGBACKUP_ARCHIVE_CACHE' is missing or empty"
+
+    # Find highest-numbered archive for this node prefix (archive names are ${BORGBACKUP_ARCHIVE_PREFIX}_<number>)
+    latest_archive=$( grep "^${BORGBACKUP_ARCHIVE_PREFIX}_" "$BORGBACKUP_ARCHIVE_CACHE" | LC_ALL=C sort -t_ -k2,2n | tail -n 1 )
+    if [[ -n $latest_archive ]]; then
+        printf '%s\n' "$latest_archive" > "$BORGBACKUP_ARCHIVE_CACHE"
+        archive_cache_lines_total=1
+        BORGBACKUP_RESTORE_ARCHIVES_SHOW_MAX=1
+        LogUserOutput "ENABLE_BORG_NODE_FILTER enabled: restricting restore candidates to the latest ${BORGBACKUP_ARCHIVE_PREFIX}_* archive."
     else
-      # Abort: No archive for this node found! (prevents cross-node restore)
-      Error "No archives found with prefix ${BORGBACKUP_ARCHIVE_PREFIX}_ in the Borg cache! Aborting to prevent auto-restore of WRONG node."
+        Error "ENABLE_BORG_NODE_FILTER=yes but no archives with prefix '${BORGBACKUP_ARCHIVE_PREFIX}_' exist in Borg repository $BORGBACKUP_REPO on ${BORGBACKUP_HOST:-USB}. Aborting to avoid restoring from a different node."
     fi
-  fi
 fi
-#How to Enable After Your Change
-#Just add this to your /etc/rear/local.conf:
-#ENABLE_BORG_NODE_FILTER="yes"
-#export ENABLE_BORG_NODE_FILTER
-# End  Node-specific archive restriction for BORG restores
 while true ; do
     UserOutput ""
     LogUserOutput "$( cat -n "$BORGBACKUP_ARCHIVE_CACHE" \

--- a/usr/share/rear/restore/BORG/default/300_load_archives.sh
+++ b/usr/share/rear/restore/BORG/default/300_load_archives.sh
@@ -47,7 +47,41 @@ local archive_cache_lines_last_shown=0
 # When pagination is disabled by the user, show everything
 [[ $BORGBACKUP_RESTORE_ARCHIVES_SHOW_MAX -eq 0 ]] \
     && BORGBACKUP_RESTORE_ARCHIVES_SHOW_MAX=$archive_cache_lines_total
-
+# -----------------------------------------------------------------------------
+# Optional: Node-specific archive restriction for BORG restores
+#
+# If ENABLE_BORG_NODE_FILTER is set to "yes" (e.g. in /etc/rear/local.conf),
+# this section restricts the available restore archives to only the most recent
+# (highest-numbered) backup with this node's BORGBACKUP_ARCHIVE_PREFIX.
+#
+# This prevents accidental restore of the wrong system in shared repositories,
+# especially in unattended/AUTO_CONFIRM scenarios.
+#
+# If no matching archive is found, ReaR aborts with a clear error and NEVER
+# restores from another node's backup.
+#
+# This block is fully backward compatible: if ENABLE_BORG_NODE_FILTER is not "yes",
+# ReaR shows all available BORG archives as before.
+# -----------------------------------------------------------------------------
+if [[ "${ENABLE_BORG_NODE_FILTER}" == "yes" ]]; then
+  if [ -n "$BORGBACKUP_ARCHIVE_PREFIX" ] && [ -f "$BORGBACKUP_ARCHIVE_CACHE" ]; then
+    # Find highest-numbered archive for this node prefix
+    latest_archive=$(grep "^${BORGBACKUP_ARCHIVE_PREFIX}_" "$BORGBACKUP_ARCHIVE_CACHE" | sort -t_ -k2,2n | tail -n 1)
+    if [ -n "$latest_archive" ]; then
+      echo "$latest_archive" > "$BORGBACKUP_ARCHIVE_CACHE"
+      archive_cache_lines_total=1
+      export BORGBACKUP_ARCHIVE_TO_RECOVER=1
+    else
+      # Abort: No archive for this node found! (prevents cross-node restore)
+      Error "No archives found with prefix ${BORGBACKUP_ARCHIVE_PREFIX}_ in the Borg cache! Aborting to prevent auto-restore of WRONG node."
+    fi
+  fi
+fi
+#How to Enable After Your Change
+#Just add this to your /etc/rear/local.conf:
+#ENABLE_BORG_NODE_FILTER="yes"
+#export ENABLE_BORG_NODE_FILTER
+# End  Node-specific archive restriction for BORG restores
 while true ; do
     UserOutput ""
     LogUserOutput "$( cat -n "$BORGBACKUP_ARCHIVE_CACHE" \


### PR DESCRIPTION
If ENABLE_BORG_NODE_FILTER is set to "yes", ReaR will:
- Filter available BORG restores to only the latest backup for the current node (archive with the highest suffix, by BORGBACKUP_ARCHIVE_PREFIX).
- Abort restore (with clear error) if no such archive exists, preventing accidental restoration of data from the wrong node in shared repositories, even with AUTO_CONFIRM enabled.

Fully backward compatible—feature is disabled unless user explicitly opts in.

---

#### Relax-and-Recover (ReaR) Pull Request Template

##### Pull Request Details:

- **Type:** New Feature / Enhancement
- **Impact:** High (for anyone using ReaR+BORG with shared repositories)
- **Reference to related issue (URL):** N/A (no existing issue, but addresses a longstanding risk)

**How was this pull request tested?**
- Manually tested in shared BORG repo environments with multiple nodes.
- Verified safe-guard abort when no matching backup is present.
- Confirmed restore works as before when not enabled.

**Description of the changes in this pull request:**
This PR introduces an opt-in safety mechanism for ReaR+BORG in multi-node (shared repo) environments:

- If ENABLE_BORG_NODE_FILTER="yes" (set in local.conf):
  - ReaR only offers and autoselects the latest backup for the current node (by archive name/number) during restore.
  - If NO matching archive is found for the node, the restore process aborts immediately with a clear error, preventing any possible restoration of another node's data.
  - This enables safe, fully-automated AUTO_CONFIRM="yes" restores across all hosts in a shared BORG repository with zero cross-contamination risk.
- By default, this feature is OFF—users must explicitly enable it.
- No change to existing flows unless variable is set.

**How to enable:**  
Add to your `/etc/rear/local.conf`:
```sh
ENABLE_BORG_NODE_FILTER="yes"
export ENABLE_BORG_NODE_FILTER