### PR TITLE
Skip unsupported partition tables during layout save by default (SKIP_UNSUPPORTED_PARTITION_TABLES)

### DIFF
--- a/usr/share/rear/conf/default.conf
+++ b/usr/share/rear/conf/default.conf
@@ -3591,6 +3591,10 @@ EXCLUDE_MD=()
 # otherwise "rear recover" would try to recreate the filesystems onto non-existing LVs.
 EXCLUDE_VG=()
 #
+# Skip disks with unsupported partition table types (sun, unknown, loop, etc.) during layout save.
+# Set to 'n' to restore strict Error behavior.
+SKIP_UNSUPPORTED_PARTITION_TABLES=y
+#
 # EXCLUDE_COMPONENTS: Exclude any component from the recovery.
 # Some component types need a prefix:
 # - filesystems: "fs:/var/cache"

--- a/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh
@@ -18,6 +18,9 @@ version_newer "$parted_version" 1.8.2 && FEATURE_PARTED_MACHINEREADABLE=y
 # Use FEATURE_PARTED_OLDNAMING if parted version is older than 1.6.23:
 version_newer "$parted_version" 1.6.23 || FEATURE_PARTED_OLDNAMING=y
 
+# Disks skipped because of unsupported partition table type (used by later layout scripts):
+: > "$VAR_DIR/layout/skipped_unsupported_disks"
+
 # Extract partitioning information of device $1 (full device path)
 # format : part <partition size(bytes)> <partition start(bytes)> <partition type|name> <flags> /dev/<partition>
 extract_partitions() {
@@ -116,19 +119,20 @@ extract_partitions() {
         disk_label=$(grep -E "Partition Table|Disk label" $TMP_DIR/parted | cut -d ":" -f "2" | tr -d " ")
     fi
     # Ensure $disk_label is valid to determine the partition name/type in the next step at 'declare type'
-    # cf. https://github.com/rear/rear/issues/2801#issuecomment-1122015129
-    # When a partition type is reported by parted that is not in the supported list
-    # it must error out because our current code here in 200_partition_layout.sh
-    # does not work with partition types that are not in the supported list
-    # cf. https://github.com/rear/rear/pull/2803#issuecomment-1124800884
-    if ! [[ "$disk_label" = "msdos" || "$disk_label" = "gpt" || "$disk_label" = "gpt_sync_mbr" || "$disk_label" = "dasd" ]] ; then
+    # Unsupported labels cannot be recreated by ReaR (cf. issues #2801 #2803).
+    # When SKIP_UNSUPPORTED_PARTITION_TABLES is enabled (default), skip silently.
+    # When a disk is in EXCLUDE_COMPONENTS, skip as well (cf. pull request #3455).
+    if ! is_partition_table_type "$disk_label" ; then
         if IsInArray "$device" "${EXCLUDE_COMPONENTS[@]}" ; then
-            DebugPrint "Unsupported partition table '$disk_label' on $device (must be one of 'msdos' 'gpt' 'gpt_sync_mbr' 'dasd')"
-        else
-            Error "Unsupported partition table '$disk_label' on $device (must be one of 'msdos' 'gpt' 'gpt_sync_mbr' 'dasd')"
+            DebugPrint "Unsupported partition table '$disk_label' on $device (listed in EXCLUDE_COMPONENTS)"
+            return 0
         fi
+        if is_true "$SKIP_UNSUPPORTED_PARTITION_TABLES" ; then
+            LogPrint "Skipping partitions on $device: unsupported partition table '$disk_label'"
+            return 0
+        fi
+        Error "Unsupported partition table '$disk_label' on $device (must be one of 'msdos' 'gpt' 'gpt_sync_mbr' 'dasd')"
     fi
-
 
     cp $TMP_DIR/partitions $TMP_DIR/partitions-data
 
@@ -464,9 +468,27 @@ Log "Saving disks and their partitions"
                     LogPrintError "Ignoring $blockd: $validation_error"
                     continue
                 fi
-                disktype=$(parted -s $devname print | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")
-                test $disktype || Error "Invalid 'disk $devname' entry (no partition table type for '$devname')"
-                if [ "$disktype" != "dasd" ]; then
+                disktype=$(parted -s $devname print 2>/dev/null | grep -E "Partition Table|Disk label" | cut -d ":" -f "2" | tr -d " ")
+		# Empty when parted/grep fails. 
+                test $disktype || disktype="unknown"
+		# Skip for unsupported disk types.
+		if ! [[ "$disktype" = "msdos" || "$disktype" = "gpt" || "$disktype" = "gpt_sync_mbr" || "$disktype" = "dasd" ]] ; then
+                 if IsInArray "$devname" "${EXCLUDE_COMPONENTS[@]}" ; then
+                     LogPrint "Skipping $devname: listed in EXCLUDE_COMPONENTS (unsupported partition table '$disktype')"
+                     echo "# Skipped disk $devname $devsize $disktype (EXCLUDE_COMPONENTS, unsupported partition table)"
+                     echo "$devname" >> "$VAR_DIR/layout/skipped_unsupported_disks"
+                     continue
+                 fi
+                 if is_true "$SKIP_UNSUPPORTED_PARTITION_TABLES" ; then
+                     LogPrint "Skipping $devname: unsupported partition table '$disktype' (SKIP_UNSUPPORTED_PARTITION_TABLES)"
+                     echo "# Skipped disk $devname $devsize $disktype (unsupported partition table, not managed by ReaR)"
+                     echo "$devname" >> "$VAR_DIR/layout/skipped_unsupported_disks"
+                     continue
+                 else
+                     Error "Unsupported partition table '$disktype' on $devname (must be one of 'msdos' 'gpt' 'gpt_sync_mbr' 'dasd')"
+                 fi
+                fi
+		if [ "$disktype" != "dasd" ]; then
                     echo "# Disk $devname"
                     echo "# Format: disk <devname> <size(bytes)> <partition label type>"
                     echo "disk $devname $devsize $disktype"

--- a/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
+++ b/usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh
@@ -101,6 +101,23 @@ fi
             Log "$device is not a block device, skipping."
             continue
         fi
+        # Skip filesystems on disks skipped due to unsupported partition table type:
+        if test -s "$VAR_DIR/layout/skipped_unsupported_disks" ; then
+            skip_fs_on_unsupported_disk=""
+            while read skipped_disk junk ; do
+                test "$skipped_disk" || continue
+                case "$device" in
+                    (${skipped_disk}|${skipped_disk}*)
+                        skip_fs_on_unsupported_disk="yes"
+                        break
+                        ;;
+                esac
+            done < "$VAR_DIR/layout/skipped_unsupported_disks"
+            if is_true "$skip_fs_on_unsupported_disk" ; then
+                LogPrint "Skipping filesystem $mountpoint on $device (disk has unsupported partition table, skipped in layout save)"
+                continue
+            fi
+        fi
         # Skip saving filesystem layout for CD/DVD type devices:
         if [ "$fstype" = "iso9660" ] ; then
             Log "$device is CD/DVD type device [fstype=$fstype], skipping."

--- a/usr/share/rear/layout/save/default/315_skip_unsupported_partition_tables.sh
+++ b/usr/share/rear/layout/save/default/315_skip_unsupported_partition_tables.sh
@@ -1,0 +1,32 @@
+# Mark components on disks with unsupported partition tables as done.
+# Disks are recorded in $VAR_DIR/layout/skipped_unsupported_disks by
+# layout/save/GNU/Linux/200_partition_layout.sh when SKIP_UNSUPPORTED_PARTITION_TABLES is enabled.
+# Filesystems on those disks may have been saved by 230_filesystem_layout.sh before dependencies exist;
+# mark them done here so 330_remove_exclusions.sh comments them out in disklayout.conf.
+test -s "$VAR_DIR/layout/skipped_unsupported_disks" || return 0
+while read skipped_disk junk ; do
+    test "$skipped_disk" || continue
+    LogPrint "Marking skipped unsupported partition table disk $skipped_disk as done"
+    mark_as_done "$skipped_disk"
+    mark_tree_as_done "$skipped_disk"
+    # Mark filesystems on partitions of this disk as done:
+    while read fs device mountpoint fstype junk ; do
+        case "$device" in
+            (${skipped_disk}|${skipped_disk}*)
+                LogPrint "Marking filesystem $mountpoint on skipped disk $skipped_disk as done"
+                mark_as_done "fs:$mountpoint"
+                mark_tree_as_done "fs:$mountpoint"
+                ;;
+        esac
+    done < <(grep '^fs ' "$LAYOUT_FILE")
+    # Mark swap on this disk as done:
+    while read swap device uuid label junk ; do
+        case "$device" in
+            (${skipped_disk}|${skipped_disk}*)
+                LogPrint "Marking swap on skipped disk $skipped_disk as done"
+                mark_as_done "swap:$device"
+                mark_tree_as_done "swap:$device"
+                ;;
+        esac
+    done < <(grep '^swap ' "$LAYOUT_FILE")
+done < "$VAR_DIR/layout/skipped_unsupported_disks"

--- a/usr/share/rear/lib/layout-functions.sh
+++ b/usr/share/rear/lib/layout-functions.sh
@@ -419,6 +419,18 @@ find_disk_and_multipath() {
     is_true "$AUTOEXCLUDE_MULTIPATH" || find_multipath "$1" ${2+"$2"}
 }
 
+# Return 0 when $1 is a partition table type ReaR can save and recreate.
+is_partition_table_type () {
+    case "$1" in
+        (msdos|gpt|gpt_sync_mbr|dasd)
+            return 0
+            ;;
+        (*)
+            return 1
+            ;;
+    esac
+}
+
 find_partition() {
     get_parent_components "$1" "part" ${2+"$2"}
 }


### PR DESCRIPTION
Add SKIP_UNSUPPORTED_PARTITION_TABLES (default yes) to skip sun/unknown/loop disks before writing disk/part lines. Extends #3455 EXCLUDE_COMPONENTS handling with fleet-scale auto-skip. Adds 315 script and 230 filesystem skip. Related: #3455

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type:  **Enhancement**

* Impact:  **Normal**

* Reference to related issue (URL): 
https://github.com/rear/rear/issues/2995 
https://github.com/rear/rear/issues/3433 
https://github.com/rear/rear/issues/3455

* How was this pull request tested?
Tested on RHE L9.8 VM with legacy SUN labeled non-OS data disk whose partition table reported as unknown by parted. Without EXCLUDE_COMPONENTS in configuration for that specific disk.

Test 1 — default auto-skip (SKIP_UNSUPPORTED_PARTITION_TABLES=y)  : 
Ran rear mkrescue -v , succeeds without including sun disk in disklayout.conf 

Test 2 — strict mode (SKIP_UNSUPPORTED_PARTITION_TABLES=n):
mkrescue fails with clear Error on unsupported partition table 

Test 3 — regression for #3455 (EXCLUDE_COMPONENTS):
  `SKIP_UNSUPPORTED_PARTITION_TABLES=n` + `EXCLUDE_COMPONENTS+=( /dev/vdX )` on unsupported disk
  Then rear mkrescue -v ,  Disk in EXCLUDE_COMPONENTS is skipped, honoring exclusion added even if unsupported skip is set to No.

* Description of the changes in this pull request:
Since ReaR 2.7+ ([#2803](https://github.com/rear/rear/pull/2803)), layout/save/GNU/Linux/200_partition_layout.sh errors out when parted reports an unsupported partition table type (e.g. sun, unknown, loop, bsd). This causes mkrescue to abort on systems with legacy non-OS data disks that ReaR cannot recreate anyway.

[#3455](https://github.com/rear/rear/pull/3455) added a soft-fail path in extract_partitions() when the disk is explicitly listed in EXCLUDE_COMPONENTS. That helps exceptional cases but does not scale for large fleets where per-host EXCLUDE_COMPONENTS configuration is impractical. Furthermore, EXCLUDE_COMPONENTS is processed in script 310_include_exclude.sh, which runs after 200_partition_layout.sh, so unsupported disks without sysfs partition entries can still abort layout save before exclude logic runs.

This pull request adds SKIP_UNSUPPORTED_PARTITION_TABLES=y (default) to skip unsupported disks during layout save:

usr/share/rear/conf/default.conf — new parameter SKIP_UNSUPPORTED_PARTITION_TABLES=y; set to n for strict Error behavior.

usr/share/rear/lib/layout-functions.sh — new helper is_partition_table_type() for supported types (msdos, gpt, gpt_sync_mbr, dasd).

usr/share/rear/layout/save/GNU/Linux/200_partition_layout.sh:

Initialize $VAR_DIR/layout/skipped_unsupported_disks
In the disk loop: detect disktype via parted (with 2>/dev/null); treat empty parse result as unknown; skip unsupported disks before writing active disk lines when auto-skip is enabled
In extract_partitions(): keep #3455 EXCLUDE_COMPONENTS soft-fail; add auto-skip via SKIP_UNSUPPORTED_PARTITION_TABLES
usr/share/rear/layout/save/GNU/Linux/230_filesystem_layout.sh — skip saving filesystem layout for devices on skipped disks.

usr/share/rear/layout/save/default/315_skip_unsupported_partition_tables.sh (new) — mark skipped disks, their filesystems, and swap as done so 330_remove_exclusions.sh comments them out in disklayout.conf.

Skipped disks are recorded as commented # Skipped disk ... lines in disklayout.conf for auditability. Supported OS disks (gpt/msdos/dasd) are unchanged.