### PR TITLE
Error out when KERNEL_VERSION is not set

### DIFF
--- a/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
+++ b/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
@@ -16,11 +16,6 @@ if test "no_modules" = "$MODULES" ; then
     return
 fi
 
-# KERNEL_VERSION must be set.
-# It is set in default.conf to $( uname -r ) if not set by the user via the '-r' option of sbin/rear
-# so if it is not set it is likely an error by the user (e.g. empty setting in local.conf):
-test "$KERNEL_VERSION" || Error "KERNEL_VERSION must be set"
-
 # As general condition the /lib/modules/$KERNEL_VERSION directory must exist:
 if ! test -d "/lib/modules/$KERNEL_VERSION" ; then
     Error "Cannot copy kernel modules because /lib/modules/$KERNEL_VERSION does not exist"

--- a/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
+++ b/usr/share/rear/build/GNU/Linux/400_copy_modules.sh
@@ -16,8 +16,12 @@ if test "no_modules" = "$MODULES" ; then
     return
 fi
 
+# KERNEL_VERSION must be set.
+# It is set in default.conf to $( uname -r ) if not set by the user via the '-r' option of sbin/rear
+# so if it is not set it is likely an error by the user (e.g. empty setting in local.conf):
+test "$KERNEL_VERSION" || Error "KERNEL_VERSION must be set"
+
 # As general condition the /lib/modules/$KERNEL_VERSION directory must exist:
-test "$KERNEL_VERSION" || KERNEL_VERSION="$( uname -r )"
 if ! test -d "/lib/modules/$KERNEL_VERSION" ; then
     Error "Cannot copy kernel modules because /lib/modules/$KERNEL_VERSION does not exist"
 fi

--- a/usr/share/rear/prep/GNU/Linux/400_guess_kernel.sh
+++ b/usr/share/rear/prep/GNU/Linux/400_guess_kernel.sh
@@ -7,8 +7,9 @@
 
 # KERNEL_VERSION must be set in any case.
 # It is set in default.conf to $( uname -r ) if not set by the user via the '-r' option of sbin/rear
-# so if it is not set it is likely an error by the user (e.g. empty setting in local.conf):
-test "$KERNEL_VERSION" || Error "KERNEL_VERSION must be set"
+# so if it is not set it is likely an error by the user (e.g. wrong setting in local.conf).
+# Using plain test to ensure KERNEL_VERSION is a single non empty and non blank word:
+test $KERNEL_VERSION || Error "KERNEL_VERSION='$KERNEL_VERSION' is not a single non empty and non blank word"
 
 # When KERNEL_FILE is specified by the user use that as is or error out
 # cf. https://github.com/rear/rear/pull/1985#discussion_r237451729

--- a/usr/share/rear/prep/GNU/Linux/400_guess_kernel.sh
+++ b/usr/share/rear/prep/GNU/Linux/400_guess_kernel.sh
@@ -5,6 +5,11 @@
 # This file is part of Relax-and-Recover, licensed under the GNU General
 # Public License. Refer to the included COPYING for full text of license.
 
+# KERNEL_VERSION must be set in any case.
+# It is set in default.conf to $( uname -r ) if not set by the user via the '-r' option of sbin/rear
+# so if it is not set it is likely an error by the user (e.g. empty setting in local.conf):
+test "$KERNEL_VERSION" || Error "KERNEL_VERSION must be set"
+
 # When KERNEL_FILE is specified by the user use that as is or error out
 # cf. https://github.com/rear/rear/pull/1985#discussion_r237451729
 # (KERNEL_FILE is empty in default.conf):


### PR DESCRIPTION

* Type: **Bug Fix**

* Impact: **Low**

* Reference to related issue (URL):
https://github.com/rear/rear/pull/3614#discussion_r3528343520

* How was this pull request tested?
 
For me it Errors out for those wrong settings in local.conf
```
KERNEL_VERSION=''
KERNEL_VERSION=' '
KERNEL_VERSION='foo bar'
unset KERNEL_VERSION
```

* Description of the changes in this pull request:

In build/GNU/Linux/400_copy_modules.sh
KERNEL_VERSION must be set.
It is set in default.conf to $( uname -r ) 
if not set by the user via the '-r' option of sbin/rear
so if it is not set it is likely an error by the user
(e.g. empty setting in local.conf).
If we set it to $( uname -r ) if not set,
we would falsely hide an error, cf.
"In case of errors better abort than to blindly proceed" in
https://github.com/rear/rear/wiki/Coding-Style

So we Error out now, see
https://github.com/rear/rear/pull/3614#discussion_r3528343520

But now the test is moved from
build/GNU/Linux/400_copy_modules.sh
to
prep/GNU/Linux/400_guess_kernel.sh
because this is the first script that uses KERNEL_VERSION
and the test now ensures KERNEL_VERSION is
a single non empty and non blank word.
