### PR TITLE
Add is_writable_only_by_owner function (improve trusted sourcing)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -104,6 +104,7 @@ SECRET_VARIABLES=( $( grep -v '^[[:space:]]*#' $SHARE_DIR/conf/default.conf | gr
 ####
 # TRUSTED_OWNERS
 # TRUSTED_PATHS
+# TRUSTED_FILES
 #
 # General protection against code injection via 'source'.
 #
@@ -115,6 +116,7 @@ SECRET_VARIABLES=( $( grep -v '^[[:space:]]*#' $SHARE_DIR/conf/default.conf | gr
 # To provide reasonable protection against code injection in general
 # ReaR only executes files via the bash builtin 'source'
 # when the file owner is one of the TRUSTED_OWNERS and
+# when only the file owner has write permission and
 # when the file is located below one of the TRUSTED_PATHS.
 # ReaR refuses to execute files via the bash builtin '.'
 # because it is basically impossible with reasonable effort
@@ -143,10 +145,19 @@ TRUSTED_OWNERS=()
 # then all paths are trusted which disables protection via TRUSTED_PATHS.
 TRUSTED_PATHS=()
 #
+# The by default empty TRUSTED_FILES can be used for exceptional cases
+# to specify files that are trusted regardless of owner / path / permissions
+# in particular when a trusted file has write permissions for a trusted group.
+# Files in TRUSTED_FILES must be specified as the full path of the actual file
+# (i.e. what 'readlink -e file' results).
+TRUSTED_FILES=()
+#
 # Because ReaR reads and executes configuration files via the bash builtin 'source'
-# TRUSTED_OWNERS and TRUSTED_PATHS can only be specified in a user configuration file
+# TRUSTED_OWNERS TRUSTED_PATHS TRUSTED_FILES can only be specified in a user configuration file
 # when the configuration file owner is one of the default TRUSTED_OWNERS (usually 'root') and
 # when the configuration file is located below one of the default TRUSTED_PATHS (usually /etc/).
+# The basic ReaR scripts in usr/share/rear/lib/ cannot be specified in TRUSTED_FILES
+# because those scripts get sourced before the configuration files get sourced.
 ####
 
 ####

--- a/usr/share/rear/lib/_framework-setup-and-functions.sh
+++ b/usr/share/rear/lib/_framework-setup-and-functions.sh
@@ -1521,6 +1521,22 @@ function ProgressInfo () {
 
 # Sourcing functions to enforce trusted sourcing:
 
+# Check the file (i.e. with symlinks resolved) is trusted
+# regardless of owner / path / permissions
+# see https://github.com/rear/rear/pull/3621#issuecomment-5175531546
+function is_trusted_file () {
+    local file="$1"
+    local actual_file=""
+    local trusted_file=""
+    # Get the full path of the actual file (i.e. with leading / and symlinks resolved)
+    # e.g. /etc/os-release is a symbolic link to /usr/lib/os-release (at least on openSUSE Leap 15.6):
+    actual_file="$( readlink -e "$file" )" || Error "is_trusted_file(): 'readlink -e $file' failed"
+    for trusted_file in "${TRUSTED_FILES[@]}" ; do
+        test "$actual_file" = "$trusted_file" && return 0
+    done
+    return 1
+}
+
 # Specify default TRUSTED_OWNERS (used by the is_trusted_owner function):
 #
 # The owner of sbin/rear is always trusted.
@@ -1558,9 +1574,6 @@ function is_trusted_owner () {
 function is_writable_only_by_owner () {
     local file="$1"
     local permission_chars=""
-    # Empty TRUSTED_OWNERS means all regular file owners are blindly trusted,
-    # cf https://github.com/rear/rear/pull/3379#issuecomment-2633123866
-    test ${#TRUSTED_OWNERS[@]} -eq 0 && return 0
     # Do not error out in 'stat' when it is neither a regular file nor a link to a regular file
     # but it is not trusted when it is neither a regular file nor a link to a regular file:
     test -f "$file" || return 1
@@ -1747,12 +1760,14 @@ function source () {
         Debug "Skipped sourcing '$source_file' (no regular file)"
         return 1
     fi
-    # Enforce source file owner is trusted:
-    is_trusted_owner "$source_file" || Error "Forbidden to source '$source_file' (not a TRUSTED_OWNERS: ${TRUSTED_OWNERS[*]})"
-    # Enforce source file is at most writable by its owner:
-    is_writable_only_by_owner "$source_file" || Error "Forbidden to source '$source_file' (group or others have write permission)"
-    # Enforce source file starts with a trusted path:
-    is_trusted_path "$source_file" || Error "Forbidden to source '$source_file' (not below TRUSTED_PATHS: ${TRUSTED_PATHS[*]})"
+    if ! is_trusted_file "$source_file" ; then
+        # Enforce source file owner is trusted:
+        is_trusted_owner "$source_file" || Error "Forbidden to source '$source_file' (not a TRUSTED_OWNERS: ${TRUSTED_OWNERS[*]})"
+        # Enforce source file is at most writable by its owner:
+        is_writable_only_by_owner "$source_file" || Error "Forbidden to source '$source_file' (group or others have write permission)"
+        # Enforce source file starts with a trusted path:
+        is_trusted_path "$source_file" || Error "Forbidden to source '$source_file' (not below TRUSTED_PATHS: ${TRUSTED_PATHS[*]})"
+    fi
   } 2>>/dev/$DISPENSABLE_OUTPUT_DEV
     # The actual work (source the source file):
     builtin source "$@"

--- a/usr/share/rear/lib/_framework-setup-and-functions.sh
+++ b/usr/share/rear/lib/_framework-setup-and-functions.sh
@@ -1579,7 +1579,7 @@ function is_writable_only_by_owner () {
     # When there is an ACL, the group permission bits specify the ACL mask.
     # When the ACL mask has no write permission it masks all ACL write permissions of named users and groups.
     # So no write permission for the group means no write permission for any ACL named users and groups.
-    # Therfore it is not needed here to analyze and check what an ACL may additionally specify.
+    # Therefore it is not needed here to analyze and check what an ACL may additionally specify.
     # Test that group_write_permission and others_write_permission are explicitly '-' (i.e. explicitly no write permission):
     test "$group_write_permission" = '-' -a "$others_write_permission" = '-' && return 0
     return 1

--- a/usr/share/rear/lib/_framework-setup-and-functions.sh
+++ b/usr/share/rear/lib/_framework-setup-and-functions.sh
@@ -1553,6 +1553,38 @@ function is_trusted_owner () {
     return 1
 }
 
+# Check that none except the file owner has write permissions
+# i.e. check that there is no write permission for the group or for others:
+function is_writable_only_by_owner () {
+    local file="$1"
+    local permission_chars=""
+    # Empty TRUSTED_OWNERS means all regular file owners are blindly trusted,
+    # cf https://github.com/rear/rear/pull/3379#issuecomment-2633123866
+    test ${#TRUSTED_OWNERS[@]} -eq 0 && return 0
+    # Do not error out in 'stat' when it is neither a regular file nor a link to a regular file
+    # but it is not trusted when it is neither a regular file nor a link to a regular file:
+    test -f "$file" || return 1
+    # '-L' forces stat to follow symlinks (and error out if that fails):
+    permission_chars="$( stat -L -c %A "$file" )" || Error "is_writable_only_by_owner(): 'stat -L -c %A $file' failed"
+    # permission_chars are e.g. -rwxrw-r-- so
+    # the character offsets are 0123456789 so that
+    # the character at offset 5 is the write permission for the group and
+    # the character at offset 8 is the write permission for others
+    # so group_write_permission and others_write_permission are 'w' or '-'
+    local group_write_permission="${permission_chars:5:1}"
+    local others_write_permission="${permission_chars:8:1}"
+    # To check that none except the file owner has write permissions
+    # we only need to check if there is a write permission for the group or for others.
+    # We do not check owner permissions because they do not matter for this function.
+    # When there is an ACL, the group permission bits specify the ACL mask.
+    # When the ACL mask has no write permission it masks all ACL write permissions of named users and groups.
+    # So no write permission for the group means no write permission for any ACL named users and groups.
+    # Therfore it is not needed here to analyze and check what an ACL may additionally specify.
+    # Test that group_write_permission and others_write_permission are explicitly '-' (i.e. explicitly no write permission):
+    test "$group_write_permission" = '-' -a "$others_write_permission" = '-' && return 0
+    return 1
+}
+
 # Specify default TRUSTED_PATHS (used by the is_trusted_path function) and
 # specify default REAR_SOURCE_PATHS (used by the is_rear_source function):
 #
@@ -1717,6 +1749,8 @@ function source () {
     fi
     # Enforce source file owner is trusted:
     is_trusted_owner "$source_file" || Error "Forbidden to source '$source_file' (not a TRUSTED_OWNERS: ${TRUSTED_OWNERS[*]})"
+    # Enforce source file is at most writable by its owner:
+    is_writable_only_by_owner "$source_file" || Error "Forbidden to source '$source_file' (group or others have write permission)"
     # Enforce source file starts with a trusted path:
     is_trusted_path "$source_file" || Error "Forbidden to source '$source_file' (not below TRUSTED_PATHS: ${TRUSTED_PATHS[*]})"
   } 2>>/dev/$DISPENSABLE_OUTPUT_DEV


### PR DESCRIPTION

* Type: **Enhancement**

* Impact: **Critical**

* Reference to related issue (URL):

https://github.com/rear/rear/issues/3260
therein in particular
https://github.com/rear/rear/issues/3260#issuecomment-5131205171

* How was this pull request tested?

Tested "rear mkrescue/mkbackup" and "rear recover"
on SLES 15 SP 6 with default btrfs structure
i.e. same kind of system as in
https://github.com/rear/rear/wiki/Test-Matrix-ReaR-2.8#sles-15-sp-6-with-default-btrfs-structure

* Description of the changes in this pull request:

In _framework-setup-and-functions.sh
add `is_writable_only_by_owner` function to check
that none except the file owner has write permissions
and call that in the 'source' wrapper function
to improve enforcement of trusted sourcing.

For background information
how Gemini CLI helped me to make that function see
https://github.com/jsmeix/check_writable
therein in particular
https://github.com/jsmeix/check_writable/blob/main/check_writable.simplified.md
