### PR TITLE
Avoid "just" "simple" "easy" (issue #3129)

### DIFF
--- a/doc/rear.8.md
+++ b/doc/rear.8.md
@@ -344,7 +344,7 @@ To backup to NFS disk, use `BACKUP_URL=nfs://nfs-server-name/share/path`
 
 * BACKUP_URL=*tape://*:
 To backup to tape device, use `BACKUP_URL=tape:///dev/nst0` or alternatively,
-simply define `TAPE_DEVICE=/dev/nst0`
+define `TAPE_DEVICE=/dev/nst0`
 
 * BACKUP_URL=*rsync://*:
 When backup method `BACKUP=RSYNC` is chosen then we need to define a corresponding `BACKUP_URL` rule:

--- a/doc/user-guide/02-getting-started.md
+++ b/doc/user-guide/02-getting-started.md
@@ -109,7 +109,7 @@ The latest stable versions of Fedora and SLES can be installed via `yum` and `zy
 
 ## From RPM packages
 
-Simply install (or update) the provided packages using
+Install (or update) the provided packages using
 the command: `rpm -Uhv rear-1.17-1.fc20.noarch.rpm`
 
 You can test your installation by running `rear dump`:
@@ -138,7 +138,7 @@ On Debian (Ubuntu) use the following command to install missing dependencies:
 
 The latest and greatest sources are available at GitHub location : [https://github.com/rear/rear](https://github.com/rear/rear)
 
-To make local copy with our github repository just type:
+To make local copy with our github repository, type:
 
     git clone git@github.com:rear/rear.git
 

--- a/doc/user-guide/03-configuration.md
+++ b/doc/user-guide/03-configuration.md
@@ -156,7 +156,7 @@ at least `BACKUP_URL=usb` requires USB_SUFFIX to be set
 to work with incremental or differential backup.
 
 * BACKUP=REQUESTRESTORE:
-No backup, just ask user to somehow restore the filesystems.
+No backup, request the user to somehow restore the filesystems.
 
 * BACKUP=EXTERNAL:
 Use a custom strategy by providing backup and restore commands.
@@ -188,7 +188,7 @@ To backup to NFS disk, use `BACKUP_URL=nfs://nfs-server-name/share/path`
 
 * BACKUP_URL=tape://:
 To backup to tape device, use `BACKUP_URL=tape:///dev/nst0` or alternatively,
-simply define `TAPE_DEVICE=/dev/nst0`
+define `TAPE_DEVICE=/dev/nst0`
 
 * BACKUP_URL=cifs://:
 To backup to a Samba share (CIFS), use

--- a/doc/user-guide/04-scenarios.md
+++ b/doc/user-guide/04-scenarios.md
@@ -3,7 +3,7 @@
 
 ## Bootable ISO
 
-If you simply want a bootable ISO on a central server, you would do:
+If you only want a bootable ISO on a central server, you would do:
 
     OUTPUT=ISO
     OUTPUT_URL=http://server/path-to-push/
@@ -15,7 +15,7 @@ If you rely on your backup software to do the full restore of a system then you 
     OUTPUT=ISO
     BACKUP=[TSM|NSR|DP|NBU|GALAXY10|SEP|DUPLICITY|BACULA|BAREOS|RBME|FDRUPSTREAM]
 
-When using one of the above backup solution (commercial or open source) then there is no need to use `rear mkbackup` as the backup workflow would be empty. Just use `rear mkrescue`
+When using one of the above backup solution (commercial or open source) then there is no need to use `rear mkbackup` as the backup workflow would be empty. Use `rear mkrescue` instead.
 
 ReaR will incorporate the needed executables and libraries of your chosen backup solution into the rescue image of ReaR.
 
@@ -381,7 +381,7 @@ Using USB devices with Relax-and-Recover can be appealing for several reasons:
  - If you only need to have a bootable rescue environment,
    a USB device is a cheap device to store it (needs up to about 1 GB)
 
- - When you have plenty of space, it could be a simple solution
+ - When you have plenty of space, it could be a solution
    to store complete disaster recovery images (rescue environment + backup)
 
 However USB devices may be slow for backup purposes,
@@ -626,7 +626,7 @@ different system.
 #### Restoring from Bacula tape
 
 Now you need to continue with restoring the actual Bacula backup, for this you
-have multiple options of which `bextract` is the most easy and
+have multiple options of which `bextract` is most
 straightforward, but also the slowest and unsafest.
 
 
@@ -648,7 +648,7 @@ or
     VolSessionId = 1
     VolSessionTime = 108927638
 
-Using a bootstrap file with bextract is easy, simply do:
+Using a bootstrap file with bextract is straightforward, do:
 `bextract -b bootstrap.txt Ultrium-1 /mnt/local`
 
 TIP: It helps to know exactly how many files you need to restore, and using
@@ -880,7 +880,7 @@ restore instructions on screen as an aid during recovery.
 
 #### Making the OBDR rescue tape
 
-To create a rescue environment that can boot from an OBDR tape, simply run
+To create a rescue environment that can boot from an OBDR tape, run
 `rear -v mkrescue` with a *REAR-000* -labeled tape inserted.
 
     [root@system ~]# rear -v mkrescue
@@ -900,7 +900,7 @@ To create a rescue environment that can boot from an OBDR tape, simply run
     Finished in 119 seconds.
 
 WARNING: The message above about _/dev/cciss/c1d0_ not being used makes sense
-as this is not a real disk but simply an entry for manipulating the controller.
+as this is not a real disk but an entry for manipulating the controller.
 This is specific to CCISS controllers with only a tape device attached.
 
 
@@ -1144,7 +1144,7 @@ for more information about how to restore a Bacula tape.
 An OBDR backup tape is similar to an OBDR rescue tape, but next to the rescue
 environment, it also consists of a complete backup of the system. This is
 very convenient in that a single tape can be use for disaster recovery, and
-recovery is much more simple and completely automated.
+recovery is much more straightforward and completely automated.
 
 CAUTION: Please make sure that the system fits onto a single tape uncompressed.
          For an LTO4 Ultrium that would mean no more than 1.6TB.
@@ -1163,7 +1163,7 @@ shows how to use the tape for storing *both* the rescue image and the backup.
 
 #### Making the OBDR backup tape
 
-To create a bootable backup tape that can boot from OBDR, simply run
+To create a bootable backup tape that can boot from OBDR, run
 `rear -v mkbackup` with a *REAR-000* -labeled tape inserted.
 
     [root@system ~]# rear -v mkbackup
@@ -1302,7 +1302,7 @@ Once booted on your recovery image, the `mountonly` workflow will:
 
 thereby making it possible for you to explore your system at will,
 correcting any configuration mistake that may have prevented its startup,
-or allowing you to simply `chroot` into it and further repair it using its
+or allowing you to `chroot` into it and further repair it using its
 own administrative tools.
 
 One important point to remember is that the `mountonly` workflow on its own
@@ -1369,7 +1369,7 @@ verbose):
     Running exit tasks
 
 As you can see in the output above, you will first be asked to confirm
-running the workflow (`Proceed with 'mountonly'`) -- simply press return.
+running the workflow (`Proceed with 'mountonly'`) -- press return.
 All the target filesystems should now be mounted below `/mnt/local` (including
 LUKS-encrypted ones if present and all needed virtual ones). In case any of
 them fails to mount, you will be offered to review the mount script and to

--- a/doc/user-guide/06-layout-configuration.md
+++ b/doc/user-guide/06-layout-configuration.md
@@ -69,7 +69,7 @@ described in a later section. It is already clear that this file is human
 readable and thus human editable. It is also machine readable and all
 information necessary to restore a system is listed.
 
-It's easy to see that there are 3 disks attached to the system. `/dev/sda` is the internal disk of the system. Its filesystems are normally mounted. The other devices are external disks. One of them has just normal partitions. The other one has a physical volume on one of the partitions.
+It is clear that there are 3 disks attached to the system. `/dev/sda` is the internal disk of the system. Its filesystems are normally mounted. The other devices are external disks. One of them has only normal partitions. The other one has a physical volume on one of the partitions.
 
 ## Excluding components
 
@@ -184,7 +184,7 @@ Another approach would be to exclude the backup volume group. This is achieved b
 
 ## Restore to the same hardware
 
-Restoring the system to the same hardware is simple. Type `rear recover` in
+Restoring the system to the same hardware is straightforward. Type `rear recover` in
 the rescue system prompt. Relax-and-Recover will detect that it's restoring to
 the same system and will make sure things like UUIDs match. It also asks for
 your LUKS encryption password.
