### PR TITLE
NETFS/tar: robust error reporting when backup subshell is signal-killed

### DIFF
--- a/usr/share/rear/backup/NETFS/default/500_make_backup.sh
+++ b/usr/share/rear/backup/NETFS/default/500_make_backup.sh
@@ -306,7 +306,26 @@ sleep 1
 case "$(basename $BACKUP_PROG)" in
     (tar)
         if (( $backup_prog_rc != 0 )); then
-            prog="$(cat $FAILING_BACKUP_PROG_FILE)"
+            # The backup subshell records the failing pipe component in
+            # $FAILING_BACKUP_PROG_FILE / $FAILING_BACKUP_PROG_RC_FILE only when it
+            # reaches its PIPESTATUS-processing loop above. If the subshell (or its
+            # tar/dd/... children) was terminated by a signal before that loop ran
+            # (e.g. SIGTERM from a timeout, the OOM killer, or a session/scope teardown,
+            # which makes 'wait' report backup_prog_rc = 128 + signal number), those
+            # files do not exist. Read them only when present and otherwise fall back
+            # to basename($BACKUP_PROG) and the known backup_prog_rc, instead of emitting
+            # "cat: .../failing_backup_prog: No such file or directory" and reporting an
+            # empty program name and empty return code.
+            if [ -s "$FAILING_BACKUP_PROG_FILE" ] ; then
+                prog="$(cat "$FAILING_BACKUP_PROG_FILE")"
+            else
+                prog="$(basename "$BACKUP_PROG")"
+            fi
+            if [ -s "$FAILING_BACKUP_PROG_RC_FILE" ] ; then
+                rc="$(cat "$FAILING_BACKUP_PROG_RC_FILE")"
+            else
+                rc="$backup_prog_rc"
+            fi
             # Suppress purely informational tar messages from output like
             #   tar: Removing leading / from member names
             #   tar: Removing leading / from hard link targets
@@ -327,8 +346,21 @@ or may not be a perfect copy of the system. Relax-and-Recover
 will continue, however it is highly advisable to verify the
 backup in order to be sure to safely recover this system.
 "
+            elif (( backup_prog_rc > 128 )); then
+                # The backup program was terminated by a signal (128 + signal number).
+                # No pipe component return code was recorded, so report the signal
+                # instead of an empty/misleading "failed with return code" message.
+                signum=$(( backup_prog_rc - 128 ))
+                signame="$( kill -l $signum 2>/dev/null )"
+                Error "$prog was terminated by signal $signum (SIG$signame), exit code $backup_prog_rc.
+The archiving process was killed before it could record which pipe
+component failed. This is usually caused by an external termination
+(e.g. a timeout, the OOM killer, or a session/scope teardown) or by a
+broken output pipe (e.g. the backup target became unavailable).
+As a result it is unlikely you can recover this system properly.
+Relax-and-Recover is therefore aborting execution.
+"
             else
-                rc=$(cat $FAILING_BACKUP_PROG_RC_FILE)
                 Error "$prog failed with return code $rc and below output (last 5 lines):
   ---snip---
 $( sed -n -e '/^tar: .*\(socket ignored\|Removing leading\)/d;/^'"$prog"':/s/^/  /p' "${TMP_DIR}/${BACKUP_PROG_ARCHIVE}.log" | tail -n5 )


### PR DESCRIPTION
  ## Relax-and-Recover (ReaR) Pull Request Template

  Please fill in the following items before submitting a Pull Request

  ### Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] Bug fix / robustness improvement (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] This change requires a documentation update

  ### Pull Request (PR) description

  The NETFS `tar` backup reporting code (run after `wait $BackupPID` in
  `backup/NETFS/default/500_make_backup.sh`) unconditionally reads
  `$FAILING_BACKUP_PROG_FILE` and `$FAILING_BACKUP_PROG_RC_FILE` whenever
  `backup_prog_rc != 0`:

      prog="$(cat $FAILING_BACKUP_PROG_FILE)"
      ...
      rc=$(cat $FAILING_BACKUP_PROG_RC_FILE)

  Those two files are written **only inside the backup subshell**, in the
  `PIPESTATUS`-processing loop. If the subshell (or its `tar`/`dd`/... children)
  is terminated by a signal *before* that loop runs — e.g. the whole `rear`
  process tree receives `SIGTERM` from a timeout, the OOM killer, or a
  session/scope teardown — the files are never created. `wait` then reports
  `backup_prog_rc = 128 + signal`, and reporting emits:

      cat: /var/tmp/rear.XXXX/tmp/failing_backup_prog: No such file or directory
      cat: /var/tmp/rear.XXXX/tmp/failing_backup_prog_rc: No such file or directory
      ERROR:  failed with return code  and below output:
        ---snip---

        ----------

  i.e. an empty program name and an empty return code, so all diagnostic
  information about *why* the backup ended is lost. This makes real-world
  incidents (backup killed at a fixed elapsed time, target/pipe dropping,
  external job reaper) very hard to diagnose.

  This PR makes the reporting path robust:

  * Read `FAILING_BACKUP_PROG_FILE` / `FAILING_BACKUP_PROG_RC_FILE` only when
    they exist and are non-empty (`-s`); otherwise fall back to
    `basename "$BACKUP_PROG"` and the known `$backup_prog_rc` from `wait`.
    This removes the `cat: ... No such file or directory` messages and the
    empty program name / return code in the error output.
  * Add an explicit `elif (( backup_prog_rc > 128 ))` branch that decodes the
    signal (`128 + N`) and reports it, e.g.:

        ERROR: tar was terminated by signal 15 (SIGTERM), exit code 143.
        The archiving process was killed before it could record which pipe
        component failed. ...

  The change is confined to the `(tar)` reporting `case` branch and does not
  alter behaviour for the normal success path, the `rc == 1` "files changed"
  warning, or the ordinary non-zero return code error path.

  Related to #1913 (NETFS+tar can report a wrong/empty exit code and lose the
  real failure reason).

  ### How was this PR tested?

  * Distribution/version(s): Fedora/RHEL family (reproduced originally on
    `rear-2.6-28.el9`); fix developed against current `master`.
  * `bash -n usr/share/rear/backup/NETFS/default/500_make_backup.sh` → passes.
  * Verified against a real incident log where `rear mkbackup` (BACKUP=NETFS,
    tar → dd → NFS) was killed with exit code 143 (SIGTERM). Before the change
    the log showed the two `cat: ... No such file or directory` lines and
    `ERROR:  failed with return code  and below output:` (blank prog and rc).
    With the change, the reporting no longer references the missing files and
    instead reports the terminating signal and exit code.

  ### Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [x] I ran `bash -n` on the changed script and it reports no syntax errors

 A few notes:

  - Title suggestion (≤70 chars): NETFS/tar: robust error reporting when backup subshell is signal-killed
  - I kept the "requires documentation update" and "corresponding changes to the documentation" boxes unchecked — this is a diagnostics-only behavior fix, no doc changes needed.