### PR TITLE
Support ISO_DEFAULT and ISO_RECOVER_MODE for GRUB2/UEFI

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1134,7 +1134,8 @@ ISO_FILES=()
 ISO_PREFIX="rear-$HOSTNAME"
 #
 # Default boot option (i.e. what gets booted automatically after some timeout)
-# when SYSLINUX boots the ISO image on BIOS systems.
+# when SYSLINUX boots the ISO image on BIOS systems, and also when GRUB2 is used
+# (UEFI ISO / USB with GRUB2) via create_grub2_cfg in lib/bootloader-functions.sh.
 # This variable ISO_DEFAULT should be better named ISO_BIOS_BOOT_DEFAULT
 # (cf. USB_BIOS_BOOT_DEFAULT below) but we won't rename existing config variables
 # to avoid regressions for users who use existing config variable names
@@ -1155,7 +1156,7 @@ ISO_PREFIX="rear-$HOSTNAME"
 # where one must manually log in as 'root', manually type "rear recover", and manually reboot.
 # ISO_DEFAULT="automatic" boots the ReaR recovery system with the 'auto_recover' kernel command line option
 # that runs "rear recover" automatically without automated reboot (see "man rear").
-# For details see the make_syslinux_config function in lib/bootloader-functions.sh
+# For details see the make_syslinux_config / create_grub2_cfg function in lib/bootloader-functions.sh
 ISO_DEFAULT="boothd"
 #
 # ISO_RECOVER_MODE="unattended" boots the ReaR recovery system with the 'unattended' kernel command line option
@@ -3995,7 +3996,9 @@ GRUB2_MODULES_UEFI=()
 # Valid values are (see the create_grub2_cfg function in lib/bootloader-functions.sh):
 # rear             : Relax-and-Recover (BIOS or UEFI without Secure Boot)
 #                    Relax-and-Recover (BIOS or UEFI in legacy BIOS mode)
+# rear_automatic             : same as 'rear' plus auto_recover / ISO_RECOVER_MODE on the kernel cmdline
 # rear_secure_boot : Relax-and-Recover (UEFI and Secure Boot)
+# rear_secure_boot_automatic : same as 'rear_secure_boot' plus auto_recover / ISO_RECOVER_MODE
 # chainloader      : Boot next EFI
 #                    Boot from second disk hd1 (usually the original system disk)
 # reboot           : Reboot
@@ -4006,6 +4009,10 @@ GRUB2_DEFAULT_BOOT="chainloader"
 # GRUB2_TIMEOUT
 # The timeout in seconds to automatically boot GRUB2_DEFAULT_BOOT
 # when GRUB2 is used as bootloader for the ReaR recovery system.
