### PR TITLE
Set TRUSTED_FILES 'readonly' after sourcing config files

### DIFF
--- a/usr/sbin/rear
+++ b/usr/sbin/rear
@@ -889,8 +889,8 @@ fi
 if [ "$saved_tmpdir" != "$TMPDIR" ] ; then
     Error "Setting TMPDIR in a configuration file is not supported. To specify a working area directory prefix, export TMPDIR before executing '$PROGRAM'"
 fi
-# After the user configuration files were sourced set TRUSTED_OWNERS and TRUSTED_PATHS and REAR_SOURCE_PATHS 'readonly':
-readonly TRUSTED_OWNERS TRUSTED_PATHS REAR_SOURCE_PATHS
+# After the user configuration files were sourced set TRUSTED_OWNERS and TRUSTED_PATHS and REAR_SOURCE_PATHS and TRUSTED_FILES 'readonly':
+readonly TRUSTED_OWNERS TRUSTED_PATHS REAR_SOURCE_PATHS TRUSTED_FILES
 # Show the final TRUSTED_OWNERS and TRUSTED_PATHS to the user in debug mode
 # to help him if he cannot source additional configuration files in non-default paths:
 DebugPrint "Sourced files must be owned by one of the TRUSTED_OWNERS: ${TRUSTED_OWNERS[*]:-all owners are trusted}"

--- a/usr/share/rear/lib/_framework-setup-and-functions.sh
+++ b/usr/share/rear/lib/_framework-setup-and-functions.sh
@@ -1571,14 +1571,14 @@ function is_trusted_owner () {
 
 # Check that none except the file owner has write permissions
 # i.e. check that there is no write permission for the group or for others:
-function is_writable_only_by_owner () {
+function is_trusted_write () {
     local file="$1"
     local permission_chars=""
     # Do not error out in 'stat' when it is neither a regular file nor a link to a regular file
     # but it is not trusted when it is neither a regular file nor a link to a regular file:
     test -f "$file" || return 1
     # '-L' forces stat to follow symlinks (and error out if that fails):
-    permission_chars="$( stat -L -c %A "$file" )" || Error "is_writable_only_by_owner(): 'stat -L -c %A $file' failed"
+    permission_chars="$( stat -L -c %A "$file" )" || Error "is_trusted_write(): 'stat -L -c %A $file' failed"
     # permission_chars are e.g. -rwxrw-r-- so
     # the character offsets are 0123456789 so that
     # the character at offset 5 is the write permission for the group and
@@ -1724,6 +1724,26 @@ function is_trusted_path () {
     return 1
 }
 
+# Check a file is trusted.
+# A file is trused
+# when the file owner is one of the TRUSTED_OWNERS
+# and when only the file owner has write permission
+# and when the file is located below one of the TRUSTED_PATHS
+# unless the actual file path (i.e. with symlinks resolved)
+# is specified by the user in the TRUSTED_FILES config array
+# so the file is trusted regardless of owner / path / permissions.
+function is_trusted () {
+    local file="$1"
+    # To be on the safe side it is not trusted
+    # (at least for now - if really needed we may change that)
+    # when it is neither a regular file nor a link to a regular file:
+    test -f "$file" || return 1
+    is_trusted_file "$file" && return 0
+    is_trusted_owner "$file" || return 2
+    is_trusted_write "$file" || return 3
+    is_trusted_path "$file" || return 4
+}
+
 # Check the actual file path (i.e. with symlinks resolved)
 # is a ReaR script or a ReaR config file (i.e. a file that belongs to ReaR)
 # see https://github.com/rear/rear/pull/3434#issuecomment-2742598092
@@ -1764,7 +1784,7 @@ function source () {
         # Enforce source file owner is trusted:
         is_trusted_owner "$source_file" || Error "Forbidden to source '$source_file' (not a TRUSTED_OWNERS: ${TRUSTED_OWNERS[*]})"
         # Enforce source file is at most writable by its owner:
-        is_writable_only_by_owner "$source_file" || Error "Forbidden to source '$source_file' (group or others have write permission)"
+        is_trusted_write "$source_file" || Error "Forbidden to source '$source_file' (group or others have write permission)"
         # Enforce source file starts with a trusted path:
         is_trusted_path "$source_file" || Error "Forbidden to source '$source_file' (not below TRUSTED_PATHS: ${TRUSTED_PATHS[*]})"
     fi


### PR DESCRIPTION
* Type: **Enhancement**

* Impact: **Security**

Not setting TRUSTED_FILES 'readonly' would be a security issue.

* Reference to related issue (URL):

A follow up of https://github.com/rear/rear/pull/3621

* How was this pull request tested?

Tested same as in
https://github.com/rear/rear/pull/3621#issuecomment-5179082263

* Description of the changes in this pull request:

Set TRUSTED_FILES 'readonly' after the
user config files were sourced.

Additionally
rename the function 'is_writable_only_by_owner' into
'is_trusted_write' (abbreviation for 'is_trusted_write_permissions')
so all functions for trust checking
have the same prefix 'is_trusted_'.

Also added a convenience function 'is_trusted'
to call the trust checking functions all together, see
https://github.com/rear/rear/issues/3260#issuecomment-5204202527
