### PR TITLE
Update 380_request_client_destination.sh to accept more bp.conf syntaxes

### DIFF
--- a/usr/share/rear/verify/NBU/default/380_request_client_destination.sh
+++ b/usr/share/rear/verify/NBU/default/380_request_client_destination.sh
@@ -4,11 +4,29 @@
 # OR Request the user to hit ENTER to do a normal restore to the same client.
 
 # read NBU vars from NBU config file bp.conf
-while read KEY VALUE ; do
-    echo "$KEY" | grep -qi '^#' && continue
-    test -z "$KEY" && continue
-    KEY="$( echo "$KEY" | tr '[:lower:]' '[:upper:]' )"
-    export NBU_$KEY="$( echo "$VALUE" | sed -e 's/=//' -e 's/ //g' )"
+while read -r line || [[ -n "$line" ]]; do
+    # Skip comments and empty lines
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    
+    # Split on '=' if present, otherwise on the first whitespace
+    if [[ "$line" == *=* ]]; then
+        KEY="${line%%=*}"
+        VALUE="${line#*=}"
+    else
+        read -r KEY VALUE <<< "$line"
+    fi
+    
+    # Strip leading/trailing whitespaces
+    KEY=$(echo "$KEY" | xargs)
+    VALUE=$(echo "$VALUE" | xargs)
+    
+    # Ensure KEY is not empty after trimming
+    [[ -z "$KEY" ]] && continue
+    
+    # Convert KEY to uppercase and export
+    KEY="$(echo "$KEY" | tr '[:lower:]' '[:upper:]')"
+    export "NBU_${KEY}=${VALUE}"
 done </usr/openv/netbackup/bp.conf
 
 NBU_CLIENT_SOURCE="${NBU_CLIENT_NAME}"


### PR DESCRIPTION

#### Relax-and-Recover (ReaR) Pull Request Template

Please fill in the following items before submitting a new pull request:

##### Pull Request Details:

* Type: **Bug Fix**

* Impact: **Normal** 

* Reference to related issue (URL):

* How was this pull request tested?
tested manually this part of the script with different syntaxes.

* Description of the changes in this pull request:

bp.conf can have different syntaxes: 

KEY = value
KEY=value
KEY value 1 2 3
KEY = value 4 5 6

The current implementation accepts only the 1st one. If the key does not contains space around '=' or has multiple values, it fails, and then the recover do not complete (UUID are not updated to /etc/fstab for example) 