+# Default is USER_INPUT_TIMEOUT (interactive use).
+# When ISO_DEFAULT="automatic", create_grub2_cfg uses 5 seconds (same idea as SYSLINUX timeout 50)
+# unless GRUB2_TIMEOUT is set explicitly to a value different from USER_INPUT_TIMEOUT
+# (e.g. GRUB2_TIMEOUT=10 for 10 seconds timeout).
 GRUB2_TIMEOUT="$USER_INPUT_TIMEOUT"
 #
 # GRUB2_SET_ROOT_COMMAND

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -1,4 +1,4 @@
- auto_recover $ISO_RECOVER_MODE# Test for the syslinux version
+# Test for the syslinux version
 function get_syslinux_version {
     local syslinux_version
 
@@ -607,6 +607,9 @@ function create_grub2_cfg {
     local grub2_default_menu_entry="$GRUB2_DEFAULT_BOOT"
     test "$grub2_default_menu_entry" || grub2_default_menu_entry="chainloader"
 
+    local grub2_timeout="$GRUB2_TIMEOUT"
+    test "$grub2_timeout" || grub2_timeout=300
+
     case "$ISO_DEFAULT" in
       (automatic)
           grub2_default_menu_entry="rear_automatic"   # not secure-boot variant
@@ -624,9 +627,6 @@ function create_grub2_cfg {
           ;;
       # boothd / empty: keep GRUB2_DEFAULT_BOOT (usually chainloader)
     esac
-
-    local grub2_timeout="$GRUB2_TIMEOUT"
-    test "$grub2_timeout" || grub2_timeout=300
 
     local root_uuid=$( get_root_disk_UUID )
     test -b /dev/disk/by-uuid/$root_uuid || Error "root_uuid device '/dev/disk/by-uuid/$root_uuid' is no block device"
@@ -738,7 +738,7 @@ menuentry "Relax-and-Recover (BIOS or UEFI in legacy BIOS mode)" --id=rear {
     echo 'Loading initial ramdisk $grub2_initrd ...'
     initrd $grub2_initrd
 }
-menuentry "Autoamtic Relax-and-Recover (BIOS or UEFI in legacy BIOS mode)" --id=rear_automatic {
+menuentry "Automatic Relax-and-Recover (BIOS or UEFI in legacy BIOS mode)" --id=rear_automatic {
     insmod gzio
     insmod xzio
     echo 'Loading kernel $grub2_kernel ...'

--- a/usr/share/rear/lib/bootloader-functions.sh
+++ b/usr/share/rear/lib/bootloader-functions.sh
@@ -1,4 +1,4 @@
-# Test for the syslinux version
+ auto_recover $ISO_RECOVER_MODE# Test for the syslinux version
 function get_syslinux_version {
     local syslinux_version
 
@@ -607,6 +607,24 @@ function create_grub2_cfg {
     local grub2_default_menu_entry="$GRUB2_DEFAULT_BOOT"
     test "$grub2_default_menu_entry" || grub2_default_menu_entry="chainloader"
 
+    case "$ISO_DEFAULT" in
+      (automatic)
+          grub2_default_menu_entry="rear_automatic"   # not secure-boot variant
+          # If the user set GRUB2_TIMEOUT in local.conf (different from the
+          # default inheritance of USER_INPUT_TIMEOUT), honor it.
+          # Otherwise use 5s — same as SYSLINUX "timeout 50" for automatic.
+          if test -n "$GRUB2_TIMEOUT" && test "$GRUB2_TIMEOUT" != "$USER_INPUT_TIMEOUT" ; then
+              grub2_timeout="$GRUB2_TIMEOUT"
+          else
+              grub2_timeout=5
+          fi
+          ;;
+      (manual)
+          grub2_default_menu_entry="rear"
+          ;;
+      # boothd / empty: keep GRUB2_DEFAULT_BOOT (usually chainloader)
+    esac
+
     local grub2_timeout="$GRUB2_TIMEOUT"
     test "$grub2_timeout" || grub2_timeout=300
 
@@ -691,6 +709,24 @@ menuentry "Relax-and-Recover (UEFI and Secure Boot)" --id=rear_secure_boot {
     echo 'Loading initial ramdisk $grub2_initrd ...'
     initrdefi $grub2_initrd
 }
+
+menuentry "Automatic Relax-and-Recover (BIOS or UEFI without Secure Boot)" --id=rear_automatic {
+    insmod gzio
+    insmod xzio
+    echo 'Loading kernel $grub2_kernel ...'
+    linux $grub2_kernel root=UUID=$root_uuid $KERNEL_CMDLINE auto_recover $ISO_RECOVER_MODE
+    echo 'Loading initial ramdisk $grub2_initrd ...'
+    initrd $grub2_initrd
+}
+menuentry "Automatic Relax-and-Recover (UEFI and Secure Boot)" --id=rear_secure_boot_automatic {
+    insmod gzio
+    insmod xzio
+    echo 'Loading kernel $grub2_kernel ...'
+    linuxefi $grub2_kernel root=UUID=$root_uuid $KERNEL_CMDLINE auto_recover $ISO_RECOVER_MODE
+    echo 'Loading initial ramdisk $grub2_initrd ...'
+    initrdefi $grub2_initrd
+}
+
 EOF
         else
             cat << EOF
@@ -702,6 +738,15 @@ menuentry "Relax-and-Recover (BIOS or UEFI in legacy BIOS mode)" --id=rear {
     echo 'Loading initial ramdisk $grub2_initrd ...'
     initrd $grub2_initrd
 }
+menuentry "Autoamtic Relax-and-Recover (BIOS or UEFI in legacy BIOS mode)" --id=rear_automatic {
+    insmod gzio
+    insmod xzio
+    echo 'Loading kernel $grub2_kernel ...'
+    linux $grub2_kernel root=UUID=$root_uuid $KERNEL_CMDLINE auto_recover $ISO_RECOVER_MODE
+    echo 'Loading initial ramdisk $grub2_initrd ...'
+    initrd $grub2_initrd
+}
+
 EOF
         fi
     # End of function create_grub2_rear_boot_entry


### PR DESCRIPTION
UEFI ISO used GRUB2 without the SYSLINUX automatic/unattended kernel options.
Add automatic menu entries and honor ISO_DEFAULT so unattended recover works like on BIOS.

Fixes #2970

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):

https://github.com/rear/rear/issues/2970

* How was this pull request tested?

Built ISO on UEFI host with ISO_DEFAULT=automatic, ISO_RECOVER_MODE=unattended, GRUB2_TIMEOUT=10 (optional)

Resulting Screenshots : 
<img width="1807" height="989" alt="rear-auto-recover-grub-menu" src="https://github.com/user-attachments/assets/f948dba8-d81f-4108-a04e-06367471ffe0" />
<img width="1807" height="1002" alt="rear-auto-recover-started" src="https://github.com/user-attachments/assets/49987f4d-8333-4b31-b36a-1a68eaad9823" />