@@ -255,7 +255,7 @@ partitions.
 Let's try to restore our system to a different system. Instead of one 160G
 disk, there is now one 5G and one 10G disk. That's not enough space to restore
 the complete system, but for purposes of this demonstration, we do not care
-about that. We're also not going to use the first disk, but we just want to
+about that. We're also not going to use the first disk, but we only want to
 show that Relax-and-Recover handles the renaming automatically.
 
     RESCUE firefly:~ # rear recover
@@ -328,7 +328,7 @@ The renaming operation was successful.
 
 On the other hand, we can already see quite a few problems. A partition with negative sizes. I do not think any tool would like to create that. Still, we don't care at this moment. Do you like entering partition sizes in bytes? Neither do I. There has to be a better way to handle it. We will show it during the next step.
 
-The `/kvm` and `/vmware` filesystems are quite big. We don't care about them, so just put some nice comments on them and their logical volumes.
+The `/kvm` and `/vmware` filesystems are quite big. We don't care about them, so comment out them and their logical volumes.
 
 The resulting layout file looks like this:
 
@@ -400,7 +400,7 @@ Now, this is where human friendly resizes are possible. Edit the file. Find the 
     sleep 10
 
 
-It's simple bash code. Change it to use better values. Parted is happy to accept partitions in Megabytes.
+It is bash code. Change it to use better values. Parted accepts partitions in Megabytes.
 
     if create_component "/dev/sdb" "disk" ; then
     # Create /dev/sdb (disk)
@@ -482,7 +482,7 @@ Relax-and-Recover produces exceptionally good logs. Let's check them.
 
 Yes, we resized the home partition from 20GB to 2G in the previous step. The root user wants more reserved blocks than the total number of available blocks.
 
-Fixing it is simple. Edit the restore script, option 4. Find the code responsible for filesystem creation.
+Fixing it is straightforward. Edit the restore script, option 4. Find the code responsible for filesystem creation.
 
     if create_component "fs:/home" "fs" ; then
     # Create fs:/home (fs)
@@ -498,7 +498,7 @@ Fixing it is simple. Edit the restore script, option 4. Find the code responsibl
         LogPrint "Skipping fs:/home (fs) as it has already been created."
     fi
  
-The `-r` parameter is causing the error. We just remove it and do the same for the other filesystems.
+The `-r` parameter is causing the error. We remove it and do the same for the other filesystems.
 
     if create_component "fs:/home" "fs" ; then
     # Create fs:/home (fs)
@@ -581,7 +581,7 @@ where keyword denotes one kind of component (disk, partition, filesystem, ...)
 and keyword and all the values are separated by single space characters
 (which means spaces in values are forbidden - there is neither quoting nor escaping)
 so that one can get the lines that belong to a particular component
-with particular value1 and value2 via simple commands like
+with particular value1 and value2 via basic commands like
 
     grep "^keyword value1 value2 " /var/lib/rear/layout/disklayout.conf
 

--- a/doc/user-guide/07-tips-and-tricks.md
+++ b/doc/user-guide/07-tips-and-tricks.md
@@ -28,7 +28,7 @@ This results in the following useful tips and tricks:
     troubleshoot, or modify an important file during recovery.
 
  4. If you have keyboard problems using a HP iLO 2 Remote Console, type the
-    following command +loadkeys -d+ (or simply use the up arrow key to get
+    following command +loadkeys -d+ (or use the up arrow key to get
     this command from your shell history).
 
  5. If the original system was configured to log on remotely through the use

--- a/doc/user-guide/08-troubleshooting.md
+++ b/doc/user-guide/08-troubleshooting.md
@@ -87,7 +87,7 @@ _Here is a list of known issues during recovery:_
 * Failed to clear HP SmartArray controller 1:
 This error may be caused by trying to clear an HP SmartArray controller
 that does not have a configuration or does not exist. Since we have no
-means to know whether this is a fatal condition or not we simply try to
+means to know whether this is a fatal condition or not we try to
 recreate the logical drive(s) and see what happens.
 
     This message is harmless, but may help troubleshoot the subsequent error

--- a/doc/user-guide/10-integrating-external-backup.md
+++ b/doc/user-guide/10-integrating-external-backup.md
@@ -74,7 +74,7 @@ Again, think burp, and you probably also need these directories to be created:
     $ mkdir --mode=755 /usr/share/rear/{finalize,prep,rescue,restore,verify}/BURP
 
 
-Another easy trick is to look at the existing scripts of NBU (as a starter):
+Another approach is to look at the existing scripts of NBU (as a starter):
 
     $ sudo rear -s mkrescue | grep NBU
     Source prep/NBU/default/400_prep_nbu.sh

--- a/doc/user-guide/12-BLOCKCLONE.md
+++ b/doc/user-guide/12-BLOCKCLONE.md
@@ -39,7 +39,7 @@ ReaR with BLOCKCLONE is capable of doing backup of Linux/Windows dual boot
 
 #### Configuration
 
-This is very basic and most simple scenario where we will do backup
+This is a basic scenario where we will do backup
  of single partition (_/dev/sdc1_) located on separate disk (_/dev/sdc_). +
 First we need to set some global options in _local.conf_,
  like target for backups.

--- a/doc/user-guide/13-tcg-opal-support.md
+++ b/doc/user-guide/13-tcg-opal-support.md
@@ -63,7 +63,7 @@ encryption key (DEK) will be generated. While `rear opaladmin` includes safety
 measures to avoid accidentally erasing a partitioned disk, do not rely on this
 solely. *Always back up your data and have a current rescue system available.*
 
-* Boot the rescue system just created.
+* Boot the created rescue system.
 * *RE-CHECK. The following command will erase selected disks.*
 * Run `rear opaladmin setupERASE _DEVICE_ ...`
 * `_DEVICE_` is the disk device path like `/dev/sda`, or `ALL` for all available
@@ -110,7 +110,7 @@ whether it is locked or not:
 
 * In addition to its regular contents, an Opal disk contains a special area for
 additional boot code, the (unfortunately named) _shadow MBR_. It is small (the
-spec guarantees just 128 MB), write-protected, and normally hidden.
+spec guarantees only 128 MB), write-protected, and normally hidden.
 
 * When *unlocked*, an Opal disk shows its regular contents like any other disk.
 In this state, the system firmware would boot the regular operating system.
@@ -144,7 +144,7 @@ To create a pre-boot authentication (PBA) system image:
 copy it onto a disk boot medium (a USB stick will do) with `dd
 if="$image_file" bs=1MB of="$usb_device"` (use the entire disk device, not a
 partition),
-boot from the medium just created.
+boot from the created medium.
 
 To create a rescue system with an integrated PBA system image:
 

--- a/doc/user-guide/15-EFISTUB.md
+++ b/doc/user-guide/15-EFISTUB.md
@@ -5,7 +5,7 @@ EFISTUB booting allows EFI firmware to directly load Linux kernel as an EFI exec
 When using traditional boot-loaders ((E)LILO, Grub), ReaR does not auto-magically recreate booting information on restore, but respective code must exist and this also applies for EFISTUB booting.
 
 ## Prerequisites
-There is plenty of ways how EFISTUB can be setup on source system but for the start I've decided to keep first EFISTUB implementation as simple as possible and eventually cover more robust configuration later (if need arise). For this reason ReaR currently offers very basic implementation, where:
+There is plenty of ways how EFISTUB can be setup on source system but for the start I've decided to keep first EFISTUB implementation as basic as possible and eventually cover more robust configuration later (if need arise). For this reason ReaR currently offers very basic implementation, where:
 
 - active Linux kernel must be compiled with **CONFIG_EFI_STUB=y**
 - active Linux kernel and initrd are located directly on **vfat** partition
@@ -23,7 +23,7 @@ To enable EFISTUB booting in ReaR one must specify following variable in _local.
 
 ## Migration
 Migrating from traditional boot-loader to EFISTUB is kind of side effect of current implementation. Current EFISTUB code can't reliably determine if system is configured with EFISTUB boot hence user must explicitly specify that he wishes his system is considered EFISTUB bootable by ReaR.
-If operating system is set to boot using intermediate boot loaders and despite this `EFI_STUB="yes"` is explicitly set, ReaR will omit installation of intermediate boot loaders and just creates UEFI boot entry pointing directly to EFISTUB boot capable kernel when system is restored.
+If operating system is set to boot using intermediate boot loaders and despite this `EFI_STUB="yes"` is explicitly set, ReaR will omit installation of intermediate boot loaders and only create a UEFI boot entry pointing directly to EFISTUB boot capable kernel when system is restored.
 
 ## Checks done by ReaR
 When user enables EFISTUB, ReaR does some basic checks and tries to ensure that ReaR recovery runs without problems and resulting operating system is able to boot. However it is very hard to cover all configuration possibilities and corner cases, so it is important to ALWAYS TEST full ReaR backup and restore before relying on it. Short list of checks done by ReaR during `rear mkbackup/mkrescue` includes:

