### PR TITLE
Enhance Btrfs filesystem support Part 1

### DIFF
--- a/doc/user-guide/06-layout-configuration.md
+++ b/doc/user-guide/06-layout-configuration.md
@@ -681,7 +681,7 @@ They can be excluded when hand-crafting a layout file line.
 
 ### Filesystems
 
-    fs <device> <mountpoint> <filesystem type> [uuid=<uuid>] [label=<label>] [blocksize=<block size(B)>] [<reserved_blocks=<nr of reserved blocks>] [max_mounts=<nr>] [check_interval=<number of days>d] [options=<filesystem options>]
+    fs <device> <mountpoint> <filesystem type> [uuid=<uuid>] [label=<label>] [blocksize=<block size(B)>] [<reserved_blocks=<nr of reserved blocks>] [max_mounts=<nr>] [check_interval=<number of days>d] [nodesize=<btrfs node size>] [sectorsize=<btrfs sector size>] [features=<btrfs filesystem features>] [options=<filesystem options>]
 
 
 ### Btrfs Default SubVolumes

--- a/tests/bats/001_filesystems_functions.bats
+++ b/tests/bats/001_filesystems_functions.bats
@@ -283,6 +283,51 @@ no-holes"
     [ "$output" = "$features" ]
 }
 
+@test "Get available Btrfs features: v6.2.2" {
+    function has_binary() {
+        [ "$1" = "mkfs.btrfs" ]
+    }
+
+    function mkfs.btrfs() {
+        [ "$1 $2" = "-O list-all" ] && {
+            echo "Filesystem features available:"
+            echo "mixed-bg            - mixed data and metadata block groups (compat=2.6.37, safe=2.6.37)"
+            echo "extref              - increased hardlink limit per file to 65536 (compat=3.7, safe=3.12, default=3.12)"
+            echo "raid56              - raid56 extended format (compat=3.9)"
+            echo "skinny-metadata     - reduced-size metadata extent refs (compat=3.10, safe=3.18, default=3.18)"
+            echo "no-holes            - no explicit hole extents for files (compat=3.14, safe=4.0, default=5.15)"
+            echo "raid1c34            - RAID1 with 3 or 4 copies (compat=5.5)"
+            echo "zoned               - support zoned devices (compat=5.12)"
+            return 0
+        } >&2
+        [ "$1 $2" = "-R list-all" ] && {
+            echo "Runtime features available:"
+            echo "quota               - quota support (qgroups) (compat=3.4)"
+            echo "free-space-tree     - free space tree (space_cache=v2) (compat=4.5, safe=4.9, default=5.15)"
+            return 0
+        } >&2
+
+        return 1
+    }
+
+    function get_btrfs_version() {
+        echo "6.2.2"
+    }
+
+    local features="mixed-bg
+extref
+raid56
+skinny-metadata
+no-holes
+raid1c34
+zoned
+quota
+free-space-tree"
+
+    run -0 get_available_btrfs_features
+    [ "$output" = "$features" ]
+}
+
 @test "Get enabled Btrfs features: a filesystem UUID is not passed" {
     run -3 get_enabled_btrfs_features
 }

