### PR TITLE
Some fixes for SEP Sesam related backup mode

### DIFF
--- a/usr/share/rear/lib/sesam-functions.sh
+++ b/usr/share/rear/lib/sesam-functions.sh
@@ -17,6 +17,8 @@ SESAM_LD_LIBRARY_PATH=$SM_BIN_SESAM:$SM_BIN_SESAM/python3/:$SM_BIN_SMS
 SM_INI="$( grep SM_INI $sesam2000ini_file 2>/dev/null | cut -d '=' -f 2 )"
 test -z "$SM_INI" && return 0
 
+# set SESAM_*_DIR variables to values from sm.ini (with trailing slashes removed!)
+
 # Avoid ShellCheck false error indication
 # SC1097: Unexpected ==. For assignment, use =
 # for code like
@@ -24,14 +26,26 @@ test -z "$SM_INI" && return 0
 # by quoting the assigned character:
 while IFS='=' read key value ; do
     case "$key" in
-        (gv_ro) SESAM_BIN_DIR="$value" ;;
-        (gv_rw) SESAM_VAR_DIR="$value" ;;
+        (gv_ro)      SESAM_BIN_DIR="${value%%/}" ;;
+        (gv_rw)      SESAM_VAR_DIR="${value%%/}" ;;
+        (gv_rw_work) SESAM_WORK_DIR="${value%%/}" ;;
+        (gv_rw_tmp)  SESAM_TMP_DIR="${value%%/}" ;;
+        (gv_rw_lis)  SESAM_LIS_DIR="${value%%/}" ;;
+        (gv_rw_lgc)  SESAM_LGC_DIR="${value%%/}" ;;
+        (gv_rw_stpd) SESAM_SMS_DIR="${value%%/}" ;;
+        (gv_rw_prot) SESAM_PROT_DIR="${value%%/}" ;;
     esac
 done <"$SM_INI"
 
-SESAM_WORK_DIR="${SESAM_VAR_DIR%%/}/var/work/*"
-SESAM_TMP_DIR="${SESAM_VAR_DIR%%/}/var/tmp/*"
-SESAM_LIS_DIR="${SESAM_VAR_DIR%%/}/var/lis"
-SESAM_LGC_DIR="${SESAM_VAR_DIR%%/}/var/log/lgc/*"
-SESAM_SMS_DIR="${SESAM_VAR_DIR%%/}/var/log/sms/*"
-SESAM_PROT_DIR="${SESAM_VAR_DIR%%/}/var/prot/*"
+# set variables to default values if automatic setting did not work
+# (e.g. gv_rw_lis, gv_rw_stpd and gv_rw_prot do not exist on sesam clients)
+# to prevent 'everything' excludes "/*" in 400_prep_sesam.sh
+test -z "${SESAM_BIN_DIR}"  && SESAM_BIN_DIR=/opt/sesam
+test -z "${SESAM_VAR_DIR}"  && SESAM_VAR_DIR=/var/opt/sesam
+test -z "${SESAM_WORK_DIR}" && SESAM_WORK_DIR=${SESAM_VAR_DIR}/var/work
+test -z "${SESAM_TMP_DIR}"  && SESAM_TMP_DIR=${SESAM_VAR_DIR}/var/tmp
+test -z "${SESAM_LIS_DIR}"  && SESAM_LIS_DIR=${SESAM_VAR_DIR}/var/lis
+test -z "${SESAM_LGC_DIR}"  && SESAM_LGC_DIR=${SESAM_VAR_DIR}/var/log/lgc
+test -z "${SESAM_SMS_DIR}"  && SESAM_SMS_DIR=${SESAM_VAR_DIR}/var/log/sms
+test -z "${SESAM_PROT_DIR}" && SESAM_PROT_DIR=${SESAM_VAR_DIR}/var/prot
+

--- a/usr/share/rear/lib/sesam-functions.sh
+++ b/usr/share/rear/lib/sesam-functions.sh
@@ -15,7 +15,7 @@ source $sesam2000ini_file
 SESAM_LD_LIBRARY_PATH=$SM_BIN_SESAM:$SM_BIN_SESAM/python3/:$SM_BIN_SMS
 
 SM_INI="$( grep SM_INI $sesam2000ini_file 2>/dev/null | cut -d '=' -f 2 )"
-test -z "$SM_INI" && return 0
+test -r "$SM_INI" -a -f "$SM_INI" || SM_INI=/dev/null
 
 # set SESAM_*_DIR variables to values from sm.ini (with trailing slashes removed!)
 

--- a/usr/share/rear/prep/SESAM/default/400_prep_sesam.sh
+++ b/usr/share/rear/prep/SESAM/default/400_prep_sesam.sh
@@ -20,16 +20,22 @@ if [ -e /etc/sesam2000.ini ]; then
             /etc/sesam2000.ini
         )
 
-        # do not include certain sesam folders as generated boot
-        # image will grow too big if sesam listing and temporary
-        # files are included
+        # do not include certain sesam folders content as generated boot
+        # image will grow too big if sesam listing, temporary, working and log
+        # files are included (don't also exclude the directories themselves
+        # as they're required for the sesam client to work in the recovery
+        # environment); double-quoting is required to prevent the shell from
+        # expanding those entries already here, which does not include e.g.
+        # hidden files/dirs like /var/opt/sesam/var/tmp/.guestfs-0/ - if tar
+        # is given such an exclude it does it right ...
         COPY_AS_IS_EXCLUDE+=(
             "${COPY_AS_IS_EXCLUDE_SESAM[@]}" 
-            $SESAM_TMP_DIR 
-            $SESAM_LIS_DIR 
-            $SESAM_LGC_DIR 
-            $SESAM_SMS_DIR
-            $SESAM_PROT_DIR 
+            "${SESAM_WORK_DIR}/*"
+            "${SESAM_TMP_DIR}/*"
+            "${SESAM_LIS_DIR}/*"
+            "${SESAM_LGC_DIR}/*"
+            "${SESAM_SMS_DIR}/*"
+            "${SESAM_PROT_DIR}/*"
         )
 
         # include libssl as it is needed to run sesam sm_sshd if included

--- a/usr/share/rear/skel/SESAM/etc/scripts/system-setup.d/59-start-sesam-client.sh
+++ b/usr/share/rear/skel/SESAM/etc/scripts/system-setup.d/59-start-sesam-client.sh
@@ -6,8 +6,10 @@ if [ -e /etc/sesam2000.ini ]; then
         # set the sesam environment profile
         source $SESAM_VAR_DIR/var/ini/sesam2000.profile
 
-        # create sesam Semaphore directory
+        # create sesam minimal directory structure for client
+        # to start in recovery environment
         mkdir -p $SESAM_WORK_DIR/sem/
+        mkdir -p $SESAM_WORK_DIR/ctl/
 
         # start sesam client daemon
         $SESAM_BIN_DIR/bin/sesam/sm_main start


### PR DESCRIPTION
Hi,

see attached pull request, it includes some fixes for the SESAM related backup mode:

1) create the sesam ctl directory that is required for client startup during recovery, as work directory is excluded by default (on purpose)
2) fix the defaults to exclude directory contents only, add more directories to the default excludes that may result in too big ISO images
3) if auto-detection of default variables via sesam configuration file fails, use default values