--- a/usr/share/rear/backup/BLOCKCLONE/default/500_start_clone.sh
+++ b/usr/share/rear/backup/BLOCKCLONE/default/500_start_clone.sh
@@ -25,7 +25,7 @@ if is_true "$BLOCKCLONE_TRY_UNMOUNT" && [ "$is_mounted" = "1" ]; then
     fi
 fi
 
-# Just put entry into log, that backup of mounted device was made
+# Write an entry to the log, that backup of mounted device was made
 is_mounted=$(is_device_mounted $BLOCKCLONE_SOURCE_DEV)
 if [ "$is_mounted" = "1" ]; then
     LogPrint "BLOCKCLONE was made on mounted device."

--- a/usr/share/rear/backup/RSYNC/default/600_remove_old_rsync_backup.sh
+++ b/usr/share/rear/backup/RSYNC/default/600_remove_old_rsync_backup.sh
@@ -17,7 +17,7 @@ if [[ ${#rsyncbackup[@]} -ge $BACKUP_RSYNC_RETENTION_DAYS ]] ; then
     # the first in the array list is the oldest rsync path
     remove_rsync_backup_path="${rsyncbackup[0]}"
 else
-    # nothing to remove; just return
+    # nothing to remove; return
     return
 fi
 

--- a/usr/share/rear/backup/YUM/default/500_make_backup.sh
+++ b/usr/share/rear/backup/YUM/default/500_make_backup.sh
@@ -36,7 +36,7 @@ LogPrint "Cataloging all unmodified files provided by RPM packages"
 for file in $(rpm -Vva | grep '^\.\.\.\.\.\.\.\.\.' | grep -v '^...........c' | cut -c 14-); do [ -f $file ] && echo $file; done | sort | uniq > $yum_backup_dir/rpm_provided_files.dat
 
 # Gather RPM verification data
-rpm -Va > $yum_backup_dir/rpm_verification.dat || true		# don't fail - we're just capturing RPM file verification
+rpm -Va > $yum_backup_dir/rpm_verification.dat || true		# don't fail - we are only capturing RPM file verification
 
 # Use the RPM verification data to catalog RPM-provided files which have been modified...
 grep -v ^missing $yum_backup_dir/rpm_verification.dat | cut -c 14- > $yum_backup_dir/rpm_modified_files.dat

--- a/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
+++ b/usr/share/rear/build/GNU/Linux/100_copy_as_is.sh
@@ -137,7 +137,7 @@ local copy_as_is_file=""
 while read -r copy_as_is_file ; do
     # Skip non-regular files like directories, device files, and 'tar' error messages (e.g. in case of non-existent files, see above)
     # but do not skip symbolic links. Their targets will be copied later by build/default/490_fix_broken_links.sh.
-    # We thus need library dependencies for symlinked executables just like for normal executables
+    # We thus need library dependencies for symlinked executables similar to normal executables
     # and build/default/490_fix_broken_links.sh does not perform library dependency scan.
     # See GitHub PR https://github.com/rear/rear/pull/3073
     # and issue https://github.com/rear/rear/issues/3064 for details.

--- a/usr/share/rear/build/GNU/Linux/620_verify_os_release_file.sh
+++ b/usr/share/rear/build/GNU/Linux/620_verify_os_release_file.sh
@@ -2,7 +2,7 @@
 # Because of issue 778 (where /etc/os-release is linked to /usr/lib/os-release) the copy of /etc/os-release fails
 # This is the case on Fedora 23
 
-[[ ! -f /etc/os-release ]] && return  # if /etc/os-release does not exist just return (pre-systemd distro)
+[[ ! -f /etc/os-release ]] && return  # if /etc/os-release does not exist return (pre-systemd distro)
 
 [[ -h $ROOTFS_DIR/etc/os-release ]] && rm -f $ROOTFS_DIR/etc/os-release      # if it is a link remove it first
 

--- a/usr/share/rear/build/default/960_remove_encryption_keys.sh
+++ b/usr/share/rear/build/default/960_remove_encryption_keys.sh
@@ -30,13 +30,13 @@ for configfile in $( find ${ROOTFS_DIR}/etc/rear ${ROOTFS_DIR}/usr/share/rear/co
     # Avoid that the escaped BACKUP_PROG_CRYPT_KEY value in escaped_regexp is shown in debugscript mode as described above.
     # Without '-q' grep would output the escaped BACKUP_PROG_CRYPT_KEY value in escaped_regexp on stdout which is redirected to the log:
     { grep -q "BACKUP_PROG_CRYPT_KEY=.*$escaped_regexp" $configfile ; } 2>>/dev/$SECRET_OUTPUT_DEV || continue
-    # It must work for simple unquoted assignment as in
+    # It must work for unquoted assignment as in
     #   BACKUP_PROG_CRYPT_KEY=my_secret_passphrase
     # but also for more advanced things like
     #   { BACKUP_PROG_CRYPT_KEY='my;secret;passphrase' ; } 2>>/dev/$SECRET_OUTPUT_DEV
     # cf. the example in doc/user-guide/04-scenarios.adoc
     # To avoid arbitrary syntax matching via complicated regular expressions
-    # we simply remove all BACKUP_PROG_CRYPT_KEY values in lines that contain 'BACKUP_PROG_CRYPT_KEY='.
+    # we remove all BACKUP_PROG_CRYPT_KEY values in lines that contain 'BACKUP_PROG_CRYPT_KEY='.
     # Avoid that the escaped BACKUP_PROG_CRYPT_KEY value in escaped_regexp is shown in debugscript mode as described above:
     if { sed -i -e "/BACKUP_PROG_CRYPT_KEY=/s/$escaped_regexp//g" $configfile ; } 2>>/dev/$SECRET_OUTPUT_DEV ; then
         DebugPrint "Removed BACKUP_PROG_CRYPT_KEY value from $configfile"

--- a/usr/share/rear/build/default/990_verify_rootfs.sh
+++ b/usr/share/rear/build/default/990_verify_rootfs.sh
@@ -84,7 +84,7 @@ local actually_found_library_symlink_target_relpath=""
 local actually_missing_libraries="no"
 # Third-party backup tools may use LD_LIBRARY_PATH to find their libraries
 # so that for testing such third-party backup tools we must also use their
-# special LD_LIBRARY_PATH here, otherwise just use the default:
+# special LD_LIBRARY_PATH here, otherwise use the default:
 if contains_visible_char "$LD_LIBRARY_PATH_FOR_BACKUP_TOOL" ; then
     if test $LD_LIBRARY_PATH; then
         backup_tool_LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LD_LIBRARY_PATH_FOR_BACKUP_TOOL"
@@ -225,7 +225,7 @@ for binary in $( find "$ROOTFS_DIR" -xdev -type f \( -executable -o -name '*.so'
         # Show files from inside the recovery system to the user as relative path without leading slashes
         # (extglob is set in usr/sbin/rear):
         not_found_library_relpath="${not_found_library##+(/)}"
-        # We prefer a simple grep pipe over dealing with 'find' and its -name versus -path options.
+        # We prefer a grep pipe over dealing with 'find' and its -name versus -path options.
         # 'find' what the full path is from within the recovery system i.e. without leading ROOTFS_DIR but with leading slash
         # so e.g. /var/tmp/rear.XXXXXXXXXXXXXXX/rootfs/usr/lib64/libparted.so.2.0.1 is output as /usr/lib64/libparted.so.2.0.1
         # to ensure that grep matches e.g. when not_found_library="/usr/lib64/libparted.so.2.0.1" (has a leading slash).
@@ -322,7 +322,7 @@ fi
 # Finally after all tests had been done (so that the user gets all result messages) error out if needed:
 
 # It is a BugError when at this stage required programs are missing in the recovery system
-# because just before this script the script build/default/950_check_missing_programs.sh
+# because before this script the script build/default/950_check_missing_programs.sh
 # was run which errors out when there are missing required programs on the original system
 # so that at this stage it means the required programs exist on the original system
 # and something went wrong when making the recovery system:

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -385,7 +385,7 @@ PROGRESS_WAIT_SECONDS="1"
 # The UserInput timeout must be sufficiently long for the user
 # to read and understand the possibly unexpected UserInput() message
 # and then some more time to make a decision whether or not
-# the default action ("just proceed") is actually the right one
+# the default action ("proceed") is actually the right one
 # in his particular case and finally even more time to enter
 # his particular input when the default is not the right one.
 USER_INPUT_TIMEOUT="${USER_INPUT_TIMEOUT:-300}"
@@ -899,7 +899,7 @@ OPAL_PBA_TKNBIND="no"
 OPAL_PBA_TKN2FAMAXTRIES=3
 #
 # Whether to wipe/destroy AuthToken after TKN2FAMAXTRIES exceeded
-# These 2FA options combined allow to have a simple-enough 'everyday' password (2FA one)
+# These 2FA options combined allow to have an 'everyday' password (2FA one)
 # protecting a complex Opal password in a secure-enough way to keep the token inserted all the time
 OPAL_PBA_TKN2FAFAILWIPE="no"
 #
@@ -980,7 +980,7 @@ OUTPUT_PREFIX="$HOSTNAME"
 KEEP_OLD_OUTPUT_COPY=
 
 # The remote file system layout for OUTPUT=PXE can be modified to accommodate different TFTP server layouts
-# (simply overwrite OUTPUT_PREFIX_PXE).
+# (overwrite OUTPUT_PREFIX_PXE).
 #OUTPUT_PREFIX_PXE="$OUTPUT_PREFIX"    # make it empty - see issue #570 (DRLM will fill it up)
 OUTPUT_PREFIX_PXE=""
 
@@ -1448,7 +1448,7 @@ PXE_TFTP_PREFIX=$HOSTNAME.
 # Optional support for downloading kernel and initrd by HTTP, thus making
 # downloads considerably faster.
 # First, you have to use lpxelinux.0 instead of pxelinux.0, the former supports
-# HTTP downloads. It's compatible, just replace pxelinux.0 in your TFTP
+# HTTP downloads. It's compatible, replace pxelinux.0 in your TFTP
 # directory or set bootfile-name/filename to lpxelinux.0 in your DHCP server.
 # PXE_CONFIG_GRUB_STYLE must NOT be set to yes.
 #
@@ -1712,7 +1712,7 @@ BACKUP_INTEGRITY_CHECK=
 # ReaR is neither a backup software nor a backup management software and it is not meant to be one
 # (cf. "Relax-and-Recover versus backup and restore" in https://en.opensuse.org/SDB:Disaster_Recovery).
 # In particular do not expect too much from ReaR's internal backup methods like 'tar'.
-# For simple tasks ReaR's internal backup methods should be o.k. but
+# For basic tasks ReaR's internal backup methods should be o.k. but
 # ReaR's internal backup methods are not meant as professional backup solutions.
 # In general the backup and restore of the files is "external functionality" for ReaR.
 # ReaR only calls an external tool and that tool does the backup and restore of the files.
@@ -3151,7 +3151,7 @@ REQUESTRESTORE_COMMAND=
 # ReaR will wait for the finished file to appear and continue with the recovery,
 # or abort the recovery if the abort file appears. The content of the abort file is
 # shown and logged as abort reason.
-# Instead of the manual prompt ReaR will simply show an info message and the disk
+# Instead of the manual prompt ReaR will show an info message and the disk
 # usage of the target filesystems.
 REQUESTRESTORE_FINISHED_FILE=${REQUESTRESTORE_FINISHED_FILE:-}
 REQUESTRESTORE_ABORT_FILE=${REQUESTRESTORE_ABORT_FILE:-}
@@ -3928,7 +3928,7 @@ REBUILD_INITRAMFS="yes"
 # (i.e. one of what is listed in layout/save/default/450_check_bootloader_files.sh).
 # What is currently listed in layout/save/default/450_check_bootloader_files.sh
 # is: GRUB2-EFI EFI GRUB2 GRUB ELILO LILO PPC ARM ARM-ALLWINNER ZIPL
-# - ARM is a dummy that does nothing, as on Raspberry Pi and most TI devices you just need
+# - ARM is a dummy that does nothing, as on Raspberry Pi and most TI devices you only need
 #   to include the first FAT partition (with the MLO or bootcode.bin) in your backup
 # - ARM-ALLWINNER is for Allwinner devices and will backup and restore the 2nd stage bootloader
 # With an unknown or unsupported bootloader value setting ReaR would fail:
@@ -4476,7 +4476,7 @@ DRLM_ID="$HOSTNAME"
 # The deprecation keyword can be added to the DISABLE_DEPRECATION_ERRORS array
 # to override the deprecation error and continue to use the deprecated feature.
 # Users who do this without talking to the ReaR project via a GitHub issue
-# risk that a deprecated feature gets "just removed" without further notice.
+# risk that a deprecated feature gets removed without further notice.
 DISABLE_DEPRECATION_ERRORS=()
 
 ####

--- a/usr/share/rear/conf/examples/RHEL7-ISO-Oracle-example.conf
+++ b/usr/share/rear/conf/examples/RHEL7-ISO-Oracle-example.conf
@@ -25,7 +25,7 @@
 # /dev/mapper/vg07-lvflashback                         123791692  16794321 106997371  14% /oracle/S30/flashback
 
 OUTPUT=ISO
-# We want all volume groups to be covered not just the system disk
+# We want all volume groups to be covered, not only the system disk
 #ONLY_INCLUDE_VG=( "vg00" )
 
 BACKUP=NETFS

--- a/usr/share/rear/conf/templates/EFI_readme.txt
+++ b/usr/share/rear/conf/templates/EFI_readme.txt
@@ -50,7 +50,7 @@ Device mapping table
 At the Shell> prompt select the disk you want, e.g.
 Shell> fs2:
 
-Just like with a DOS command prompt use cd and dir commands to view the FAT16
+Similar to a DOS command prompt use cd and dir commands to view the FAT16
 content:
 
 fs2:\> cd efi
@@ -69,11 +69,11 @@ Directory of: fs2:\EFI
 
 fs2:\EFI> cd redhat
 
-To boot redhat just enter:
+To boot redhat enter:
 
 fs2:\EFI\redhat> elilo
 ELILO boot: Uncompressing Linux... done
 Loading file initrd...
 
-Just let it boot 'till you get the login prompt.
+Let it boot until you get the login prompt.
 Feedback on the above? Use 'rear validate' to mail us your comments.

--- a/usr/share/rear/conf/templates/RESULT_usage_RAWDISK.txt
+++ b/usr/share/rear/conf/templates/RESULT_usage_RAWDISK.txt
@@ -5,7 +5,7 @@ How to recover your system:
    (a USB stick will do).
 
    * Always use the complete disk device (like /dev/sdc)
-     instead of just a disk partition (like /dev/sdc1).
+     instead of only a disk partition (like /dev/sdc1).
 
    * Be careful to select the right device,
      DISK CONTENTS WILL BE OVERWRITTEN.

--- a/usr/share/rear/finalize/Linux-i386/610_EFISTUB_run_efibootmgr.sh
+++ b/usr/share/rear/finalize/Linux-i386/610_EFISTUB_run_efibootmgr.sh
@@ -2,7 +2,7 @@
 # in this directory. If EFI_STUB is enabled, we will automatically set
 # NOBOOTLOADER variable empty to avoid other boot loader installation attempts,
 # which will most probably fail (due missing binaries on original system).
-# If creation process of boot entry later fails, we will just print information
+# If creation process of boot entry later fails, we will print information
 # message to user to create boot entry manually, because ending restore process
 # with error in such late stage is not desirable.
 

--- a/usr/share/rear/finalize/Linux-ppc64le/660_install_grub2.sh
+++ b/usr/share/rear/finalize/Linux-ppc64le/660_install_grub2.sh
@@ -88,7 +88,7 @@ fi
 local grub2_config_generated="yes"
 if ! chroot $TARGET_FS_ROOT /bin/bash --login -c "$grub_name-mkconfig -o /boot/$grub_name/grub.cfg" ; then
     grub2_config_generated="no"
-    # TODO: We should make this fatal.  Outdated/incomplete/just wrong grub2.cfg may result into an unbootable system.
+    # TODO: We should make this fatal. Outdated/incomplete/wrong grub2.cfg may result into an unbootable system.
     LogPrintError "Failed to generate boot/$grub_name/grub.cfg in $TARGET_FS_ROOT - trying to install GRUB2 nevertheless"
 fi
 

--- a/usr/share/rear/finalize/default/880_check_for_mount_by_id.sh
+++ b/usr/share/rear/finalize/default/880_check_for_mount_by_id.sh
@@ -126,7 +126,7 @@ while read major minor blocks name ; do
         # Perhaps ID_SERIAL could be used because it is not set for a non-existent device
         # but it seems to be set for existent devices, see https://github.com/rear/rear/issues/3383
         # but how far could or should we rely on possibly changing scsi_id behaviour in general?
-        # So we keep it simple and straightforward and focus on what we are actually interested in
+        # So we keep it straightforward and focus on what we are actually interested in
         # i.e. only the scsi_id output of ID_VENDOR ID_MODEL ID_SERIAL (as a string without newlines):
         scsi_id_output="$( /usr/lib/udev/scsi_id -x -g -d $device_path | grep -E "$egrep_pattern" | tr -s '\n' ' ' )"
     else

--- a/usr/share/rear/format/USB/default/300_format_usb_disk.sh
+++ b/usr/share/rear/format/USB/default/300_format_usb_disk.sh
@@ -85,7 +85,7 @@ fi
 # * backup/storage/data partition
 
 # In case of GPT with BIOS boot we need a 'bios_grub' partition
-# In case of MSDOS partition table we just need some free space in between the partition table and the first partition
+# In case of MSDOS partition table we only need some free space in between the partition table and the first partition
 # This partition should be the first one afaik this has a better chance to work with odd BIOS firmwares
 if is_true "$FORMAT_BIOS" ; then
     if [[ "$USB_DEVICE_PARTED_LABEL" == "gpt" ]] ; then

--- a/usr/share/rear/init/default/100_check_stale_nfs_mounts.sh
+++ b/usr/share/rear/init/default/100_check_stale_nfs_mounts.sh
@@ -1,5 +1,5 @@
 # 100_check_stale_nfs_mounts.sh
-# Purpose is to have a simple test if we have stale NFS mount points which
+# Purpose is to have a basic test if we have stale NFS mount points which
 # could lead to a hanging ReaR session.
 # In case there is a stale NFS present we bail out with an error to get it fixed before
 # running ReaR again.

--- a/usr/share/rear/layout/prep-for-mount/default/600_show_unprocessed.sh
+++ b/usr/share/rear/layout/prep-for-mount/default/600_show_unprocessed.sh
@@ -20,7 +20,7 @@ while read status name type junk ; do
         # The default user input is "Continue" to make it possible to run ReaR unattended
         # so that 'rear mountonly' proceeds after the timeout regardless that it probably fails
         # when the component is not recreated but perhaps it could succeed in migration mode
-        # on different replacement hardware where it might be even right to simply "Continue".
+        # on different replacement hardware where it might be even right to "Continue".
         # Generate a runtime-specific user_input_ID so that for each missing component
         # a different user_input_ID is used for the UserInput call so that the user can specify
         # for each missing component a different predefined user input.

--- a/usr/share/rear/layout/prepare/GNU/Linux/133_include_mount_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/133_include_mount_filesystem_code.sh
@@ -53,7 +53,7 @@ mount_fs() {
         (btrfs)
             # The following commands are basically the same as in the default/fallback case.
             # The explicit case for btrfs is only there to be prepared for special adaptions for btrfs related file systems.
-            # Because the btrfs filesystem was created anew just before by the create_fs function in 131_include_filesystem_code.sh
+            # Because the btrfs filesystem was created anew before by the create_fs function in 131_include_filesystem_code.sh
             # the code here mounts the whole btrfs filesystem because by default when creating a btrfs filesystem
             # its top-level/root subvolume is the btrfs default subvolume which gets mounted when no other subvolume is specified.
             # For a plain btrfs filesystem without subvolumes it is effectively the same as for other filesystems (like ext2/3/4).

--- a/usr/share/rear/layout/prepare/default/600_show_unprocessed.sh
+++ b/usr/share/rear/layout/prepare/default/600_show_unprocessed.sh
@@ -20,7 +20,7 @@ while read status name type junk ; do
         # The default user input is "Continue" to make it possible to run ReaR unattended
         # so that 'rear recover' proceeds after the timeout regardless that it probably fails
         # when the component is not recreated but perhaps it could succeed in migration mode
-        # on different replacement hardware where it might be even right to simply "Continue".
+        # on different replacement hardware where it might be even right to "Continue".
         # Generate a runtime-specific user_input_ID so that for each missing component
         # a different user_input_ID is used for the UserInput call so that the user can specify
         # for each missing component a different predefined user input.

--- a/usr/share/rear/layout/recreate/default/README.wipe_disks
+++ b/usr/share/rear/layout/recreate/default/README.wipe_disks
@@ -288,7 +288,7 @@ and under normal circumstances contain same functional metadata.
 The binary header size ensures that the binary header is always written to only one sector (atomic write).
 Binary data in the keyslots area is allocated on-demand. There is no redundancy in the binary keyslots area
 ...
-To allow for an easy recovery, the secondary header must start at a fixed offset listed in Table 1.
+For a straightforward recovery, the secondary header must start at a fixed offset listed in Table 1.
  Offset            JSON area
 [bytes]     (hexa)      [kB]
   16384 (0x004000)       12
@@ -582,7 +582,7 @@ do
   pvremove -ff $_pv
 done
 
-# just in case some were missed... (some always are)
+# in case some were missed... (some always are)
 for _pv in $disks
 do
   pvremove -ff $_pv

--- a/usr/share/rear/layout/save/GNU/Linux/150_save_diskbyid_mappings.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/150_save_diskbyid_mappings.sh
@@ -3,7 +3,7 @@
 ls /dev/disk/by-id | while read ID;
 do
 	# create diskbyid_mappings file:
-	# we need to keep absolute PATH for device in order to be able to easily use apply_mappings() function.
+	# we need to keep absolute PATH for device to be able to use apply_mappings() function.
 	# and apply disk mapping during migration.
 	#
 	# example:	scsi-360060e8015268c000001268c000065c0-part4 /dev/sda4

--- a/usr/share/rear/layout/save/GNU/Linux/340_false_blacklisted.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/340_false_blacklisted.sh
@@ -20,7 +20,7 @@ falsempathdev=$( multipath -l | grep "HP,LOGICAL" | awk '{print $1}' )  # mpatha
 
 blockdev=$( get_parent_components  /dev/mapper/mpatha )   # /dev/sdy
 if [[ ! -b $blockdev ]]; then
-    # not a block device; to be prudent we just return
+    # not a block device; to be prudent we return
     return
 fi
 

--- a/usr/share/rear/layout/save/default/310_autoexclude_usb.sh
+++ b/usr/share/rear/layout/save/default/310_autoexclude_usb.sh
@@ -2,7 +2,7 @@
 # Reason: issue #645
 # /dev/sdb1                           240234164 2996672 225027564   2% /mnt
 # is not detected as an USB path which causing rsync to loop until usb output_url is full
-# If we find an USB device we will just add it to AUTOEXCLUDE_USB_PATH
+# If we find a USB device we will add it to AUTOEXCLUDE_USB_PATH
 
 for URL in "$OUTPUT_URL" "$BACKUP_URL" ; do
     if [[ ! -z "$URL" ]] ; then

--- a/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
+++ b/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
@@ -226,7 +226,7 @@ done < <( grep "^lvmdev " "$DISKLAYOUT_FILE" )
 # Finally after all tests had been done (so that the user gets all result messages) error out if needed:
 
 # It is a BugError when at this stage the entries in disklayout.conf are broken
-# because just before this script the entries in disklayout.conf were created
+# because before this script the entries in disklayout.conf were created
 # by various 'layout/save' scripts where each of those 'layout/save' scripts should error out
 # when it cannot create a valid entry (e.g. because of whatever reasons outside of ReaR).
 local disklayout_file_is_broken=""

--- a/usr/share/rear/lib/_framework-setup-and-functions.sh
+++ b/usr/share/rear/lib/_framework-setup-and-functions.sh
@@ -75,7 +75,7 @@ function RemoveExitTask () {
 # where each PID is output on a separated line.
 # Calling "ps --ppid $parent_pid -o pid=" recursively is needed
 # because otherwise it does not work on all systems.
-# E.g. on SLES10 and SLES11 it would work to simply call "ps -g $parent_pid -o pid="
+# E.g. on SLES10 and SLES11 it would work to call "ps -g $parent_pid -o pid="
 #   # sleep 20 | grep foo & ( sleep 30 | grep bar & ) ; sleep 1 ; ps f -g $$
 #   [1] 3622
 #     PID TTY      STAT   TIME COMMAND

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -376,7 +376,7 @@ function make_syslinux_config {
 
         if [[ ! -r "$SYSLINUX_DIR/chain.c32" ]]; then
             # this should be above under the if chain.c32 section but it comes here because it will work only if localboot is supported
-            # if you use old extlinux then you just cannot boot from other device unless chain.c32 is available :-(
+            # if you use old extlinux then you cannot boot from other device unless chain.c32 is available :-(
             echo "say boot80 - Boot from first BIOS disk 0x80"
             echo "label boot80"
             syslinux_menu "label Boot First ^Local BIOS disk (0x80)"

--- a/usr/share/rear/lib/config-functions.sh
+++ b/usr/share/rear/lib/config-functions.sh
@@ -132,7 +132,7 @@ See '$SHARE_DIR/lib/config-functions.sh' for more details."
     esac
 
     # Set master version to the MAJOR release version. ReaR assumes that OS_MASTER_VERSION
-    # is just the major release number extracted from OS_VERSION and not the version of the derived OS.
+    # is the major release number extracted from OS_VERSION and not the version of the derived OS.
     # If OS_VERSION is of the form 12.34.56, OS_MASTER_VERSION is only the first part '12'.
     #
     # Because openSUSE Tumbleweed has rolling releases, OS_VERSION is a date of the form YYYYMMDD.

--- a/usr/share/rear/lib/global-functions.sh
+++ b/usr/share/rear/lib/global-functions.sh
@@ -440,7 +440,7 @@ function scheme_accepts_files() {
 ### The actual path will be returned by backup_path() / output_path().
 ### If returns false, using backup_path() / output_path() has no sense
 ### and one must use a scheme-specific method (like lftp or writing them to a tape)
-### to upload files to the destination instead of just "cp" or other direct filesystem access.
+### to upload files to the destination instead of "cp" or other direct filesystem access.
 ### Returning true does not imply that the URL is currently mounted at a filesystem and usable,
 ### only that it can be mounted (use mount_url() first)
 function scheme_supports_filesystem() {
@@ -820,7 +820,7 @@ function umount_davfs() {
         # Wait for 3 sek. then remove the cache-dir /var/cache/davfs
         sleep 30
         # TODO: put in here the cache-dir from /etc/davfs2/davfs.conf
-        # and delete only the just used cache
+        # and delete only the recently used cache
         #rm -rf /var/cache/davfs2/*<mountpoint-hash>*
         rm -rf /var/cache/davfs2/*outputfs*
     else
@@ -857,7 +857,7 @@ function umount_mountpoint() {
     ### First, try a normal unmount using a timeout in case mountpoint became unresponsive
     ### due to QoS squeezing or due to stale NFS as the NFS server became unreachable (during mkbackup)
     ### That is the reason why we use a timeout in front of the umount command.
-    ### However, when tar is busy and the NFS becomes stale then ReaR processes will just hang forever
+    ### However, when tar is busy and the NFS becomes stale then ReaR processes will hang forever
     ### until we kill them manually.
     Log "Unmounting '$mountpoint'"
     timeout $timeout_secs umount $v "$mountpoint" && return 0
@@ -878,7 +878,7 @@ function umount_mountpoint() {
     Log "$mountpoint is still in use by ('kernel mount' is always there)"
     # The -M option avoids that fuser may show all processes using the '/' filesystem
     # e.g. for mountpoint $TMP_DIR/somedir ($TMP_DIR = $BUILD_DIR/tmp = /var/tmp/rear.XXXXXXXXXXXXXXX/tmp/)
-    # when $TMP_DIR/somedir got umounted just before fuser starts, see "man fuser":
+    # when $TMP_DIR/somedir got umounted before fuser starts, see "man fuser":
     #   The mount -m option will match any file within the same device as the specified file,
     #   use the -M option as well if you mean to specify only the mount point.
     # So when $TMP_DIR/somedir is umounted 'fuser -v -M -m $TMP_DIR/somedir' only shows
@@ -970,7 +970,7 @@ function umount_mountpoint_retry_lazy() {
     Log "$what_is_mounted is still in use by ('kernel mount' is always there)"
     # The -M option avoids that fuser may show all processes using the '/' filesystem
     # e.g. for mountpoint $TMP_DIR/somedir ($TMP_DIR = $BUILD_DIR/tmp = /var/tmp/rear.XXXXXXXXXXXXXXX/tmp/)
-    # when $TMP_DIR/somedir got umounted just before fuser starts, see "man fuser":
+    # when $TMP_DIR/somedir got umounted before fuser starts, see "man fuser":
     #   The mount -m option will match any file within the same device as the specified file,
     #   use the -M option as well if you mean to specify only the mount point.
     # So when $TMP_DIR/somedir is umounted 'fuser -v -M -m $TMP_DIR/somedir' only shows

--- a/usr/share/rear/lib/linux-functions.sh
+++ b/usr/share/rear/lib/linux-functions.sh
@@ -36,7 +36,7 @@ function my_udevtrigger () {
         test "$udevd_pid" && kill $udevd_pid
         udevstart </dev/null &>/dev/null && return 0
     fi
-    # as final fallback just wait a bit and hope for the best
+    # as final fallback wait a bit and hope for the best
     sleep 10
 }
 
@@ -57,7 +57,7 @@ function my_udevsettle () {
         done
         return 0
     fi
-    # as final fallback just wait a bit and hope for the best
+    # as final fallback wait a bit and hope for the best
     sleep 10
 }
 

--- a/usr/share/rear/lib/opal-functions.sh
+++ b/usr/share/rear/lib/opal-functions.sh
@@ -30,7 +30,7 @@ function opal_devices() {
 function opal_device_disks() {
     local device="${1:?}"
     # prints all block devices belonging to the given Opal device.
-    # Normally, this is just the Opal device itself, however, NVME devices have one or more namespaces per primary
+    # Normally, this is the Opal device itself, however, NVME devices have one or more namespaces per primary
     # device and these namespaces act as disks.
 
     case "$device" in

--- a/usr/share/rear/lib/uefi-functions.sh
+++ b/usr/share/rear/lib/uefi-functions.sh
@@ -64,7 +64,7 @@ function build_boot_efi {
     else
         # This build_boot_efi function is only called in 250_populate_efibootimg.sh
         # and 100_create_efiboot.sh and 940_grub2_rescue.sh
-        # only if UEFI is used so that we simply error out here if we cannot make a bootable EFI image of GRUB2
+        # only if UEFI is used so that we error out here if we cannot make a bootable EFI image of GRUB2
         # (normally a function should not exit but return to its caller with a non-zero return code):
         Error "Cannot make bootable EFI image of GRUB2 (neither grub-mkstandalone nor grub2-mkstandalone found)"
     fi

--- a/usr/share/rear/lib/validate-workflow.sh
+++ b/usr/share/rear/lib/validate-workflow.sh
@@ -82,7 +82,7 @@ Example: LVM, MD, SCSI, $BACKUP, $OUTPUT, EMAIL, ...
 -------------------
 Please let us know any comments you have about $PRODUCT in your
 environment that would help others to better use $PRODUCT or have
-less trouble installing it or maybe simply that you employ $PRODUCT
+less trouble installing it or maybe that you employ $PRODUCT
 in a very large data centre with thousands of servers and that
 $PRODUCT is the central component of your disaster recovery
 preparations for your data centre.

--- a/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
+++ b/usr/share/rear/output/ISO/Linux-i386/700_create_efibootimg.sh
@@ -6,7 +6,7 @@ is_true $USING_UEFI_BOOTLOADER || return 0 # empty or 0 means NO UEFI
 # The virtual image must be aligned to 32MiB blocks
 # therefore the size of directory is measured in 32MiB blocks.
 # The du output is stored in an artificial bash array
-# so that $efi_img_sz can be simply used to get the first word
+# so that $efi_img_sz can be used to get the first word
 # which is the disk usage of the directory measured in 32MiB blocks:
 efi_img_sz=( $( du --block-size=32M --summarize $TMP_DIR/mnt ) ) || Error "Failed to determine disk usage of EFI virtual image content directory."
 

--- a/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
+++ b/usr/share/rear/output/RSYNC/default/900_copy_result_files.sh
@@ -14,7 +14,7 @@ proto="$(rsync_proto "$OUTPUT_URL")"
 
 LogPrint "Copying resulting files to $OUTPUT_URL location"
 
-# if called as mkbackuponly then we just don't have any result files.
+# if called as mkbackuponly then we don't have any result files.
 if test "$RESULT_FILES" ; then
     Log "Copying files '${RESULT_FILES[*]}' to $OUTPUT_URL location"
     cp $v "${RESULT_FILES[@]}" "${TMP_DIR}/rsync/${RSYNC_PREFIX}/" \

--- a/usr/share/rear/prep/BACULA/default/400_prep_bacula.sh
+++ b/usr/share/rear/prep/BACULA/default/400_prep_bacula.sh
@@ -11,7 +11,7 @@ if ! test -d "$BACULA_BIN_DIR" ; then
     test -d "/opt/bacula/bin" && BACULA_BIN_DIR="/opt/bacula/bin"
 fi
 export PATH=$PATH:$BACULA_BIN_DIR
-CLONE_GROUPS+=( bacula ) # default CLONE_ALL_USERS_GROUPS="true" in default.conf, but just in case...
+CLONE_GROUPS+=( bacula ) # default CLONE_ALL_USERS_GROUPS="true" in default.conf, but as a precaution...
 COPY_AS_IS_BACULA+=( $BACULA_CONF_DIR )
 COPY_AS_IS+=( "${COPY_AS_IS_BACULA[@]}" )
 COPY_AS_IS_EXCLUDE+=( "${COPY_AS_IS_EXCLUDE_BACULA[@]}" )

--- a/usr/share/rear/prep/GNU/Linux/280_include_vmware_tools.sh
+++ b/usr/share/rear/prep/GNU/Linux/280_include_vmware_tools.sh
@@ -1,6 +1,6 @@
 # $Id$
 #
-# recent vmware tools (or maybe it is just open-vm-tools on SUSE) keep their modules
+# recent vmware tools (or maybe it is open-vm-tools on SUSE) keep their modules
 # outside the /lib/modules path. To cope with that we add the vmware-tools if vmxnet
 # is loaded but modinfo cannot find it.
 

--- a/usr/share/rear/prep/NETFS/default/400_automatic_exclude_recreate.sh
+++ b/usr/share/rear/prep/NETFS/default/400_automatic_exclude_recreate.sh
@@ -18,7 +18,7 @@ case $scheme in
         # it results a backup.tar.gz that contains itself (but in a not-yet-complete state)
         # because all of the '/' filesystem is included in the backup.
         # To avoid various weird issues when the backup contains itself
-        # a backup directory in the '/' filesystem is simply forbidden
+        # a backup directory in the '/' filesystem is forbidden
         # regardless that a backup inside itself may not result fatal errors
         # see https://github.com/rear/rear/issues/926
         if ! test -e "$backup_directory" ; then

--- a/usr/share/rear/prep/RSYNC/GNU/Linux/200_selinux_in_use.sh
+++ b/usr/share/rear/prep/RSYNC/GNU/Linux/200_selinux_in_use.sh
@@ -1,5 +1,5 @@
 
-# check if SELinux is in use, if not, just return
+# check if SELinux is in use, if not, return
 if [ -f /selinux/enforce ] ; then
     SELINUX_ENFORCE=/selinux/enforce
 elif [ -f /sys/fs/selinux/enforce ] ; then
@@ -21,7 +21,7 @@ fi
 # SELinux is found to be available on this system;
 # depending on backup program we may need to do different things
 # So far, only rsync and tar has special options for selinux.
-# Others, just disable SELinux during backup only!
+# Others, disable SELinux during backup only!
 case $(basename $BACKUP_PROG) in
 
     (rsync)

--- a/usr/share/rear/prep/USB/Linux-i386/350_check_usb_disk.sh
+++ b/usr/share/rear/prep/USB/Linux-i386/350_check_usb_disk.sh
@@ -25,7 +25,7 @@ elif [ "$TEMP_USB_DEVICE" -a -d "/sys/block/$TEMP_USB_DEVICE" ]; then
 # If we're passed a raw device, ala /dev/sdb, TEMP_USB_DEVICE will be set to "block"
 # and RAW_USB_DEVICE won't be set.  "block" is not useful.  TEMP_USB_DEVICE will not be
 # set if udev doesn't know anything about the device we were passed. So, if we've 
-# gotten here and either are not set, let's just assert what we know from udev
+# gotten here and either are not set, let's assert what we know from udev
 # about the device.
 elif [ -z "$TEMP_USB_DEVICE" ] || [ -z "$RAW_USB_DEVICE" ] ; then
     RAW_USB_DEVICE="/dev/$(my_udevinfo -q name -n "$REAL_USB_DEVICE")"

--- a/usr/share/rear/prep/default/050_check_keep_old_output_copy_var.sh
+++ b/usr/share/rear/prep/default/050_check_keep_old_output_copy_var.sh
@@ -1,4 +1,4 @@
 # align the variables NETFS_KEEP_OLD_BACKUP_COPY and KEEP_OLD_OUTPUT_COPY
-[[ ! -z "$KEEP_OLD_OUTPUT_COPY" ]] && return  # if KEEP_OLD_OUTPUT_COPY=y just return
+[[ ! -z "$KEEP_OLD_OUTPUT_COPY" ]] && return  # if KEEP_OLD_OUTPUT_COPY=y return
 [[ -z "$KEEP_OLD_OUTPUT_COPY" ]] && [[ ! -z "$NETFS_KEEP_OLD_BACKUP_COPY" ]] && \
     [[ "$WORKFLOW" = "mkbackup" ]] &&  KEEP_OLD_OUTPUT_COPY=y

--- a/usr/share/rear/rescue/GNU/Linux/220_load_modules_from_initrd.sh
+++ b/usr/share/rear/rescue/GNU/Linux/220_load_modules_from_initrd.sh
@@ -30,7 +30,7 @@ if test -s /etc/dracut.conf ; then
     )
 fi
 
-# Debian & Ubuntu use initramfs-tools and we include that as-is in 400_copy_modules.sh because we just
+# Debian & Ubuntu use initramfs-tools and we include that as-is in 400_copy_modules.sh because we
 # append the initrd modules file to the general modules file. Nevertheless we must ensure that those
 # modules are actually included in the rescue system
 if test -s /etc/initramfs-tools/modules ; then

--- a/usr/share/rear/rescue/GNU/Linux/990_sysreqs.sh
+++ b/usr/share/rear/rescue/GNU/Linux/990_sysreqs.sh
@@ -2,7 +2,7 @@
 # the minimal system requirements we need to recreate this
 # system in a remote DRP site
 # Output file: /var/lib/rear/sysreqs/Minimal_System_Requirements.txt
-# This is just for your information and the output is nowhere else
+# This is only for your information and the output is nowhere else
 # used by ReaR whatsoever.
 
 # `rear mkopalpba' creates a system where some information gathered below is missing (and not useful anyway): skip it.

--- a/usr/share/rear/rescue/default/500_ssh.sh
+++ b/usr/share/rear/rescue/default/500_ssh.sh
@@ -116,7 +116,7 @@ echo "ssh:23:respawn:/etc/scripts/run-sshd" >>$ROOTFS_DIR/etc/inittab
   fi
 } 2>>/dev/$SECRET_OUTPUT_DEV
 
-# Set the SSH root password; if pw is encrypted just copy it otherwise use openssl (for backward compatibility)
+# Set the SSH root password; if pw is encrypted copy it otherwise use openssl (for backward compatibility)
 # Encryption syntax is detected as a '$D$' or '$Dx$' prefix in the password, where D is a single digit and x is one lowercase character.
 # For more information on encryption IDs, check out the NOTES section of the man page for crypt(3).
 # The extglob shell option is required for this to work.

--- a/usr/share/rear/restore/BLOCKCLONE/default/390_create_partitions.sh
+++ b/usr/share/rear/restore/BLOCKCLONE/default/390_create_partitions.sh
@@ -36,7 +36,7 @@ if [ ! -b "$BLOCKCLONE_SOURCE_DEV" ]; then
         # and as we are in GNU/Linux world, we let user to shoot him self
         # in the foot ...
 
-        # Just a naive check if we are dealing with same disk.
+        # A naive check if we are dealing with same disk.
         # At this stage kernel is missing any info about BLOCKCLONE_SOURCE_DEV,
         # so we can't reliably determine relation between disks.
         if [ $(echo $BLOCKCLONE_SOURCE_DEV | \

--- a/usr/share/rear/restore/BLOCKCLONE/default/400_restore_clone.sh
+++ b/usr/share/rear/restore/BLOCKCLONE/default/400_restore_clone.sh
@@ -29,7 +29,7 @@ if is_true "$BLOCKCLONE_TRY_UNMOUNT" && [ "$is_mounted" = "1" ]; then
     fi
 fi
 
-# Just put entry into log, that restore of mounted device was made
+# Write an entry to the log, that restore of mounted device was made
 is_mounted=$(is_device_mounted $BLOCKCLONE_SOURCE_DEV)
 if [ "$is_mounted" = "1" ]; then
     LogPrint "BLOCKCLONE was made on mounted device."

--- a/usr/share/rear/restore/GALAXY11/default/901_stop_galaxy_daemons.sh
+++ b/usr/share/rear/restore/GALAXY11/default/901_stop_galaxy_daemons.sh
@@ -4,5 +4,5 @@
 #
 #
 
-# we ignore errors because this is just a safety measure and the recovery should proceed regardless
+# we ignore errors because this is a safety measure and the recovery should proceed regardless
 Galaxy stop || :

--- a/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
+++ b/usr/share/rear/restore/NETFS/default/400_restore_backup.sh
@@ -199,7 +199,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                     #   block 5882679: root/rear/var/log/rear/rear-f79.28698.log
                     #   block 5882679: ** Block of NULs **
                     # cf. https://github.com/rear/rear/issues/1116#issuecomment-267065150
-                    # Use an array to easily separate the parts (i.e. each message word is an array member):
+                    # Use an array to separate the parts (i.e. each message word is an array member):
                     latest_tar_restore_message=( $( tail -n1 $backup_restore_log_file ) )
                     # An usual 'tar' restore message looks like 'block 219: etc/fstab'
                     # so that ${latest_tar_restore_message[1]} is '219:' in this example.

--- a/usr/share/rear/restore/VEEAM/default/500_restore.sh
+++ b/usr/share/rear/restore/VEEAM/default/500_restore.sh
@@ -8,7 +8,7 @@ if mount | grep -q /mnt/backup; then
     : # veeamconfig backup mount managed to mount the backup
 else
     # on some systems veamconfig backup mount doesn't manage (for unclear reasons) to actually mount
-    # the loopback device with the backup data, we simply try to do it ourselves
+    # the loopback device with the backup data, so we try to do it ourselves
     veeammount -d /tmp/veeamflr/*/FileLevelBackup_0 -p /mnt/backup -o ro -m || Error "Failed to mount Veeam loopback device"
 fi
 

--- a/usr/share/rear/restore/YUM/default/410_restore_backup.sh
+++ b/usr/share/rear/restore/YUM/default/410_restore_backup.sh
@@ -187,7 +187,7 @@ for restore_input in "${RESTORE_ARCHIVES[@]}" ; do
                     #   block 5882679: root/rear/var/log/rear/rear-f79.28698.log
                     #   block 5882679: ** Block of NULs **
                     # cf. https://github.com/rear/rear/issues/1116#issuecomment-267065150
-                    # Use an array to easily separate the parts (i.e. each message word is an array member):
+                    # Use an array to separate the parts (i.e. each message word is an array member):
                     latest_tar_restore_message=( $( tail -n1 ${TMP_DIR}/${BACKUP_PROG_ARCHIVE}-restore.log ) )
                     # An usual 'tar' restore message looks like 'block 219: etc/fstab'
                     # so that ${latest_tar_restore_message[1]} is '219:' in this example.

--- a/usr/share/rear/skel/default/etc/scripts/dhcp-setup-functions.sh
+++ b/usr/share/rear/skel/default/etc/scripts/dhcp-setup-functions.sh
@@ -101,7 +101,7 @@ make_resolv_conf() {
                 # Remove instances of \032 (#450042)
                 search="${new_domain_search//\\032/ }"
             elif [ -n "${new_domain_name}" ]; then
-                # Note that the DHCP 'Domain Name Option' is really just a domain
+                # Note that the DHCP 'Domain Name Option' is really only a domain
                 # name, and that this practice of using the domain name option as
                 # a search path is both nonstandard and deprecated.
                 search="${new_domain_name}"

--- a/usr/share/rear/skel/default/etc/scripts/run-syslog
+++ b/usr/share/rear/skel/default/etc/scripts/run-syslog
@@ -22,7 +22,7 @@ elif type -p syslogd >/dev/null ; then
     klogd -c 1 -x
     exec syslogd -f /etc/syslog.conf -n
 else
-    ### no syslog, so just keep running a loop
+    ### no syslog, so keep running a loop
     while true ; do
         sleep 10
     done

--- a/usr/share/rear/skel/default/etc/scripts/system-setup
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup
@@ -130,7 +130,7 @@ for system_setup_script in /etc/scripts/system-setup.d/*.sh ; do
         # In non-debug mode when a system setup script results non-zero exit code
         # do not show an 'exit code' message (like the above) to avoid false alarm
         # cf. https://github.com/rear/rear/pull/3070#discussion_r1393738863
-        # but just wait USER_INPUT_UNATTENDED_TIMEOUT (by default 3 seconds)
+        # but wait USER_INPUT_UNATTENDED_TIMEOUT (by default 3 seconds)
         # so that the user could at least notice potential error messages from the script
         # unless in unattended_recovery mode where there is normally no watching user:
         if ! source $system_setup_script ; then

--- a/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
+++ b/usr/share/rear/skel/default/etc/scripts/system-setup.d/55-migrate-network-devices.sh
@@ -58,7 +58,7 @@ elif [ -s $tmp_mac_mapping_file ] ; then
     # Else, if some devices were renamed, we also need a migration, but it will
     # be automatic thanks to the $tmp_mac_mapping_file mapping file
 
-    # We do not need the $MAC_MAPPING_FILE file from the user, just overwrite it
+    # We do not need the $MAC_MAPPING_FILE file from the user, overwrite it
     # Later, we will remove that file to not have finalize() modify the ifcfg-*
     # files.
     mkdir -p $(dirname $MAC_MAPPING_FILE)
@@ -109,7 +109,7 @@ if read_and_strip_file $MAC_MAPPING_FILE ; then
 fi
 
 if unattended_recovery ; then
-    # we gonna cheat a bit and say we have map made (but we did not and just hope that the interfaces
+    # we gonna cheat a bit and say we have map made (but we did not and hope that the interfaces
     # will be in the same order on the recover vm as on the client vm)
     # For some background info see https://github.com/gdha/rear-automated-testing/issues/36
     test $MANUAL_MAC_MAPPING || MANUAL_MAC_MAPPING=unattended
@@ -265,7 +265,7 @@ fi
 # Reload udev if we have MAC mappings:
 if is_true $reload_udev ; then
     echo -n "Reloading udev ... "
-    # Force udev to reload rules (as they were just changed)
+    # Force udev to reload rules (as they were recently changed)
     # Failback to "udevadm control --reload" in case of problem (as specify in udevadm manpage in SLES12)
     # If nothing work, then wait 1 second delay. It should let the time for udev to detect changes in the rules files.
     udevadm control --reload-rules || udevadm control --reload || sleep 1

--- a/usr/share/rear/skel/default/usr/lib/systemd/system/syslog.socket
+++ b/usr/share/rear/skel/default/usr/lib/systemd/system/syslog.socket
@@ -15,7 +15,7 @@ SocketMode=0666
 # is the main syslog daemon in the system. Another syslog
 # implementation (which might be started via on-boot or another
 # non-socket activation) can take over possession of the socket and
-# terminate systemd-kmsg-syslogd. It could also simply replace the
+# terminate systemd-kmsg-syslogd. It could also replace the
 # socket in the file system, and leave systemd-kmsg-syslogd untouched.
 
 Service=rsyslog.service

--- a/usr/share/rear/verify/NSR/default/390_request_point_in_time_restore_parameters.sh
+++ b/usr/share/rear/verify/NSR/default/390_request_point_in_time_restore_parameters.sh
@@ -8,7 +8,7 @@
 NSR_ENDTIME=()      
 NSR_HAS_PROMPT=0
 
-# Ask for a point-in-time (PIT) recovery date/time just in case 
+# Ask for a point-in-time (PIT) recovery date/time as a precaution 
 # NSR_CLIENT_MODE = YES and NSR_CLIENT_REQUESTRESTORE = NO else skip
 
 if is_true "$NSR_CLIENT_MODE"; then

--- a/usr/share/rear/verify/PPDM/default/410_find_backup_sets.sh
+++ b/usr/share/rear/verify/PPDM/default/410_find_backup_sets.sh
@@ -29,7 +29,7 @@
 # We read the backup query output line by line and store the SSID for every Asset Name ONCE. That gives us the
 # most recent SSID for every Asset Name and we use that to restore the filesystems.
 #
-# For point-in-time recovery we simply skip all lines where the Backup Time is newer that the PIT time. If a user
+# For point-in-time recovery we skip all lines where the Backup Time is newer that the PIT time. If a user
 # happens to choose a PIT time that falls between the backup times of the different file systems on the same server,
 # then it can happen that a PIT recovery can use different backup job runs for different filesystems. For example here,
 # if the PIT would be Wed Jan 17 20:00:14 2024 then / would be restored from Wed Jan 17 20:00:14 2024 and /boot from


### PR DESCRIPTION

* Type: **Enhancement**

* Impact: **Low**

* Reference to related issue (URL):

https://github.com/rear/rear/issues/3129

* How was this pull request tested?

Not tested - no code is changed.
Only the wording in code comments and in documentation is changed.

* Description of the changes in this pull request:

Replace the words "just" "simple"/"simply" "easy"/"easily"
in documentation texts and code comments
with better alternatives as far as possible.
For the reasoning behind see
https://github.com/rear/rear/issues/3129#issue-2083218008