--- a/tests/bats/001_filesystems_functions.bats
+++ b/tests/bats/001_filesystems_functions.bats
@@ -1,0 +1,564 @@
+#!/usr/bin/env bats
+
+#
+# Unit tests for filesystem functions
+#
+
+bats_require_minimum_version 1.5.0
+
+function setup_file() {
+    REAR_SHARE_DIR="$(realpath "$BATS_TEST_DIRNAME/../../usr/share/rear")"
+    export REAR_SHARE_DIR
+}
+
+function setup() {
+    # shellcheck disable=SC1091
+    source "$REAR_SHARE_DIR/lib/filesystems-functions.sh"
+
+    function LogPrintError() {
+        echo "$@"
+    }
+}
+
+@test "Check Btrfs version: btrfs is missing" {
+    function has_binary() {
+        [ "$1" != "btrfs" ]
+    }
+
+    run -127 get_btrfs_version
+}
+
+@test "Check Btrfs version: unexpected output" {
+    function has_binary() {
+        [ "$1" = "btrfs" ]
+    }
+
+    function btrfs() {
+        [ "$1" = "version" ] || return 1
+        echo "btrfs-progs unexpected output"
+    }
+
+    run -1 get_btrfs_version
+}
+
+@test "Check Btrfs version: v6.14" {
+    function has_binary() {
+        [ "$1" = "btrfs" ]
+    }
+
+    function btrfs() {
+        [ "$1" = "version" ] || return 1
+        echo "btrfs-progs v6.14"
+        echo "-EXPERIMENTAL -INJECT -STATIC +LZO +ZSTD +UDEV +FSVERITY +ZONED CRYPTO=builtin"
+    }
+
+    run -0 get_btrfs_version
+    [ "$output" = "6.14" ]
+}
+
+@test "Check Btrfs version: v5.16.2" {
+    function has_binary() {
+        [ "$1" = "btrfs" ]
+    }
+
+    function btrfs() {
+        [ "$1" = "version" ] || return 1
+        echo "btrfs-progs v5.16.2"
+    }
+
+    run -0 get_btrfs_version
+    [ "$output" = "5.16.2" ]
+}
+
+@test "Check Btrfs version: v4.5.3+20160729" {
+    function has_binary() {
+        [ "$1" = "btrfs" ]
+    }
+
+    function btrfs() {
+        [ "$1" = "version" ] || return 1
+        echo "btrfs-progs v4.5.3"
+    }
+
+    run -0 get_btrfs_version
+    [ "$output" = "4.5.3" ]
+}
+
+@test "Get available Btrfs features: mkfs.btrfs is missing" {
+    function has_binary() {
+        [ "$1" != "mkfs.btrfs" ]
+    }
+
+    run -127 get_available_btrfs_features
+}
+
+@test "Get available Btrfs features: failed to get filesystem features" {
+    function has_binary() {
+        [ "$1" = "mkfs.btrfs" ]
+    }
+
+    function mkfs.btrfs() {
+        [ "$1 $2" != "-O list-all" ]
+    }
+
+    run -1 get_available_btrfs_features
+    [ "$output" = "Failed to get the list of available Btrfs filesystem features using mkfs.btrfs -O list-all." ]
+}
+
+@test "Get available Btrfs features: v6.14" {
+    function has_binary() {
+        [ "$1" = "mkfs.btrfs" ]
+    }
+
+    function mkfs.btrfs() {
+        [ "$1 $2" = "-O list-all" ] || return 1
+        {
+            echo "Filesystem features available:"
+            echo "mixed-bg            - mixed data and metadata block groups (compat=2.6.37, safe=2.6.37)"
+            echo "quota               - hierarchical quota group support (qgroups) (compat=3.4)"
+            echo "extref              - increased hardlink limit per file to 65536 (compat=3.7, safe=3.12, default=3.12)"
+            echo "raid56              - raid56 extended format (compat=3.9)"
+            echo "skinny-metadata     - reduced-size metadata extent refs (compat=3.10, safe=3.18, default=3.18)"
+            echo "no-holes            - no explicit hole extents for files (compat=3.14, safe=4.0, default=5.15)"
+            echo "fst                 - free-space-tree alias"
+            echo "free-space-tree     - free space tree, improved space tracking (space_cache=v2) (compat=4.5, safe=4.9, default=5.15)"
+            echo "raid1c34            - RAID1 with 3 or 4 copies (compat=5.5)"
+            echo "zoned               - support zoned (SMR/ZBC/ZNS) devices (compat=5.12)"
+            echo "bgt                 - block-group-tree alias"
+            echo "block-group-tree    - block group tree, more efficient block group tracking to reduce mount time (compat=6.1)"
+            echo "squota              - squota support (simple accounting qgroups) (compat=6.7)"
+        } >&2
+    }
+
+    function get_btrfs_version() {
+        echo "6.14"
+    }
+
+    local features="mixed-bg
+quota
+extref
+raid56
+skinny-metadata
+no-holes
+free-space-tree
+raid1c34
+zoned
+block-group-tree
+squota"
+
+    run -0 get_available_btrfs_features
+    [ "$output" = "$features" ]
+}
+
+@test "Get available Btrfs features: failed to get runtime features on v5.16.2" {
+    function has_binary() {
+        [ "$1" = "mkfs.btrfs" ]
+    }
+
+    function mkfs.btrfs() {
+        [ "$1 $2" = "-O list-all" ] || return 1
+        {
+            echo "Filesystem features available:"
+            echo "mixed-bg            - mixed data and metadata block groups (0x4, compat=2.6.37, safe=2.6.37)"
+            echo "extref              - increased hardlink limit per file to 65536 (0x40, compat=3.7, safe=3.12, default=3.12)"
+            echo "raid56              - raid56 extended format (0x80, compat=3.9)"
+            echo "skinny-metadata     - reduced-size metadata extent refs (0x100, compat=3.10, safe=3.18, default=3.18)"
+            echo "no-holes            - no explicit hole extents for files (0x200, compat=3.14, safe=4.0, default=5.15)"
+            echo "raid1c34            - RAID1 with 3 or 4 copies (0x800, compat=5.5)"
+            echo "zoned               - support zoned devices (0x1000, compat=5.12)"
+        } >&2
+    }
+
+    function get_btrfs_version() {
+        echo "5.16.2"
+    }
+
+    run -1 get_available_btrfs_features
+    [ "$output" = "Failed to get the list of available Btrfs runtime features using mkfs.btrfs -R list-all." ]
+}
+
+@test "Get available Btrfs features: v5.16.2" {
+    function has_binary() {
+        [ "$1" = "mkfs.btrfs" ]
+    }
+
+    function mkfs.btrfs() {
+        [ "$1 $2" = "-O list-all" ] && {
+            echo "Filesystem features available:"
+            echo "mixed-bg            - mixed data and metadata block groups (0x4, compat=2.6.37, safe=2.6.37)"
+            echo "extref              - increased hardlink limit per file to 65536 (0x40, compat=3.7, safe=3.12, default=3.12)"
+            echo "raid56              - raid56 extended format (0x80, compat=3.9)"
+            echo "skinny-metadata     - reduced-size metadata extent refs (0x100, compat=3.10, safe=3.18, default=3.18)"
+            echo "no-holes            - no explicit hole extents for files (0x200, compat=3.14, safe=4.0, default=5.15)"
+            echo "raid1c34            - RAID1 with 3 or 4 copies (0x800, compat=5.5)"
+            echo "zoned               - support zoned devices (0x1000, compat=5.12)"
+            return 0
+        } >&2
+
+        [ "$1 $2" = "-R list-all" ] && {
+            echo "Runtime features available:"
+            echo "quota               - quota support (qgroups) (0x1, compat=3.4)"
+            echo "free-space-tree     - free space tree (space_cache=v2) (0x2, compat=4.5, safe=4.9, default=5.15)"
+            return 0
+        } >&2
+
+        return 1
+    }
+
+    function get_btrfs_version() {
+        echo "5.16.2"
+    }
+
+    local features="mixed-bg
+extref
+raid56
+skinny-metadata
+no-holes
+raid1c34
+zoned
+quota
+free-space-tree"
+
+    run -0 get_available_btrfs_features
+    [ "$output" = "$features" ]
+}
+
+@test "Get available Btrfs features: v4.5.3" {
+    function has_binary() {
+        [ "$1" = "mkfs.btrfs" ]
+    }
+
+    function mkfs.btrfs() {
+        [ "$1 $2" = "-O list-all" ] && {
+            echo "Filesystem features available:"
+            echo "mixed-bg            - mixed data and metadata block groups (0x4)"
+            echo "extref              - increased hardlink limit per file to 65536 (0x40, default)"
+            echo "raid56              - raid56 extended format (0x80)"
+            echo "skinny-metadata     - reduced-size metadata extent refs (0x100, default)"
+            echo "no-holes            - no explicit hole extents for files (0x200)"
+            return 0
+        } >&2
+
+        return 1
+    }
+
+    function get_btrfs_version() {
+        echo "4.5.3"
+    }
+
+    local features="mixed-bg
+extref
+raid56
+skinny-metadata
+no-holes"
+
+    run -0 get_available_btrfs_features
+    [ "$output" = "$features" ]
+}
+
+@test "Get enabled Btrfs features: a filesystem UUID is not passed" {
+    run -3 get_enabled_btrfs_features
+}
+
+@test "Get enabled Btrfs features: no such directory" {
+    local uuid="32ecb07a-e4d4-4c14-b1a8-8cb0148e5bfe"
+
+    function find() {
+        [ "$*" != "/sys/fs/btrfs/$uuid/features/ -maxdepth 1 -type f -exec grep -qx 1 {} ; -printf %f\\n" ]
+    }
+
+    run -1 get_enabled_btrfs_features "$uuid"
+    [ "$output" = "Failed to get enabled Btrfs filesystem features from '/sys/fs/btrfs/$uuid/features/'." ]
+}
+
+@test "Get enabled Btrfs features: failed to get available Btrfs filesystem features" {
+    local uuid="32ecb07a-e4d4-4c14-b1a8-8cb0148e5bfe"
+
+    function find() {
+        [ "$*" = "/sys/fs/btrfs/$uuid/features/ -maxdepth 1 -type f -exec grep -qx 1 {} ; -printf %f\\n" ] || return 1
+        echo "default_subvol"
+        echo "free_space_tree"
+        echo "no_holes"
+        echo "skinny_metadata"
+        echo "extended_iref"
+    }
+
+    function get_available_btrfs_features() {
+        return 1
+    }
+
+    run -1 get_enabled_btrfs_features "$uuid"
+    [ "$output" = "Failed to get the list of available Btrfs features to filter out enabled features for the filesystem with UUID $uuid." ]
+}
+
+@test "Get enabled Btrfs features: filter out features that are not allowed be passed to mkfs.btrfs -O" {
+    local uuid="32ecb07a-e4d4-4c14-b1a8-8cb0148e5bfe"
+
+    function find() {
+        [ "$*" = "/sys/fs/btrfs/$uuid/features/ -maxdepth 1 -type f -exec grep -qx 1 {} ; -printf %f\\n" ] || return 1
+        echo "default_subvol"
+        echo "mixed_backref"
+        echo "mixed_groups"
+        echo "free_space_tree"
+        echo "no_holes"
+        echo "skinny_metadata"
+        echo "extended_iref"
+        echo "big_metadata"
+        echo "simple_quota"
+    }
+
+    function get_available_btrfs_features() {
+        echo "mixed-bg"
+        echo "quota"
+        echo "extref"
+        echo "raid56"
+        echo "skinny-metadata"
+        echo "no-holes"
+        echo "free-space-tree"
+        echo "raid1c34"
+        echo "zoned"
+        echo "block-group-tree"
+        echo "squota"
+    }
+
+    function are_btrfs_qgroups_enabled() {
+        return 1
+    }
+
+    run -0 get_enabled_btrfs_features "$uuid"
+    [ "$output" = "extref,free-space-tree,mixed-bg,no-holes,skinny-metadata,squota" ]
+}
+
+@test "Get enabled Btrfs features: qgroups are enabled" {
+    local uuid="32ecb07a-e4d4-4c14-b1a8-8cb0148e5bfe"
+
+    function find() {
+        [ "$*" = "/sys/fs/btrfs/$uuid/features/ -maxdepth 1 -type f -exec grep -qx 1 {} ; -printf %f\\n" ] || return 1
+        echo "extended_iref"
+    }
+
+    function get_available_btrfs_features() {
+        echo "mixed-bg"
+        echo "quota"
+        echo "extref"
+        echo "raid56"
+        echo "skinny-metadata"
+        echo "no-holes"
+        echo "free-space-tree"
+        echo "raid1c34"
+        echo "zoned"
+        echo "block-group-tree"
+        echo "squota"
+    }
+
+    function are_btrfs_qgroups_enabled() {
+        return 0
+    }
+
+    run -0 get_enabled_btrfs_features "$uuid"
+    [ "$output" = "extref,quota" ]
+}
+
+@test "Get Btrfs features option for mkfs: failed to get the list of available Btrfs features" {
+    function get_available_btrfs_features() {
+        return 1
+    }
+
+    run -1 get_btrfs_features_option_for_mkfs
+    [ "$output" = "Failed to get the list of available Btrfs features to prepare the mkfs.btrfs -O option." ]
+}
+
+@test "Get Btrfs features option for mkfs: disable all features v6.14" {
+    function get_available_btrfs_features() {
+        echo "mixed-bg"
+        echo "quota"
+        echo "extref"
+        echo "no-holes"
+        echo "free-space-tree"
+    }
+
+    function get_btrfs_version() {
+        echo "6.14"
+    }
+
+    run -0 get_btrfs_features_option_for_mkfs
+    [ "$output" = " -O ^extref,^free-space-tree,^mixed-bg,^no-holes,^quota" ]
+}
+
+@test "Get Btrfs features option for mkfs: disable all features v5.16.2" {
+    function get_available_btrfs_features() {
+        echo "mixed-bg"
+        echo "quota"
+        echo "extref"
+        echo "no-holes"
+        echo "free-space-tree"
+    }
+
+    function get_btrfs_version() {
+        echo "5.16.2"
+    }
+
+    run -0 get_btrfs_features_option_for_mkfs
+    [ "$output" = " -R ^free-space-tree,^quota -O ^extref,^mixed-bg,^no-holes" ]
+}
+
+@test "Get Btrfs features option for mkfs: enable all features v6.14" {
+    function get_available_btrfs_features() {
+        echo "mixed-bg"
+        echo "quota"
+        echo "extref"
+        echo "raid56"
+        echo "skinny-metadata"
+        echo "no-holes"
+        echo "free-space-tree"
+        echo "raid1c34"
+        echo "zoned"
+        echo "block-group-tree"
+        echo "squota"
+    }
+
+    function get_btrfs_version() {
+        echo "6.14"
+    }
+
+    run -0 get_btrfs_features_option_for_mkfs mixed-bg,quota,extref,raid56,skinny-metadata,no-holes,free-space-tree,raid1c34,zoned,block-group-tree,squota
+    [ "$output" = " -O mixed-bg,quota,extref,raid56,skinny-metadata,no-holes,free-space-tree,raid1c34,zoned,block-group-tree,squota" ]
+}
+
+@test "Get Btrfs features option for mkfs: enable all features v5.16.2" {
+    function get_available_btrfs_features() {
+        echo "mixed-bg"
+        echo "quota"
+        echo "extref"
+        echo "raid56"
+        echo "skinny-metadata"
+        echo "no-holes"
+        echo "free-space-tree"
+        echo "raid1c34"
+        echo "zoned"
+        echo "squota"
+    }
+
+    function get_btrfs_version() {
+        echo "5.16.2"
+    }
+
+    run -0 get_btrfs_features_option_for_mkfs mixed-bg,quota,extref,raid56,skinny-metadata,no-holes,free-space-tree,raid1c34,zoned,squota
+    [ "$output" = " -R free-space-tree,quota -O mixed-bg,extref,raid56,skinny-metadata,no-holes,raid1c34,zoned,squota" ]
+}
+
+@test "Get Btrfs features option for mkfs: skip unsupported Btrfs features" {
+    function get_available_btrfs_features() {
+        echo "quota"
+        echo "free-space-tree"
+    }
+
+    function get_btrfs_version() {
+        echo "5.16.2"
+    }
+
+    run -0 get_btrfs_features_option_for_mkfs quota,free-space-tree,block-group-tree,squota
+    [ "${lines[0]}" = "'block-group-tree' is an unsupported Btrfs filesystem feature in the version of mkfs.btrfs used by the rescue system and cannot be recovered." ]
+    [ "${lines[1]}" = "'squota' is an unsupported Btrfs filesystem feature in the version of mkfs.btrfs used by the rescue system and cannot be recovered." ]
+    [ "${lines[2]}" = " -R free-space-tree,quota" ]
+}
+
+@test "Get Btrfs features option for mkfs: default case for v5.16.2" {
+    function get_available_btrfs_features() {
+        echo "mixed-bg"
+        echo "extref"
+        echo "raid56"
+        echo "skinny-metadata"
+        echo "no-holes"
+        echo "raid1c34"
+        echo "zoned"
+        echo "quota"
+        echo "free-space-tree"
+    }
+
+    function get_btrfs_version() {
+        echo "5.16.2"
+    }
+
+    run -0 get_btrfs_features_option_for_mkfs extref,free-space-tree,no-holes,skinny-metadata
+    [ "$output" = " -R free-space-tree,^quota -O extref,no-holes,skinny-metadata,^mixed-bg,^raid1c34,^raid56,^zoned" ]
+}
+
+@test "Get Btrfs features option for mkfs: default case for v6.14" {
+    function get_available_btrfs_features() {
+        echo "mixed-bg"
+        echo "quota"
+        echo "extref"
+        echo "raid56"
+        echo "skinny-metadata"
+        echo "no-holes"
+        echo "free-space-tree"
+        echo "raid1c34"
+        echo "zoned"
+        echo "block-group-tree"
+        echo "squota"
+    }
+
+    function get_btrfs_version() {
+        echo "6.14"
+    }
+
+    run -0 get_btrfs_features_option_for_mkfs extref,free-space-tree,no-holes,skinny-metadata
+    [ "$output" = " -O extref,free-space-tree,no-holes,skinny-metadata,^block-group-tree,^mixed-bg,^quota,^raid1c34,^raid56,^squota,^zoned" ]
+}
+
+@test "Get Btrfs nodesize: UUID is missing" {
+    run -3 get_btrfs_nodesize
+}
+
+@test "Get Btrfs sectorsize: UUID is missing" {
+    run -3 get_btrfs_sectorsize
+}
+
+@test "Are Btrfs qgroups enabled: UUID is missing" {
+    run -3 are_btrfs_qgroups_enabled
+}
+
+@test "Is Btrfs node size valid: empty nodesize is invalid" {
+    run -1 is_btrfs_nodesize_valid
+}
+
+@test "Is Btrfs nodesize valid: 16384 is valid" {
+    is_btrfs_nodesize_valid 16384
+}
+
+@test "Is Btrfs nodesize valid: nodesize must be a power of 2" {
+    run -1 is_btrfs_nodesize_valid 1023
+}
+
+@test "Is Btrfs nodesize valid: nodesize must be not larger than 64KiB" {
+    run -1 is_btrfs_nodesize_valid 131072
+}
+
+@test "Is Btrfs nodesize valid: nodesize containing non-numeric characters is invalid" {
+    run -1 is_btrfs_nodesize_valid "16384;rm -rf /"
+}
+
+@test "Is Btrfs sectorsize valid: empty sectorsize is invalid" {
+    run -1 is_btrfs_sectorsize_valid
+}
+
+@test "Is Btrfs sectorsize valid: 16384 is valid" {
+    is_btrfs_sectorsize_valid 16384
+}
+
+@test "Is Btrfs nodesize valid: sectorsize must be a power of 2" {
+    run -1 is_btrfs_sectorsize_valid 1023
+}
+
+@test "Is Btrfs sectorsize valid: sectorsize containing non-numeric characters is invalid" {
+    run -1 is_btrfs_sectorsize_valid "4096;rm -rf /"
+}
+
+@test "Is Btrfs list of features valid: valid list is passed" {
+    is_btrfs_list_of_features_valid "mixed-bg,extref,raid1c34"
+}
+
+@test "Is Btrfs list of features valid: malicious code injected" {
+    run -1 is_btrfs_list_of_features_valid "mixed-bg,;rm -rf /;extref"
+}

--- a/tests/bats/001_filesystems_functions.bats
+++ b/tests/bats/001_filesystems_functions.bats
@@ -150,6 +150,33 @@ squota"
     [ "$output" = "$features" ]
 }
 
+@test "Get available Btrfs features: failed to get version to check whether mkfs.btrfs -R list-all must be used" {
+    function has_binary() {
+        [ "$1" = "mkfs.btrfs" ]
+    }
+
+    function mkfs.btrfs() {
+        [ "$1 $2" = "-O list-all" ] || return 1
+        {
+            echo "Filesystem features available:"
+            echo "mixed-bg            - mixed data and metadata block groups (0x4, compat=2.6.37, safe=2.6.37)"
+            echo "extref              - increased hardlink limit per file to 65536 (0x40, compat=3.7, safe=3.12, default=3.12)"
+            echo "raid56              - raid56 extended format (0x80, compat=3.9)"
+            echo "skinny-metadata     - reduced-size metadata extent refs (0x100, compat=3.10, safe=3.18, default=3.18)"
+            echo "no-holes            - no explicit hole extents for files (0x200, compat=3.14, safe=4.0, default=5.15)"
+            echo "raid1c34            - RAID1 with 3 or 4 copies (0x800, compat=5.5)"
+            echo "zoned               - support zoned devices (0x1000, compat=5.12)"
+        } >&2
+    }
+
+    function get_btrfs_version() {
+        return 1
+    }
+
+    run -1 get_available_btrfs_features
+    [ "$output" = "Failed to determine the Btrfs version to check whether mkfs.btrfs -R list-all must be used." ]
+}
+
 @test "Get available Btrfs features: failed to get runtime features on v5.16.2" {
     function has_binary() {
         [ "$1" = "mkfs.btrfs" ]
@@ -368,6 +395,24 @@ no-holes"
     [ "$output" = "Failed to get the list of available Btrfs features to prepare the mkfs.btrfs -O option." ]
 }
 
+
+@test "Get Btrfs features option for mkfs: failed to get version to check whether mkfs.btrfs -R list-all must be used" {
+    function get_available_btrfs_features() {
+        echo "mixed-bg"
+        echo "quota"
+        echo "extref"
+        echo "no-holes"
+        echo "free-space-tree"
+    }
+
+    function get_btrfs_version() {
+        return 1
+    }
+
+    run -1 get_btrfs_features_option_for_mkfs
+    [ "$output" = "Failed to determine the Btrfs version to check whether mkfs.btrfs -R list-all must be used." ]
+}
+
 @test "Get Btrfs features option for mkfs: disable all features v6.14" {
     function get_available_btrfs_features() {
         echo "mixed-bg"
@@ -547,7 +592,7 @@ no-holes"
     is_btrfs_sectorsize_valid 16384
 }
 
-@test "Is Btrfs nodesize valid: sectorsize must be a power of 2" {
+@test "Is Btrfs sectorsize valid: sectorsize must be a power of 2" {
     run -1 is_btrfs_sectorsize_valid 1023
 }
 

--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -1771,6 +1771,7 @@ bash
 bc
 cat
 cmp
+comm
 cp
 cpio
 cut

--- a/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
+++ b/usr/share/rear/layout/prepare/GNU/Linux/131_include_filesystem_code.sh
@@ -220,6 +220,25 @@ function create_fs () {
             fi
             ;;
         (btrfs)
+            # Btrfs filesystem parameters:
+            local features="" nodesize="" sectorsize=""
+            local option="" name="" value=""
+            for option in $options ; do
+                name=${option%=*}
+                value=${option#*=}
+                case "$name" in
+                    (features)
+                        features=$(get_btrfs_features_option_for_mkfs "$value")
+                        ;;
+                    (nodesize)
+                        nodesize=" -n $value"
+                        ;;
+                    (sectorsize)
+                        sectorsize=" -s $value"
+                        ;;
+                esac
+            done
+
             # Cleanup disk partition provided the disk partition is not already mounted:
             echo "mount | grep -q $device || $cleanup_command" >> "$LAYOUT_CODE"
 
@@ -234,10 +253,10 @@ function create_fs () {
                 # User -f [force] to force overwriting an existing btrfs on that disk partition
                 # when the disk was already used before, see https://bugzilla.novell.com/show_bug.cgi?id=878870
                 (   echo "  # Try to create btrfs with UUID"
-                    echo "  if ! mkfs -t $fstype -U $uuid -f $device >&2 ; then"
+                    echo "  if ! mkfs -t $fstype -U $uuid -f ${nodesize}${sectorsize}${features} $device >&2 ; then"
                     # Problem with old btrfs version is that UUID cannot be set during mkfs! So, we must map it and
                     # change later the /etc/fstab, /boot/grub/menu.lst, etc.
-                    echo "      mkfs -t $fstype -f $device >&2"
+                    echo "      mkfs -t $fstype -f ${nodesize}${sectorsize}${features} $device >&2"
                     echo "      new_uuid=\$( btrfs filesystem show $device 2>/dev/null | grep -o 'uuid: .*' | cut -d ':' -f 2 | tr -d '[:space:]' )"
                     echo "      if [ $uuid != \$new_uuid ] ; then"
                     echo "          # The following grep command intentionally also"
@@ -257,7 +276,7 @@ function create_fs () {
             else
                 # UUID is not provided. Create FS without UUID
                 # Latest version of btrfs provides -U option to specify UUID druring the filesystem creation.
-                echo "  mkfs -t $fstype -f $device" >> "$LAYOUT_CODE"
+                echo "  mkfs -t $fstype -f ${nodesize}${sectorsize}${features} $device" >> "$LAYOUT_CODE"
             fi
 
             # Set the label:

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -245,6 +245,24 @@ fi
                 label=$( btrfs filesystem show $device | grep -o 'Label: [^ ]*' | cut -d ':' -f 2 | tr -d '[:space:]' )
                 test "none" = "$label" && label=
                 echo -n " uuid=$uuid label=$label"
+
+                if nodesize=$(get_btrfs_nodesize "$uuid"); then
+                    echo -n " nodesize=$nodesize"
+                else
+                    LogPrintError "Failed to get Btrfs nodesize for $device"
+                fi
+
+                if sectorsize=$(get_btrfs_sectorsize "$uuid"); then
+                    echo -n " sectorsize=$sectorsize"
+                else
+                    LogPrintError "Failed to get Btrfs sectorsize for $device"
+                fi
+
+                if features=$(get_enabled_btrfs_features "$uuid" ); then
+                    echo -n " features=$features"
+                else
+                    LogPrintError "Failed to get enabled Btrfs features for $device"
+                fi
                 ;;
         esac
         # Remove parenthesis (from the traditional mount command output) from the list of options:

--- a/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
+++ b/usr/share/rear/layout/save/default/950_verify_disklayout_file.sh
@@ -222,6 +222,29 @@ while read keyword volume_group pv_device junk ; do
    grep -q "^lvmvol $volume_group " "$DISKLAYOUT_FILE" || broken_lvm_errors+=( "LVM no 'lvmvol $volume_group' for 'lvmdev $volume_group'" )
 done < <( grep "^lvmdev " "$DISKLAYOUT_FILE" )
 
+Log "Verifying that the Btrfs filesystem entries in $DISKLAYOUT_FILE are correct"
+local broken_btrfs_errors=()
+while read -r _ device _ _ _ _ options; do
+    local option="" name="" value=""
+    for option in $options ; do
+        name=${option%=*}
+        value=${option#*=}
+        case "$name" in
+            (features)
+                is_btrfs_list_of_features_valid "$value" \
+                    || broken_btrfs_errors+=( "$device Btrfs features $value is not empty and is not a comma-separated list of features" )
+                ;;
+            (nodesize)
+                is_btrfs_nodesize_valid "$value" || \
+                    broken_btrfs_errors+=( "$device Btrfs nodesize $value is not valid (must be a power of 2 and not larger than 65536)" )
+                ;;
+            (sectorsize)
+                is_btrfs_sectorsize_valid "$value" || \
+                    broken_btrfs_errors+=( "$device Btrfs sectorsize $value is not valid (must be a power of 2)" )
+                ;;
+        esac
+    done
+done < <( awk '$1 == "fs" && $4 == "btrfs"' "$DISKLAYOUT_FILE" )
 
 # Finally after all tests had been done (so that the user gets all result messages) error out if needed:
 
@@ -254,6 +277,12 @@ if is_false $FEATURE_PARTED_RESIZEPART && is_false $FEATURE_PARTED_RESIZE ; then
 fi
 # LVM errors:
 for error_message in "${broken_lvm_errors[@]}" ; do
+    contains_visible_char "$error_message" || continue
+    LogPrintError "$error_message"
+    disklayout_file_is_broken="yes"
+done
+# Btrfs errors:
+for error_message in "${broken_btrfs_errors[@]}" ; do
     contains_visible_char "$error_message" || continue
     LogPrintError "$error_message"
     disklayout_file_is_broken="yes"

--- a/usr/share/rear/lib/filesystems-functions.sh
+++ b/usr/share/rear/lib/filesystems-functions.sh
@@ -42,6 +42,202 @@ function btrfs_subvolume_exists() {
     # Return awk's exit status
 }
 
+function get_btrfs_version() {
+    if ! has_binary btrfs; then
+        return 127
+    fi
+
+    btrfs version | grep -oP '(?<=btrfs-progs v)[\d.]+'
+}
+
+function get_available_btrfs_features() {
+    if ! has_binary mkfs.btrfs; then
+        return 127
+    fi
+
+    local buffer
+    if ! buffer="$(mkfs.btrfs -O list-all 2>&1)"; then
+        LogPrintError "Failed to get the list of available Btrfs filesystem features using mkfs.btrfs -O list-all."
+        return 1
+    fi
+
+    local features
+    # Filter out aliases such as 'bgt - block-group-tree alias'.
+    features="$(echo "$buffer" | awk 'NR>1 && !/alias$/ {print $1}')"
+
+    # We need to get runtime features using mkfs.btrfs -R list-all for versions
+    # between 5.7 and 6.2. Since 6.3, the -R option has been deprecated,
+    # and all features have been merged into the -O option.
+    if printf '%s\n' "5.7" "$(get_btrfs_version)" "6.2" | sort -V -C; then
+        if ! buffer="$(mkfs.btrfs -R list-all 2>&1)"; then
+            LogPrintError "Failed to get the list of available Btrfs runtime features using mkfs.btrfs -R list-all."
+            return 1
+        fi
+        features+=$'\n'
+        features+="$(echo "$buffer" | awk 'NR>1 {print $1}')"
+    fi
+
+    echo "$features"
+}
+
+# $1 - a filesystem UUID
+function are_btrfs_qgroups_enabled() {
+    local uuid=$1
+    if [ -z "$uuid" ]; then
+        return 3
+    fi
+
+    local qgroups_dir="/sys/fs/btrfs/$uuid/qgroups"
+    if [ ! -f "${qgroups_dir}/enabled" ] || [ ! -f "${qgroups_dir}/mode" ]; then
+        return 1
+    fi
+
+    [ "$(cat "${qgroups_dir}/enabled")" = "1" ] && [ "$(cat "${qgroups_dir}/mode")" = "qgroup" ]
+}
+
+# $1 - a filesystem UUID
+function get_enabled_btrfs_features() {
+    local uuid=$1
+    if [ -z "$uuid" ]; then
+        return 3
+    fi
+
+    local features_dir="/sys/fs/btrfs/$uuid/features/"
+
+    local enabled_features
+    if ! enabled_features=$(find "$features_dir" -maxdepth 1 -type f -exec grep -qx "1" {} \; -printf "%f\n"); then
+        LogPrintError "Failed to get enabled Btrfs filesystem features from '$features_dir'."
+        return 1
+    fi
+    # Translate sysfs feature names to mkfs.btrfs -O flag names
+    enabled_features="${enabled_features//_/-}"
+    enabled_features="${enabled_features/mixed-groups/mixed-bg}"
+    enabled_features="${enabled_features/extended-iref/extref}"
+    enabled_features="${enabled_features/simple-quota/squota}"
+
+    # Check whether qgroups are enabled separately because there isn't a dedicated flag in /sys/fs/btrfs/UUID/features/
+    if are_btrfs_qgroups_enabled "$uuid"; then
+        enabled_features+=$'\n'"quota"
+    fi
+
+    # Filter out filesystem features that can't be passed to the mkfs.btrfs -O option 
+    local available_features
+    if ! available_features=$(get_available_btrfs_features); then
+        LogPrintError "Failed to get the list of available Btrfs features to filter out enabled features for the filesystem with UUID $uuid."
+        return 1
+    fi
+    enabled_features=$(comm -12 <(echo "$available_features" | sort) <(echo "$enabled_features" | sort))
+
+    enabled_features="${enabled_features//$'\n'/,}"
+
+    echo "$enabled_features"
+}
+
+# $1 - a comma-separated list of enabled Btrfs features
+function get_btrfs_features_option_for_mkfs() {
+    local features=$1
+
+    local available_features
+    if ! available_features=$(get_available_btrfs_features); then
+        LogPrintError "Failed to get the list of available Btrfs features to prepare the mkfs.btrfs -O option."
+        return 1
+    fi
+    available_features=$(echo "$available_features" | sort)
+
+    local unsupported_features
+    unsupported_features=$(comm -13 <(echo "$available_features") <(echo "$features" | tr ',' '\n' | sort))
+
+    local unsupported_feature
+    for unsupported_feature in $unsupported_features; do
+        LogPrintError "'$unsupported_feature' is an unsupported Btrfs filesystem feature in the version of mkfs.btrfs used by the rescue system and cannot be recovered."
+        # Remove unsupported features caused by using an older mkfs.btrfs on the rescue system than mkfs.btrfs used to create a filesystem.
+        features=$(echo "$features" | sed -E "s/(^|,)${unsupported_feature}(,|$)/\1/;s/,$//")
+    done
+
+    local disabled_features
+    disabled_features=$(comm -23 <(echo "$available_features") <(echo "$features" | tr ',' '\n' | sort))
+
+    local disabled_feature
+    for disabled_feature in $disabled_features; do
+        # Explicitly turn off disabled features to prevent them from being enabled by default.
+        features+=",^$disabled_feature"
+    done
+
+    local result=""
+
+    # For versions 5.7 through 6.2, runtime features must be controlled using the -R option.
+    if printf '%s\n' "5.7" "$(get_btrfs_version)" "6.2" | sort -V -C; then
+        local runtime_features=""
+        for runtime_feature in free-space-tree quota; do
+            local found
+            if found=$(echo "$features" | grep -oP '(?<![a-z])\^?'"$runtime_feature"',?'); then
+                features="${features/$found/}"
+                runtime_features+=",${found%,}"
+            fi
+        done
+
+        if [ -n "$runtime_features" ]; then
+            result+=" -R ${runtime_features#,}"
+        fi
+
+        features=${features%,}
+    fi
+
+    if [ -n "$features" ]; then
+        result+=" -O ${features#,}"
+    fi
+
+    echo "$result"
+}
+
+# $1 - a filesystem UUID
+function get_btrfs_nodesize() {
+    local uuid=$1
+    if [ -z "$uuid" ]; then
+        return 3
+    fi
+
+    local nodesize_path=/sys/fs/btrfs/$uuid/nodesize
+    if [ ! -f "$nodesize_path" ]; then
+        return 127
+    fi
+
+    cat "$nodesize_path"
+}
+
+# $1 - a filesystem UUID
+function get_btrfs_sectorsize() {
+    local uuid=$1
+    if [ -z "$uuid" ]; then
+        return 3
+    fi
+
+    local sectorsize_path=/sys/fs/btrfs/$uuid/sectorsize
+    if [ ! -f "$sectorsize_path" ]; then
+        return 127
+    fi
+
+    cat "$sectorsize_path"
+}
+
+# $1 - nodesize
+function is_btrfs_nodesize_valid() {
+    local nodesize=$1
+    # The nodesize must be not larger than 64KiB and a power of 2
+    (( nodesize > 0 && nodesize <= 65536 && (nodesize & (nodesize - 1)) == 0 ))
+}
+
+# $1 - sectorsize
+function is_btrfs_sectorsize_valid() {
+    local sectorsize=$1
+    (( sectorsize > 0 && (sectorsize & (sectorsize - 1)) == 0 ))
+}
+
+# $1 - a comma-separated list of features
+function is_btrfs_list_of_features_valid() {
+    local list=$1
+    [ -z "$list" ] || [[ "$list" =~ ^[0-9a-z-]+(,[0-9a-z-]+)*$ ]]
+}
 
 #Parse output from xfs_info for later use by mkfs.xfs
 

--- a/usr/share/rear/lib/filesystems-functions.sh
+++ b/usr/share/rear/lib/filesystems-functions.sh
@@ -68,7 +68,13 @@ function get_available_btrfs_features() {
     # We need to get runtime features using mkfs.btrfs -R list-all for versions
     # between 5.7 and 6.2. Since 6.3, the -R option has been deprecated,
     # and all features have been merged into the -O option.
-    if printf '%s\n' "5.7" "$(get_btrfs_version)" "6.2" | sort -V -C; then
+    local btrfs_version
+    if ! btrfs_version=$(get_btrfs_version); then
+        LogPrintError "Failed to determine the Btrfs version to check whether mkfs.btrfs -R list-all must be used."
+        return 1
+    fi
+
+    if printf '%s\n' "5.7" "$btrfs_version" "6.2" | sort -V -C; then
         if ! buffer="$(mkfs.btrfs -R list-all 2>&1)"; then
             LogPrintError "Failed to get the list of available Btrfs runtime features using mkfs.btrfs -R list-all."
             return 1
@@ -166,7 +172,12 @@ function get_btrfs_features_option_for_mkfs() {
     local result=""
 
     # For versions 5.7 through 6.2, runtime features must be controlled using the -R option.
-    if printf '%s\n' "5.7" "$(get_btrfs_version)" "6.2" | sort -V -C; then
+    local btrfs_version
+    if ! btrfs_version=$(get_btrfs_version); then
+        LogPrintError "Failed to determine the Btrfs version to check whether mkfs.btrfs -R list-all must be used."
+        return 1
+    fi
+    if printf '%s\n' "5.7" "$btrfs_version" "6.2" | sort -V -C; then
         local runtime_features=""
         for runtime_feature in free-space-tree quota; do
             local found
@@ -223,6 +234,7 @@ function get_btrfs_sectorsize() {
 # $1 - nodesize
 function is_btrfs_nodesize_valid() {
     local nodesize=$1
+    [[ "$nodesize" =~ ^[0-9]+$ ]] || return 1
     # The nodesize must be not larger than 64KiB and a power of 2
     (( nodesize > 0 && nodesize <= 65536 && (nodesize & (nodesize - 1)) == 0 ))
 }
@@ -230,6 +242,8 @@ function is_btrfs_nodesize_valid() {
 # $1 - sectorsize
 function is_btrfs_sectorsize_valid() {
     local sectorsize=$1
+    [[ "$sectorsize" =~ ^[0-9]+$ ]] || return 1
+    # The sectorsize must be a power of 2
     (( sectorsize > 0 && (sectorsize & (sectorsize - 1)) == 0 ))
 }
 

--- a/usr/share/rear/lib/filesystems-functions.sh
+++ b/usr/share/rear/lib/filesystems-functions.sh
@@ -66,7 +66,7 @@ function get_available_btrfs_features() {
     features="$(echo "$buffer" | awk 'NR>1 && !/alias$/ {print $1}')"
 
     # We need to get runtime features using mkfs.btrfs -R list-all for versions
-    # between 5.7 and 6.2. Since 6.3, the -R option has been deprecated,
+    # between 5.7 and 6.2.2. Since 6.3, the -R option has been deprecated,
     # and all features have been merged into the -O option.
     local btrfs_version
     if ! btrfs_version=$(get_btrfs_version); then
@@ -74,7 +74,7 @@ function get_available_btrfs_features() {
         return 1
     fi
 
-    if printf '%s\n' "5.7" "$btrfs_version" "6.2" | sort -V -C; then
+    if printf '%s\n' "5.7" "$btrfs_version" "6.2.2" | sort -V -C; then
         if ! buffer="$(mkfs.btrfs -R list-all 2>&1)"; then
             LogPrintError "Failed to get the list of available Btrfs runtime features using mkfs.btrfs -R list-all."
             return 1
@@ -171,13 +171,13 @@ function get_btrfs_features_option_for_mkfs() {
 
     local result=""
 
-    # For versions 5.7 through 6.2, runtime features must be controlled using the -R option.
+    # For versions 5.7 through 6.2.2, runtime features must be controlled using the -R option.
     local btrfs_version
     if ! btrfs_version=$(get_btrfs_version); then
         LogPrintError "Failed to determine the Btrfs version to check whether mkfs.btrfs -R list-all must be used."
         return 1
     fi
-    if printf '%s\n' "5.7" "$btrfs_version" "6.2" | sort -V -C; then
+    if printf '%s\n' "5.7" "$btrfs_version" "6.2.2" | sort -V -C; then
         local runtime_features=""
         for runtime_feature in free-space-tree quota; do
             local found


### PR DESCRIPTION


##### Pull Request Details:

* Type: **Enhancement**

* Impact: **Normal**

* Reference to related issue (URL):

* How was this pull request tested?
  SLES 16.0, openSUSE Leap 16.1 and SLES 12.5 were recovered successfully.

  I created Btrfs filesystems with individual features enabled (for `block-group-tree`, the `no-holes` and `free-space-tree` features were also enabled as it's mandatory), with all features enabled and with all features disabled. In all cases, the filesystems were recovered with the expected feature set. For the `mixed-bg` feature, `sectorsize` and `nodesize` must be identical, and recovery preserved this requirement correctly.
  Example:
  `mkfs.btrfs -f --sectorsize 4096 --nodesize 4096 -O mixed-bg,^quota,^extref,^raid56,^skinny-metadata,^no-holes,^free-space-tree,^raid1c34,^zoned,^block-group-tree,^squota /dev/sdb1`

* Description of the changes in this pull request:
  Support recovery of enabled Btrfs filesystem features, `nodesize`, and `sectorsize` by backing up their actual values and implicitly passing them to mkfs.btrfs during recovery, preventing them from being overridden by default values.

  The newly supported options are stored in `disklayout.conf` in the same way as `blocksize`, `fragmentsize`, etc. are stored for `ext*` filesystems.

  The validation logic was added primarily to mitigate code injection risks and to ensure that the recovered values are valid.

  Additionally, I wrote unit tests to simplify the development and validation process. If you would prefer not to include them, let me know and I will remove the test file. Tests can be run with: `bats tests/bats/001_filesystems_functions.bats`

  I’m also preparing additional changes to further improve Btrfs support, but I’d first like to hear your feedback on changes in this PR as it may not be interesting enough.

  Potentially fixes https://github.com/rear/rear/issues/3545

  Pages that I've used during development:
    https://btrfs.readthedocs.io/en/latest/mkfs.btrfs.html#man-mkfs-filesystem-features
    https://btrfs.readthedocs.io/en/latest/btrfs-man5.html#filesystem-features
